### PR TITLE
Delete `transaction_mutex` in store

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3968,8 +3968,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         ops.push(StoreOp::PutBlock(block_root, signed_block.clone()));
         ops.push(StoreOp::PutState(block.state_root(), &state));
 
-        let txn_lock = self.store.hot_db.begin_rw_transaction();
-
         if let Err(e) = self.store.do_atomically_with_block_and_blobs_cache(ops) {
             error!(
                 msg = "Restoring fork choice from disk",
@@ -3981,7 +3979,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .err()
                 .unwrap_or(e.into()));
         }
-        drop(txn_lock);
 
         // The fork choice write-lock is dropped *after* the on-disk database has been updated.
         // This prevents inconsistency between the two at the expense of concurrency.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -120,7 +120,7 @@ use std::time::Duration;
 use store::iter::{BlockRootsIterator, ParentRootBlockIterator, StateRootsIterator};
 use store::{
     BlobSidecarListFromRoot, DatabaseBlock, Error as DBError, HotColdDB, HotStateSummary,
-    KeyValueStore, KeyValueStoreOp, StoreItem, StoreOp,
+    KeyValueStoreOp, StoreItem, StoreOp,
 };
 use task_executor::{ShutdownReason, TaskExecutor};
 use tokio_stream::Stream;

--- a/beacon_node/store/src/database/interface.rs
+++ b/beacon_node/store/src/database/interface.rs
@@ -105,15 +105,6 @@ impl<E: EthSpec> KeyValueStore<E> for BeaconNodeBackend<E> {
         }
     }
 
