### PR TITLE
blanket signed root

### DIFF
--- a/consensus/types/src/aggregate_and_proof.rs
+++ b/consensus/types/src/aggregate_and_proof.rs
@@ -144,6 +144,3 @@ impl<E: EthSpec> AggregateAndProof<E> {
         self.selection_proof().verify(validator_pubkey, message)
     }
 }
-
-impl<E: EthSpec> SignedRoot for AggregateAndProof<E> {}
-impl<E: EthSpec> SignedRoot for AggregateAndProofRef<'_, E> {}

--- a/consensus/types/src/attestation_data.rs
+++ b/consensus/types/src/attestation_data.rs
@@ -1,5 +1,5 @@
 use crate::test_utils::TestRandom;
-use crate::{Checkpoint, Hash256, SignedRoot, Slot};
+use crate::{Checkpoint, Hash256, Slot};
 
 use crate::slot_data::SlotData;
 use serde::{Deserialize, Serialize};
@@ -37,8 +37,6 @@ pub struct AttestationData {
     pub source: Checkpoint,
     pub target: Checkpoint,
 }
-
-impl SignedRoot for AttestationData {}
 
 impl SlotData for AttestationData {
     fn get_slot(&self) -> Slot {

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -81,9 +81,6 @@ pub struct BeaconBlock<E: EthSpec, Payload: AbstractExecPayload<E> = FullPayload
 
 pub type BlindedBeaconBlock<E> = BeaconBlock<E, BlindedPayload<E>>;
 
-impl<E: EthSpec, Payload: AbstractExecPayload<E>> SignedRoot for BeaconBlock<E, Payload> {}
-impl<E: EthSpec, Payload: AbstractExecPayload<E>> SignedRoot for BeaconBlockRef<'_, E, Payload> {}
-
 /// Empty block trait for each block variant to implement.
 pub trait EmptyBlock {
     /// Returns an empty block to be used during genesis.

--- a/consensus/types/src/beacon_block_header.rs
+++ b/consensus/types/src/beacon_block_header.rs
@@ -33,8 +33,6 @@ pub struct BeaconBlockHeader {
     pub body_root: Hash256,
 }
 
-impl SignedRoot for BeaconBlockHeader {}
-
 impl BeaconBlockHeader {
     /// Returns the `tree_hash_root` of the header.
     ///

--- a/consensus/types/src/bls_to_execution_change.rs
+++ b/consensus/types/src/bls_to_execution_change.rs
@@ -27,8 +27,6 @@ pub struct BlsToExecutionChange {
     pub to_execution_address: Address,
 }
 
-impl SignedRoot for BlsToExecutionChange {}
-
 impl BlsToExecutionChange {
     pub fn sign(
         self,

--- a/consensus/types/src/builder_bid.rs
+++ b/consensus/types/src/builder_bid.rs
@@ -98,8 +98,6 @@ impl<E: EthSpec> ForkVersionDecode for BuilderBid<E> {
     }
 }
 
-impl<E: EthSpec> SignedRoot for BuilderBid<E> {}
-
 /// Validator registration, for use in interacting with servers implementing the builder API.
 #[derive(PartialEq, Debug, Encode, Serialize, Deserialize, Clone)]
 #[serde(bound = "E: EthSpec")]

--- a/consensus/types/src/consolidation_request.rs
+++ b/consensus/types/src/consolidation_request.rs
@@ -1,4 +1,4 @@
-use crate::{test_utils::TestRandom, Address, PublicKeyBytes, SignedRoot};
+use crate::{test_utils::TestRandom, Address, PublicKeyBytes};
 use serde::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
@@ -36,8 +36,6 @@ impl ConsolidationRequest {
         .len()
     }
 }
-
-impl SignedRoot for ConsolidationRequest {}
 
 #[cfg(test)]
 mod tests {

--- a/consensus/types/src/contribution_and_proof.rs
+++ b/consensus/types/src/contribution_and_proof.rs
@@ -1,5 +1,5 @@
 use super::{
-    ChainSpec, EthSpec, Fork, Hash256, SecretKey, Signature, SignedRoot, SyncCommitteeContribution,
+    ChainSpec, EthSpec, Fork, Hash256, SecretKey, Signature, SyncCommitteeContribution,
     SyncSelectionProof,
 };
 use crate::test_utils::TestRandom;
@@ -68,5 +68,3 @@ impl<E: EthSpec> ContributionAndProof<E> {
         }
     }
 }
-
-impl<E: EthSpec> SignedRoot for ContributionAndProof<E> {}

--- a/consensus/types/src/deposit_message.rs
+++ b/consensus/types/src/deposit_message.rs
@@ -28,8 +28,6 @@ pub struct DepositMessage {
     pub amount: u64,
 }
 
-impl SignedRoot for DepositMessage {}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/consensus/types/src/fork_data.rs
+++ b/consensus/types/src/fork_data.rs
@@ -1,5 +1,5 @@
 use crate::test_utils::TestRandom;
-use crate::{Hash256, SignedRoot};
+use crate::Hash256;
 
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -27,8 +27,6 @@ pub struct ForkData {
     pub current_version: [u8; 4],
     pub genesis_validators_root: Hash256,
 }
-
-impl SignedRoot for ForkData {}
 
 #[cfg(test)]
 mod tests {

--- a/consensus/types/src/signing_data.rs
+++ b/consensus/types/src/signing_data.rs
@@ -33,3 +33,5 @@ pub trait SignedRoot: TreeHash {
         .tree_hash_root()
     }
 }
+
+impl<T: TreeHash> SignedRoot for T {}

--- a/consensus/types/src/slot_epoch.rs
+++ b/consensus/types/src/slot_epoch.rs
@@ -11,7 +11,7 @@
 //! may lead to programming errors which are not detected by the compiler.
 
 use crate::test_utils::TestRandom;
-use crate::{ChainSpec, SignedRoot};
+use crate::ChainSpec;
 
 use rand::RngCore;
 use safe_arith::{ArithError, SafeArith};

--- a/consensus/types/src/slot_epoch_macros.rs
+++ b/consensus/types/src/slot_epoch_macros.rs
@@ -292,8 +292,6 @@ macro_rules! impl_ssz {
             }
         }
 
-        impl SignedRoot for $type {}
-
         impl TestRandom for $type {
             fn random_for_test(rng: &mut impl RngCore) -> Self {
                 $type::from(u64::random_for_test(rng))

--- a/consensus/types/src/sync_aggregator_selection_data.rs
+++ b/consensus/types/src/sync_aggregator_selection_data.rs
@@ -1,5 +1,5 @@
 use crate::test_utils::TestRandom;
-use crate::{SignedRoot, Slot};
+use crate::Slot;
 
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -24,8 +24,6 @@ pub struct SyncAggregatorSelectionData {
     #[serde(with = "serde_utils::quoted_u64")]
     pub subcommittee_index: u64,
 }
-
-impl SignedRoot for SyncAggregatorSelectionData {}
 
 #[cfg(test)]
 mod tests {

--- a/consensus/types/src/sync_committee_contribution.rs
+++ b/consensus/types/src/sync_committee_contribution.rs
@@ -1,4 +1,4 @@
-use super::{AggregateSignature, EthSpec, SignedRoot};
+use super::{AggregateSignature, EthSpec};
 use crate::slot_data::SlotData;
 use crate::{test_utils::TestRandom, BitVector, Hash256, Slot, SyncCommitteeMessage};
 use serde::{Deserialize, Serialize};
@@ -74,8 +74,6 @@ impl<E: EthSpec> SyncCommitteeContribution<E> {
         self.signature.add_assign_aggregate(&other.signature);
     }
 }
-
-impl SignedRoot for Hash256 {}
 
 /// This is not in the spec, but useful for determining uniqueness of sync committee contributions
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]

--- a/consensus/types/src/validator_registration_data.rs
+++ b/consensus/types/src/validator_registration_data.rs
@@ -21,8 +21,6 @@ pub struct ValidatorRegistrationData {
     pub pubkey: PublicKeyBytes,
 }
 
-impl SignedRoot for ValidatorRegistrationData {}
-
 impl SignedValidatorRegistrationData {
     pub fn verify_signature(&self, spec: &ChainSpec) -> bool {
         self.message

--- a/consensus/types/src/voluntary_exit.rs
+++ b/consensus/types/src/voluntary_exit.rs
@@ -31,8 +31,6 @@ pub struct VoluntaryExit {
     pub validator_index: u64,
 }
 
-impl SignedRoot for VoluntaryExit {}
-
 impl VoluntaryExit {
     pub fn sign(
         self,


### PR DESCRIPTION
## Issue Addressed

We ([Helix](https://github.com/gattaca-com/helix) relay), have recently switched our consensus types to Lighthouse. During integration we made a few small quality of life changes that would be great to upstream so we can get rid of the fork. Overall all the changes are quite small and don't change any core logic.

## Proposed Changes

Make a blanket implementation of `SignedRoot` for all impls of `TreeHash`
