### PR TITLE
Fix Kurtosis doppelganger CI

### DIFF
--- a/scripts/tests/doppelganger_protection.sh
+++ b/scripts/tests/doppelganger_protection.sh
@@ -75,17 +75,27 @@ if [[ "$BEHAVIOR" == "failure" ]]; then
     service_name=vc-1-doppelganger
 
     kurtosis service add \
-      --files /validator_keys:$vc_1_keys_artifact_id,/testnet:el_cl_genesis_data \
-      $ENCLAVE_NAME $service_name $LH_IMAGE_NAME -- lighthouse \
-      vc \
-      --debug-level info \
-      --testnet-dir=/testnet \
-      --validators-dir=/validator_keys/keys \
-      --secrets-dir=/validator_keys/secrets \
-      --init-slashing-protection \
-      --beacon-nodes=http://$bn_2_url:$bn_2_port \
-      --enable-doppelganger-protection \
-      --suggested-fee-recipient 0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990
+      $ENCLAVE_NAME $service_name --json-service-config - <<EOF
+      {
+  "image": "$LH_IMAGE_NAME",
+  "files": {
+    "/validator_keys": ["$vc_1_keys_artifact_id"],
+    "/testnet": ["el_cl_genesis_data"]
+  },
+  "cmd": [
+    "lighthouse",
+    "vc",
+    "--debug-level", "info",
+    "--testnet-dir=/testnet",
+    "--validators-dir=/validator_keys/keys",
+    "--secrets-dir=/validator_keys/secrets",
+    "--init-slashing-protection",
+    "--beacon-nodes=http://$bn_2_url:$bn_2_port",
+    "--enable-doppelganger-protection",
+    "--suggested-fee-recipient", "0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990"
+  ]
+}
+EOF
 
     # Check if doppelganger VC has stopped and exited. Exit code 1 means the check timed out and VC is still running.
     check_exit_cmd="until [ \$(get_service_status $service_name) != 'RUNNING' ]; do sleep 1; done"
@@ -111,17 +121,27 @@ if [[ "$BEHAVIOR" == "success" ]]; then
     service_name=vc-4
 
     kurtosis service add \
-          --files /validator_keys:$vc_4_keys_artifact_id,/testnet:el_cl_genesis_data \
-          $ENCLAVE_NAME $service_name $LH_IMAGE_NAME -- lighthouse \
-          vc \
-          --debug-level debug \
-          --testnet-dir=/testnet \
-          --validators-dir=/validator_keys/keys \
-          --secrets-dir=/validator_keys/secrets \
-          --init-slashing-protection \
-          --beacon-nodes=http://$bn_2_url:$bn_2_port \
-          --enable-doppelganger-protection \
-          --suggested-fee-recipient 0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990
+          $ENCLAVE_NAME $service_name --json-service-config - << EOF
+{
+  "image": "$LH_IMAGE_NAME",
+  "files": {
+    "/validator_keys": ["$vc_4_keys_artifact_id"],
+    "/testnet": ["el_cl_genesis_data"]
+  },
+  "cmd": [
+    "lighthouse",
+    "vc",
+    "--debug-level", "info",
+    "--testnet-dir=/testnet",
+    "--validators-dir=/validator_keys/keys",
+    "--secrets-dir=/validator_keys/secrets",
+    "--init-slashing-protection",
+    "--beacon-nodes=http://$bn_2_url:$bn_2_port",
+    "--enable-doppelganger-protection",
+    "--suggested-fee-recipient", "0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990"
+  ]
+}
+EOF
 
     doppelganger_failure=0
 

--- a/scripts/tests/doppelganger_protection.sh
+++ b/scripts/tests/doppelganger_protection.sh
@@ -74,27 +74,26 @@ if [[ "$BEHAVIOR" == "failure" ]]; then
     vc_1_keys_artifact_id="1-lighthouse-geth-$vc_1_range_start-$vc_1_range_end"
     service_name=vc-1-doppelganger
 
