### PR TITLE
Update crossbeam to fix `cargo audit` failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Issue Addressed

There is a `cargo audit` failure related to this CVE: https://rustsec.org/advisories/RUSTSEC-2025-0024

## Proposed Changes

Unblock CI by updating `crossbeam-channel`

