### PR TITLE
Add `pending_consolidations` Beacon API endpoint

### DIFF
--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -821,6 +821,26 @@ impl BeaconNodeHttpClient {
         self.get_opt(path).await
     }
 
+    /// `GET beacon/states/{state_id}/pending_consolidations`
+    ///
+    /// Returns `Ok(None)` on a 404 error.
+    pub async fn get_beacon_states_pending_consolidations(
+        &self,
+        state_id: StateId,
+    ) -> Result<Option<ExecutionOptimisticFinalizedResponse<Vec<PendingConsolidation>>>, Error>
+    {
+        let mut path = self.eth_path(V1)?;
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("beacon")
+            .push("states")
+            .push(&state_id.to_string())
+            .push("pending_consolidations");
+
+        self.get_opt(path).await
+    }
+
     /// `GET beacon/light_client/updates`
     ///
     /// Returns `Ok(None)` on a 404 error.

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -7,7 +7,7 @@ set -Eeuo pipefail
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ENCLAVE_NAME=local-testnet
 NETWORK_PARAMS_FILE=$SCRIPT_DIR/network_params.yaml
-ETHEREUM_PKG_VERSION=main
+ETHEREUM_PKG_VERSION=7e9a17f2f71d3346bd3ea7cff7e7828061ff757e
 
 BUILD_IMAGE=true
 BUILDER_PROPOSALS=false

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -7,7 +7,7 @@ set -Eeuo pipefail
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ENCLAVE_NAME=local-testnet
 NETWORK_PARAMS_FILE=$SCRIPT_DIR/network_params.yaml
-ETHEREUM_PKG_VERSION=7e9a17f2f71d3346bd3ea7cff7e7828061ff757e
+ETHEREUM_PKG_VERSION=main
 
 BUILD_IMAGE=true
 BUILDER_PROPOSALS=false


### PR DESCRIPTION
## Issue Addressed

#7282 

## Proposed Changes

Adds the missing `beacon/states/{state_id}/pending_consolidations` Beacon API endpoint along with related tests.

## Additional Info

This follows the same patterns set by #7006
