### PR TITLE
Update and cleanup Electra preset

### DIFF
--- a/consensus/types/presets/mainnet/electra.yaml
+++ b/consensus/types/presets/mainnet/electra.yaml
@@ -7,44 +7,44 @@ MIN_ACTIVATION_BALANCE: 32000000000
 # 2**11 * 10**9 (= 2,048,000,000,000) Gwei
 MAX_EFFECTIVE_BALANCE_ELECTRA: 2048000000000
 
-# State list lengths
+# Rewards and penalties
 # ---------------------------------------------------------------
-# `uint64(2**27)` (= 134,217,728)
-PENDING_DEPOSITS_LIMIT: 134217728
-# `uint64(2**27)` (= 134,217,728)
-PENDING_PARTIAL_WITHDRAWALS_LIMIT: 134217728
-# `uint64(2**18)` (= 262,144)
-PENDING_CONSOLIDATIONS_LIMIT: 262144
-
-# Reward and penalty quotients
-# ---------------------------------------------------------------
-# `uint64(2**12)` (= 4,096)
+# 2**12 (= 4,096)
 MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA: 4096
-# `uint64(2**12)` (= 4,096)
+# 2**12 (= 4,096)
 WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA: 4096
 
-# # Max operations per block
+# State list lengths
 # ---------------------------------------------------------------
-# `uint64(2**0)` (= 1)
+# 2**27 (= 134,217,728) pending deposits
+PENDING_DEPOSITS_LIMIT: 134217728
+# 2**27 (= 134,217,728) pending partial withdrawals
+PENDING_PARTIAL_WITHDRAWALS_LIMIT: 134217728
+# 2**18 (= 262,144) pending consolidations
+PENDING_CONSOLIDATIONS_LIMIT: 262144
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**0 (= 1) attester slashings
 MAX_ATTESTER_SLASHINGS_ELECTRA: 1
-# `uint64(2**3)` (= 8)
+# 2**3 (= 8) attestations
 MAX_ATTESTATIONS_ELECTRA: 8
-# `uint64(2**1)` (= 2)
-MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: 2
 
 # Execution
 # ---------------------------------------------------------------
-# 2**13 (= 8192) deposit requests
+# 2**13 (= 8,192) deposit requests
 MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: 8192
 # 2**4 (= 16) withdrawal requests
 MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 16
+# 2**1 (= 2) consolidation requests
+MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: 2
 
 # Withdrawals processing
 # ---------------------------------------------------------------
-# 2**3 ( = 8) pending withdrawals
+# 2**3 (= 8) pending withdrawals
 MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: 8
 
 # Pending deposits processing
 # ---------------------------------------------------------------
-# 2**4 ( = 4) pending deposits
+# 2**4 (= 16) pending deposits
 MAX_PENDING_DEPOSITS_PER_EPOCH: 16

--- a/consensus/types/presets/minimal/electra.yaml
+++ b/consensus/types/presets/minimal/electra.yaml
@@ -7,44 +7,44 @@ MIN_ACTIVATION_BALANCE: 32000000000
 # 2**11 * 10**9 (= 2,048,000,000,000) Gwei
 MAX_EFFECTIVE_BALANCE_ELECTRA: 2048000000000
 
-# State list lengths
+# Rewards and penalties
 # ---------------------------------------------------------------
-# `uint64(2**27)` (= 134,217,728)
-PENDING_DEPOSITS_LIMIT: 134217728
-# [customized] `uint64(2**6)` (= 64)
-PENDING_PARTIAL_WITHDRAWALS_LIMIT: 64
-# [customized] `uint64(2**6)` (= 64)
-PENDING_CONSOLIDATIONS_LIMIT: 64
-
-# Reward and penalty quotients
-# ---------------------------------------------------------------
-# `uint64(2**12)` (= 4,096)
+# 2**12 (= 4,096)
 MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA: 4096
-# `uint64(2**12)` (= 4,096)
+# 2**12 (= 4,096)
 WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA: 4096
 
-# # Max operations per block
+# State list lengths
 # ---------------------------------------------------------------
-# `uint64(2**0)` (= 1)
+# 2**27 (= 134,217,728) pending deposits
+PENDING_DEPOSITS_LIMIT: 134217728
+# [customized] 2**6 (= 64) pending partial withdrawals
+PENDING_PARTIAL_WITHDRAWALS_LIMIT: 64
+# [customized] 2**6 (= 64) pending consolidations
+PENDING_CONSOLIDATIONS_LIMIT: 64
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**0 (= 1) attester slashings
 MAX_ATTESTER_SLASHINGS_ELECTRA: 1
