### PR TITLE
Update proposer_slashings and attester_slashings amounts for electra.

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_block_reward.rs
+++ b/beacon_node/beacon_chain/src/beacon_block_reward.rs
@@ -139,7 +139,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 state
                     .get_validator(proposer_slashing.proposer_index() as usize)?
                     .effective_balance
-                    .safe_div(self.spec.whistleblower_reward_quotient)?,
+                    .safe_div(self.spec.whistleblower_reward_quotient_for_state(state))?,
             )?;
         }
 
@@ -161,7 +161,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     state
                         .get_validator(attester_index as usize)?
                         .effective_balance
-                        .safe_div(self.spec.whistleblower_reward_quotient)?,
+                        .safe_div(self.spec.whistleblower_reward_quotient_for_state(state))?,
                 )?;
             }
         }

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -20,6 +20,7 @@ use derivative::Derivative;
 use either::Either;
 use futures::Stream;
 use futures_util::StreamExt;
+use lighthouse::StandardBlockReward;
 use lighthouse_network::PeerId;
 use pretty_reqwest_error::PrettyReqwestError;
 pub use reqwest;
@@ -1677,17 +1678,18 @@ impl BeaconNodeHttpClient {
     }
 
     /// `GET beacon/rewards/blocks`
-    pub async fn get_beacon_rewards_blocks(&self, epoch: Epoch) -> Result<(), Error> {
+    pub async fn get_beacon_rewards_blocks(
+        &self,
+        block_id: BlockId,
+    ) -> Result<GenericResponse<StandardBlockReward>, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()
             .map_err(|()| Error::InvalidUrl(self.server.clone()))?
             .push("beacon")
             .push("rewards")
-            .push("blocks");
-
-        path.query_pairs_mut()
-            .append_pair("epoch", &epoch.to_string());
+            .push("blocks")
+            .push(&block_id.to_string());
 
         self.get(path).await
     }


### PR DESCRIPTION
## Issue Addressed

Did not find a specific issue beside https://github.com/sigp/lighthouse/issues/6821

## Proposed Changes

Leverage `whistleblower_reward_quotient_for_state` to have accurate post-electra `proposer_slashings` and `attester_slashings` fields returned by `/eth/v1/beacon/rewards/blocks/<id>`.

## Additional Info

While testing on Hoodi RPCs I noticed the amounts returned were wrong.

Example https://dora.hoodi.ethpandaops.io/slot/151980 
`/eth/v1/beacon/rewards/blocks/151980` returns `"proposer_slashings":"4000000000"` (4ETH) instead of 0,5ETH.