### PR TITLE
Use latest stable fork in default ChainSpec

### DIFF
--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -445,7 +445,9 @@ impl EthSpec for MainnetEthSpec {
     type MaxPendingDepositsPerEpoch = U16;
 
     fn default_spec() -> ChainSpec {
-        ChainSpec::mainnet()
+        // We use a test spec with the latest fork enabled from genesis.
+        // For actual mainnet, we should be loading the `ChainSpec` from the `Eth2NetworkConfig`.
+        ForkName::latest_stable().make_genesis_spec(ChainSpec::mainnet())
     }
 
     fn spec_name() -> EthSpecId {
@@ -513,7 +515,7 @@ impl EthSpec for MinimalEthSpec {
     });
 
     fn default_spec() -> ChainSpec {
-        ChainSpec::minimal()
+        ForkName::latest_stable().make_genesis_spec(ChainSpec::minimal())
     }
 
     fn spec_name() -> EthSpecId {
@@ -578,7 +580,7 @@ impl EthSpec for GnosisEthSpec {
     type KzgCommitmentsInclusionProofDepth = U4;
 
     fn default_spec() -> ChainSpec {
-        ChainSpec::gnosis()
+        ForkName::latest_stable().make_genesis_spec(ChainSpec::gnosis())
     }
 
     fn spec_name() -> EthSpecId {


### PR DESCRIPTION
## Issue Addressed

The `E::default_spec()` functions are used in tests, but are a little strange in that they use the "real" spec for their `EthSpec`, e.g. the `MainnetEthSpec::default_spec()` is currently the spec for Ethereum mainnet!

This PR changes these functions to return simpler specs with the latest stable fork initialised from genesis. In test functions at low slot counts, this ensures we are testing the latest specs and not random phase0 stuff.

I suspect some of the tests will fail, so this is WIP for now.