### PR TITLE
Always run build.rs for eth2_network_config

### DIFF
--- a/common/eth2_network_config/build.rs
+++ b/common/eth2_network_config/build.rs
@@ -7,6 +7,9 @@ use std::io;
 use zip::ZipArchive;
 
 fn main() {
+    // This file doesn't exist, so Cargo treats it as changed.
+    println!("cargo:rerun-if-changed=non_existent_file");
+
     for network in ETH2_NET_DIRS {
         match uncompress_state(network) {
             Ok(()) => (),


### PR DESCRIPTION
## Issue Addressed

When eth2_network_config is cached,  the build script doesn't run, and the genesis file can't be found. See https://github.com/sigp/anchor/pull/240

## Proposed Changes

Make the build script always run using `println!("cargo:rerun-if-changed=non_existent_file");`

