### PR TITLE
Refactored ForkVersionedResponse and ForkVersionDeserialize

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -6106,7 +6106,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         payload_attributes: payload_attributes.into(),
                     },
                     metadata: Default::default(),
-                    version: Some(self.spec.fork_name_at_slot::<T::EthSpec>(prepare_slot)),
+                    version: self.spec.fork_name_at_slot::<T::EthSpec>(prepare_slot),
                 }));
             }
         }

--- a/beacon_node/builder_client/src/lib.rs
+++ b/beacon_node/builder_client/src/lib.rs
@@ -147,7 +147,7 @@ impl BuilderHttpClient {
                 self.ssz_available.store(true, Ordering::SeqCst);
                 T::from_ssz_bytes_by_fork(&response_bytes, fork_name)
                     .map(|data| ForkVersionedResponse {
-                        version: Some(fork_name),
+                        version: fork_name,
                         metadata: EmptyMetadata {},
                         data,
                     })

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2116,9 +2116,9 @@ fn verify_builder_bid<E: EthSpec>(
             payload: header.block_number(),
             expected: block_number,
         }))
-    } else if bid.version != Some(current_fork) {
+    } else if bid.version != current_fork {
         Err(Box::new(InvalidBuilderPayload::Fork {
-            payload: bid.version,
+            payload: Some(bid.version),
             expected: current_fork,
         }))
     } else if !is_signature_valid {

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -980,7 +980,7 @@ pub fn serve<E: EthSpec>(
                         .await
                         .map_err(|e| warp::reject::custom(Custom(e)))?;
                     let resp: ForkVersionedResponse<_> = ForkVersionedResponse {
-                        version: Some(fork_name),
+                        version: fork_name,
                         metadata: Default::default(),
                         data: payload,
                     };
@@ -1040,7 +1040,7 @@ pub fn serve<E: EthSpec>(
                     ),
                     eth2::types::Accept::Json | eth2::types::Accept::Any => {
                         let resp: ForkVersionedResponse<_> = ForkVersionedResponse {
-                            version: Some(fork_name),
+                            version: fork_name,
                             metadata: Default::default(),
                             data: signed_bid,
                         };

--- a/beacon_node/http_api/src/aggregate_attestation.rs
+++ b/beacon_node/http_api/src/aggregate_attestation.rs
@@ -52,7 +52,7 @@ pub fn get_aggregate_attestation<T: BeaconChainTypes>(
 
     if endpoint_version == V2 {
         let fork_versioned_response = ForkVersionedResponse {
-            version: Some(fork_name),
+            version: fork_name,
             metadata: EmptyMetadata {},
             data: aggregate_attestation,
         };

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1698,6 +1698,13 @@ pub fn serve<T: BeaconChainTypes>(
         .and(task_spawner_filter.clone())
         .and(chain_filter.clone());
 
+    let beacon_blocks_path_v2 = eth_v2
+        .and(warp::path("beacon"))
+        .and(warp::path("blocks"))
+        .and(block_id_or_err)
+        .and(task_spawner_filter.clone())
+        .and(chain_filter.clone());
+
     let beacon_blocks_path_any = any_version
         .and(warp::path("beacon"))
         .and(warp::path("blocks"))
@@ -1706,13 +1713,12 @@ pub fn serve<T: BeaconChainTypes>(
         .and(chain_filter.clone());
 
     // GET beacon/blocks/{block_id}
-    let get_beacon_block = beacon_blocks_path_any
+    let get_beacon_block_v2 = beacon_blocks_path_v2
         .clone()
         .and(warp::path::end())
         .and(warp::header::optional::<api_types::Accept>("accept"))
         .then(
-            |endpoint_version: EndpointVersion,
-             block_id: BlockId,
+            |block_id: BlockId,
              task_spawner: TaskSpawner<T::EthSpec>,
              chain: Arc<BeaconChain<T>>,
              accept_header: Option<api_types::Accept>| {
@@ -1735,7 +1741,7 @@ pub fn serve<T: BeaconChainTypes>(
                                 ))
                             }),
                         _ => execution_optimistic_finalized_fork_versioned_response(
-                            endpoint_version,
+                            V2,
                             fork_name,
                             execution_optimistic,
                             finalized,
@@ -4840,7 +4846,7 @@ pub fn serve<T: BeaconChainTypes>(
                 .uor(get_beacon_state_pending_consolidations)
                 .uor(get_beacon_headers)
                 .uor(get_beacon_headers_block_id)
-                .uor(get_beacon_block)
+                .uor(get_beacon_block_v2)
                 .uor(get_beacon_block_attestations)
                 .uor(get_beacon_blinded_block)
                 .uor(get_beacon_block_root)

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -4604,7 +4604,7 @@ pub fn serve<T: BeaconChainTypes>(
     let post_lighthouse_block_rewards = warp::path("lighthouse")
         .and(warp::path("analysis"))
         .and(warp::path("block_rewards"))
-        .and(warp_utils::json::json())
+        .and(warp_utils::json::fork_version_json())
         .and(warp::path::end())
         .and(task_spawner_filter.clone())
         .and(chain_filter.clone())

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2026,7 +2026,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and(warp::query::<api_types::AttestationPoolQuery>())
         .then(
-            |endpoint_version: EndpointVersion,
+            |_endpoint_version: EndpointVersion,
              task_spawner: TaskSpawner<T::EthSpec>,
              chain: Arc<BeaconChain<T>>,
              query: api_types::AttestationPoolQuery| {
@@ -2069,7 +2069,7 @@ pub fn serve<T: BeaconChainTypes>(
                         })
                         .collect::<Vec<_>>();
 
-                    let res = fork_versioned_response(endpoint_version, fork_name, &attestations)?;
+                    let res = fork_versioned_response(fork_name, &attestations);
                     Ok(add_consensus_version_header(
                         warp::reply::json(&res).into_response(),
                         fork_name,
@@ -2133,7 +2133,7 @@ pub fn serve<T: BeaconChainTypes>(
             .and(warp::path("attester_slashings"))
             .and(warp::path::end())
             .then(
-                |endpoint_version: EndpointVersion,
+                |_endpoint_version: EndpointVersion,
                  task_spawner: TaskSpawner<T::EthSpec>,
                  chain: Arc<BeaconChain<T>>| {
                     task_spawner.blocking_response_task(Priority::P1, move || {
@@ -2158,7 +2158,7 @@ pub fn serve<T: BeaconChainTypes>(
                             })
                             .collect::<Vec<_>>();
 
-                        let res = fork_versioned_response(endpoint_version, fork_name, &slashings)?;
+                        let res = fork_versioned_response(fork_name, &slashings);
                         Ok(add_consensus_version_header(
                             warp::reply::json(&res).into_response(),
                             fork_name,
@@ -3377,7 +3377,7 @@ pub fn serve<T: BeaconChainTypes>(
                     if endpoint_version == V3 {
                         produce_block_v3(accept_header, chain, slot, query).await
                     } else {
-                        produce_block_v2(endpoint_version, accept_header, chain, slot, query).await
+                        produce_block_v2(accept_header, chain, slot, query).await
                     }
                 })
             },
@@ -3407,8 +3407,7 @@ pub fn serve<T: BeaconChainTypes>(
              chain: Arc<BeaconChain<T>>| {
                 task_spawner.spawn_async_with_rejection(Priority::P0, async move {
                     not_synced_filter?;
-                    produce_blinded_block_v2(EndpointVersion(2), accept_header, chain, slot, query)
-                        .await
+                    produce_blinded_block_v2(accept_header, chain, slot, query).await
                 })
             },
         );

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2601,7 +2601,7 @@ pub fn serve<T: BeaconChainTypes>(
                                 ))
                             }),
                         _ => Ok(warp::reply::json(&ForkVersionedResponse {
-                            version: Some(fork_name),
+                            version: fork_name,
                             metadata: EmptyMetadata {},
                             data: update,
                         })
@@ -2650,7 +2650,7 @@ pub fn serve<T: BeaconChainTypes>(
                                 ))
                             }),
                         _ => Ok(warp::reply::json(&ForkVersionedResponse {
-                            version: Some(fork_name),
+                            version: fork_name,
                             metadata: EmptyMetadata {},
                             data: update,
                         })

--- a/beacon_node/http_api/src/light_client.rs
+++ b/beacon_node/http_api/src/light_client.rs
@@ -1,5 +1,5 @@
 use crate::version::{
-    add_consensus_version_header, add_ssz_content_type_header, fork_versioned_response, V1,
+    add_consensus_version_header, add_ssz_content_type_header, fork_versioned_response,
 };
 use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
 use eth2::types::{
@@ -52,7 +52,7 @@ pub fn get_light_client_updates<T: BeaconChainTypes>(
             let fork_versioned_response = light_client_updates
                 .iter()
                 .map(|update| map_light_client_update_to_json_response::<T>(&chain, update.clone()))
-                .collect::<Result<Vec<ForkVersionedResponse<LightClientUpdate<T::EthSpec>>>, Rejection>>()?;
+                .collect::<Vec<ForkVersionedResponse<LightClientUpdate<T::EthSpec>>>>();
             Ok(warp::reply::json(&fork_versioned_response).into_response())
         }
     }
@@ -88,10 +88,8 @@ pub fn get_light_client_bootstrap<T: BeaconChainTypes>(
                 warp_utils::reject::custom_server_error(format!("failed to create response: {}", e))
             }),
         _ => {
-            let fork_versioned_response = map_light_client_bootstrap_to_json_response::<T>(
-                fork_name,
-                light_client_bootstrap,
-            )?;
+            let fork_versioned_response =
+                map_light_client_bootstrap_to_json_response::<T>(fork_name, light_client_bootstrap);
             Ok(warp::reply::json(&fork_versioned_response).into_response())
         }
     }
@@ -177,17 +175,17 @@ fn map_light_client_update_to_ssz_chunk<T: BeaconChainTypes>(
 fn map_light_client_bootstrap_to_json_response<T: BeaconChainTypes>(
     fork_name: ForkName,
     light_client_bootstrap: LightClientBootstrap<T::EthSpec>,
-) -> Result<ForkVersionedResponse<LightClientBootstrap<T::EthSpec>>, Rejection> {
-    fork_versioned_response(V1, fork_name, light_client_bootstrap)
+) -> ForkVersionedResponse<LightClientBootstrap<T::EthSpec>> {
+    fork_versioned_response(fork_name, light_client_bootstrap)
 }
 
 fn map_light_client_update_to_json_response<T: BeaconChainTypes>(
     chain: &BeaconChain<T>,
     light_client_update: LightClientUpdate<T::EthSpec>,
-) -> Result<ForkVersionedResponse<LightClientUpdate<T::EthSpec>>, Rejection> {
+) -> ForkVersionedResponse<LightClientUpdate<T::EthSpec>> {
     let fork_name = chain
         .spec
         .fork_name_at_slot::<T::EthSpec>(*light_client_update.signature_slot());
 
-    fork_versioned_response(V1, fork_name, light_client_update)
+    fork_versioned_response(fork_name, light_client_update)
 }

--- a/beacon_node/http_api/src/produce_block.rs
+++ b/beacon_node/http_api/src/produce_block.rs
@@ -9,9 +9,7 @@ use crate::{
 use beacon_chain::{
     BeaconBlockResponseWrapper, BeaconChain, BeaconChainTypes, ProduceBlockVerification,
 };
-use eth2::types::{
-    self as api_types, EndpointVersion, ProduceBlockV3Metadata, SkipRandaoVerification,
-};
+use eth2::types::{self as api_types, ProduceBlockV3Metadata, SkipRandaoVerification};
 use ssz::Encode;
 use std::sync::Arc;
 use types::{payload::BlockProductionVersion, *};
@@ -129,7 +127,6 @@ pub fn build_response_v3<T: BeaconChainTypes>(
 }
 
 pub async fn produce_blinded_block_v2<T: BeaconChainTypes>(
-    endpoint_version: EndpointVersion,
     accept_header: Option<api_types::Accept>,
     chain: Arc<BeaconChain<T>>,
     slot: Slot,
@@ -155,11 +152,10 @@ pub async fn produce_blinded_block_v2<T: BeaconChainTypes>(
         .await
         .map_err(warp_utils::reject::unhandled_error)?;
 
-    build_response_v2(chain, block_response_type, endpoint_version, accept_header)
+    build_response_v2(chain, block_response_type, accept_header)
 }
 
 pub async fn produce_block_v2<T: BeaconChainTypes>(
-    endpoint_version: EndpointVersion,
     accept_header: Option<api_types::Accept>,
     chain: Arc<BeaconChain<T>>,
     slot: Slot,
@@ -186,13 +182,12 @@ pub async fn produce_block_v2<T: BeaconChainTypes>(
         .await
         .map_err(warp_utils::reject::unhandled_error)?;
 
-    build_response_v2(chain, block_response_type, endpoint_version, accept_header)
+    build_response_v2(chain, block_response_type, accept_header)
 }
 
 pub fn build_response_v2<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
     block_response: BeaconBlockResponseWrapper<T::EthSpec>,
-    endpoint_version: EndpointVersion,
     accept_header: Option<api_types::Accept>,
 ) -> Result<Response<Body>, warp::Rejection> {
     let fork_name = block_response
@@ -210,8 +205,10 @@ pub fn build_response_v2<T: BeaconChainTypes>(
             .map_err(|e| {
                 warp_utils::reject::custom_server_error(format!("failed to create response: {}", e))
             }),
-        _ => fork_versioned_response(endpoint_version, fork_name, block_contents)
-            .map(|response| warp::reply::json(&response).into_response())
-            .map(|res| add_consensus_version_header(res, fork_name)),
+        _ => {
+            let res = warp::reply::json(&fork_versioned_response(fork_name, block_contents))
+                .into_response();
+            Ok(add_consensus_version_header(res, fork_name))
+        }
     }
 }

--- a/beacon_node/http_api/src/produce_block.rs
+++ b/beacon_node/http_api/src/produce_block.rs
@@ -115,7 +115,7 @@ pub fn build_response_v3<T: BeaconChainTypes>(
                 warp_utils::reject::custom_server_error(format!("failed to create response: {}", e))
             }),
         _ => Ok(warp::reply::json(&ForkVersionedResponse {
-            version: Some(fork_name),
+            version: fork_name,
             metadata,
             data: block_contents,
         })

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -21,18 +21,15 @@ pub fn fork_versioned_response<T: Serialize>(
     fork_name: ForkName,
     data: T,
 ) -> Result<ForkVersionedResponse<T>, warp::reject::Rejection> {
-    let fork_name = if endpoint_version == V1 {
-        None
-    } else if endpoint_version == V2 || endpoint_version == V3 {
-        Some(fork_name)
+    if endpoint_version == V1 || endpoint_version == V2 || endpoint_version == V3 {
+        Ok(ForkVersionedResponse {
+            version: fork_name,
+            metadata: Default::default(),
+            data,
+        })
     } else {
-        return Err(unsupported_version_rejection(endpoint_version));
-    };
-    Ok(ForkVersionedResponse {
-        version: fork_name,
-        metadata: Default::default(),
-        data,
-    })
+        Err(unsupported_version_rejection(endpoint_version))
+    }
 }
 
 pub fn execution_optimistic_finalized_fork_versioned_response<T: Serialize>(
@@ -42,13 +39,10 @@ pub fn execution_optimistic_finalized_fork_versioned_response<T: Serialize>(
     finalized: bool,
     data: T,
 ) -> Result<ExecutionOptimisticFinalizedForkVersionedResponse<T>, warp::reject::Rejection> {
-    let fork_name = if endpoint_version == V1 {
-        None
-    } else if endpoint_version == V2 {
-        Some(fork_name)
-    } else {
+    if endpoint_version != V2 {
         return Err(unsupported_version_rejection(endpoint_version));
-    };
+    }
+
     Ok(ExecutionOptimisticFinalizedForkVersionedResponse {
         version: fork_name,
         metadata: ExecutionOptimisticFinalizedMetadata {

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -17,18 +17,13 @@ pub const V2: EndpointVersion = EndpointVersion(2);
 pub const V3: EndpointVersion = EndpointVersion(3);
 
 pub fn fork_versioned_response<T: Serialize>(
-    endpoint_version: EndpointVersion,
     fork_name: ForkName,
     data: T,
-) -> Result<ForkVersionedResponse<T>, warp::reject::Rejection> {
-    if endpoint_version == V1 || endpoint_version == V2 || endpoint_version == V3 {
-        Ok(ForkVersionedResponse {
-            version: fork_name,
-            metadata: Default::default(),
-            data,
-        })
-    } else {
-        Err(unsupported_version_rejection(endpoint_version))
+) -> ForkVersionedResponse<T> {
+    ForkVersionedResponse {
+        version: fork_name,
+        metadata: Default::default(),
+        data,
     }
 }
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1598,10 +1598,7 @@ impl ApiTester {
 
             if let (Some(json), Some(expected)) = (&json_result, &expected) {
                 assert_eq!(&json.data, expected.as_ref(), "{:?}", block_id);
-                assert_eq!(
-                    json.version,
-                    Some(expected.fork_name(&self.chain.spec).unwrap())
-                );
+                assert_eq!(json.version, expected.fork_name(&self.chain.spec).unwrap());
             } else {
                 assert_eq!(json_result, None);
                 assert_eq!(expected, None);
@@ -1620,13 +1617,11 @@ impl ApiTester {
                 block_id
             );
 
-            // Check that the legacy v1 API still works but doesn't return a version field.
+            // Check that the legacy v1 API still works.
             let v1_result = self.client.get_beacon_blocks_v1(block_id.0).await.unwrap();
             if let (Some(v1_result), Some(expected)) = (&v1_result, &expected) {
-                assert_eq!(v1_result.version, None);
                 assert_eq!(&v1_result.data, expected.as_ref());
             } else {
-                assert_eq!(v1_result, None);
                 assert_eq!(expected, None);
             }
 
@@ -1686,10 +1681,7 @@ impl ApiTester {
 
             if let (Some(json), Some(expected)) = (&json_result, &expected) {
                 assert_eq!(&json.data, expected, "{:?}", block_id);
-                assert_eq!(
-                    json.version,
-                    Some(expected.fork_name(&self.chain.spec).unwrap())
-                );
+                assert_eq!(json.version, expected.fork_name(&self.chain.spec).unwrap());
             } else {
                 assert_eq!(json_result, None);
                 assert_eq!(expected, None);
@@ -2650,10 +2642,7 @@ impl ApiTester {
 
             if let (Some(json), Some(expected)) = (&result_json, &expected) {
                 assert_eq!(json.data, *expected, "{:?}", state_id);
-                assert_eq!(
-                    json.version,
-                    Some(expected.fork_name(&self.chain.spec).unwrap())
-                );
+                assert_eq!(json.version, expected.fork_name(&self.chain.spec).unwrap());
             } else {
                 assert_eq!(result_json, None);
                 assert_eq!(expected, None);
@@ -3254,7 +3243,7 @@ impl ApiTester {
     ) {
         // Compare fork name to ForkVersionedResponse rather than metadata consensus_version, which
         // is deserialized to a dummy value.
-        assert_eq!(Some(metadata.consensus_version), response.version);
+        assert_eq!(Some(metadata.consensus_version), Some(response.version));
         assert_eq!(ForkName::Base, response.metadata.consensus_version);
         assert_eq!(
             metadata.execution_payload_blinded,

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1617,14 +1617,6 @@ impl ApiTester {
                 block_id
             );
 
-            // Check that the legacy v1 API still works.
-            let v1_result = self.client.get_beacon_blocks_v1(block_id.0).await.unwrap();
-            if let (Some(v1_result), Some(expected)) = (&v1_result, &expected) {
-                assert_eq!(&v1_result.data, expected.as_ref());
-            } else {
-                assert_eq!(expected, None);
-            }
-
             // Check that version headers are provided.
             let url = self.client.get_beacon_blocks_path(block_id.0).unwrap();
 

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1254,24 +1254,6 @@ impl BeaconNodeHttpClient {
         Ok(Some(response.json().await?))
     }
 
-    /// `GET v1/beacon/blocks` (LEGACY)
-    ///
-    /// Returns `Ok(None)` on a 404 error.
-    pub async fn get_beacon_blocks_v1<E: EthSpec>(
-        &self,
-        block_id: BlockId,
-    ) -> Result<Option<GenericResponse<SignedBeaconBlock<E>>>, Error> {
-        let mut path = self.eth_path(V1)?;
-
-        path.path_segments_mut()
-            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
-            .push("beacon")
-            .push("blocks")
-            .push(&block_id.to_string());
-
-        self.get_opt(path).await
-    }
-
     /// `GET beacon/blocks` as SSZ
     ///
     /// Returns `Ok(None)` on a 404 error.

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1260,7 +1260,7 @@ impl BeaconNodeHttpClient {
     pub async fn get_beacon_blocks_v1<E: EthSpec>(
         &self,
         block_id: BlockId,
-    ) -> Result<Option<ForkVersionedResponse<SignedBeaconBlock<E>>>, Error> {
+    ) -> Result<Option<GenericResponse<SignedBeaconBlock<E>>>, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1150,9 +1150,14 @@ impl<E: EthSpec> EventKind<E> {
 
     pub fn from_sse_bytes(event: &str, data: &str) -> Result<Self, ServerError> {
         match event {
-            "attestation" => Ok(EventKind::Attestation(serde_json::from_str(data).map_err(
-                |e| ServerError::InvalidServerSentEvent(format!("Attestation: {:?}", e)),
-            )?)),
+            // TODO(fork-deserialize) is this always a base attestation?
+            "attestation" => Ok(EventKind::Attestation(Box::new(
+                serde_json::from_str(data)
+                    .map(Attestation::Base)
+                    .map_err(|e| {
+                        ServerError::InvalidServerSentEvent(format!("Attestation: {:?}", e))
+                    })?,
+            ))),
             "single_attestation" => Ok(EventKind::SingleAttestation(
                 serde_json::from_str(data).map_err(|e| {
                     ServerError::InvalidServerSentEvent(format!("SingleAttestation: {:?}", e))

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use test_random_derive::TestRandom;
 use types::beacon_block_body::KzgCommitments;
+use types::fork_versioned_response::ForkVersionDeserializeError;
 use types::test_utils::TestRandom;
 pub use types::*;
 
@@ -1051,47 +1052,47 @@ pub type SseExtendedPayloadAttributes = SseExtendedPayloadAttributesGeneric<SseP
 pub type VersionedSsePayloadAttributes = ForkVersionedResponse<SseExtendedPayloadAttributes>;
 
 impl ForkVersionDeserialize for SsePayloadAttributes {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         match fork_name {
             ForkName::Bellatrix => serde_json::from_value(value)
                 .map(Self::V1)
-                .map_err(serde::de::Error::custom),
+                .map_err(ForkVersionDeserializeError::SerdeJsonError),
             ForkName::Capella => serde_json::from_value(value)
                 .map(Self::V2)
-                .map_err(serde::de::Error::custom),
+                .map_err(ForkVersionDeserializeError::SerdeJsonError),
             ForkName::Deneb => serde_json::from_value(value)
                 .map(Self::V3)
-                .map_err(serde::de::Error::custom),
+                .map_err(ForkVersionDeserializeError::SerdeJsonError),
             ForkName::Electra => serde_json::from_value(value)
                 .map(Self::V3)
-                .map_err(serde::de::Error::custom),
+                .map_err(ForkVersionDeserializeError::SerdeJsonError),
             ForkName::Fulu => serde_json::from_value(value)
                 .map(Self::V3)
-                .map_err(serde::de::Error::custom),
-            ForkName::Base | ForkName::Altair => Err(serde::de::Error::custom(format!(
-                "SsePayloadAttributes deserialization for {fork_name} not implemented"
-            ))),
+                .map_err(ForkVersionDeserializeError::SerdeJsonError),
+            ForkName::Base | ForkName::Altair => Err(
+                ForkVersionDeserializeError::UnsupportedForkVersion(fork_name.to_string()),
+            ),
         }
     }
 }
 
 impl ForkVersionDeserialize for SseExtendedPayloadAttributes {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         let helper: SseExtendedPayloadAttributesGeneric<serde_json::Value> =
-            serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+            serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
         Ok(Self {
             proposal_slot: helper.proposal_slot,
             proposer_index: helper.proposer_index,
             parent_block_root: helper.parent_block_root,
             parent_block_number: helper.parent_block_number,
             parent_block_hash: helper.parent_block_hash,
-            payload_attributes: SsePayloadAttributes::deserialize_by_fork::<D>(
+            payload_attributes: SsePayloadAttributes::deserialize_by_fork(
                 helper.payload_attributes,
                 fork_name,
             )?,
@@ -1730,18 +1731,18 @@ impl<E: EthSpec> FullBlockContents<E> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for FullBlockContents<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         if fork_name.deneb_enabled() {
             Ok(FullBlockContents::BlockContents(
-                BlockContents::deserialize_by_fork::<'de, D>(value, fork_name)?,
+                BlockContents::deserialize_by_fork(value, fork_name)?,
             ))
         } else {
-            Ok(FullBlockContents::Block(
-                BeaconBlock::deserialize_by_fork::<'de, D>(value, fork_name)?,
-            ))
+            Ok(FullBlockContents::Block(BeaconBlock::deserialize_by_fork(
+                value, fork_name,
+            )?))
         }
     }
 }
@@ -1911,10 +1912,10 @@ pub struct BlockContents<E: EthSpec> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for BlockContents<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         #[derive(Deserialize)]
         #[serde(bound = "E: EthSpec")]
         struct Helper<E: EthSpec> {
@@ -1923,17 +1924,18 @@ impl<E: EthSpec> ForkVersionDeserialize for BlockContents<E> {
             #[serde(with = "ssz_types::serde_utils::list_of_hex_fixed_vec")]
             blobs: BlobsList<E>,
         }
-        let helper: Helper<E> = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        let helper: Helper<E> =
+            serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
 
         Ok(Self {
-            block: BeaconBlock::deserialize_by_fork::<'de, D>(helper.block, fork_name)?,
+            block: BeaconBlock::deserialize_by_fork(helper.block, fork_name)?,
             kzg_proofs: helper.kzg_proofs,
             blobs: helper.blobs,
         })
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Encode)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encode)]
 #[serde(untagged)]
 #[serde(bound = "E: EthSpec")]
 #[ssz(enum_behaviour = "transparent")]
@@ -1999,27 +2001,27 @@ impl<E: EthSpec> FullPayloadContents<E> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for FullPayloadContents<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         if fork_name.deneb_enabled() {
-            ExecutionPayloadAndBlobs::deserialize_by_fork::<'de, D>(value, fork_name)
+            ExecutionPayloadAndBlobs::deserialize_by_fork(value, fork_name)
                 .map(Self::PayloadAndBlobs)
-                .map_err(serde::de::Error::custom)
         } else if fork_name.bellatrix_enabled() {
-            ExecutionPayload::deserialize_by_fork::<'de, D>(value, fork_name)
-                .map(Self::Payload)
-                .map_err(serde::de::Error::custom)
+            ExecutionPayload::deserialize_by_fork(value, fork_name).map(Self::Payload)
         } else {
-            Err(serde::de::Error::custom(format!(
-                "FullPayloadContents deserialization for {fork_name} not implemented"
-            )))
+            Err(ForkVersionDeserializeError::UnsupportedForkVersion(
+                format!(
+                    "FullPayloadContents deserialization not supported for fork '{}'",
+                    fork_name
+                ),
+            ))
         }
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Encode)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encode)]
 #[serde(bound = "E: EthSpec")]
 pub struct ExecutionPayloadAndBlobs<E: EthSpec> {
     pub execution_payload: ExecutionPayload<E>,
@@ -2027,19 +2029,20 @@ pub struct ExecutionPayloadAndBlobs<E: EthSpec> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for ExecutionPayloadAndBlobs<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         #[derive(Deserialize)]
         #[serde(bound = "E: EthSpec")]
         struct Helper<E: EthSpec> {
             execution_payload: serde_json::Value,
             blobs_bundle: BlobsBundle<E>,
         }
-        let helper: Helper<E> = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        let helper: Helper<E> =
+            serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
         Ok(Self {
-            execution_payload: ExecutionPayload::deserialize_by_fork::<'de, D>(
+            execution_payload: ExecutionPayload::deserialize_by_fork(
                 helper.execution_payload,
                 fork_name,
             )?,
@@ -2290,7 +2293,7 @@ mod test {
         fork_name: ForkName,
     ) {
         let val = Value::deserialize(deserializer).unwrap();
-        let roundtrip = O::deserialize_by_fork::<'de, D>(val, fork_name).unwrap();
+        let roundtrip = O::deserialize_by_fork(val, fork_name).unwrap();
         assert_eq!(original, roundtrip);
     }
 }

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1017,7 +1017,7 @@ pub struct SseLateHead {
     variants(V1, V2, V3),
     variant_attributes(derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize))
 )]
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 #[serde(untagged)]
 pub struct SsePayloadAttributes {
     #[superstruct(getter(copy))]
@@ -1034,7 +1034,7 @@ pub struct SsePayloadAttributes {
     pub parent_beacon_block_root: Hash256,
 }
 
-#[derive(PartialEq, Debug, Deserialize, Serialize, Clone)]
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
 pub struct SseExtendedPayloadAttributesGeneric<T> {
     pub proposal_slot: Slot,
     #[serde(with = "serde_utils::quoted_u64")]
@@ -1597,7 +1597,7 @@ mod tests {
     }
 }
 
-#[derive(Debug, Encode, Serialize, Deserialize)]
+#[derive(Debug, Encode, Serialize)]
 #[serde(untagged)]
 #[serde(bound = "E: EthSpec")]
 #[ssz(enum_behaviour = "transparent")]
@@ -1610,7 +1610,7 @@ pub type JsonProduceBlockV3Response<E> =
     ForkVersionedResponse<ProduceBlockV3Response<E>, ProduceBlockV3Metadata>;
 
 /// A wrapper over a [`BeaconBlock`] or a [`BlockContents`].
-#[derive(Debug, Encode, Serialize, Deserialize)]
+#[derive(Debug, Encode, Serialize)]
 #[serde(untagged)]
 #[serde(bound = "E: EthSpec")]
 #[ssz(enum_behaviour = "transparent")]
@@ -1896,7 +1896,7 @@ pub struct SignedBlockContents<E: EthSpec> {
     pub blobs: BlobsList<E>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Encode)]
+#[derive(Debug, Clone, Serialize, Encode)]
 #[serde(bound = "E: EthSpec")]
 pub struct BlockContents<E: EthSpec> {
     pub block: BeaconBlock<E>,
@@ -1928,7 +1928,7 @@ impl<E: EthSpec> ForkVersionDeserialize for BlockContents<E> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encode)]
+#[derive(Clone, Debug, PartialEq, Serialize, Encode)]
 #[serde(untagged)]
 #[serde(bound = "E: EthSpec")]
 #[ssz(enum_behaviour = "transparent")]
@@ -2014,7 +2014,7 @@ impl<E: EthSpec> ForkVersionDeserialize for FullPayloadContents<E> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encode)]
+#[derive(Clone, Debug, PartialEq, Serialize, Encode)]
 #[serde(bound = "E: EthSpec")]
 pub struct ExecutionPayloadAndBlobs<E: EthSpec> {
     pub execution_payload: ExecutionPayload<E>,

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -9,7 +9,7 @@ use enr::{CombinedKey, Enr};
 use mediatype::{names, MediaType, MediaTypeList};
 use multiaddr::Multiaddr;
 use reqwest::header::HeaderMap;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_utils::quoted_u64::Quoted;
 use ssz::{Decode, DecodeError};
@@ -2285,7 +2285,7 @@ mod test {
 
     fn generic_deserialize_by_fork<
         'de,
-        D: Deserializer<'de>,
+        D: serde::Deserializer<'de>,
         O: ForkVersionDeserialize + PartialEq + Debug,
     >(
         deserializer: D,

--- a/common/warp_utils/src/json.rs
+++ b/common/warp_utils/src/json.rs
@@ -2,8 +2,8 @@ use bytes::Bytes;
 use eth2::{CONSENSUS_VERSION_HEADER, CONTENT_TYPE_HEADER, SSZ_CONTENT_TYPE_HEADER};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use types::{ForkName, ForkVersionDeserialize};
 use std::error::Error as StdError;
+use types::{ForkName, ForkVersionDeserialize};
 use warp::{Filter, Rejection};
 
 use crate::reject;
@@ -37,25 +37,31 @@ pub fn json<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error =
 struct ForkVersionJson;
 
 impl ForkVersionJson {
-    fn decode_with_fork<T: ForkVersionDeserialize>(bytes: Bytes, fork_name: ForkName) -> Result<T, BoxError> {
+    fn decode_with_fork<T: ForkVersionDeserialize>(
+        bytes: Bytes,
+        fork_name: ForkName,
+    ) -> Result<T, BoxError> {
         let value: Value = serde_json::from_slice(&bytes)?;
         T::deserialize_by_fork(value, fork_name).map_err(Into::into)
     }
 }
 
-pub fn fork_version_json<Send>() -> impl Filter<Extract = (T,), Error = Rejection> + Copy {
+pub fn fork_version_json<T: ForkVersionDeserialize + Send>(
+) -> impl Filter<Extract = (T,), Error = Rejection> + Copy {
     warp::header::header::<ForkName>(CONSENSUS_VERSION_HEADER)
         .and(warp::header::optional::<String>(CONTENT_TYPE_HEADER))
         .and(warp::body::bytes())
-        .and_then(|fork_name: ForkName, content_type_header: Option<String>, bytes: Bytes| async move {
-            if let Some(content_type_header) = header {
-                if header == SSZ_CONTENT_TYPE_HEADER {
-                    return Err(reject::unsupported_media_type(
-                        "The request's content-type is not supported".to_string(),
-                    ));
+        .and_then(
+            |fork_name: ForkName, content_type_header: Option<String>, bytes: Bytes| async move {
+                if let Some(header) = content_type_header {
+                    if header == SSZ_CONTENT_TYPE_HEADER {
+                        return Err(reject::unsupported_media_type(
+                            "The request's content-type is not supported".to_string(),
+                        ));
+                    }
                 }
-            }
-            ForkVersionJson::decode_with_fork(bytes, fork_name)
-                .map_err(|err| reject::custom_deserialize_error(format!("{:?}", err)))
-        })
+                ForkVersionJson::decode_with_fork(bytes, fork_name)
+                    .map_err(|err| reject::custom_deserialize_error(format!("{:?}", err)))
+            },
+        )
 }

--- a/common/warp_utils/src/json.rs
+++ b/common/warp_utils/src/json.rs
@@ -1,6 +1,8 @@
 use bytes::Bytes;
-use eth2::{CONTENT_TYPE_HEADER, SSZ_CONTENT_TYPE_HEADER};
+use eth2::{CONSENSUS_VERSION_HEADER, CONTENT_TYPE_HEADER, SSZ_CONTENT_TYPE_HEADER};
 use serde::de::DeserializeOwned;
+use serde_json::Value;
+use types::{ForkName, ForkVersionDeserialize};
 use std::error::Error as StdError;
 use warp::{Filter, Rejection};
 
@@ -28,6 +30,32 @@ pub fn json<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error =
                 }
             }
             Json::decode(bytes)
+                .map_err(|err| reject::custom_deserialize_error(format!("{:?}", err)))
+        })
+}
+
+struct ForkVersionJson;
+
+impl ForkVersionJson {
+    fn decode_with_fork<T: ForkVersionDeserialize>(bytes: Bytes, fork_name: ForkName) -> Result<T, BoxError> {
+        let value: Value = serde_json::from_slice(&bytes)?;
+        T::deserialize_by_fork(value, fork_name).map_err(Into::into)
+    }
+}
+
+pub fn fork_version_json<Send>() -> impl Filter<Extract = (T,), Error = Rejection> + Copy {
+    warp::header::header::<ForkName>(CONSENSUS_VERSION_HEADER)
+        .and(warp::header::optional::<String>(CONTENT_TYPE_HEADER))
+        .and(warp::body::bytes())
+        .and_then(|fork_name: ForkName, content_type_header: Option<String>, bytes: Bytes| async move {
+            if let Some(content_type_header) = header {
+                if header == SSZ_CONTENT_TYPE_HEADER {
+                    return Err(reject::unsupported_media_type(
+                        "The request's content-type is not supported".to_string(),
+                    ));
+                }
+            }
+            ForkVersionJson::decode_with_fork(bytes, fork_name)
                 .map_err(|err| reject::custom_deserialize_error(format!("{:?}", err)))
         })
 }

--- a/consensus/types/src/attestation.rs
+++ b/consensus/types/src/attestation.rs
@@ -7,6 +7,7 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::BitVector;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
+use crate::fork_versioned_response::ForkVersionDeserializeError; 
 use superstruct::superstruct;
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
@@ -533,37 +534,37 @@ impl<'a, E: EthSpec> From<AttestationRefOnDisk<'a, E>> for AttestationRef<'a, E>
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for Attestation<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::Value,
         fork_name: crate::ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         if fork_name.electra_enabled() {
             let attestation: AttestationElectra<E> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
             Ok(Attestation::Electra(attestation))
         } else {
             let attestation: AttestationBase<E> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
             Ok(Attestation::Base(attestation))
         }
     }
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for Vec<Attestation<E>> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::Value,
         fork_name: crate::ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         if fork_name.electra_enabled() {
             let attestations: Vec<AttestationElectra<E>> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
             Ok(attestations
                 .into_iter()
                 .map(Attestation::Electra)
                 .collect::<Vec<_>>())
         } else {
             let attestations: Vec<AttestationBase<E>> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
             Ok(attestations
                 .into_iter()
                 .map(Attestation::Base)

--- a/consensus/types/src/attestation.rs
+++ b/consensus/types/src/attestation.rs
@@ -1,3 +1,4 @@
+use crate::fork_versioned_response::ForkVersionDeserializeError;
 use crate::slot_data::SlotData;
 use crate::{test_utils::TestRandom, Hash256, Slot};
 use crate::{Checkpoint, ForkVersionDeserialize};
@@ -7,7 +8,6 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::BitVector;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
-use crate::fork_versioned_response::ForkVersionDeserializeError; 
 use superstruct::superstruct;
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
@@ -539,12 +539,12 @@ impl<E: EthSpec> ForkVersionDeserialize for Attestation<E> {
         fork_name: crate::ForkName,
     ) -> Result<Self, ForkVersionDeserializeError> {
         if fork_name.electra_enabled() {
-            let attestation: AttestationElectra<E> =
-                serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
+            let attestation: AttestationElectra<E> = serde_json::from_value(value)
+                .map_err(ForkVersionDeserializeError::SerdeJsonError)?;
             Ok(Attestation::Electra(attestation))
         } else {
-            let attestation: AttestationBase<E> =
-                serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
+            let attestation: AttestationBase<E> = serde_json::from_value(value)
+                .map_err(ForkVersionDeserializeError::SerdeJsonError)?;
             Ok(Attestation::Base(attestation))
         }
     }
@@ -556,15 +556,15 @@ impl<E: EthSpec> ForkVersionDeserialize for Vec<Attestation<E>> {
         fork_name: crate::ForkName,
     ) -> Result<Self, ForkVersionDeserializeError> {
         if fork_name.electra_enabled() {
-            let attestations: Vec<AttestationElectra<E>> =
-                serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
+            let attestations: Vec<AttestationElectra<E>> = serde_json::from_value(value)
+                .map_err(ForkVersionDeserializeError::SerdeJsonError)?;
             Ok(attestations
                 .into_iter()
                 .map(Attestation::Electra)
                 .collect::<Vec<_>>())
         } else {
-            let attestations: Vec<AttestationBase<E>> =
-                serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
+            let attestations: Vec<AttestationBase<E>> = serde_json::from_value(value)
+                .map_err(ForkVersionDeserializeError::SerdeJsonError)?;
             Ok(attestations
                 .into_iter()
                 .map(Attestation::Base)

--- a/consensus/types/src/attester_slashing.rs
+++ b/consensus/types/src/attester_slashing.rs
@@ -1,7 +1,10 @@
 use crate::indexed_attestation::{
     IndexedAttestationBase, IndexedAttestationElectra, IndexedAttestationRef,
 };
-use crate::{test_utils::TestRandom, EthSpec};
+use crate::{
+    fork_versioned_response::ForkVersionDeserializeError, test_utils::TestRandom, EthSpec,
+};
+
 use derivative::Derivative;
 use rand::{Rng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -172,20 +175,20 @@ impl<E: EthSpec> TestRandom for AttesterSlashing<E> {
 }
 
 impl<E: EthSpec> crate::ForkVersionDeserialize for Vec<AttesterSlashing<E>> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::Value,
         fork_name: crate::ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         if fork_name.electra_enabled() {
-            let slashings: Vec<AttesterSlashingElectra<E>> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+            let slashings: Vec<AttesterSlashingElectra<E>> = serde_json::from_value(value)
+                .map_err(ForkVersionDeserializeError::SerdeJsonError)?;
             Ok(slashings
                 .into_iter()
                 .map(AttesterSlashing::Electra)
                 .collect::<Vec<_>>())
         } else {
-            let slashings: Vec<AttesterSlashingBase<E>> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+            let slashings: Vec<AttesterSlashingBase<E>> = serde_json::from_value(value)
+                .map_err(ForkVersionDeserializeError::SerdeJsonError)?;
             Ok(slashings
                 .into_iter()
                 .map(AttesterSlashing::Base)

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -1,4 +1,5 @@
 use crate::attestation::AttestationBase;
+use crate::fork_versioned_response::{ForkVersionDeserialize, ForkVersionDeserializeError};
 use crate::test_utils::TestRandom;
 use crate::*;
 use derivative::Derivative;
@@ -11,7 +12,6 @@ use superstruct::superstruct;
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
-use crate::fork_versioned_response::ForkVersionDeserializeError;
 
 use self::indexed_attestation::IndexedAttestationBase;
 
@@ -45,9 +45,7 @@ use self::indexed_attestation::IndexedAttestationBase;
     map_ref_into(BeaconBlockBodyRef, BeaconBlock),
     map_ref_mut_into(BeaconBlockBodyRefMut)
 )]
-#[derive(
-    Debug, Clone, Serialize, Encode, TreeHash, Derivative, arbitrary::Arbitrary,
-)]
+#[derive(Debug, Clone, Serialize, Encode, TreeHash, Derivative, arbitrary::Arbitrary)]
 #[derivative(PartialEq, Hash(bound = "E: EthSpec"))]
 #[serde(untagged)]
 #[serde(bound = "E: EthSpec, Payload: AbstractExecPayload<E>")]
@@ -780,6 +778,22 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> ForkVersionDeserialize
         ))
     }
 }
+
+impl<E: EthSpec> ForkVersionDeserialize for Vec<BeaconBlock<E, BlindedPayload<E>>> {
+    fn deserialize_by_fork(
+        value: serde_json::value::Value,
+        fork_name: ForkName,
+    ) -> Result<Self, ForkVersionDeserializeError> {
+        let blocks: Vec<serde_json::value::Value> =
+            serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
+
+        blocks
+            .into_iter()
+            .map(|block_value| BeaconBlock::deserialize_by_fork(block_value, fork_name))
+            .collect()
+    }
+}
+
 pub enum BlockImportSource {
     Gossip,
     Lookup,

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -11,6 +11,7 @@ use superstruct::superstruct;
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
+use crate::fork_versioned_response::ForkVersionDeserializeError;
 
 use self::indexed_attestation::IndexedAttestationBase;
 
@@ -45,7 +46,7 @@ use self::indexed_attestation::IndexedAttestationBase;
     map_ref_mut_into(BeaconBlockBodyRefMut)
 )]
 #[derive(
-    Debug, Clone, Serialize, Deserialize, Encode, TreeHash, Derivative, arbitrary::Arbitrary,
+    Debug, Clone, Serialize, Encode, TreeHash, Derivative, arbitrary::Arbitrary,
 )]
 #[derivative(PartialEq, Hash(bound = "E: EthSpec"))]
 #[serde(untagged)]
@@ -768,17 +769,14 @@ impl<E: EthSpec> From<BeaconBlock<E, FullPayload<E>>>
 impl<E: EthSpec, Payload: AbstractExecPayload<E>> ForkVersionDeserialize
     for BeaconBlock<E, Payload>
 {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         Ok(map_fork_name!(
             fork_name,
             Self,
-            serde_json::from_value(value).map_err(|e| serde::de::Error::custom(format!(
-                "BeaconBlock failed to deserialize: {:?}",
-                e
-            )))?
+            serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?
         ))
     }
 }

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -2757,8 +2757,7 @@ impl<E: EthSpec> ForkVersionDeserialize for BeaconState<E> {
         Ok(map_fork_name!(
             fork_name,
             Self,
-            serde_json::from_value(value)
-                .map_err(ForkVersionDeserializeError::SerdeJsonError)?
+            serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?
         ))
     }
 }

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1,4 +1,5 @@
 use self::committee_cache::get_active_validator_indices;
+use crate::fork_versioned_response::ForkVersionDeserializeError;
 use crate::historical_summary::HistoricalSummary;
 use crate::test_utils::TestRandom;
 use crate::FixedBytesExtended;
@@ -2749,17 +2750,15 @@ impl<E: EthSpec> CompareFields for BeaconState<E> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for BeaconState<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         Ok(map_fork_name!(
             fork_name,
             Self,
-            serde_json::from_value(value).map_err(|e| serde::de::Error::custom(format!(
-                "BeaconState failed to deserialize: {:?}",
-                e
-            )))?
+            serde_json::from_value(value)
+                .map_err(|e| ForkVersionDeserializeError::SerdeJsonError(e))?
         ))
     }
 }

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -2758,7 +2758,7 @@ impl<E: EthSpec> ForkVersionDeserialize for BeaconState<E> {
             fork_name,
             Self,
             serde_json::from_value(value)
-                .map_err(|e| ForkVersionDeserializeError::SerdeJsonError(e))?
+                .map_err(ForkVersionDeserializeError::SerdeJsonError)?
         ))
     }
 }

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -1,6 +1,7 @@
 use crate::test_utils::TestRandom;
 use crate::{
-    beacon_block_body::BLOB_KZG_COMMITMENTS_INDEX, AbstractExecPayload, BeaconBlockHeader,
+    beacon_block_body::BLOB_KZG_COMMITMENTS_INDEX,
+    fork_versioned_response::ForkVersionDeserializeError, AbstractExecPayload, BeaconBlockHeader,
     BeaconStateError, Blob, ChainSpec, Epoch, EthSpec, FixedVector, ForkName,
     ForkVersionDeserialize, Hash256, KzgProofs, RuntimeFixedVector, RuntimeVariableList,
     SignedBeaconBlock, SignedBeaconBlockHeader, Slot, VariableList,
@@ -298,10 +299,11 @@ pub type FixedBlobSidecarList<E> = RuntimeFixedVector<Option<Arc<BlobSidecar<E>>
 pub type BlobsList<E> = VariableList<Blob<E>, <E as EthSpec>::MaxBlobCommitmentsPerBlock>;
 
 impl<E: EthSpec> ForkVersionDeserialize for BlobSidecarList<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         _: ForkName,
-    ) -> Result<Self, D::Error> {
-        serde_json::from_value::<BlobSidecarList<E>>(value).map_err(serde::de::Error::custom)
+    ) -> Result<Self, ForkVersionDeserializeError> {
+        serde_json::from_value::<BlobSidecarList<E>>(value)
+            .map_err(ForkVersionDeserializeError::SerdeJsonError)
     }
 }

--- a/consensus/types/src/builder_bid.rs
+++ b/consensus/types/src/builder_bid.rs
@@ -1,4 +1,5 @@
 use crate::beacon_block_body::KzgCommitments;
+use crate::fork_versioned_response::ForkVersionDeserializeError;
 use crate::{
     ChainSpec, EthSpec, ExecutionPayloadHeaderBellatrix, ExecutionPayloadHeaderCapella,
     ExecutionPayloadHeaderDeneb, ExecutionPayloadHeaderElectra, ExecutionPayloadHeaderFulu,
@@ -9,7 +10,6 @@ use bls::PublicKeyBytes;
 use bls::Signature;
 use serde::{Deserialize, Serialize};
 use ssz::Decode;
-use crate::fork_versioned_response::ForkVersionDeserializeError;
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
@@ -131,8 +131,12 @@ impl<E: EthSpec> ForkVersionDeserialize for BuilderBid<E> {
         value: serde_json::value::Value,
         fork_name: ForkName,
     ) -> Result<Self, ForkVersionDeserializeError> {
-        let convert_err =
-            |e| ForkVersionDeserializeError::SerdeValueError(serde::de::Error::custom(format!("BuilderBid failed to deserialize: {:?}", e)));
+        let convert_err = |e| {
+            ForkVersionDeserializeError::SerdeValueError(serde::de::Error::custom(format!(
+                "BuilderBid failed to deserialize: {:?}",
+                e
+            )))
+        };
 
         Ok(match fork_name {
             ForkName::Bellatrix => {
@@ -143,10 +147,12 @@ impl<E: EthSpec> ForkVersionDeserialize for BuilderBid<E> {
             ForkName::Electra => Self::Electra(serde_json::from_value(value).map_err(convert_err)?),
             ForkName::Fulu => Self::Fulu(serde_json::from_value(value).map_err(convert_err)?),
             ForkName::Base | ForkName::Altair => {
-                return Err(ForkVersionDeserializeError::UnsupportedForkVersion(format!(
-                    "BuilderBid failed to deserialize: unsupported fork '{}'",
-                    fork_name
-                )))
+                return Err(ForkVersionDeserializeError::UnsupportedForkVersion(
+                    format!(
+                        "BuilderBid failed to deserialize: unsupported fork '{}'",
+                        fork_name
+                    ),
+                ))
             }
         })
     }
@@ -162,7 +168,8 @@ impl<E: EthSpec> ForkVersionDeserialize for SignedBuilderBid<E> {
             pub message: serde_json::Value,
             pub signature: Signature,
         }
-        let helper: Helper = serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
+        let helper: Helper =
+            serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
 
         Ok(Self {
             message: BuilderBid::deserialize_by_fork(helper.message, fork_name)?,

--- a/consensus/types/src/builder_bid.rs
+++ b/consensus/types/src/builder_bid.rs
@@ -132,7 +132,7 @@ impl<E: EthSpec> ForkVersionDeserialize for BuilderBid<E> {
         fork_name: ForkName,
     ) -> Result<Self, ForkVersionDeserializeError> {
         let convert_err = |e| {
-            ForkVersionDeserializeError::SerdeValueError(serde::de::Error::custom(format!(
+            ForkVersionDeserializeError::SerdeJsonError(serde::de::Error::custom(format!(
                 "BuilderBid failed to deserialize: {:?}",
                 e
             )))

--- a/consensus/types/src/builder_bid.rs
+++ b/consensus/types/src/builder_bid.rs
@@ -7,8 +7,9 @@ use crate::{
 };
 use bls::PublicKeyBytes;
 use bls::Signature;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use ssz::Decode;
+use crate::fork_versioned_response::ForkVersionDeserializeError;
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
@@ -126,12 +127,12 @@ impl<E: EthSpec> ForkVersionDecode for SignedBuilderBid<E> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for BuilderBid<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         let convert_err =
-            |e| serde::de::Error::custom(format!("BuilderBid failed to deserialize: {:?}", e));
+            |e| ForkVersionDeserializeError::SerdeValueError(serde::de::Error::custom(format!("BuilderBid failed to deserialize: {:?}", e)));
 
         Ok(match fork_name {
             ForkName::Bellatrix => {
@@ -142,29 +143,29 @@ impl<E: EthSpec> ForkVersionDeserialize for BuilderBid<E> {
             ForkName::Electra => Self::Electra(serde_json::from_value(value).map_err(convert_err)?),
             ForkName::Fulu => Self::Fulu(serde_json::from_value(value).map_err(convert_err)?),
             ForkName::Base | ForkName::Altair => {
-                return Err(serde::de::Error::custom(format!(
+                return Err(ForkVersionDeserializeError::UnsupportedForkVersion(format!(
                     "BuilderBid failed to deserialize: unsupported fork '{}'",
                     fork_name
-                )));
+                )))
             }
         })
     }
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for SignedBuilderBid<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         #[derive(Deserialize)]
         struct Helper {
             pub message: serde_json::Value,
             pub signature: Signature,
         }
-        let helper: Helper = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        let helper: Helper = serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?;
 
         Ok(Self {
-            message: BuilderBid::deserialize_by_fork::<'de, D>(helper.message, fork_name)?,
+            message: BuilderBid::deserialize_by_fork(helper.message, fork_name)?,
             signature: helper.signature,
         })
     }

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -1,4 +1,4 @@
-use crate::{test_utils::TestRandom, *};
+use crate::{fork_versioned_response::ForkVersionDeserializeError, test_utils::TestRandom, *};
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
@@ -134,13 +134,11 @@ impl<E: EthSpec> ExecutionPayload<E> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for ExecutionPayload<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        let convert_err = |e| {
-            serde::de::Error::custom(format!("ExecutionPayload failed to deserialize: {:?}", e))
-        };
+    ) -> Result<Self, ForkVersionDeserializeError> {
+        let convert_err = |e| ForkVersionDeserializeError::SerdeJsonError(e);
 
         Ok(match fork_name {
             ForkName::Bellatrix => {
@@ -151,10 +149,12 @@ impl<E: EthSpec> ForkVersionDeserialize for ExecutionPayload<E> {
             ForkName::Electra => Self::Electra(serde_json::from_value(value).map_err(convert_err)?),
             ForkName::Fulu => Self::Fulu(serde_json::from_value(value).map_err(convert_err)?),
             ForkName::Base | ForkName::Altair => {
-                return Err(serde::de::Error::custom(format!(
-                    "ExecutionPayload failed to deserialize: unsupported fork '{}'",
-                    fork_name
-                )));
+                return Err(ForkVersionDeserializeError::UnsupportedForkVersion(
+                    format!(
+                        "ExecutionPayload failed to deserialize: unsupported fork '{}'",
+                        fork_name
+                    ),
+                ));
             }
         })
     }

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -1,4 +1,4 @@
-use crate::{test_utils::TestRandom, *};
+use crate::{fork_versioned_response::ForkVersionDeserializeError, test_utils::TestRandom, *};
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
@@ -473,16 +473,11 @@ impl<E: EthSpec> TryFrom<ExecutionPayloadHeader<E>> for ExecutionPayloadHeaderFu
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for ExecutionPayloadHeader<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        let convert_err = |e| {
-            serde::de::Error::custom(format!(
-                "ExecutionPayloadHeader failed to deserialize: {:?}",
-                e
-            ))
-        };
+    ) -> Result<Self, ForkVersionDeserializeError> {
+        let convert_err = |e| ForkVersionDeserializeError::SerdeJsonError(e);
 
         Ok(match fork_name {
             ForkName::Bellatrix => {
@@ -493,10 +488,12 @@ impl<E: EthSpec> ForkVersionDeserialize for ExecutionPayloadHeader<E> {
             ForkName::Electra => Self::Electra(serde_json::from_value(value).map_err(convert_err)?),
             ForkName::Fulu => Self::Fulu(serde_json::from_value(value).map_err(convert_err)?),
             ForkName::Base | ForkName::Altair => {
-                return Err(serde::de::Error::custom(format!(
-                    "ExecutionPayloadHeader failed to deserialize: unsupported fork '{}'",
-                    fork_name
-                )));
+                return Err(ForkVersionDeserializeError::UnsupportedForkVersion(
+                    format!(
+                        "ExecutionPayloadHeader failed to deserialize: unsupported fork '{}'",
+                        fork_name
+                    ),
+                ));
             }
         })
     }

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -2,7 +2,39 @@ use crate::ForkName;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::value::Value;
+use std::error::Error as StdError;
 use std::sync::Arc;
+
+pub enum ForkVersionDeserializeError {
+    // TODO(fork-deserialize) we probably don't need these two similar variants
+    SerdeJsonError(serde_json::Error),
+    SerdeValueError(serde::de::value::Error),
+    UnsupportedForkVersion(String)
+}
+
+impl From<serde::de::value::Error> for ForkVersionDeserializeError {
+    fn from(err: serde::de::value::Error) -> Self {
+        ForkVersionDeserializeError::SerdeValueError(err)
+    }
+}
+
+impl std::fmt::Display for ForkVersionDeserializeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            ForkVersionDeserializeError::SerdeValueError(ref err) => {
+                write!(f, "Serde deserialization error: {}", err)
+            }
+            ForkVersionDeserializeError::SerdeJsonError(ref err) => {
+                write!(f, "Serde deserialization error: {}", err)
+            }
+            ForkVersionDeserializeError::UnsupportedForkVersion(ref fork) => {
+                write!(f, "Unsupported fork: {}", fork)
+            }
+        }
+    }
+}
+
+pub type ForVersionResponseError = Box<dyn StdError + Send + Sync>;
 
 pub trait ForkVersionDecode: Sized {
     /// SSZ decode with explicit fork variant.
@@ -10,10 +42,10 @@ pub trait ForkVersionDecode: Sized {
 }
 
 pub trait ForkVersionDeserialize: Sized {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error>;
+    ) -> Result<Self, ForkVersionDeserializeError>;
 }
 
 /// Deserialize is only implemented for types that implement ForkVersionDeserialize.
@@ -64,7 +96,7 @@ where
         }
 
         let helper = Helper::deserialize(deserializer)?;
-        let data = F::deserialize_by_fork::<'de, D>(helper.data, helper.version)?;
+        let data = F::deserialize_by_fork(helper.data, helper.version).map_err(serde::de::Error::custom)?;
         let metadata = serde_json::from_value(helper.metadata).map_err(serde::de::Error::custom)?;
 
         Ok(ForkVersionedResponse {
@@ -76,11 +108,11 @@ where
 }
 
 impl<F: ForkVersionDeserialize> ForkVersionDeserialize for Arc<F> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        Ok(Arc::new(F::deserialize_by_fork::<'de, D>(
+    ) -> Result<Self, ForkVersionDeserializeError> {
+        Ok(Arc::new(F::deserialize_by_fork(
             value, fork_name,
         )?))
     }

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -9,7 +9,7 @@ pub trait ForkVersionDecode: Sized {
     fn from_ssz_bytes_by_fork(bytes: &[u8], fork_name: ForkName) -> Result<Self, ssz::DecodeError>;
 }
 
-pub trait ForkVersionDeserialize: Sized + DeserializeOwned {
+pub trait ForkVersionDeserialize: Sized {
     fn deserialize_by_fork<'de, D: Deserializer<'de>>(
         value: Value,
         fork_name: ForkName,
@@ -23,8 +23,7 @@ pub trait ForkVersionDeserialize: Sized + DeserializeOwned {
 /// `Deserialize`.
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct ForkVersionedResponse<T, M = EmptyMetadata> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<ForkName>,
+    pub version: ForkName,
     #[serde(flatten)]
     pub metadata: M,
     pub data: T,
@@ -58,17 +57,14 @@ where
     {
         #[derive(Deserialize)]
         struct Helper {
-            version: Option<ForkName>,
+            version: ForkName,
             #[serde(flatten)]
             metadata: serde_json::Value,
             data: serde_json::Value,
         }
 
         let helper = Helper::deserialize(deserializer)?;
-        let data = match helper.version {
-            Some(fork_name) => F::deserialize_by_fork::<'de, D>(helper.data, fork_name)?,
-            None => serde_json::from_value(helper.data).map_err(serde::de::Error::custom)?,
-        };
+        let data = F::deserialize_by_fork::<'de, D>(helper.data, helper.version)?;
         let metadata = serde_json::from_value(helper.metadata).map_err(serde::de::Error::custom)?;
 
         Ok(ForkVersionedResponse {
@@ -120,7 +116,7 @@ mod fork_version_response_tests {
 
         let response_json =
             serde_json::to_string(&json!(ForkVersionedResponse::<ExecutionPayload<E>> {
-                version: Some(ForkName::Bellatrix),
+                version: ForkName::Bellatrix,
                 metadata: Default::default(),
                 data: ExecutionPayload::Bellatrix(ExecutionPayloadBellatrix::default()),
             }))
@@ -138,7 +134,7 @@ mod fork_version_response_tests {
 
         let response_json =
             serde_json::to_string(&json!(ForkVersionedResponse::<ExecutionPayload<E>> {
-                version: Some(ForkName::Capella),
+                version: ForkName::Capella,
                 metadata: Default::default(),
                 data: ExecutionPayload::Bellatrix(ExecutionPayloadBellatrix::default()),
             }))

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -34,8 +34,6 @@ impl std::fmt::Display for ForkVersionDeserializeError {
     }
 }
 
-pub type ForVersionResponseError = Box<dyn StdError + Send + Sync>;
-
 pub trait ForkVersionDecode: Sized {
     /// SSZ decode with explicit fork variant.
     fn from_ssz_bytes_by_fork(bytes: &[u8], fork_name: ForkName) -> Result<Self, ssz::DecodeError>;

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -8,8 +8,6 @@ use std::sync::Arc;
 pub enum ForkVersionDeserializeError {
     SerdeJsonError(serde_json::Error),
     UnsupportedForkVersion(String),
-    SsePayloadDeserializationError(String),
-    FullPayloadDeserializationError(String),
 }
 
 impl std::fmt::Display for ForkVersionDeserializeError {
@@ -20,20 +18,6 @@ impl std::fmt::Display for ForkVersionDeserializeError {
             }
             ForkVersionDeserializeError::UnsupportedForkVersion(ref fork) => {
                 write!(f, "Unsupported fork: {}", fork)
-            }
-            ForkVersionDeserializeError::SsePayloadDeserializationError(ref fork) => {
-                write!(
-                    f,
-                    "SsePayloadAttributes deserialization for {} not implemented",
-                    fork
-                )
-            }
-            ForkVersionDeserializeError::FullPayloadDeserializationError(ref fork) => {
-                write!(
-                    f,
-                    "FullPayloadContents deserialization for {} not implemented",
-                    fork
-                )
             }
         }
     }

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -6,26 +6,15 @@ use std::sync::Arc;
 
 #[derive(Debug)]
 pub enum ForkVersionDeserializeError {
-    // TODO(fork-deserialize) we probably don't need these two similar variants
     SerdeJsonError(serde_json::Error),
-    SerdeValueError(serde::de::value::Error),
     UnsupportedForkVersion(String),
     SsePayloadDeserializationError(String),
     FullPayloadDeserializationError(String),
 }
 
-impl From<serde::de::value::Error> for ForkVersionDeserializeError {
-    fn from(err: serde::de::value::Error) -> Self {
-        ForkVersionDeserializeError::SerdeValueError(err)
-    }
-}
-
 impl std::fmt::Display for ForkVersionDeserializeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
-            ForkVersionDeserializeError::SerdeValueError(ref err) => {
-                write!(f, "Serde deserialization error: {}", err)
-            }
             ForkVersionDeserializeError::SerdeJsonError(ref err) => {
                 write!(f, "Serde deserialization error: {}", err)
             }

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -2,14 +2,16 @@ use crate::ForkName;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::value::Value;
-use std::error::Error as StdError;
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub enum ForkVersionDeserializeError {
     // TODO(fork-deserialize) we probably don't need these two similar variants
     SerdeJsonError(serde_json::Error),
     SerdeValueError(serde::de::value::Error),
-    UnsupportedForkVersion(String)
+    UnsupportedForkVersion(String),
+    SsePayloadDeserializationError(String),
+    FullPayloadDeserializationError(String),
 }
 
 impl From<serde::de::value::Error> for ForkVersionDeserializeError {
@@ -30,9 +32,25 @@ impl std::fmt::Display for ForkVersionDeserializeError {
             ForkVersionDeserializeError::UnsupportedForkVersion(ref fork) => {
                 write!(f, "Unsupported fork: {}", fork)
             }
+            ForkVersionDeserializeError::SsePayloadDeserializationError(ref fork) => {
+                write!(
+                    f,
+                    "SsePayloadAttributes deserialization for {} not implemented",
+                    fork
+                )
+            }
+            ForkVersionDeserializeError::FullPayloadDeserializationError(ref fork) => {
+                write!(
+                    f,
+                    "FullPayloadContents deserialization for {} not implemented",
+                    fork
+                )
+            }
         }
     }
 }
+
+impl std::error::Error for ForkVersionDeserializeError {}
 
 pub trait ForkVersionDecode: Sized {
     /// SSZ decode with explicit fork variant.
@@ -94,7 +112,8 @@ where
         }
 
         let helper = Helper::deserialize(deserializer)?;
-        let data = F::deserialize_by_fork(helper.data, helper.version).map_err(serde::de::Error::custom)?;
+        let data = F::deserialize_by_fork(helper.data, helper.version)
+            .map_err(serde::de::Error::custom)?;
         let metadata = serde_json::from_value(helper.metadata).map_err(serde::de::Error::custom)?;
 
         Ok(ForkVersionedResponse {
@@ -110,9 +129,7 @@ impl<F: ForkVersionDeserialize> ForkVersionDeserialize for Arc<F> {
         value: Value,
         fork_name: ForkName,
     ) -> Result<Self, ForkVersionDeserializeError> {
-        Ok(Arc::new(F::deserialize_by_fork(
-            value, fork_name,
-        )?))
+        Ok(Arc::new(F::deserialize_by_fork(value, fork_name)?))
     }
 }
 

--- a/consensus/types/src/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client_bootstrap.rs
@@ -1,11 +1,12 @@
 use crate::{
-    light_client_update::*, test_utils::TestRandom, BeaconState, ChainSpec, EthSpec, FixedVector,
-    ForkName, ForkVersionDeserialize, Hash256, LightClientHeader, LightClientHeaderAltair,
+    fork_versioned_response::ForkVersionDeserializeError, light_client_update::*,
+    test_utils::TestRandom, BeaconState, ChainSpec, EthSpec, FixedVector, ForkName,
+    ForkVersionDeserialize, Hash256, LightClientHeader, LightClientHeaderAltair,
     LightClientHeaderCapella, LightClientHeaderDeneb, LightClientHeaderElectra,
     LightClientHeaderFulu, SignedBlindedBeaconBlock, Slot, SyncCommittee,
 };
 use derivative::Derivative;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
@@ -214,18 +215,20 @@ impl<E: EthSpec> LightClientBootstrap<E> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for LightClientBootstrap<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         if fork_name.altair_enabled() {
-            Ok(serde_json::from_value::<LightClientBootstrap<E>>(value)
-                .map_err(serde::de::Error::custom))?
+            serde_json::from_value::<LightClientBootstrap<E>>(value)
+                .map_err(ForkVersionDeserializeError::SerdeJsonError)
         } else {
-            Err(serde::de::Error::custom(format!(
-                "LightClientBootstrap failed to deserialize: unsupported fork '{}'",
-                fork_name
-            )))
+            Err(ForkVersionDeserializeError::UnsupportedForkVersion(
+                format!(
+                    "LightClientBootstrap failed to deserialize: unsupported fork '{}'",
+                    fork_name
+                ),
+            ))
         }
     }
 }

--- a/consensus/types/src/light_client_finality_update.rs
+++ b/consensus/types/src/light_client_finality_update.rs
@@ -1,12 +1,13 @@
 use super::{EthSpec, FixedVector, Hash256, LightClientHeader, Slot, SyncAggregate};
 use crate::ChainSpec;
 use crate::{
-    light_client_update::*, test_utils::TestRandom, ForkName, ForkVersionDeserialize,
-    LightClientHeaderAltair, LightClientHeaderCapella, LightClientHeaderDeneb,
-    LightClientHeaderElectra, LightClientHeaderFulu, SignedBlindedBeaconBlock,
+    fork_versioned_response::ForkVersionDeserializeError, light_client_update::*,
+    test_utils::TestRandom, ForkName, ForkVersionDeserialize, LightClientHeaderAltair,
+    LightClientHeaderCapella, LightClientHeaderDeneb, LightClientHeaderElectra,
+    LightClientHeaderFulu, SignedBlindedBeaconBlock,
 };
 use derivative::Derivative;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ssz::{Decode, Encode};
 use ssz_derive::Decode;
@@ -234,18 +235,20 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for LightClientFinalityUpdate<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         if fork_name.altair_enabled() {
             serde_json::from_value::<LightClientFinalityUpdate<E>>(value)
-                .map_err(serde::de::Error::custom)
+                .map_err(ForkVersionDeserializeError::SerdeJsonError)
         } else {
-            Err(serde::de::Error::custom(format!(
-                "LightClientFinalityUpdate failed to deserialize: unsupported fork '{}'",
-                fork_name
-            )))
+            Err(ForkVersionDeserializeError::UnsupportedForkVersion(
+                format!(
+                    "LightClientFinalityUpdate failed to deserialize: unsupported fork '{}'",
+                    fork_name
+                ),
+            ))
         }
     }
 }

--- a/consensus/types/src/light_client_header.rs
+++ b/consensus/types/src/light_client_header.rs
@@ -1,12 +1,12 @@
 use crate::ChainSpec;
 use crate::ForkName;
 use crate::ForkVersionDeserialize;
-use crate::{light_client_update::*, BeaconBlockBody};
 use crate::{
-    test_utils::TestRandom, EthSpec, ExecutionPayloadHeaderCapella, ExecutionPayloadHeaderDeneb,
-    ExecutionPayloadHeaderElectra, ExecutionPayloadHeaderFulu, FixedVector, Hash256,
-    SignedBlindedBeaconBlock,
+    fork_versioned_response::ForkVersionDeserializeError, test_utils::TestRandom, EthSpec,
+    ExecutionPayloadHeaderCapella, ExecutionPayloadHeaderDeneb, ExecutionPayloadHeaderElectra,
+    ExecutionPayloadHeaderFulu, FixedVector, Hash256, SignedBlindedBeaconBlock,
 };
+use crate::{light_client_update::*, BeaconBlockBody};
 use crate::{BeaconBlockHeader, ExecutionPayloadHeader};
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
@@ -335,29 +335,29 @@ impl<E: EthSpec> Default for LightClientHeaderFulu<E> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for LightClientHeader<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         match fork_name {
             ForkName::Altair | ForkName::Bellatrix => serde_json::from_value(value)
                 .map(|light_client_header| Self::Altair(light_client_header))
-                .map_err(serde::de::Error::custom),
+                .map_err(ForkVersionDeserializeError::SerdeJsonError),
             ForkName::Capella => serde_json::from_value(value)
                 .map(|light_client_header| Self::Capella(light_client_header))
-                .map_err(serde::de::Error::custom),
+                .map_err(ForkVersionDeserializeError::SerdeJsonError),
             ForkName::Deneb => serde_json::from_value(value)
                 .map(|light_client_header| Self::Deneb(light_client_header))
-                .map_err(serde::de::Error::custom),
+                .map_err(ForkVersionDeserializeError::SerdeJsonError),
             ForkName::Electra => serde_json::from_value(value)
                 .map(|light_client_header| Self::Electra(light_client_header))
-                .map_err(serde::de::Error::custom),
+                .map_err(ForkVersionDeserializeError::SerdeJsonError),
             ForkName::Fulu => serde_json::from_value(value)
                 .map(|light_client_header| Self::Fulu(light_client_header))
-                .map_err(serde::de::Error::custom),
-            ForkName::Base => Err(serde::de::Error::custom(format!(
-                "LightClientHeader deserialization for {fork_name} not implemented"
-            ))),
+                .map_err(ForkVersionDeserializeError::SerdeJsonError),
+            ForkName::Base => Err(ForkVersionDeserializeError::UnsupportedForkVersion(
+                format!("LightClientHeader deserialization for {fork_name} not implemented"),
+            )),
         }
     }
 }

--- a/consensus/types/src/light_client_optimistic_update.rs
+++ b/consensus/types/src/light_client_optimistic_update.rs
@@ -1,12 +1,12 @@
 use super::{EthSpec, ForkName, ForkVersionDeserialize, LightClientHeader, Slot, SyncAggregate};
 use crate::test_utils::TestRandom;
 use crate::{
-    light_client_update::*, ChainSpec, LightClientHeaderAltair, LightClientHeaderCapella,
-    LightClientHeaderDeneb, LightClientHeaderElectra, LightClientHeaderFulu,
-    SignedBlindedBeaconBlock,
+    fork_versioned_response::ForkVersionDeserializeError, light_client_update::*, ChainSpec,
+    LightClientHeaderAltair, LightClientHeaderCapella, LightClientHeaderDeneb,
+    LightClientHeaderElectra, LightClientHeaderFulu, SignedBlindedBeaconBlock,
 };
 use derivative::Derivative;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ssz::{Decode, Encode};
 use ssz_derive::Decode;
@@ -207,20 +207,20 @@ impl<E: EthSpec> LightClientOptimisticUpdate<E> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for LightClientOptimisticUpdate<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         if fork_name.altair_enabled() {
-            Ok(
-                serde_json::from_value::<LightClientOptimisticUpdate<E>>(value)
-                    .map_err(serde::de::Error::custom),
-            )?
+            serde_json::from_value::<LightClientOptimisticUpdate<E>>(value)
+                .map_err(ForkVersionDeserializeError::SerdeJsonError)
         } else {
-            Err(serde::de::Error::custom(format!(
-                "LightClientOptimisticUpdate failed to deserialize: unsupported fork '{}'",
-                fork_name
-            )))
+            Err(ForkVersionDeserializeError::UnsupportedForkVersion(
+                format!(
+                    "LightClientOptimisticUpdate failed to deserialize: unsupported fork '{}'",
+                    fork_name
+                ),
+            ))
         }
     }
 }

--- a/consensus/types/src/light_client_update.rs
+++ b/consensus/types/src/light_client_update.rs
@@ -2,14 +2,15 @@ use super::{EthSpec, FixedVector, Hash256, Slot, SyncAggregate, SyncCommittee};
 use crate::light_client_header::LightClientHeaderElectra;
 use crate::LightClientHeader;
 use crate::{
-    beacon_state, test_utils::TestRandom, ChainSpec, Epoch, ForkName, ForkVersionDeserialize,
-    LightClientHeaderAltair, LightClientHeaderCapella, LightClientHeaderDeneb,
-    LightClientHeaderFulu, SignedBlindedBeaconBlock,
+    beacon_state, fork_versioned_response::ForkVersionDeserializeError, test_utils::TestRandom,
+    ChainSpec, Epoch, ForkName, ForkVersionDeserialize, LightClientHeaderAltair,
+    LightClientHeaderCapella, LightClientHeaderDeneb, LightClientHeaderFulu,
+    SignedBlindedBeaconBlock,
 };
 use derivative::Derivative;
 use safe_arith::ArithError;
 use safe_arith::SafeArith;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ssz::{Decode, Encode};
 use ssz_derive::Decode;
@@ -181,17 +182,20 @@ pub struct LightClientUpdate<E: EthSpec> {
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for LightClientUpdate<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         match fork_name {
-            ForkName::Base => Err(serde::de::Error::custom(format!(
-                "LightClientUpdate failed to deserialize: unsupported fork '{}'",
-                fork_name
-            ))),
-            _ => Ok(serde_json::from_value::<LightClientUpdate<E>>(value)
-                .map_err(serde::de::Error::custom))?,
+            ForkName::Base => Err(ForkVersionDeserializeError::UnsupportedForkVersion(
+                format!(
+                    "LightClientUpdate failed to deserialize: unsupported fork
+                '{}'",
+                    fork_name
+                ),
+            )),
+            _ => serde_json::from_value::<LightClientUpdate<E>>(value)
+                .map_err(ForkVersionDeserializeError::SerdeJsonError),
         }
     }
 }

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -712,7 +712,7 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> ForkVersionDeserialize
             fork_name,
             Self,
             serde_json::from_value(value)
-                .map_err(|e| ForkVersionDeserializeError::SerdeJsonError(e))?
+                .map_err(ForkVersionDeserializeError::SerdeJsonError)?
         ))
     }
 }

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -1,4 +1,5 @@
 use crate::beacon_block_body::{format_kzg_commitments, BLOB_KZG_COMMITMENTS_INDEX};
+use crate::fork_versioned_response::ForkVersionDeserializeError;
 use crate::*;
 use derivative::Derivative;
 use merkle_proof::MerkleTree;
@@ -703,17 +704,15 @@ impl<E: EthSpec> SignedBeaconBlock<E> {
 impl<E: EthSpec, Payload: AbstractExecPayload<E>> ForkVersionDeserialize
     for SignedBeaconBlock<E, Payload>
 {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+    fn deserialize_by_fork(
         value: serde_json::value::Value,
         fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+    ) -> Result<Self, ForkVersionDeserializeError> {
         Ok(map_fork_name!(
             fork_name,
             Self,
-            serde_json::from_value(value).map_err(|e| serde::de::Error::custom(format!(
-                "SignedBeaconBlock failed to deserialize: {:?}",
-                e
-            )))?
+            serde_json::from_value(value)
+                .map_err(|e| ForkVersionDeserializeError::SerdeJsonError(e))?
         ))
     }
 }

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -711,8 +711,7 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> ForkVersionDeserialize
         Ok(map_fork_name!(
             fork_name,
             Self,
-            serde_json::from_value(value)
-                .map_err(ForkVersionDeserializeError::SerdeJsonError)?
+            serde_json::from_value(value).map_err(ForkVersionDeserializeError::SerdeJsonError)?
         ))
     }
 }

--- a/lcli.log
+++ b/lcli.log
@@ -1,6 +1,0 @@
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.45s
-     Running `target/debug/lcli mock-el --jwt-output-path /Users/eitan/.secrets/jwt-sigma-prime.hex --all-payloads-valid true --shanghai-time 0 --cancun-time 0 --prague-time 0 --osaka-time 1744212912`
-No logfile path provided, logging to file is disabled
-Using --all-payloads-valid=true can be dangerous. Never use this flag when operating validators.
-This tool is for TESTING PURPOSES ONLY. Do not use in production or on mainnet. It cannot perform validator duties. It may cause nodes to follow an invalid chain.
-Server listening on 127.0.0.1:8551

--- a/lcli.log
+++ b/lcli.log
@@ -1,0 +1,6 @@
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.45s
+     Running `target/debug/lcli mock-el --jwt-output-path /Users/eitan/.secrets/jwt-sigma-prime.hex --all-payloads-valid true --shanghai-time 0 --cancun-time 0 --prague-time 0 --osaka-time 1744212912`
+No logfile path provided, logging to file is disabled
+Using --all-payloads-valid=true can be dangerous. Never use this flag when operating validators.
+This tool is for TESTING PURPOSES ONLY. Do not use in production or on mainnet. It cannot perform validator duties. It may cause nodes to follow an invalid chain.
+Server listening on 127.0.0.1:8551

--- a/testing/ef_tests/src/cases/common.rs
+++ b/testing/ef_tests/src/cases/common.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
 use std::fmt::Debug;
-use types::ForkName;
+use types::{ForkName, ForkVersionDeserialize};
 
 /// Macro to wrap U128 and U256 so they deserialize correctly.
 macro_rules! uint_wrapper {
@@ -54,6 +54,18 @@ pub trait SszStaticType:
 
 impl<T> SszStaticType for T where
     T: serde::de::DeserializeOwned + Encode + Clone + PartialEq + Debug + Sync
+{
+}
+
+
+/// Trait for types that can be used in SSZ static tests.
+pub trait ForkVersionedSszStaticType:
+    ForkVersionDeserialize + Encode + Clone + PartialEq + Debug + Sync
+{
+}
+
+impl<T> ForkVersionedSszStaticType for T where
+    T: ForkVersionDeserialize + Encode + Clone + PartialEq + Debug + Sync
 {
 }
 

--- a/testing/ef_tests/src/cases/common.rs
+++ b/testing/ef_tests/src/cases/common.rs
@@ -57,7 +57,6 @@ impl<T> SszStaticType for T where
 {
 }
 
-
 /// Trait for types that can be used in SSZ static tests.
 pub trait ForkVersionedSszStaticType:
     ForkVersionDeserialize + Encode + Clone + PartialEq + Debug + Sync

--- a/testing/ef_tests/src/cases/ssz_static.rs
+++ b/testing/ef_tests/src/cases/ssz_static.rs
@@ -77,7 +77,6 @@ impl<T: SszStaticType> LoadCase for SszStaticWithSpec<T> {
     }
 }
 
-
 pub fn check_fork_version_serialization<T: ForkVersionedSszStaticType>(
     value: &T,
     serialized: &[u8],

--- a/testing/ef_tests/src/cases/ssz_static.rs
+++ b/testing/ef_tests/src/cases/ssz_static.rs
@@ -1,3 +1,4 @@
+use super::common::ForkVersionedSszStaticType;
 use super::*;
 use crate::case_result::compare_result;
 use crate::decode::{snappy_decode_file, yaml_decode_file};
@@ -76,6 +77,24 @@ impl<T: SszStaticType> LoadCase for SszStaticWithSpec<T> {
     }
 }
 
+
+pub fn check_fork_version_serialization<T: ForkVersionedSszStaticType>(
+    value: &T,
+    serialized: &[u8],
+    deserializer: impl FnOnce(&[u8]) -> Result<T, ssz::DecodeError>,
+) -> Result<(), Error> {
+    // Check serialization
+    let serialized_result = value.as_ssz_bytes();
+    compare_result::<usize, Error>(&Ok(value.ssz_bytes_len()), &Some(serialized.len()))?;
+    compare_result::<Vec<u8>, Error>(&Ok(serialized_result), &Some(serialized.to_vec()))?;
+
+    // Check deserialization
+    let deserialized_result = deserializer(serialized);
+    compare_result(&deserialized_result, &Some(value.clone()))?;
+
+    Ok(())
+}
+
 pub fn check_serialization<T: SszStaticType>(
     value: &T,
     serialized: &[u8],
@@ -127,7 +146,7 @@ impl<E: EthSpec> Case for SszStaticTHC<BeaconState<E>> {
 impl<E: EthSpec> Case for SszStaticWithSpec<BeaconBlock<E>> {
     fn result(&self, _case_index: usize, fork_name: ForkName) -> Result<(), Error> {
         let spec = &testing_spec::<E>(fork_name);
-        check_serialization(&self.value, &self.serialized, |bytes| {
+        check_fork_version_serialization(&self.value, &self.serialized, |bytes| {
             BeaconBlock::from_ssz_bytes(bytes, spec)
         })?;
         check_tree_hash(&self.roots.root, self.value.tree_hash_root().as_slice())?;


### PR DESCRIPTION
## Issue Addressed

Fixes #7286 

## Proposed Changes

- Removed the bound from ForkVersionDeserialize
- Made the version field mandatory in ForkVersionedResponse

## Additional Info

Currently, only one test is failing, at `beacon_node/http_api/tests/tests.rs` at line 1621, all other tests pass