-    kurtosis service add \
-      $ENCLAVE_NAME $service_name --json-service-config - <<EOF
-      {
-  "image": "$LH_IMAGE_NAME",
-  "files": {
-    "/validator_keys": ["$vc_1_keys_artifact_id"],
-    "/testnet": ["el_cl_genesis_data"]
-  },
-  "cmd": [
-    "lighthouse",
-    "vc",
-    "--debug-level", "info",
-    "--testnet-dir=/testnet",
-    "--validators-dir=/validator_keys/keys",
-    "--secrets-dir=/validator_keys/secrets",
-    "--init-slashing-protection",
-    "--beacon-nodes=http://$bn_2_url:$bn_2_port",
-    "--enable-doppelganger-protection",
-    "--suggested-fee-recipient", "0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990"
-  ]
-}
+    kurtosis service add $ENCLAVE_NAME $service_name --json-service-config - << EOF
+    {
+        "image": "$LH_IMAGE_NAME",
+        "files": {
+            "/validator_keys": ["$vc_1_keys_artifact_id"],
+            "/testnet": ["el_cl_genesis_data"]
+        },
+        "cmd": [
+            "lighthouse",
+            "vc",
+            "--debug-level", "info",
+            "--testnet-dir=/testnet",
+            "--validators-dir=/validator_keys/keys",
+            "--secrets-dir=/validator_keys/secrets",
+            "--init-slashing-protection",
+            "--beacon-nodes=http://$bn_2_url:$bn_2_port",
+            "--enable-doppelganger-protection",
+            "--suggested-fee-recipient", "0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990"
+        ]
+    }
 EOF
 
     # Check if doppelganger VC has stopped and exited. Exit code 1 means the check timed out and VC is still running.
@@ -120,27 +119,26 @@ if [[ "$BEHAVIOR" == "success" ]]; then
     vc_4_keys_artifact_id="4-lighthouse-geth-$vc_4_range_start-$vc_4_range_end"
     service_name=vc-4
 
-    kurtosis service add \
-          $ENCLAVE_NAME $service_name --json-service-config - << EOF
-{
-  "image": "$LH_IMAGE_NAME",
-  "files": {
-    "/validator_keys": ["$vc_4_keys_artifact_id"],
-    "/testnet": ["el_cl_genesis_data"]
-  },
-  "cmd": [
-    "lighthouse",
-    "vc",
-    "--debug-level", "info",
-    "--testnet-dir=/testnet",
-    "--validators-dir=/validator_keys/keys",
-    "--secrets-dir=/validator_keys/secrets",
-    "--init-slashing-protection",
-    "--beacon-nodes=http://$bn_2_url:$bn_2_port",
-    "--enable-doppelganger-protection",
-    "--suggested-fee-recipient", "0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990"
-  ]
-}
+    kurtosis service add $ENCLAVE_NAME $service_name --json-service-config - << EOF
+    {
+        "image": "$LH_IMAGE_NAME",
+        "files": {
+            "/validator_keys": ["$vc_4_keys_artifact_id"],
+            "/testnet": ["el_cl_genesis_data"]
+        },
+        "cmd": [
+            "lighthouse",
+            "vc",
+            "--debug-level", "info",
+            "--testnet-dir=/testnet",
+            "--validators-dir=/validator_keys/keys",
+            "--secrets-dir=/validator_keys/secrets",
+            "--init-slashing-protection",
+            "--beacon-nodes=http://$bn_2_url:$bn_2_port",
+            "--enable-doppelganger-protection",
+            "--suggested-fee-recipient", "0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990"
+        ]
+    }
 EOF
 
     doppelganger_failure=0


### PR DESCRIPTION
In recent Kurtosis update: https://github.com/kurtosis-tech/kurtosis/pull/2689
`kurtosis service add` cannot take many arguments anymore, rather, we can pass the arguments in `--json-service-config`

This PR updates the doppelganger tests scripts to follow the new format