### PR TITLE
Store peer penality records in the PeerDB in PeerInfo

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -4,7 +4,7 @@ use crate::{metrics, multiaddr::Multiaddr, types::Subnet, Enr, EnrExt, Gossipsub
 use itertools::Itertools;
 use logging::crit;
 use peer_info::{ConnectionDirection, PeerConnectionStatus, PeerInfo};
-use score::{PeerAction, ReportSource, Score, ScoreState, PenaltyRecord};
+use score::{PeerAction, ReportSource, Score, ScoreState, PenaltyRecord, MAX_STORED_PENALTY_RECORDS};
 use std::net::IpAddr;
 use std::time::Instant;
 use std::{cmp::Ordering, fmt::Display};

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -774,7 +774,7 @@ impl<E: EthSpec> PeerDB<E> {
         match self.peers.get(peer_id) {
             Some(info) => Some(info.get_penalty_records()),
             None => {
-                error!(%peer_id, "Adding a penalty record to a non-existant peer");
+                error!(%peer_id, "Getting the penalty records of a non-existant peer");
                 None
             },
         }

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -769,6 +769,17 @@ impl<E: EthSpec> PeerDB<E> {
         info.add_penalty_record(penalty_record);
     }
 
+    /// Gets all the penalty records for a given peer id
+    pub fn get_penalty_records(&self, peer_id: &PeerId) -> Option<impl Iterator<Item = &PenaltyRecord>> {
+        match self.peers.get(peer_id) {
+            Some(info) => Some(info.get_penalty_records()),
+            None => {
+                error!(%peer_id, "Adding a penalty record to a non-existant peer");
+                None
+            },
+        }
+    }
+
     /// The connection state of the peer has been changed. Modify the peer in the db to ensure all
     /// variables are in sync with libp2p.
     /// Updating the state can lead to a `BanOperation` which needs to be processed via the peer

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -4,7 +4,8 @@ use crate::{metrics, multiaddr::Multiaddr, types::Subnet, Enr, EnrExt, Gossipsub
 use itertools::Itertools;
 use logging::crit;
 use peer_info::{ConnectionDirection, PeerConnectionStatus, PeerInfo};
-use score::{PeerAction, ReportSource, Score, ScoreState, PenaltyRecord, MAX_STORED_PENALTY_RECORDS};
+use score::{PeerAction, PenaltyRecord, ReportSource, Score, ScoreState};
+use serde::Serialize;
 use std::net::IpAddr;
 use std::time::Instant;
 use std::{cmp::Ordering, fmt::Display};
@@ -12,12 +13,11 @@ use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     fmt::Formatter,
 };
+use strum::AsRefStr;
 use sync_status::SyncStatus;
 use tracing::{debug, error, trace, warn};
 use types::data_column_custody_group::compute_subnets_for_node;
 use types::{ChainSpec, DataColumnSubnetId, EthSpec};
-use serde::Serialize;
-use strum::AsRefStr;
 
 pub mod client;
 pub mod peer_info;
@@ -562,7 +562,11 @@ impl<E: EthSpec> PeerDB<E> {
                 info.apply_peer_action_to_score(action);
                 metrics::inc_counter_vec(
                     &metrics::PEER_ACTION_EVENTS_PER_CLIENT,
-                    &[info.client().kind.as_ref(), action.as_ref(), source.as_ref()],
+                    &[
+                        info.client().kind.as_ref(),
+                        action.as_ref(),
+                        source.as_ref(),
+                    ],
                 );
                 let result = Self::handle_score_transition(previous_state, peer_id, info);
                 if previous_state == info.score_state() {
@@ -573,7 +577,11 @@ impl<E: EthSpec> PeerDB<E> {
                         "Peer score adjusted"
                     );
                 }
-                let final_result = match result {
+                self.add_penalty_record(
+                    peer_id,
+                    PenaltyRecord::new(action, source, msg, result.clone()),
+                );
+                match result {
                     ScoreTransitionResult::Banned => {
                         // The peer was banned as a result of this action.
                         self.update_connection_state(peer_id, NewConnectionState::Banned)
@@ -598,9 +606,7 @@ impl<E: EthSpec> PeerDB<E> {
                         );
                         ScoreUpdateResult::NoAction
                     }
-                };
-                self.add_penalty_record(peer_id, PenaltyRecord::new(action, source, msg, final_result.clone()));
-                final_result
+                }
             }
             None => {
                 debug!(
@@ -756,7 +762,6 @@ impl<E: EthSpec> PeerDB<E> {
         peer_id
     }
 
-
     fn add_penalty_record(&mut self, peer_id: &PeerId, penalty_record: PenaltyRecord) {
         let info = self.peers.entry(*peer_id).or_insert_with(|| {
             error!(%peer_id, "Adding a penalty record to a non-existant peer");
@@ -770,13 +775,16 @@ impl<E: EthSpec> PeerDB<E> {
     }
 
     /// Gets all the penalty records for a given peer id
-    pub fn get_penalty_records(&self, peer_id: &PeerId) -> Option<impl Iterator<Item = &PenaltyRecord>> {
+    pub fn get_penalty_records(
+        &self,
+        peer_id: &PeerId,
+    ) -> Option<impl Iterator<Item = &PenaltyRecord>> {
         match self.peers.get(peer_id) {
             Some(info) => Some(info.get_penalty_records()),
             None => {
                 error!(%peer_id, "Getting the penalty records of a non-existant peer");
                 None
-            },
+            }
         }
     }
 
@@ -1253,7 +1261,9 @@ enum NewConnectionState {
 }
 
 /// The result of applying a score transition to a peer.
-enum ScoreTransitionResult {
+#[derive(Clone, Debug, Serialize, AsRefStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum ScoreTransitionResult {
     /// The peer has become disconnected.
     Disconnected,
     /// The peer has been banned.
@@ -1265,8 +1275,6 @@ enum ScoreTransitionResult {
 }
 
 /// The type of results that can happen from executing the `report_peer` function.
-#[derive(Clone, Debug, Serialize, AsRefStr)]
-#[strum(serialize_all = "snake_case")]
 pub enum ScoreUpdateResult {
     /// The reported peer must be banned.
     Ban(BanOperation),
@@ -1377,6 +1385,7 @@ impl BannedPeersCount {
 mod tests {
     use super::*;
     use libp2p::core::multiaddr::Protocol;
+    use score::MAX_STORED_PENALTY_RECORDS;
     use std::net::{Ipv4Addr, Ipv6Addr};
     use types::MinimalEthSpec;
 
@@ -1939,8 +1948,14 @@ mod tests {
         assert!(pdb.get_penalty_records(&random_peer).is_some());
 
         // Check to see if there are no initial penalty records
-        assert_eq!(pdb.get_penalty_records(&random_peer).unwrap().into_iter().count(),0);
-        
+        assert_eq!(
+            pdb.get_penalty_records(&random_peer)
+                .unwrap()
+                .into_iter()
+                .count(),
+            0
+        );
+
         let _ = pdb.report_peer(
             &random_peer,
             PeerAction::HighToleranceError,
@@ -1949,21 +1964,38 @@ mod tests {
         );
 
         // Check to see if there was a penalty record added
-        assert_eq!(pdb.get_penalty_records(&random_peer).unwrap().into_iter().count(),1);
+        assert_eq!(
+            pdb.get_penalty_records(&random_peer)
+                .unwrap()
+                .into_iter()
+                .count(),
+            1
+        );
 
-        let first_record = pdb.get_penalty_records(&random_peer).unwrap().into_iter().next().unwrap();
+        let first_record = pdb
+            .get_penalty_records(&random_peer)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
 
         // Check to see the correct report action for the penalty record
-        assert!(matches!(first_record.action(),PeerAction::HighToleranceError));
+        assert!(matches!(
+            first_record.action,
+            PeerAction::HighToleranceError
+        ));
 
         // Check to see the correct report source for the penalty record
-        assert!(matches!(first_record.source(),ReportSource::PeerManager));
+        assert!(matches!(first_record.source, ReportSource::PeerManager));
 
         // Check to see the correct message for the penalty record
-        assert_eq!(*first_record.msg(),"Minor report action".to_string());
+        assert_eq!(*first_record.msg, "Minor report action".to_string());
 
         // Check to see the correct result for the penalty record
-        assert!(matches!(first_record.result(),ScoreUpdateResult::NoAction));
+        assert!(matches!(
+            first_record.result,
+            ScoreTransitionResult::NoAction
+        ));
 
         let _ = pdb.report_peer(
             &random_peer,
@@ -1973,9 +2005,15 @@ mod tests {
         );
 
         // Check to see if there was a penalty record added
-        assert_eq!(pdb.get_penalty_records(&random_peer).unwrap().into_iter().count(),2);
+        assert_eq!(
+            pdb.get_penalty_records(&random_peer)
+                .unwrap()
+                .into_iter()
+                .count(),
+            2
+        );
 
-        for _ in 1..(MAX_STORED_PENALTY_RECORDS+1) {
+        for _ in 1..(MAX_STORED_PENALTY_RECORDS + 1) {
             let _ = pdb.report_peer(
                 &random_peer,
                 PeerAction::HighToleranceError,
@@ -1985,7 +2023,13 @@ mod tests {
         }
 
         // Check to make sure that the number of penalty records don't exceed the maximum
-        assert_eq!(pdb.get_penalty_records(&random_peer).unwrap().into_iter().count(),MAX_STORED_PENALTY_RECORDS);
+        assert_eq!(
+            pdb.get_penalty_records(&random_peer)
+                .unwrap()
+                .into_iter()
+                .count(),
+            MAX_STORED_PENALTY_RECORDS
+        );
     }
 
     #[test]

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -1297,8 +1297,6 @@ impl From<Option<BanOperation>> for ScoreUpdateResult {
 }
 
 /// When attempting to ban a peer provides the peer manager with the operation that must be taken.
-#[derive(Clone, Debug, Serialize, AsRefStr)]
-#[strum(serialize_all = "snake_case")]
 pub enum BanOperation {
     /// Optionally temporarily ban this peer to prevent instantaneous reconnection.
     /// The peer manager will decide if temporary banning is required.

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -1918,6 +1918,66 @@ mod tests {
     }
 
     #[test]
+    fn test_add_penalty_record() {
+        let mut pdb = get_db();
+        let random_peer = PeerId::random();
+
+        pdb.connect_ingoing(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+
+        // Check to see if get_penalty_records is able to get the associated peer info
+        assert!(pdb.get_penalty_records(&random_peer).is_some());
+
+        // Check to see if there are no initial penalty records
+        assert_eq!(pdb.get_penalty_records(&random_peer).unwrap().into_iter().count(),0);
+        
+        let _ = pdb.report_peer(
+            &random_peer,
+            PeerAction::HighToleranceError,
+            ReportSource::PeerManager,
+            "Minor report action",
+        );
+
+        // Check to see if there was a penalty record added
+        assert_eq!(pdb.get_penalty_records(&random_peer).unwrap().into_iter().count(),1);
+
+        let first_record = pdb.get_penalty_records(&random_peer).unwrap().into_iter().next().unwrap();
+
+        // Check to see the correct report action for the penalty record
+        assert!(matches!(first_record.action(),PeerAction::HighToleranceError));
+
+        // Check to see the correct report source for the penalty record
+        assert!(matches!(first_record.source(),ReportSource::PeerManager));
+
+        // Check to see the correct message for the penalty record
+        assert_eq!(*first_record.msg(),"Minor report action".to_string());
+
+        // Check to see the correct result for the penalty record
+        assert!(matches!(first_record.result(),ScoreUpdateResult::NoAction));
+
+        let _ = pdb.report_peer(
+            &random_peer,
+            PeerAction::HighToleranceError,
+            ReportSource::PeerManager,
+            "Minor report action",
+        );
+
+        // Check to see if there was a penalty record added
+        assert_eq!(pdb.get_penalty_records(&random_peer).unwrap().into_iter().count(),2);
+
+        for _ in 1..(MAX_STORED_PENALTY_RECORDS+1) {
+            let _ = pdb.report_peer(
+                &random_peer,
+                PeerAction::HighToleranceError,
+                ReportSource::PeerManager,
+                "Minor report action",
+            );
+        }
+
+        // Check to make sure that the number of penalty records don't exceed the maximum
+        assert_eq!(pdb.get_penalty_records(&random_peer).unwrap().into_iter().count(),MAX_STORED_PENALTY_RECORDS);
+    }
+
+    #[test]
     fn test_ban_address() {
         let mut pdb = get_db();
 

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -4,7 +4,7 @@ use crate::{metrics, multiaddr::Multiaddr, types::Subnet, Enr, EnrExt, Gossipsub
 use itertools::Itertools;
 use logging::crit;
 use peer_info::{ConnectionDirection, PeerConnectionStatus, PeerInfo};
-use score::{PeerAction, ReportSource, Score, ScoreState, PenaltyRecord, MAX_STORED_PENALTY_RECORDS};
+use score::{PeerAction, ReportSource, Score, ScoreState, PenaltyRecord};
 use std::net::IpAddr;
 use std::time::Instant;
 use std::{cmp::Ordering, fmt::Display};

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -4,7 +4,7 @@ use crate::{metrics, multiaddr::Multiaddr, types::Subnet, Enr, EnrExt, Gossipsub
 use itertools::Itertools;
 use logging::crit;
 use peer_info::{ConnectionDirection, PeerConnectionStatus, PeerInfo};
-use score::{PeerAction, ReportSource, Score, ScoreState};
+use score::{PeerAction, ReportSource, Score, ScoreState, PenaltyRecord};
 use std::net::IpAddr;
 use std::time::Instant;
 use std::{cmp::Ordering, fmt::Display};
@@ -16,6 +16,8 @@ use sync_status::SyncStatus;
 use tracing::{debug, error, trace, warn};
 use types::data_column_custody_group::compute_subnets_for_node;
 use types::{ChainSpec, DataColumnSubnetId, EthSpec};
+use serde::Serialize;
+use strum::AsRefStr;
 
 pub mod client;
 pub mod peer_info;
@@ -560,7 +562,7 @@ impl<E: EthSpec> PeerDB<E> {
                 info.apply_peer_action_to_score(action);
                 metrics::inc_counter_vec(
                     &metrics::PEER_ACTION_EVENTS_PER_CLIENT,
-                    &[info.client().kind.as_ref(), action.as_ref(), source.into()],
+                    &[info.client().kind.as_ref(), action.as_ref(), source.as_ref()],
                 );
                 let result = Self::handle_score_transition(previous_state, peer_id, info);
                 if previous_state == info.score_state() {
@@ -571,7 +573,7 @@ impl<E: EthSpec> PeerDB<E> {
                         "Peer score adjusted"
                     );
                 }
-                match result {
+                let final_result = match result {
                     ScoreTransitionResult::Banned => {
                         // The peer was banned as a result of this action.
                         self.update_connection_state(peer_id, NewConnectionState::Banned)
@@ -596,7 +598,9 @@ impl<E: EthSpec> PeerDB<E> {
                         );
                         ScoreUpdateResult::NoAction
                     }
-                }
+                };
+                self.add_penalty_record(peer_id, PenaltyRecord::new(action, source, msg, final_result.clone()));
+                final_result
             }
             None => {
                 debug!(
@@ -750,6 +754,19 @@ impl<E: EthSpec> PeerDB<E> {
         }
 
         peer_id
+    }
+
+
+    fn add_penalty_record(&mut self, peer_id: &PeerId, penalty_record: PenaltyRecord) {
+        let info = self.peers.entry(*peer_id).or_insert_with(|| {
+            error!(%peer_id, "Adding a penalty record to a non-existant peer");
+            if self.disable_peer_scoring {
+                PeerInfo::trusted_peer_info()
+            } else {
+                PeerInfo::default()
+            }
+        });
+        info.add_penalty_record(penalty_record);
     }
 
     /// The connection state of the peer has been changed. Modify the peer in the db to ensure all
@@ -1237,6 +1254,8 @@ enum ScoreTransitionResult {
 }
 
 /// The type of results that can happen from executing the `report_peer` function.
+#[derive(Clone, Debug, Serialize, AsRefStr)]
+#[strum(serialize_all = "snake_case")]
 pub enum ScoreUpdateResult {
     /// The reported peer must be banned.
     Ban(BanOperation),
@@ -1259,6 +1278,8 @@ impl From<Option<BanOperation>> for ScoreUpdateResult {
 }
 
 /// When attempting to ban a peer provides the peer manager with the operation that must be taken.
+#[derive(Clone, Debug, Serialize, AsRefStr)]
+#[strum(serialize_all = "snake_case")]
 pub enum BanOperation {
     /// Optionally temporarily ban this peer to prevent instantaneous reconnection.
     /// The peer manager will decide if temporary banning is required.

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -399,6 +399,12 @@ impl<E: EthSpec> PeerInfo<E> {
         }
     }
 
+    /// Gets an iterator with the penalty records
+    // VISIBILITY: The peer manager is able to add a penalty record
+    pub(in crate::peer_manager) fn get_penalty_records(&self) -> impl Iterator<Item = &PenaltyRecord>{
+        self.penalty_records.iter()
+    }
+
     /// Sets the connection status of the peer.
     pub(super) fn set_connection_status(&mut self, connection_status: PeerConnectionStatus) {
         self.connection_status = connection_status

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -1,5 +1,5 @@
 use super::client::Client;
-use super::score::{PeerAction, Score, ScoreState, PenaltyRecord, MAX_STORED_PENALTY_RECORDS};
+use super::score::{PeerAction, PenaltyRecord, Score, ScoreState, MAX_STORED_PENALTY_RECORDS};
 use super::sync_status::SyncStatus;
 use crate::discovery::Eth2Enr;
 use crate::{rpc::MetaData, types::Subnet};
@@ -58,7 +58,7 @@ pub struct PeerInfo<E: EthSpec> {
     /// None if this peer was never connected.
     connection_direction: Option<ConnectionDirection>,
     /// The enr of the peer, if known.
-    enr: Option<Enr>
+    enr: Option<Enr>,
 }
 
 impl<E: EthSpec> Default for PeerInfo<E> {
@@ -77,7 +77,7 @@ impl<E: EthSpec> Default for PeerInfo<E> {
             is_trusted: false,
             connection_direction: None,
             enr: None,
-            penalty_records: VecDeque::new()
+            penalty_records: VecDeque::new(),
         }
     }
 }
@@ -401,7 +401,9 @@ impl<E: EthSpec> PeerInfo<E> {
 
     /// Gets an iterator with the penalty records
     // VISIBILITY: The peer manager is able to add a penalty record
-    pub(in crate::peer_manager) fn get_penalty_records(&self) -> impl Iterator<Item = &PenaltyRecord>{
+    pub(in crate::peer_manager) fn get_penalty_records(
+        &self,
+    ) -> impl Iterator<Item = &PenaltyRecord> {
         self.penalty_records.iter()
     }
 

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -1,5 +1,5 @@
 use super::client::Client;
-use super::score::{PeerAction, Score, ScoreState};
+use super::score::{PeerAction, Score, ScoreState, PenaltyRecord, MAX_STORED_PENALTY_RECORDS};
 use super::sync_status::SyncStatus;
 use crate::discovery::Eth2Enr;
 use crate::{rpc::MetaData, types::Subnet};
@@ -10,7 +10,7 @@ use serde::{
     ser::{SerializeStruct, Serializer},
     Serialize,
 };
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::net::IpAddr;
 use std::time::Instant;
 use strum::AsRefStr;
@@ -46,6 +46,8 @@ pub struct PeerInfo<E: EthSpec> {
     /// Note: Another reason to keep this separate to `self.subnets` is an upcoming change to
     /// decouple custody requirements from the actual subnets, i.e. changing this to `custody_groups`.
     custody_subnets: HashSet<DataColumnSubnetId>,
+    /// The record of penalties given to a peer
+    penalty_records: VecDeque<PenaltyRecord>,
     /// The time we would like to retain this peer. After this time, the peer is no longer
     /// necessary.
     #[serde(skip)]
@@ -56,7 +58,7 @@ pub struct PeerInfo<E: EthSpec> {
     /// None if this peer was never connected.
     connection_direction: Option<ConnectionDirection>,
     /// The enr of the peer, if known.
-    enr: Option<Enr>,
+    enr: Option<Enr>
 }
 
 impl<E: EthSpec> Default for PeerInfo<E> {
@@ -75,6 +77,7 @@ impl<E: EthSpec> Default for PeerInfo<E> {
             is_trusted: false,
             connection_direction: None,
             enr: None,
+            penalty_records: VecDeque::new()
         }
     }
 }
@@ -385,6 +388,15 @@ impl<E: EthSpec> PeerInfo<E> {
     // VISIBILITY: The peer manager is able to adjust the meta_data
     pub(in crate::peer_manager) fn set_meta_data(&mut self, meta_data: MetaData<E>) {
         self.meta_data = Some(meta_data);
+    }
+
+    /// Adds a penalty record
+    // VISIBILITY: The peer manager is able to add a penalty record
+    pub(in crate::peer_manager) fn add_penalty_record(&mut self, penalty_record: PenaltyRecord) {
+        self.penalty_records.push_back(penalty_record);
+        while self.penalty_records.len() > MAX_STORED_PENALTY_RECORDS {
+            self.penalty_records.pop_front();
+        }
     }
 
     /// Sets the connection status of the peer.

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
@@ -9,9 +9,10 @@ use crate::service::gossipsub_scoring_parameters::GREYLIST_THRESHOLD as GOSSIPSU
 use serde::Serialize;
 use std::cmp::Ordering;
 use std::sync::LazyLock;
-use std::time::Instant;
+use std::time::{SystemTime, UNIX_EPOCH, Instant};
 use strum::AsRefStr;
 use tokio::time::Duration;
+use super::ScoreUpdateResult;
 
 static HALFLIFE_DECAY: LazyLock<f64> = LazyLock::new(|| -(2.0f64.ln()) / SCORE_HALFLIFE);
 
@@ -39,11 +40,43 @@ const GOSSIPSUB_NEGATIVE_SCORE_WEIGHT: f64 =
     (MIN_SCORE_BEFORE_DISCONNECT + 1.0) / GOSSIPSUB_GREYLIST_THRESHOLD;
 const GOSSIPSUB_POSITIVE_SCORE_WEIGHT: f64 = GOSSIPSUB_NEGATIVE_SCORE_WEIGHT;
 
+pub(crate) const MAX_STORED_PENALTY_RECORDS: usize = 20;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PenaltyRecord {
+    /// The action that caused the penalty
+    action: PeerAction,
+    /// Where the penalty came from
+    source: ReportSource,
+    /// The penalty message
+    msg: String,
+    /// The result of the penalty
+    result: ScoreUpdateResult,
+    /// The time when the penalty occured in unix millis
+    time_stamp: Option<u128>
+}
+
+impl PenaltyRecord {
+    /// Create a new penalty record
+    pub fn new(action: PeerAction, source:ReportSource, msg: impl Into<String>, result: ScoreUpdateResult) -> PenaltyRecord {
+        let time_stamp: Option<u128> = SystemTime::now()
+            .duration_since(UNIX_EPOCH).ok()
+            .map(|dur| dur.as_millis());
+        PenaltyRecord {
+            action: action,
+            source: source,
+            msg: msg.into(),
+            result: result,
+            time_stamp: time_stamp
+        }
+    }
+}
+
 /// A collection of actions a peer can perform which will adjust its score.
 /// Each variant has an associated score change.
 // To easily assess the behaviour of scores changes the number of variants should stay low, and
 // somewhat generic.
-#[derive(Debug, Clone, Copy, AsRefStr)]
+#[derive(Debug, Clone, Copy, AsRefStr, Serialize)]
 #[strum(serialize_all = "snake_case")]
 pub enum PeerAction {
     /// We should not communicate more with this peer.
@@ -66,7 +99,7 @@ pub enum PeerAction {
 }
 
 /// Service reporting a `PeerAction` for a peer.
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, AsRefStr)]
 pub enum ReportSource {
     Gossipsub,
     RPC,

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
@@ -70,6 +70,31 @@ impl PenaltyRecord {
             time_stamp: time_stamp
         }
     }
+
+    /// Obtains the action from the penalty record
+    pub fn action(&self) -> &PeerAction {
+        &self.action
+    }
+
+    /// Obtains the report source from the penalty record
+    pub fn source(&self) -> &ReportSource {
+        &self.source
+    }
+
+    /// Obtains the message associated with the penalty record
+    pub fn msg(&self) -> &String {
+        &self.msg
+    }
+
+    /// Obtains the result of the penalty record
+    pub fn result(&self) -> &ScoreUpdateResult {
+        &self.result
+    }
+
+    /// Obtains the time stamp of when the penalty record was made
+    pub fn time_stamp(&self) -> &Option<u128> {
+        &self.time_stamp
+    }
 }
 
 /// A collection of actions a peer can perform which will adjust its score.

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
@@ -5,14 +5,14 @@
 //! As the logic develops this documentation will advance.
 //!
 //! The scoring algorithms are currently experimental.
+use super::ScoreTransitionResult;
 use crate::service::gossipsub_scoring_parameters::GREYLIST_THRESHOLD as GOSSIPSUB_GREYLIST_THRESHOLD;
 use serde::Serialize;
 use std::cmp::Ordering;
 use std::sync::LazyLock;
-use std::time::{SystemTime, UNIX_EPOCH, Instant};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use strum::AsRefStr;
 use tokio::time::Duration;
-use super::ScoreUpdateResult;
 
 static HALFLIFE_DECAY: LazyLock<f64> = LazyLock::new(|| -(2.0f64.ln()) / SCORE_HALFLIFE);
 
@@ -45,55 +45,35 @@ pub(crate) const MAX_STORED_PENALTY_RECORDS: usize = 20;
 #[derive(Clone, Debug, Serialize)]
 pub struct PenaltyRecord {
     /// The action that caused the penalty
-    action: PeerAction,
+    pub action: PeerAction,
     /// Where the penalty came from
-    source: ReportSource,
+    pub source: ReportSource,
     /// The penalty message
-    msg: String,
+    pub msg: String,
     /// The result of the penalty
-    result: ScoreUpdateResult,
+    pub result: ScoreTransitionResult,
     /// The time when the penalty occured in unix millis
-    time_stamp: Option<u128>
+    pub time_stamp: u128,
 }
 
 impl PenaltyRecord {
     /// Create a new penalty record
-    pub fn new(action: PeerAction, source:ReportSource, msg: impl Into<String>, result: ScoreUpdateResult) -> PenaltyRecord {
-        let time_stamp: Option<u128> = SystemTime::now()
-            .duration_since(UNIX_EPOCH).ok()
-            .map(|dur| dur.as_millis());
+    pub fn new(
+        action: PeerAction,
+        source: ReportSource,
+        msg: impl Into<String>,
+        result: ScoreTransitionResult,
+    ) -> PenaltyRecord {
+        let time_stamp: u128 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |dur| dur.as_millis());
         PenaltyRecord {
             action: action,
             source: source,
             msg: msg.into(),
             result: result,
-            time_stamp: time_stamp
+            time_stamp: time_stamp,
         }
-    }
-
-    /// Obtains the action from the penalty record
-    pub fn action(&self) -> &PeerAction {
-        &self.action
-    }
-
-    /// Obtains the report source from the penalty record
-    pub fn source(&self) -> &ReportSource {
-        &self.source
-    }
-
-    /// Obtains the message associated with the penalty record
-    pub fn msg(&self) -> &String {
-        &self.msg
-    }
-
-    /// Obtains the result of the penalty record
-    pub fn result(&self) -> &ScoreUpdateResult {
-        &self.result
-    }
-
-    /// Obtains the time stamp of when the penalty record was made
-    pub fn time_stamp(&self) -> &Option<u128> {
-        &self.time_stamp
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

[#7245](https://github.com/sigp/lighthouse/issues/7245)

## Proposed Changes

Added records regarding penalty actions to the peer info. The chosen details saved to the record seem to be the most
relevant ones from my knowledge, however I'm open to changes.

## Additional Info

This is still a WIP. I'll try to test and fully validate that the changes work as expected sometime tomorrow. I'll also see if I can add some test cases as well.
