### PR TITLE
Change default state cache size back to 128

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -821,7 +821,7 @@ pub fn cli_app() -> Command {
                 .long("state-cache-size")
                 .value_name("STATE_CACHE_SIZE")
                 .help("Specifies the size of the state cache")
-                .default_value("32")
+                .default_value("128")
                 .action(ArgAction::Set)
                 .display_order(0)
         )

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -245,7 +245,9 @@ impl<E: EthSpec> StateCache<E> {
         let mut old_boundary_state_roots = vec![];
         let mut good_boundary_state_roots = vec![];
 
-        for (&state_root, (_, state)) in self.states.iter().skip(cull_exempt) {
+        // Skip the `cull_exempt` most-recently used, then reverse the iterator to start at
+        // least-recently used states.
+        for (&state_root, (_, state)) in self.states.iter().skip(cull_exempt).rev() {
             let is_advanced = state.slot() > state.latest_block_header().slot;
             let is_boundary = state.slot() % E::slots_per_epoch() == 0;
             let could_finalize =

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -389,7 +389,7 @@ Options:
           Minimum number of states to cull from the state cache when it gets
           full [default: 1]
       --state-cache-size <STATE_CACHE_SIZE>
-          Specifies the size of the state cache [default: 32]
+          Specifies the size of the state cache [default: 128]
       --suggested-fee-recipient <SUGGESTED-FEE-RECIPIENT>
           Emergency fallback fee recipient for use in case the validator client
           does not have one configured. You should set this flag on the

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1873,7 +1873,7 @@ fn block_cache_size_flag() {
 fn state_cache_size_default() {
     CommandLineTest::new()
         .run_with_zero_port()
-        .with_config(|config| assert_eq!(config.store.state_cache_size, new_non_zero_usize(32)));
+        .with_config(|config| assert_eq!(config.store.state_cache_size, new_non_zero_usize(128)));
 }
 #[test]
 fn state_cache_size_flag() {

--- a/scripts/tests/doppelganger_protection.sh
+++ b/scripts/tests/doppelganger_protection.sh
@@ -74,18 +74,27 @@ if [[ "$BEHAVIOR" == "failure" ]]; then
     vc_1_keys_artifact_id="1-lighthouse-geth-$vc_1_range_start-$vc_1_range_end"
     service_name=vc-1-doppelganger
 
-    kurtosis service add \
-      --files /validator_keys:$vc_1_keys_artifact_id,/testnet:el_cl_genesis_data \
-      $ENCLAVE_NAME $service_name $LH_IMAGE_NAME -- lighthouse \
-      vc \
-      --debug-level debug \
-      --testnet-dir=/testnet \
-      --validators-dir=/validator_keys/keys \
-      --secrets-dir=/validator_keys/secrets \
-      --init-slashing-protection \
-      --beacon-nodes=http://$bn_2_url:$bn_2_port \
-      --enable-doppelganger-protection \
-      --suggested-fee-recipient 0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990
+    kurtosis service add $ENCLAVE_NAME $service_name --json-service-config - << EOF
+    {
+        "image": "$LH_IMAGE_NAME",
+        "files": {
+            "/validator_keys": ["$vc_1_keys_artifact_id"],
+            "/testnet": ["el_cl_genesis_data"]
+        },
+        "cmd": [
+            "lighthouse",
+            "vc",
+            "--debug-level", "info",
+            "--testnet-dir=/testnet",
+            "--validators-dir=/validator_keys/keys",
+            "--secrets-dir=/validator_keys/secrets",
+            "--init-slashing-protection",
+            "--beacon-nodes=http://$bn_2_url:$bn_2_port",
+            "--enable-doppelganger-protection",
+            "--suggested-fee-recipient", "0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990"
+        ]
+    }
+EOF
 
     # Check if doppelganger VC has stopped and exited. Exit code 1 means the check timed out and VC is still running.
     check_exit_cmd="until [ \$(get_service_status $service_name) != 'RUNNING' ]; do sleep 1; done"
@@ -110,18 +119,27 @@ if [[ "$BEHAVIOR" == "success" ]]; then
     vc_4_keys_artifact_id="4-lighthouse-geth-$vc_4_range_start-$vc_4_range_end"
     service_name=vc-4
 
-    kurtosis service add \
-          --files /validator_keys:$vc_4_keys_artifact_id,/testnet:el_cl_genesis_data \
-          $ENCLAVE_NAME $service_name $LH_IMAGE_NAME -- lighthouse \
-          vc \
-          --debug-level debug \
-          --testnet-dir=/testnet \
-          --validators-dir=/validator_keys/keys \
-          --secrets-dir=/validator_keys/secrets \
-          --init-slashing-protection \
-          --beacon-nodes=http://$bn_2_url:$bn_2_port \
-          --enable-doppelganger-protection \
-          --suggested-fee-recipient 0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990
+    kurtosis service add $ENCLAVE_NAME $service_name --json-service-config - << EOF
+    {
+        "image": "$LH_IMAGE_NAME",
+        "files": {
+            "/validator_keys": ["$vc_4_keys_artifact_id"],
+            "/testnet": ["el_cl_genesis_data"]
+        },
+        "cmd": [
+            "lighthouse",
+            "vc",
+            "--debug-level", "info",
+            "--testnet-dir=/testnet",
+            "--validators-dir=/validator_keys/keys",
+            "--secrets-dir=/validator_keys/secrets",
+            "--init-slashing-protection",
+            "--beacon-nodes=http://$bn_2_url:$bn_2_port",
+            "--enable-doppelganger-protection",
+            "--suggested-fee-recipient", "0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990"
+        ]
+    }
+EOF
 
     doppelganger_failure=0
 


### PR DESCRIPTION
## Issue Addressed

Closes:

- https://github.com/sigp/lighthouse/issues/7363

## Proposed Changes

- Change default state cache size back to 128.
- Make state pruning properly LRU rather than MSU after skipping the cull-exempt states.
