### PR TITLE
Enable lighthouse to build on riscv64

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -68,6 +68,9 @@ fn bls_hardware_acceleration() -> bool {
 
     #[cfg(target_arch = "aarch64")]
     return std::arch::is_aarch64_feature_detected!("neon");
+
+    #[cfg(target_arch = "riscv64")]
+    return false;
 }
 
 fn allocator_name() -> String {


### PR DESCRIPTION
## Issue Addressed

#6297 
This will fully solve the issue and it can be closed.


## Proposed Changes

Add riscv64 architecture in the bls_hardware_acceleration() function.
It will return false in every case as there is no hardware acceleration available on this platform at the moment. This can be changed later when actual hardware acceleration is used and specific code for this hardware has been implemented


## Additional Info

Build tested on my lichee pi 3a board. 
