### PR TITLE
Fix Kurtosis testnet

### DIFF
--- a/scripts/local_testnet/network_params.yaml
+++ b/scripts/local_testnet/network_params.yaml
@@ -14,5 +14,5 @@ global_log_level: debug
 snooper_enabled: false
 additional_services:
   - dora
-  - spamoor_blob
+  - spamoor
   - prometheus_grafana


### PR DESCRIPTION
## Issue Addressed

`spamoor_blob` is removed in https://github.com/ethpandaops/ethereum-package/pull/972. When attempting to start local testnet, it will error:

`
Evaluation error: fail: Invalid additional_services spamoor_blob, allowed fields: ["assertoor", "broadcaster", "tx_fuzz", "custom_flood", "forkmon", "blockscout", "dora", "full_beaconchain_explorer", "prometheus_grafana", "blobscan", "dugtrio", "blutgang", "forky", "apache", "tracoor", "spamoor"]
`

This PR changes `spamoor_blob` to `spamoor`. 