-# `uint64(2**3)` (= 8)
+# 2**3 (= 8) attestations
 MAX_ATTESTATIONS_ELECTRA: 8
-# `uint64(2**1)` (= 2)
-MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: 2
 
 # Execution
 # ---------------------------------------------------------------
-# [customized]
+# [customized] 2**2 (= 4) deposit requests
 MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: 4
 # [customized] 2**1 (= 2) withdrawal requests
 MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 2
+# 2**1 (= 2) consolidation requests
+MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: 2
 
 # Withdrawals processing
 # ---------------------------------------------------------------
-# 2**1 ( = 2) pending withdrawals
+# 2**1 (= 2) pending withdrawals
 MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: 2
 
 # Pending deposits processing
 # ---------------------------------------------------------------
-# 2**4 ( = 4) pending deposits
+# 2**4 (= 16) pending deposits
 MAX_PENDING_DEPOSITS_PER_EPOCH: 16

--- a/consensus/types/src/preset.rs
+++ b/consensus/types/src/preset.rs
@@ -227,28 +227,36 @@ pub struct ElectraPreset {
     pub min_activation_balance: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     pub max_effective_balance_electra: u64,
+
     #[serde(with = "serde_utils::quoted_u64")]
     pub min_slashing_penalty_quotient_electra: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     pub whistleblower_reward_quotient_electra: u64,
-    #[serde(with = "serde_utils::quoted_u64")]
-    pub max_pending_partials_per_withdrawals_sweep: u64,
+
     #[serde(with = "serde_utils::quoted_u64")]
     pub pending_deposits_limit: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     pub pending_partial_withdrawals_limit: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     pub pending_consolidations_limit: u64,
-    #[serde(with = "serde_utils::quoted_u64")]
-    pub max_consolidation_requests_per_payload: u64,
-    #[serde(with = "serde_utils::quoted_u64")]
-    pub max_deposit_requests_per_payload: u64,
+
     #[serde(with = "serde_utils::quoted_u64")]
     pub max_attester_slashings_electra: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     pub max_attestations_electra: u64,
+
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub max_deposit_requests_per_payload: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     pub max_withdrawal_requests_per_payload: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub max_consolidation_requests_per_payload: u64,
+
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub max_pending_partials_per_withdrawals_sweep: u64,
+
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub max_pending_deposits_per_epoch: u64,
 }
 
 impl ElectraPreset {
@@ -256,19 +264,26 @@ impl ElectraPreset {
         Self {
             min_activation_balance: spec.min_activation_balance,
             max_effective_balance_electra: spec.max_effective_balance_electra,
+
             min_slashing_penalty_quotient_electra: spec.min_slashing_penalty_quotient_electra,
             whistleblower_reward_quotient_electra: spec.whistleblower_reward_quotient_electra,
-            max_pending_partials_per_withdrawals_sweep: spec
-                .max_pending_partials_per_withdrawals_sweep,
+
             pending_deposits_limit: E::pending_deposits_limit() as u64,
             pending_partial_withdrawals_limit: E::pending_partial_withdrawals_limit() as u64,
             pending_consolidations_limit: E::pending_consolidations_limit() as u64,
-            max_consolidation_requests_per_payload: E::max_consolidation_requests_per_payload()
-                as u64,
-            max_deposit_requests_per_payload: E::max_deposit_requests_per_payload() as u64,
+
             max_attester_slashings_electra: E::max_attester_slashings_electra() as u64,
             max_attestations_electra: E::max_attestations_electra() as u64,
+
+            max_deposit_requests_per_payload: E::max_deposit_requests_per_payload() as u64,
             max_withdrawal_requests_per_payload: E::max_withdrawal_requests_per_payload() as u64,
+            max_consolidation_requests_per_payload: E::max_consolidation_requests_per_payload()
+                as u64,
+
+            max_pending_partials_per_withdrawals_sweep: spec
+                .max_pending_partials_per_withdrawals_sweep,
+
+            max_pending_deposits_per_epoch: E::max_pending_deposits_per_epoch() as u64,
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

- Update the bundled `electra.yaml` preset files for `mainnet` and `minimal` to match `consensus-specs` as of: https://github.com/ethereum/consensus-specs/commit/bf09edef17e2900258f7e37631e9452941c26e86
- Add the field `max_pending_deposits_per_epoch` to our runtime representation of `ElectraPreset`. This results in it appearing in `/eth/v1/config/spec` where it was previously absent.

## Additional Info

I have not updated the Gnosis preset. That is happening as part of:

- https://github.com/sigp/lighthouse/pull/7296
