### PR TITLE
Fix wrong custody column count for lookup blocks

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1272,9 +1272,16 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for Arc<SignedBeaconBlock
         // Perform an early check to prevent wasting time on irrelevant blocks.
         let block_root = check_block_relevancy(&self, block_root, chain)
             .map_err(|e| BlockSlashInfo::SignatureNotChecked(self.signed_block_header(), e))?;
+        // TODO(das): This is wrong, as the block may have columns. However this codepath is
+        // currently un-used, and should be removed with https://github.com/sigp/lighthouse/pull/7008
+        let custody_column_count = 0;
         let maybe_available = chain
             .data_availability_checker
-            .verify_kzg_for_rpc_block(RpcBlock::new_without_blobs(Some(block_root), self.clone()))
+            .verify_kzg_for_rpc_block(RpcBlock::new_without_blobs(
+                Some(block_root),
+                self.clone(),
+                custody_column_count,
+            ))
             .map_err(|e| {
                 BlockSlashInfo::SignatureNotChecked(
                     self.signed_block_header(),

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1260,47 +1260,6 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for SignatureVerifiedBloc
     }
 }
 
-impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for Arc<SignedBeaconBlock<T::EthSpec>> {
-    /// Verifies the `SignedBeaconBlock` by first transforming it into a `SignatureVerifiedBlock`
-    /// and then using that implementation of `IntoExecutionPendingBlock` to complete verification.
-    fn into_execution_pending_block_slashable(
-        self,
-        block_root: Hash256,
-        chain: &Arc<BeaconChain<T>>,
-        notify_execution_layer: NotifyExecutionLayer,
-    ) -> Result<ExecutionPendingBlock<T>, BlockSlashInfo<BlockError>> {
-        // Perform an early check to prevent wasting time on irrelevant blocks.
-        let block_root = check_block_relevancy(&self, block_root, chain)
-            .map_err(|e| BlockSlashInfo::SignatureNotChecked(self.signed_block_header(), e))?;
-        // TODO(das): This is wrong, as the block may have columns. However this codepath is
-        // currently un-used, and should be removed with https://github.com/sigp/lighthouse/pull/7008
-        let custody_column_count = 0;
-        let maybe_available = chain
-            .data_availability_checker
-            .verify_kzg_for_rpc_block(RpcBlock::new_without_blobs(
-                Some(block_root),
-                self.clone(),
-                custody_column_count,
-            ))
-            .map_err(|e| {
-                BlockSlashInfo::SignatureNotChecked(
-                    self.signed_block_header(),
-                    BlockError::AvailabilityCheck(e),
-                )
-            })?;
-        SignatureVerifiedBlock::check_slashable(maybe_available, block_root, chain)?
-            .into_execution_pending_block_slashable(block_root, chain, notify_execution_layer)
-    }
-
-    fn block(&self) -> &SignedBeaconBlock<T::EthSpec> {
-        self
-    }
-
-    fn block_cloned(&self) -> Arc<SignedBeaconBlock<T::EthSpec>> {
-        self.clone()
-    }
-}
-
 impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for RpcBlock<T::EthSpec> {
     /// Verifies the `SignedBeaconBlock` by first transforming it into a `SignatureVerifiedBlock`
     /// and then using that implementation of `IntoExecutionPendingBlock` to complete verification.

--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -110,7 +110,6 @@ impl<E: EthSpec> RpcBlock<E> {
         Self {
             block_root,
             block: RpcBlockInner::Block(block),
-            // Block has zero columns
             custody_columns_count,
         }
     }

--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -103,6 +103,7 @@ impl<E: EthSpec> RpcBlock<E> {
     pub fn new_without_blobs(
         block_root: Option<Hash256>,
         block: Arc<SignedBeaconBlock<E>>,
+        custody_columns_count: usize,
     ) -> Self {
         let block_root = block_root.unwrap_or_else(|| get_block_root(&block));
 
@@ -110,7 +111,7 @@ impl<E: EthSpec> RpcBlock<E> {
             block_root,
             block: RpcBlockInner::Block(block),
             // Block has zero columns
-            custody_columns_count: 0,
+            custody_columns_count,
         }
     }
 

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -2371,11 +2371,7 @@ where
 
         // Blobs are stored as data columns from Fulu (PeerDAS)
         if self.spec.is_peer_das_enabled_for_epoch(block.epoch()) {
-            let columns = self
-                .chain
-                .get_data_columns(&block_root)
-                .unwrap()
-                .or_default();
+            let columns = self.chain.get_data_columns(&block_root).unwrap().unwrap();
             let custody_columns = columns
                 .into_iter()
                 .map(CustodyDataColumn::from_asserted_custody)
@@ -2421,7 +2417,7 @@ where
                     &self.spec,
                 )?
             } else {
-                RpcBlock::new_without_blobs(Some(block_root), block, sampling_column_count)
+                RpcBlock::new_without_blobs(Some(block_root), block, 0)
             }
         } else {
             let blobs = blob_items

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -2371,7 +2371,11 @@ where
 
         // Blobs are stored as data columns from Fulu (PeerDAS)
         if self.spec.is_peer_das_enabled_for_epoch(block.epoch()) {
-            let columns = self.chain.get_data_columns(&block_root).unwrap().unwrap();
+            let columns = self
+                .chain
+                .get_data_columns(&block_root)
+                .unwrap()
+                .or_default();
             let custody_columns = columns
                 .into_iter()
                 .map(CustodyDataColumn::from_asserted_custody)

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -2366,7 +2366,7 @@ where
             .blob_kzg_commitments()
             .is_ok_and(|c| !c.is_empty());
         if !has_blobs {
-            return RpcBlock::new_without_blobs(Some(block_root), block);
+            return RpcBlock::new_without_blobs(Some(block_root), block, 0);
         }
 
         // Blobs are stored as data columns from Fulu (PeerDAS)
@@ -2417,7 +2417,7 @@ where
                     &self.spec,
                 )?
             } else {
-                RpcBlock::new_without_blobs(Some(block_root), block)
+                RpcBlock::new_without_blobs(Some(block_root), block, sampling_column_count)
             }
         } else {
             let blobs = blob_items

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -367,9 +367,10 @@ async fn chain_segment_non_linear_parent_roots() {
 
     let (mut block, signature) = blocks[3].as_block().clone().deconstruct();
     *block.parent_root_mut() = Hash256::zero();
-    blocks[3] = harness.build_rpc_block_from_store_blobs(
+    blocks[3] = RpcBlock::new_without_blobs(
         None,
         Arc::new(SignedBeaconBlock::from_block(block, signature)),
+        harness.sampling_column_count,
     );
 
     assert!(
@@ -404,9 +405,10 @@ async fn chain_segment_non_linear_slots() {
             .collect();
     let (mut block, signature) = blocks[3].as_block().clone().deconstruct();
     *block.slot_mut() = Slot::new(0);
-    blocks[3] = harness.build_rpc_block_from_store_blobs(
+    blocks[3] = RpcBlock::new_without_blobs(
         None,
         Arc::new(SignedBeaconBlock::from_block(block, signature)),
+        harness.sampling_column_count,
     );
 
     assert!(
@@ -431,9 +433,10 @@ async fn chain_segment_non_linear_slots() {
             .collect();
     let (mut block, signature) = blocks[3].as_block().clone().deconstruct();
     *block.slot_mut() = blocks[2].slot();
-    blocks[3] = harness.build_rpc_block_from_store_blobs(
+    blocks[3] = RpcBlock::new_without_blobs(
         None,
         Arc::new(SignedBeaconBlock::from_block(block, signature)),
+        harness.sampling_column_count,
     );
 
     assert!(
@@ -575,7 +578,11 @@ async fn invalid_signature_gossip_block() {
             .into_block_error()
             .expect("should import all blocks prior to the one being tested");
         let signed_block = SignedBeaconBlock::from_block(block, junk_signature());
-        let rpc_block = harness.build_rpc_block_from_store_blobs(None, Arc::new(signed_block));
+        let rpc_block = RpcBlock::new_without_blobs(
+            None,
+            Arc::new(signed_block),
+            harness.sampling_column_count,
+        );
         let process_res = harness
             .chain
             .process_block(
@@ -1764,7 +1771,11 @@ async fn import_duplicate_block_unrealized_justification() {
     // Create two verified variants of the block, representing the same block being processed in
     // parallel.
     let notify_execution_layer = NotifyExecutionLayer::Yes;
-    let rpc_block = harness.build_rpc_block_from_store_blobs(Some(block_root), block.clone());
+    let rpc_block = RpcBlock::new_without_blobs(
+        Some(block_root),
+        block.clone(),
+        harness.sampling_column_count,
+    );
     let verified_block1 = rpc_block
         .clone()
         .into_execution_pending_block(block_root, chain, notify_execution_layer)

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -147,7 +147,7 @@ fn build_rpc_block(
             RpcBlock::new_with_custody_columns(None, block, columns.clone(), columns.len(), spec)
                 .unwrap()
         }
-        None => RpcBlock::new_without_blobs(None, block),
+        None => RpcBlock::new_without_blobs(None, block, 0),
     }
 }
 
@@ -367,7 +367,7 @@ async fn chain_segment_non_linear_parent_roots() {
 
     let (mut block, signature) = blocks[3].as_block().clone().deconstruct();
     *block.parent_root_mut() = Hash256::zero();
-    blocks[3] = RpcBlock::new_without_blobs(
+    blocks[3] = harness.build_rpc_block_from_store_blobs(
         None,
         Arc::new(SignedBeaconBlock::from_block(block, signature)),
     );
@@ -404,7 +404,7 @@ async fn chain_segment_non_linear_slots() {
             .collect();
     let (mut block, signature) = blocks[3].as_block().clone().deconstruct();
     *block.slot_mut() = Slot::new(0);
-    blocks[3] = RpcBlock::new_without_blobs(
+    blocks[3] = harness.build_rpc_block_from_store_blobs(
         None,
         Arc::new(SignedBeaconBlock::from_block(block, signature)),
     );
@@ -431,7 +431,7 @@ async fn chain_segment_non_linear_slots() {
             .collect();
     let (mut block, signature) = blocks[3].as_block().clone().deconstruct();
     *block.slot_mut() = blocks[2].slot();
-    blocks[3] = RpcBlock::new_without_blobs(
+    blocks[3] = harness.build_rpc_block_from_store_blobs(
         None,
         Arc::new(SignedBeaconBlock::from_block(block, signature)),
     );
@@ -575,11 +575,12 @@ async fn invalid_signature_gossip_block() {
             .into_block_error()
             .expect("should import all blocks prior to the one being tested");
         let signed_block = SignedBeaconBlock::from_block(block, junk_signature());
+        let rpc_block = harness.build_rpc_block_from_store_blobs(None, Arc::new(signed_block));
         let process_res = harness
             .chain
             .process_block(
-                signed_block.canonical_root(),
-                Arc::new(signed_block),
+                rpc_block.block_root(),
+                rpc_block,
                 NotifyExecutionLayer::Yes,
                 BlockImportSource::Lookup,
                 || Ok(()),
@@ -1541,12 +1542,13 @@ async fn add_base_block_to_altair_chain() {
     ));
 
     // Ensure that it would be impossible to import via `BeaconChain::process_block`.
+    let base_rpc_block = RpcBlock::new_without_blobs(None, Arc::new(base_block.clone()), 0);
     assert!(matches!(
         harness
             .chain
             .process_block(
-                base_block.canonical_root(),
-                Arc::new(base_block.clone()),
+                base_rpc_block.block_root(),
+                base_rpc_block,
                 NotifyExecutionLayer::Yes,
                 BlockImportSource::Lookup,
                 || Ok(()),
@@ -1564,7 +1566,7 @@ async fn add_base_block_to_altair_chain() {
         harness
             .chain
             .process_chain_segment(
-                vec![RpcBlock::new_without_blobs(None, Arc::new(base_block))],
+                vec![RpcBlock::new_without_blobs(None, Arc::new(base_block), 0)],
                 NotifyExecutionLayer::Yes,
             )
             .await,
@@ -1677,12 +1679,13 @@ async fn add_altair_block_to_base_chain() {
     ));
 
     // Ensure that it would be impossible to import via `BeaconChain::process_block`.
+    let altair_rpc_block = RpcBlock::new_without_blobs(None, Arc::new(altair_block.clone()), 0);
     assert!(matches!(
         harness
             .chain
             .process_block(
-                altair_block.canonical_root(),
-                Arc::new(altair_block.clone()),
+                altair_rpc_block.block_root(),
+                altair_rpc_block,
                 NotifyExecutionLayer::Yes,
                 BlockImportSource::Lookup,
                 || Ok(()),
@@ -1700,7 +1703,7 @@ async fn add_altair_block_to_base_chain() {
         harness
             .chain
             .process_chain_segment(
-                vec![RpcBlock::new_without_blobs(None, Arc::new(altair_block))],
+                vec![RpcBlock::new_without_blobs(None, Arc::new(altair_block), 0)],
                 NotifyExecutionLayer::Yes
             )
             .await,
@@ -1761,11 +1764,12 @@ async fn import_duplicate_block_unrealized_justification() {
     // Create two verified variants of the block, representing the same block being processed in
     // parallel.
     let notify_execution_layer = NotifyExecutionLayer::Yes;
-    let verified_block1 = block
+    let rpc_block = harness.build_rpc_block_from_store_blobs(Some(block_root), block.clone());
+    let verified_block1 = rpc_block
         .clone()
         .into_execution_pending_block(block_root, chain, notify_execution_layer)
         .unwrap();
-    let verified_block2 = block
+    let verified_block2 = rpc_block
         .into_execution_pending_block(block_root, chain, notify_execution_layer)
         .unwrap();
 

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -687,12 +687,15 @@ async fn invalidates_all_descendants() {
     assert_eq!(fork_parent_state.slot(), fork_parent_slot);
     let ((fork_block, _), _fork_post_state) =
         rig.harness.make_block(fork_parent_state, fork_slot).await;
+    let fork_rpc_block = rig
+        .harness
+        .build_rpc_block_from_store_blobs(None, fork_block.clone());
     let fork_block_root = rig
         .harness
         .chain
         .process_block(
-            fork_block.canonical_root(),
-            fork_block,
+            fork_rpc_block.block_root(),
+            fork_rpc_block,
             NotifyExecutionLayer::Yes,
             BlockImportSource::Lookup,
             || Ok(()),
@@ -788,12 +791,15 @@ async fn switches_heads() {
     let ((fork_block, _), _fork_post_state) =
         rig.harness.make_block(fork_parent_state, fork_slot).await;
     let fork_parent_root = fork_block.parent_root();
+    let fork_rpc_block = rig
+        .harness
+        .build_rpc_block_from_store_blobs(None, fork_block.clone());
     let fork_block_root = rig
         .harness
         .chain
         .process_block(
-            fork_block.canonical_root(),
-            fork_block,
+            fork_rpc_block.block_root(),
+            fork_rpc_block,
             NotifyExecutionLayer::Yes,
             BlockImportSource::Lookup,
             || Ok(()),
@@ -1057,8 +1063,11 @@ async fn invalid_parent() {
     ));
 
     // Ensure the block built atop an invalid payload is invalid for import.
+    let rpc_block = rig
+        .harness
+        .build_rpc_block_from_store_blobs(None, block.clone());
     assert!(matches!(
-        rig.harness.chain.process_block(block.canonical_root(), block.clone(), NotifyExecutionLayer::Yes, BlockImportSource::Lookup,
+        rig.harness.chain.process_block(rpc_block.block_root(), rpc_block, NotifyExecutionLayer::Yes, BlockImportSource::Lookup,
             || Ok(()),
         ).await,
         Err(BlockError::ParentExecutionPayloadInvalid { parent_root: invalid_root })
@@ -1380,11 +1389,14 @@ async fn recover_from_invalid_head_by_importing_blocks() {
     } = InvalidHeadSetup::new().await;
 
     // Import the fork block, it should become the head.
+    let fork_rpc_block = rig
+        .harness
+        .build_rpc_block_from_store_blobs(None, fork_block.clone());
     rig.harness
         .chain
         .process_block(
-            fork_block.canonical_root(),
-            fork_block.clone(),
+            fork_rpc_block.block_root(),
+            fork_rpc_block,
             NotifyExecutionLayer::Yes,
             BlockImportSource::Lookup,
             || Ok(()),

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -1,5 +1,6 @@
 #![cfg(not(debug_assertions))]
 
+use beacon_chain::block_verification_types::RpcBlock;
 use beacon_chain::{
     canonical_head::{CachedHead, CanonicalHead},
     test_utils::{BeaconChainHarness, EphemeralHarnessType},
@@ -687,9 +688,8 @@ async fn invalidates_all_descendants() {
     assert_eq!(fork_parent_state.slot(), fork_parent_slot);
     let ((fork_block, _), _fork_post_state) =
         rig.harness.make_block(fork_parent_state, fork_slot).await;
-    let fork_rpc_block = rig
-        .harness
-        .build_rpc_block_from_store_blobs(None, fork_block.clone());
+    let fork_rpc_block =
+        RpcBlock::new_without_blobs(None, fork_block.clone(), rig.harness.sampling_column_count);
     let fork_block_root = rig
         .harness
         .chain
@@ -791,9 +791,8 @@ async fn switches_heads() {
     let ((fork_block, _), _fork_post_state) =
         rig.harness.make_block(fork_parent_state, fork_slot).await;
     let fork_parent_root = fork_block.parent_root();
-    let fork_rpc_block = rig
-        .harness
-        .build_rpc_block_from_store_blobs(None, fork_block.clone());
+    let fork_rpc_block =
+        RpcBlock::new_without_blobs(None, fork_block.clone(), rig.harness.sampling_column_count);
     let fork_block_root = rig
         .harness
         .chain
@@ -1063,9 +1062,8 @@ async fn invalid_parent() {
     ));
 
     // Ensure the block built atop an invalid payload is invalid for import.
-    let rpc_block = rig
-        .harness
-        .build_rpc_block_from_store_blobs(None, block.clone());
+    let rpc_block =
+        RpcBlock::new_without_blobs(None, block.clone(), rig.harness.sampling_column_count);
     assert!(matches!(
         rig.harness.chain.process_block(rpc_block.block_root(), rpc_block, NotifyExecutionLayer::Yes, BlockImportSource::Lookup,
             || Ok(()),
@@ -1389,9 +1387,8 @@ async fn recover_from_invalid_head_by_importing_blocks() {
     } = InvalidHeadSetup::new().await;
 
     // Import the fork block, it should become the head.
-    let fork_rpc_block = rig
-        .harness
-        .build_rpc_block_from_store_blobs(None, fork_block.clone());
+    let fork_rpc_block =
+        RpcBlock::new_without_blobs(None, fork_block.clone(), rig.harness.sampling_column_count);
     rig.harness
         .chain
         .process_block(

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2641,12 +2641,14 @@ async fn process_blocks_and_attestations_for_unaligned_checkpoint() {
     assert_eq!(split.block_root, valid_fork_block.parent_root());
     assert_ne!(split.state_root, unadvanced_split_state_root);
 
+    let invalid_fork_rpc_block =
+        harness.build_rpc_block_from_store_blobs(None, invalid_fork_block.clone());
     // Applying the invalid block should fail.
     let err = harness
         .chain
         .process_block(
-            invalid_fork_block.canonical_root(),
-            invalid_fork_block.clone(),
+            invalid_fork_rpc_block.block_root(),
+            invalid_fork_rpc_block,
             NotifyExecutionLayer::Yes,
             BlockImportSource::Lookup,
             || Ok(()),
@@ -2656,11 +2658,13 @@ async fn process_blocks_and_attestations_for_unaligned_checkpoint() {
     assert!(matches!(err, BlockError::WouldRevertFinalizedSlot { .. }));
 
     // Applying the valid block should succeed, but it should not become head.
+    let valid_fork_rpc_block =
+        harness.build_rpc_block_from_store_blobs(None, valid_fork_block.clone());
     harness
         .chain
         .process_block(
-            valid_fork_block.canonical_root(),
-            valid_fork_block.clone(),
+            valid_fork_rpc_block.block_root(),
+            valid_fork_rpc_block,
             NotifyExecutionLayer::Yes,
             BlockImportSource::Lookup,
             || Ok(()),

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -1,6 +1,7 @@
 #![cfg(not(debug_assertions))]
 
 use beacon_chain::attestation_verification::Error as AttnError;
+use beacon_chain::block_verification_types::RpcBlock;
 use beacon_chain::builder::BeaconChainBuilder;
 use beacon_chain::data_availability_checker::AvailableBlock;
 use beacon_chain::schema_change::migrate_schema;
@@ -2641,8 +2642,11 @@ async fn process_blocks_and_attestations_for_unaligned_checkpoint() {
     assert_eq!(split.block_root, valid_fork_block.parent_root());
     assert_ne!(split.state_root, unadvanced_split_state_root);
 
-    let invalid_fork_rpc_block =
-        harness.build_rpc_block_from_store_blobs(None, invalid_fork_block.clone());
+    let invalid_fork_rpc_block = RpcBlock::new_without_blobs(
+        None,
+        invalid_fork_block.clone(),
+        harness.sampling_column_count,
+    );
     // Applying the invalid block should fail.
     let err = harness
         .chain
@@ -2658,8 +2662,11 @@ async fn process_blocks_and_attestations_for_unaligned_checkpoint() {
     assert!(matches!(err, BlockError::WouldRevertFinalizedSlot { .. }));
 
     // Applying the valid block should succeed, but it should not become head.
-    let valid_fork_rpc_block =
-        harness.build_rpc_block_from_store_blobs(None, valid_fork_block.clone());
+    let valid_fork_rpc_block = RpcBlock::new_without_blobs(
+        None,
+        valid_fork_block.clone(),
+        harness.sampling_column_count,
+    );
     harness
         .chain
         .process_block(

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -2,7 +2,7 @@ use crate::metrics;
 use std::future::Future;
 
 use beacon_chain::blob_verification::{GossipBlobError, GossipVerifiedBlob};
-use beacon_chain::block_verification_types::AsBlock;
+use beacon_chain::block_verification_types::{AsBlock, RpcBlock};
 use beacon_chain::data_column_verification::{GossipDataColumnError, GossipVerifiedDataColumn};
 use beacon_chain::validator_monitor::{get_block_delay_ms, timestamp_now};
 use beacon_chain::{
@@ -302,7 +302,11 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlock<T>>(
             );
             let import_result = Box::pin(chain.process_block(
                 block_root,
-                block.clone(),
+                RpcBlock::new_without_blobs(
+                    Some(block_root),
+                    block.clone(),
+                    network_globals.custody_columns_count() as usize,
+                ),
                 NotifyExecutionLayer::Yes,
                 BlockImportSource::HttpApi,
                 publish_fn,

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -323,12 +323,22 @@ impl TestRig {
         }
     }
 
+    pub fn custody_columns_count(&self) -> usize {
+        self.network_beacon_processor
+            .network_globals
+            .custody_columns_count() as usize
+    }
+
     pub fn enqueue_rpc_block(&self) {
         let block_root = self.next_block.canonical_root();
         self.network_beacon_processor
             .send_rpc_beacon_block(
                 block_root,
-                RpcBlock::new_without_blobs(Some(block_root), self.next_block.clone()),
+                RpcBlock::new_without_blobs(
+                    Some(block_root),
+                    self.next_block.clone(),
+                    self.custody_columns_count(),
+                ),
                 std::time::Duration::default(),
                 BlockProcessType::SingleBlock { id: 0 },
             )
@@ -340,7 +350,11 @@ impl TestRig {
         self.network_beacon_processor
             .send_rpc_beacon_block(
                 block_root,
-                RpcBlock::new_without_blobs(Some(block_root), self.next_block.clone()),
+                RpcBlock::new_without_blobs(
+                    Some(block_root),
+                    self.next_block.clone(),
+                    self.custody_columns_count(),
+                ),
                 std::time::Duration::default(),
                 BlockProcessType::SingleBlock { id: 1 },
             )

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -6,7 +6,6 @@ use crate::sync::block_lookups::{
 };
 use crate::sync::manager::BlockProcessType;
 use crate::sync::network_context::{LookupRequestResult, SyncNetworkContext};
-use beacon_chain::block_verification_types::RpcBlock;
 use beacon_chain::BeaconChainTypes;
 use lighthouse_network::service::api_types::Id;
 use parking_lot::RwLock;
@@ -97,13 +96,8 @@ impl<T: BeaconChainTypes> RequestState<T> for BlockRequestState<T::EthSpec> {
             seen_timestamp,
             ..
         } = download_result;
-        cx.send_block_for_processing(
-            id,
-            block_root,
-            RpcBlock::new_without_blobs(Some(block_root), value),
-            seen_timestamp,
-        )
-        .map_err(LookupRequestError::SendFailedProcessor)
+        cx.send_block_for_processing(id, block_root, value, seen_timestamp)
+            .map_err(LookupRequestError::SendFailedProcessor)
     }
 
     fn response_type() -> ResponseType {

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -266,7 +266,8 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                 )
                 .map_err(|e| format!("{e:?}"))?
             } else {
-                RpcBlock::new_without_blobs(Some(block_root), block)
+                // Block has no data, expects zero columns
+                RpcBlock::new_without_blobs(Some(block_root), block, 0)
             });
         }
 

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -1308,7 +1308,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         &self,
         id: Id,
         block_root: Hash256,
-        block: RpcBlock<T::EthSpec>,
+        block: Arc<SignedBeaconBlock<T::EthSpec>>,
         seen_timestamp: Duration,
     ) -> Result<(), SendErrorProcessor> {
         let span = span!(
@@ -1321,6 +1321,12 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         let beacon_processor = self
             .beacon_processor_if_enabled()
             .ok_or(SendErrorProcessor::ProcessorNotAvailable)?;
+
+        let block = RpcBlock::new_without_blobs(
+            Some(block_root),
+            block,
+            self.network_globals().custody_columns_count() as usize,
+        );
 
         debug!(block = ?block_root, id, "Sending block for processing");
         // Lookup sync event safety: If `beacon_processor.send_rpc_beacon_block` returns Ok() sync

--- a/beacon_node/network/src/sync/tests/range.rs
+++ b/beacon_node/network/src/sync/tests/range.rs
@@ -459,7 +459,8 @@ fn build_rpc_block(
             )
             .unwrap()
         }
-        None => RpcBlock::new_without_blobs(None, block),
+        // Block has no data, expects zero columns
+        None => RpcBlock::new_without_blobs(None, block, 0),
     }
 }
 

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -3,6 +3,7 @@ use crate::decode::{ssz_decode_file, ssz_decode_file_with, ssz_decode_state, yam
 use ::fork_choice::{PayloadVerificationStatus, ProposerHeadError};
 use beacon_chain::beacon_proposer_cache::compute_proposer_duties_from_head;
 use beacon_chain::blob_verification::GossipBlobError;
+use beacon_chain::block_verification_types::RpcBlock;
 use beacon_chain::chain_config::{
     DisallowedReOrgOffsets, DEFAULT_RE_ORG_HEAD_THRESHOLD,
     DEFAULT_RE_ORG_MAX_EPOCHS_SINCE_FINALIZATION, DEFAULT_RE_ORG_PARENT_THRESHOLD,
@@ -519,7 +520,7 @@ impl<E: EthSpec> Tester<E> {
         let result: Result<Result<Hash256, ()>, _> = self
             .block_on_dangerous(self.harness.chain.process_block(
                 block_root,
-                block.clone(),
+                RpcBlock::new_without_blobs(Some(block_root), block.clone(), 0),
                 NotifyExecutionLayer::Yes,
                 BlockImportSource::Lookup,
                 || Ok(()),


### PR DESCRIPTION
## Issue Addressed

Fixes
- https://github.com/sigp/lighthouse/issues/7278

## Proposed Changes

Don't assume 0 columns for `RpcBlockInner::Block`

