### PR TITLE
Make sure to log SyncingChain ID

### DIFF
--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -13,7 +13,6 @@ use logging::crit;
 use rand::seq::SliceRandom;
 use rand::Rng;
 use std::collections::{btree_map::Entry, BTreeMap, HashSet};
-use std::fmt;
 use strum::IntoStaticStr;
 use tracing::{debug, instrument, warn};
 use types::{Epoch, EthSpec, Hash256, Slot};
@@ -116,16 +115,6 @@ pub struct SyncingChain<T: BeaconChainTypes> {
     current_processing_batch: Option<BatchId>,
 }
 
-impl<T: BeaconChainTypes> fmt::Display for SyncingChain<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.chain_type {
-            SyncingChainType::Head => write!(f, "Head"),
-            SyncingChainType::Finalized => write!(f, "Finalized"),
-            SyncingChainType::Backfill => write!(f, "Backfill"),
-        }
-    }
-}
-
 #[derive(PartialEq, Debug)]
 pub enum ChainSyncingState {
     /// The chain is not being synced.
@@ -177,7 +166,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
 
     /// Get the chain's id.
     #[instrument(parent = None,level = "info", fields(chain = self.id , service = "range_sync"), skip_all)]
-    pub fn get_id(&self) -> ChainId {
+    pub fn id(&self) -> ChainId {
         self.id
     }
 

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -386,15 +386,15 @@ where
         op: &'static str,
     ) {
         if remove_reason.is_critical() {
-            crit!(?sync_type, %chain, reason = ?remove_reason,op, "Chain removed");
+            crit!(id = chain.id(), ?sync_type, reason = ?remove_reason, op, "Chain removed");
         } else {
-            debug!(?sync_type, %chain, reason = ?remove_reason,op, "Chain removed");
+            debug!(id = chain.id(), ?sync_type, reason = ?remove_reason, op, "Chain removed");
         }
 
         if let RemoveChain::ChainFailed { blacklist, .. } = remove_reason {
             if RangeSyncType::Finalized == sync_type && blacklist {
                 warn!(
-                    %chain,
+                    id = chain.id(),
                     "Chain failed! Syncing to its head won't be retried for at least the next {} seconds",
                     FAILED_CHAINS_EXPIRY_SECONDS
                 );


### PR DESCRIPTION
## Issue Addressed

Debugging an sync issue from @pawanjay176 I'm missing some key info where instead of logging the ID of the SyncingChain we just log "Finalized" (the sync type). This looks like some typo or something was lost in translation when refactoring things.

```
Apr 17 12:12:00.707 DEBUG Syncing new finalized chain                   chain: Finalized, component: "range_sync"
```

This log should include more info about the new chain but just logs "Finalized"

```
Apr 17 12:12:00.810 DEBUG New chain added to sync                       peer_id: "16Uiu2HAmHP8QLYQJwZ4cjMUEyRgxzpkJF87qPgNecLTpUdruYbdA", sync_type: Finalized, new_chain: Finalized, component: "range_sync"
```

## Proposed Changes

- Remove the Display impl and log the ID explicitly for all logs.
- Log more details when creating a new SyncingChain