-    fn begin_rw_transaction(&self) -> parking_lot::MutexGuard<()> {
-        match self {
-            #[cfg(feature = "leveldb")]
-            BeaconNodeBackend::LevelDb(txn) => leveldb_impl::LevelDB::begin_rw_transaction(txn),
-            #[cfg(feature = "redb")]
-            BeaconNodeBackend::Redb(txn) => redb_impl::Redb::begin_rw_transaction(txn),
-        }
-    }
-
     fn compact(&self) -> Result<(), Error> {
         match self {
             #[cfg(feature = "leveldb")]

--- a/beacon_node/store/src/database/leveldb_impl.rs
+++ b/beacon_node/store/src/database/leveldb_impl.rs
@@ -13,7 +13,6 @@ use leveldb::{
     iterator::{Iterable, LevelDBIterator},
     options::{Options, ReadOptions},
 };
-use parking_lot::{Mutex, MutexGuard};
 use std::collections::HashSet;
 use std::marker::PhantomData;
 use std::path::Path;

--- a/beacon_node/store/src/database/leveldb_impl.rs
+++ b/beacon_node/store/src/database/leveldb_impl.rs
@@ -23,8 +23,6 @@ use super::interface::WriteOptions;
 
 pub struct LevelDB<E: EthSpec> {
     db: Database<BytesKey>,
-    /// A mutex to synchronise sensitive read-write transactions.
-    transaction_mutex: Mutex<()>,
     _phantom: PhantomData<E>,
 }
 
@@ -43,11 +41,9 @@ impl<E: EthSpec> LevelDB<E> {
         options.create_if_missing = true;
 
         let db = Database::open(path, options)?;
-        let transaction_mutex = Mutex::new(());
 
         Ok(Self {
             db,
-            transaction_mutex,
             _phantom: PhantomData,
         })
     }
@@ -175,10 +171,6 @@ impl<E: EthSpec> LevelDB<E> {
         }
         self.db.write(self.write_options().into(), &leveldb_batch)?;
         Ok(())
-    }
-
-    pub fn begin_rw_transaction(&self) -> MutexGuard<()> {
-        self.transaction_mutex.lock()
     }
 
     /// Compact all values in the states and states flag columns.

--- a/beacon_node/store/src/database/redb_impl.rs
+++ b/beacon_node/store/src/database/redb_impl.rs
@@ -1,6 +1,6 @@
 use crate::{metrics, ColumnIter, ColumnKeyIter, Key};
 use crate::{DBColumn, Error, KeyValueStoreOp};
-use parking_lot::{Mutex, MutexGuard, RwLock};
+use parking_lot::RwLock;
 use redb::TableDefinition;
 use std::collections::HashSet;
 use std::{borrow::BorrowMut, marker::PhantomData, path::Path};

--- a/beacon_node/store/src/database/redb_impl.rs
+++ b/beacon_node/store/src/database/redb_impl.rs
@@ -13,7 +13,6 @@ pub const DB_FILE_NAME: &str = "database.redb";
 
 pub struct Redb<E: EthSpec> {
     db: RwLock<redb::Database>,
-    transaction_mutex: Mutex<()>,
     _phantom: PhantomData<E>,
 }
 
@@ -31,7 +30,6 @@ impl<E: EthSpec> Redb<E> {
     pub fn open(path: &Path) -> Result<Self, Error> {
         let db_file = path.join(DB_FILE_NAME);
         let db = redb::Database::create(db_file)?;
-        let transaction_mutex = Mutex::new(());
 
         for column in DBColumn::iter() {
             Redb::<E>::create_table(&db, column.into())?;
@@ -39,7 +37,6 @@ impl<E: EthSpec> Redb<E> {
 
         Ok(Self {
             db: db.into(),
-            transaction_mutex,
             _phantom: PhantomData,
         })
     }
@@ -59,10 +56,6 @@ impl<E: EthSpec> Redb<E> {
         let mut opts = WriteOptions::new();
         opts.sync = true;
         opts
-    }
-
-    pub fn begin_rw_transaction(&self) -> MutexGuard<()> {
-        self.transaction_mutex.lock()
     }
 
     pub fn put_bytes_with_options(

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -79,12 +79,6 @@ pub trait KeyValueStore<E: EthSpec>: Sync + Send + Sized + 'static {
     /// Execute either all of the operations in `batch` or none at all, returning an error.
     fn do_atomically(&self, batch: Vec<KeyValueStoreOp>) -> Result<(), Error>;
 
-    /// Return a mutex guard that can be used to synchronize sensitive transactions.
-    ///
-    /// This doesn't prevent other threads writing to the DB unless they also use
-    /// this method. In future we may implement a safer mandatory locking scheme.
-    fn begin_rw_transaction(&self) -> MutexGuard<()>;
-
     /// Compact a single column in the database, freeing space used by deleted items.
     fn compact_column(&self, column: DBColumn) -> Result<(), Error>;
 

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -41,7 +41,6 @@ pub use impls::{
 };
 pub use metadata::AnchorInfo;
 pub use metrics::scrape_for_metrics;
-use parking_lot::MutexGuard;
 use std::collections::HashSet;
 use std::sync::Arc;
 use strum::{EnumIter, EnumString, IntoStaticStr};

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -12,7 +12,6 @@ type DBMap = BTreeMap<BytesKey, Vec<u8>>;
 /// A thread-safe `BTreeMap` wrapper.
 pub struct MemoryStore<E: EthSpec> {
     db: RwLock<DBMap>,
-    transaction_mutex: Mutex<()>,
     _phantom: PhantomData<E>,
 }
 
@@ -21,7 +20,6 @@ impl<E: EthSpec> MemoryStore<E> {
     pub fn open() -> Self {
         Self {
             db: RwLock::new(BTreeMap::new()),
-            transaction_mutex: Mutex::new(()),
             _phantom: PhantomData,
         }
     }
@@ -105,10 +103,6 @@ impl<E: EthSpec> KeyValueStore<E> for MemoryStore<E> {
 
     fn iter_column_keys<K: Key>(&self, column: DBColumn) -> ColumnKeyIter<K> {
         Box::new(self.iter_column(column).map(|res| res.map(|(k, _)| k)))
-    }
-
-    fn begin_rw_transaction(&self) -> MutexGuard<()> {
-        self.transaction_mutex.lock()
     }
 
     fn compact_column(&self, _column: DBColumn) -> Result<(), Error> {

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::Error as DBError, get_key_for_col, hot_cold_store::BytesKey, ColumnIter, ColumnKeyIter,
     DBColumn, Error, ItemStore, Key, KeyValueStore, KeyValueStoreOp,
 };
-use parking_lot::{Mutex, MutexGuard, RwLock};
+use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
 use std::marker::PhantomData;
 use types::*;


### PR DESCRIPTION
addresses #7270 

Rationale on why it is okay to delete it can be found in
- https://github.com/sigp/lighthouse/issues/7270
