### PR TITLE
Downgrade light client errors

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4104,7 +4104,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     &mut state,
                 )
                 .unwrap_or_else(|e| {
-                    error!(self.log, "error caching light_client data {:?}", e);
+                    debug!(self.log, "error caching light_client data {:?}", e);
                 });
         }
 


### PR DESCRIPTION
## Issue Addressed

Downgrade light client errors to debug

Error messages are alarming and usually indicate somethings wrong with the beacon node. The Light Client service is supposed to minimally impact users, and most will not care if the light client server is erroring. Furthermore, the only errors we've seen in the wild are during hard forks, for the first few epochs before the fork finalizes. 