### PR TITLE
ContextDeserialize and Beacon API Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,6 @@ name = "context_deserialize_derive"
 version = "0.1.0"
 dependencies = [
  "quote",
- "serde",
  "syn 1.0.109",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,6 +1666,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "context_deserialize"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "context_deserialize_derive"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "serde",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9389,6 +9405,8 @@ dependencies = [
  "bls",
  "compare_fields",
  "compare_fields_derive",
+ "context_deserialize",
+ "context_deserialize_derive",
  "criterion",
  "derivative",
  "eth2_interop_keypairs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 name = "context_deserialize"
 version = "0.1.0"
 dependencies = [
+ "milhouse",
  "serde",
+ "ssz_types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,7 +1678,10 @@ dependencies = [
 name = "context_deserialize_derive"
 version = "0.1.0"
 dependencies = [
+ "context_deserialize",
  "quote",
+ "serde",
+ "serde_json",
  "syn 1.0.109",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ members = [
     "common/warp_utils",
     "common/workspace_members",
 
+    "consensus/context_deserialize",
+    "consensus/context_deserialize_derive",
     "consensus/fixed_bytes",
     "consensus/fork_choice",
     "consensus/int_to_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,8 @@ clap = { version = "4.5.4", features = ["derive", "cargo", "wrap_help"] }
 # feature ourselves when desired.
 c-kzg = { version = "1", default-features = false }
 compare_fields_derive = { path = "common/compare_fields_derive" }
+context_deserialize = { path = "consensus/context_deserialize" }
+context_deserialize_derive = { path = "consensus/context_deserialize_derive" }
 criterion = "0.5"
 delay_map = "0.4"
 derivative = "2"

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -6108,7 +6108,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         payload_attributes: payload_attributes.into(),
                     },
                     metadata: Default::default(),
-                    version: Some(self.spec.fork_name_at_slot::<T::EthSpec>(prepare_slot)),
+                    version: self.spec.fork_name_at_slot::<T::EthSpec>(prepare_slot),
                 }));
             }
         }

--- a/beacon_node/builder_client/src/lib.rs
+++ b/beacon_node/builder_client/src/lib.rs
@@ -1,5 +1,5 @@
+use eth2::types::beacon_response::EmptyMetadata;
 use eth2::types::builder_bid::SignedBuilderBid;
-use eth2::types::fork_versioned_response::EmptyMetadata;
 use eth2::types::{
     ContentType, ContextDeserialize, EthSpec, ExecutionBlockHash, ForkName, ForkVersionDecode,
     ForkVersionedResponse, PublicKeyBytes, SignedValidatorRegistrationData, Slot,

--- a/beacon_node/builder_client/src/lib.rs
+++ b/beacon_node/builder_client/src/lib.rs
@@ -1,7 +1,7 @@
 use eth2::types::builder_bid::SignedBuilderBid;
 use eth2::types::fork_versioned_response::EmptyMetadata;
 use eth2::types::{
-    ContentType, EthSpec, ExecutionBlockHash, ForkName, ForkVersionDecode, ForkVersionDeserialize,
+    ContentType, ContextDeserialize, EthSpec, ExecutionBlockHash, ForkName, ForkVersionDecode,
     ForkVersionedResponse, PublicKeyBytes, SignedValidatorRegistrationData, Slot,
 };
 use eth2::types::{FullPayloadContents, SignedBlindedBeaconBlock};
@@ -119,7 +119,7 @@ impl BuilderHttpClient {
     }
 
     async fn get_with_header<
-        T: DeserializeOwned + ForkVersionDecode + ForkVersionDeserialize,
+        T: DeserializeOwned + ForkVersionDecode + for<'de> ContextDeserialize<'de, ForkName>,
         U: IntoUrl,
     >(
         &self,
@@ -147,7 +147,7 @@ impl BuilderHttpClient {
                 self.ssz_available.store(true, Ordering::SeqCst);
                 T::from_ssz_bytes_by_fork(&response_bytes, fork_name)
                     .map(|data| ForkVersionedResponse {
-                        version: Some(fork_name),
+                        version: fork_name,
                         metadata: EmptyMetadata {},
                         data,
                     })
@@ -155,7 +155,15 @@ impl BuilderHttpClient {
             }
             ContentType::Json => {
                 self.ssz_available.store(false, Ordering::SeqCst);
-                serde_json::from_slice(&response_bytes).map_err(Error::InvalidJson)
+                let mut de = serde_json::Deserializer::from_slice(&response_bytes);
+                let data =
+                    T::context_deserialize(&mut de, fork_name).map_err(Error::InvalidJson)?;
+
+                Ok(ForkVersionedResponse {
+                    version: fork_name,
+                    metadata: EmptyMetadata {},
+                    data,
+                })
             }
         }
     }

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -461,7 +461,7 @@ where
                 let blobs = if block.message().body().has_blobs() {
                     debug!("Downloading finalized blobs");
                     if let Some(response) = remote
-                        .get_blobs::<E>(BlockId::Root(block_root), None)
+                        .get_blobs::<E>(BlockId::Root(block_root), None, &spec)
                         .await
                         .map_err(|e| format!("Error fetching finalized blobs from remote: {e:?}"))?
                     {

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -466,7 +466,7 @@ where
                         .map_err(|e| format!("Error fetching finalized blobs from remote: {e:?}"))?
                     {
                         debug!("Downloaded finalized blobs");
-                        Some(response.data)
+                        Some(response.into_data())
                     } else {
                         warn!(
                             block_root = %block_root,

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2116,9 +2116,9 @@ fn verify_builder_bid<E: EthSpec>(
             payload: header.block_number(),
             expected: block_number,
         }))
-    } else if bid.version != Some(current_fork) {
+    } else if bid.version != current_fork {
         Err(Box::new(InvalidBuilderPayload::Fork {
-            payload: bid.version,
+            payload: Some(bid.version),
             expected: current_fork,
         }))
     } else if !is_signature_valid {

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1980,7 +1980,7 @@ enum InvalidBuilderPayload {
         expected: Option<u64>,
     },
     Fork {
-        payload: Option<ForkName>,
+        payload: ForkName,
         expected: ForkName,
     },
     Signature {
@@ -2013,7 +2013,7 @@ impl fmt::Display for InvalidBuilderPayload {
                 write!(f, "payload block number was {} not {:?}", payload, expected)
             }
             InvalidBuilderPayload::Fork { payload, expected } => {
-                write!(f, "payload fork was {:?} not {}", payload, expected)
+                write!(f, "payload fork was {} not {}", payload, expected)
             }
             InvalidBuilderPayload::Signature { signature, pubkey } => write!(
                 f,
@@ -2118,7 +2118,7 @@ fn verify_builder_bid<E: EthSpec>(
         }))
     } else if bid.version != current_fork {
         Err(Box::new(InvalidBuilderPayload::Fork {
-            payload: Some(bid.version),
+            payload: bid.version,
             expected: current_fork,
         }))
     } else if !is_signature_valid {

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -980,7 +980,7 @@ pub fn serve<E: EthSpec>(
                         .await
                         .map_err(|e| warp::reject::custom(Custom(e)))?;
                     let resp: ForkVersionedResponse<_> = ForkVersionedResponse {
-                        version: Some(fork_name),
+                        version: fork_name,
                         metadata: Default::default(),
                         data: payload,
                     };
@@ -1040,7 +1040,7 @@ pub fn serve<E: EthSpec>(
                     ),
                     eth2::types::Accept::Json | eth2::types::Accept::Any => {
                         let resp: ForkVersionedResponse<_> = ForkVersionedResponse {
-                            version: Some(fork_name),
+                            version: fork_name,
                             metadata: Default::default(),
                             data: signed_bid,
                         };

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -743,7 +743,7 @@ impl<E: EthSpec> MockBuilder<E> {
             .await
             .map_err(|_| "couldn't get head".to_string())?
             .ok_or_else(|| "missing head block".to_string())?
-            .data;
+            .into_data();
 
         let head_block_root = head_block_root.unwrap_or(head.canonical_root());
 
@@ -761,7 +761,7 @@ impl<E: EthSpec> MockBuilder<E> {
             .await
             .map_err(|_| "couldn't get finalized block".to_string())?
             .ok_or_else(|| "missing finalized block".to_string())?
-            .data
+            .data()
             .message()
             .body()
             .execution_payload()
@@ -774,7 +774,7 @@ impl<E: EthSpec> MockBuilder<E> {
             .await
             .map_err(|_| "couldn't get justified block".to_string())?
             .ok_or_else(|| "missing justified block".to_string())?
-            .data
+            .data()
             .message()
             .body()
             .execution_payload()
@@ -815,7 +815,7 @@ impl<E: EthSpec> MockBuilder<E> {
             .await
             .map_err(|_| "couldn't get state".to_string())?
             .ok_or_else(|| "missing state".to_string())?
-            .data;
+            .into_data();
 
         let prev_randao = head_state
             .get_randao_mix(head_state.current_epoch())

--- a/beacon_node/http_api/src/aggregate_attestation.rs
+++ b/beacon_node/http_api/src/aggregate_attestation.rs
@@ -52,7 +52,7 @@ pub fn get_aggregate_attestation<T: BeaconChainTypes>(
 
     if endpoint_version == V2 {
         let fork_versioned_response = ForkVersionedResponse {
-            version: Some(fork_name),
+            version: fork_name,
             metadata: EmptyMetadata {},
             data: aggregate_attestation,
         };

--- a/beacon_node/http_api/src/aggregate_attestation.rs
+++ b/beacon_node/http_api/src/aggregate_attestation.rs
@@ -4,7 +4,7 @@ use crate::version::{add_consensus_version_header, V1, V2};
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2::types::{self, EndpointVersion, Hash256, Slot};
 use std::sync::Arc;
-use types::fork_versioned_response::EmptyMetadata;
+use types::beacon_response::EmptyMetadata;
 use types::{CommitteeIndex, ForkVersionedResponse};
 use warp::{
     hyper::{Body, Response},

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -34,7 +34,7 @@ mod validators;
 mod version;
 use crate::light_client::{get_light_client_bootstrap, get_light_client_updates};
 use crate::produce_block::{produce_blinded_block_v2, produce_block_v2, produce_block_v3};
-use crate::version::fork_versioned_response;
+use crate::version::beacon_response;
 use beacon_chain::{
     attestation_verification::VerifiedAttestation, observed_operations::ObservationOutcome,
     validator_monitor::timestamp_now, AttestationError as AttnError, BeaconChain, BeaconChainError,
@@ -89,18 +89,17 @@ use tokio_stream::{
 use tracing::{debug, error, info, warn};
 use types::AttestationData;
 use types::{
-    fork_versioned_response::EmptyMetadata, Attestation, AttestationShufflingId, AttesterSlashing,
-    BeaconStateError, ChainSpec, Checkpoint, CommitteeCache, ConfigAndPreset, Epoch, EthSpec,
-    ForkName, ForkVersionedResponse, Hash256, ProposerPreparationData, ProposerSlashing,
-    RelativeEpoch, SignedAggregateAndProof, SignedBlindedBeaconBlock, SignedBlsToExecutionChange,
-    SignedContributionAndProof, SignedValidatorRegistrationData, SignedVoluntaryExit, Slot,
-    SyncCommitteeMessage, SyncContributionData,
+    Attestation, AttestationShufflingId, AttesterSlashing, BeaconStateError, ChainSpec, Checkpoint,
+    CommitteeCache, ConfigAndPreset, Epoch, EthSpec, ForkName, Hash256, ProposerPreparationData,
+    ProposerSlashing, RelativeEpoch, SignedAggregateAndProof, SignedBlindedBeaconBlock,
+    SignedBlsToExecutionChange, SignedContributionAndProof, SignedValidatorRegistrationData,
+    SignedVoluntaryExit, Slot, SyncCommitteeMessage, SyncContributionData,
 };
 use validator::pubkey_to_validator_index;
 use version::{
     add_consensus_version_header, add_ssz_content_type_header,
-    execution_optimistic_finalized_fork_versioned_response, inconsistent_fork_rejection,
-    unsupported_version_rejection, V1, V2, V3,
+    execution_optimistic_finalized_beacon_response, inconsistent_fork_rejection,
+    unsupported_version_rejection, ResponseIncludesVersion, V1, V2, V3,
 };
 use warp::http::StatusCode;
 use warp::hyper::Body;
@@ -1723,6 +1722,12 @@ pub fn serve<T: BeaconChainTypes>(
                         .fork_name(&chain.spec)
                         .map_err(inconsistent_fork_rejection)?;
 
+                    let require_version = match endpoint_version {
+                        V1 => ResponseIncludesVersion::No,
+                        V2 | V3 => ResponseIncludesVersion::Yes(fork_name),
+                        _ => return Err(unsupported_version_rejection(endpoint_version)),
+                    };
+
                     match accept_header {
                         Some(api_types::Accept::Ssz) => Response::builder()
                             .status(200)
@@ -1734,9 +1739,8 @@ pub fn serve<T: BeaconChainTypes>(
                                     e
                                 ))
                             }),
-                        _ => execution_optimistic_finalized_fork_versioned_response(
-                            endpoint_version,
-                            fork_name,
+                        _ => execution_optimistic_finalized_beacon_response(
+                            require_version,
                             execution_optimistic,
                             finalized,
                             block,
@@ -1796,9 +1800,15 @@ pub fn serve<T: BeaconChainTypes>(
                         .attestations()
                         .map(|att| att.clone_as_attestation())
                         .collect::<Vec<_>>();
-                    let res = execution_optimistic_finalized_fork_versioned_response(
-                        endpoint_version,
-                        fork_name,
+
+                    let require_version = match endpoint_version {
+                        V1 => ResponseIncludesVersion::No,
+                        V2 | V3 => ResponseIncludesVersion::Yes(fork_name),
+                        _ => return Err(unsupported_version_rejection(endpoint_version)),
+                    };
+
+                    let res = execution_optimistic_finalized_beacon_response(
+                        require_version,
                         execution_optimistic,
                         finalized,
                         &atts,
@@ -1845,9 +1855,8 @@ pub fn serve<T: BeaconChainTypes>(
                             }),
                         _ => {
                             // Post as a V2 endpoint so we return the fork version.
-                            execution_optimistic_finalized_fork_versioned_response(
-                                V2,
-                                fork_name,
+                            execution_optimistic_finalized_beacon_response(
+                                ResponseIncludesVersion::Yes(fork_name),
                                 execution_optimistic,
                                 finalized,
                                 block,
@@ -1901,9 +1910,8 @@ pub fn serve<T: BeaconChainTypes>(
                             }),
                         _ => {
                             // Post as a V2 endpoint so we return the fork version.
-                            let res = execution_optimistic_finalized_fork_versioned_response(
-                                V2,
-                                fork_name,
+                            let res = execution_optimistic_finalized_beacon_response(
+                                ResponseIncludesVersion::Yes(fork_name),
                                 execution_optimistic,
                                 finalized,
                                 &blob_sidecar_list_filtered,
@@ -2063,7 +2071,13 @@ pub fn serve<T: BeaconChainTypes>(
                         })
                         .collect::<Vec<_>>();
 
-                    let res = fork_versioned_response(endpoint_version, fork_name, &attestations)?;
+                    let require_version = match endpoint_version {
+                        V1 => ResponseIncludesVersion::No,
+                        V2 | V3 => ResponseIncludesVersion::Yes(fork_name),
+                        _ => return Err(unsupported_version_rejection(endpoint_version)),
+                    };
+
+                    let res = beacon_response(require_version, &attestations);
                     Ok(add_consensus_version_header(
                         warp::reply::json(&res).into_response(),
                         fork_name,
@@ -2152,7 +2166,13 @@ pub fn serve<T: BeaconChainTypes>(
                             })
                             .collect::<Vec<_>>();
 
-                        let res = fork_versioned_response(endpoint_version, fork_name, &slashings)?;
+                        let require_version = match endpoint_version {
+                            V1 => ResponseIncludesVersion::No,
+                            V2 | V3 => ResponseIncludesVersion::Yes(fork_name),
+                            _ => return Err(unsupported_version_rejection(endpoint_version)),
+                        };
+
+                        let res = beacon_response(require_version, &slashings);
                         Ok(add_consensus_version_header(
                             warp::reply::json(&res).into_response(),
                             fork_name,
@@ -2600,11 +2620,10 @@ pub fn serve<T: BeaconChainTypes>(
                                     e
                                 ))
                             }),
-                        _ => Ok(warp::reply::json(&ForkVersionedResponse {
-                            version: Some(fork_name),
-                            metadata: EmptyMetadata {},
-                            data: update,
-                        })
+                        _ => Ok(warp::reply::json(&beacon_response(
+                            ResponseIncludesVersion::Yes(fork_name),
+                            update,
+                        ))
                         .into_response()),
                     }
                     .map(|resp| add_consensus_version_header(resp, fork_name))
@@ -2649,11 +2668,10 @@ pub fn serve<T: BeaconChainTypes>(
                                     e
                                 ))
                             }),
-                        _ => Ok(warp::reply::json(&ForkVersionedResponse {
-                            version: Some(fork_name),
-                            metadata: EmptyMetadata {},
-                            data: update,
-                        })
+                        _ => Ok(warp::reply::json(&beacon_response(
+                            ResponseIncludesVersion::Yes(fork_name),
+                            update,
+                        ))
                         .into_response()),
                     }
                     .map(|resp| add_consensus_version_header(resp, fork_name))
@@ -2845,7 +2863,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(task_spawner_filter.clone())
         .and(chain_filter.clone())
         .then(
-            |endpoint_version: EndpointVersion,
+            |_endpoint_version: EndpointVersion,
              state_id: StateId,
              accept_header: Option<api_types::Accept>,
              task_spawner: TaskSpawner<T::EthSpec>,
@@ -2889,9 +2907,8 @@ pub fn serve<T: BeaconChainTypes>(
                             let fork_name = state
                                 .fork_name(&chain.spec)
                                 .map_err(inconsistent_fork_rejection)?;
-                            let res = execution_optimistic_finalized_fork_versioned_response(
-                                endpoint_version,
-                                fork_name,
+                            let res = execution_optimistic_finalized_beacon_response(
+                                ResponseIncludesVersion::Yes(fork_name),
                                 execution_optimistic,
                                 finalized,
                                 &state,
@@ -3371,7 +3388,7 @@ pub fn serve<T: BeaconChainTypes>(
                     if endpoint_version == V3 {
                         produce_block_v3(accept_header, chain, slot, query).await
                     } else {
-                        produce_block_v2(endpoint_version, accept_header, chain, slot, query).await
+                        produce_block_v2(accept_header, chain, slot, query).await
                     }
                 })
             },
@@ -3401,8 +3418,7 @@ pub fn serve<T: BeaconChainTypes>(
              chain: Arc<BeaconChain<T>>| {
                 task_spawner.spawn_async_with_rejection(Priority::P0, async move {
                     not_synced_filter?;
-                    produce_blinded_block_v2(EndpointVersion(2), accept_header, chain, slot, query)
-                        .await
+                    produce_blinded_block_v2(accept_header, chain, slot, query).await
                 })
             },
         );

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1152,8 +1152,8 @@ pub fn serve<T: BeaconChainTypes>(
             |state_id: StateId,
              task_spawner: TaskSpawner<T::EthSpec>,
              chain: Arc<BeaconChain<T>>| {
-                task_spawner.blocking_json_task(Priority::P1, move || {
-                    let (data, execution_optimistic, finalized) = state_id
+                task_spawner.blocking_response_task(Priority::P1, move || {
+                    let (data, execution_optimistic, finalized, fork_name) = state_id
                         .map_state_and_execution_optimistic_and_finalized(
                             &chain,
                             |state, execution_optimistic, finalized| {
@@ -1163,15 +1163,23 @@ pub fn serve<T: BeaconChainTypes>(
                                     ));
                                 };
 
-                                Ok((deposits.clone(), execution_optimistic, finalized))
+                                Ok((
+                                    deposits.clone(),
+                                    execution_optimistic,
+                                    finalized,
+                                    state.fork_name_unchecked(),
+                                ))
                             },
                         )?;
 
-                    Ok(api_types::ExecutionOptimisticFinalizedResponse {
+                    execution_optimistic_finalized_beacon_response(
+                        ResponseIncludesVersion::Yes(fork_name),
+                        execution_optimistic,
+                        finalized,
                         data,
-                        execution_optimistic: Some(execution_optimistic),
-                        finalized: Some(finalized),
-                    })
+                    )
+                    .map(|res| warp::reply::json(&res).into_response())
+                    .map(|resp| add_consensus_version_header(resp, fork_name))
                 })
             },
         );
@@ -1185,8 +1193,8 @@ pub fn serve<T: BeaconChainTypes>(
             |state_id: StateId,
              task_spawner: TaskSpawner<T::EthSpec>,
              chain: Arc<BeaconChain<T>>| {
-                task_spawner.blocking_json_task(Priority::P1, move || {
-                    let (data, execution_optimistic, finalized) = state_id
+                task_spawner.blocking_response_task(Priority::P1, move || {
+                    let (data, execution_optimistic, finalized, fork_name) = state_id
                         .map_state_and_execution_optimistic_and_finalized(
                             &chain,
                             |state, execution_optimistic, finalized| {
@@ -1196,15 +1204,23 @@ pub fn serve<T: BeaconChainTypes>(
                                     ));
                                 };
 
-                                Ok((withdrawals.clone(), execution_optimistic, finalized))
+                                Ok((
+                                    withdrawals.clone(),
+                                    execution_optimistic,
+                                    finalized,
+                                    state.fork_name_unchecked(),
+                                ))
                             },
                         )?;
 
-                    Ok(api_types::ExecutionOptimisticFinalizedResponse {
+                    execution_optimistic_finalized_beacon_response(
+                        ResponseIncludesVersion::Yes(fork_name),
+                        execution_optimistic,
+                        finalized,
                         data,
-                        execution_optimistic: Some(execution_optimistic),
-                        finalized: Some(finalized),
-                    })
+                    )
+                    .map(|res| warp::reply::json(&res).into_response())
+                    .map(|resp| add_consensus_version_header(resp, fork_name))
                 })
             },
         );

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1740,7 +1740,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     let require_version = match endpoint_version {
                         V1 => ResponseIncludesVersion::No,
-                        V2 | V3 => ResponseIncludesVersion::Yes(fork_name),
+                        V2 => ResponseIncludesVersion::Yes(fork_name),
                         _ => return Err(unsupported_version_rejection(endpoint_version)),
                     };
 
@@ -1819,7 +1819,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     let require_version = match endpoint_version {
                         V1 => ResponseIncludesVersion::No,
-                        V2 | V3 => ResponseIncludesVersion::Yes(fork_name),
+                        V2 => ResponseIncludesVersion::Yes(fork_name),
                         _ => return Err(unsupported_version_rejection(endpoint_version)),
                     };
 
@@ -2089,7 +2089,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     let require_version = match endpoint_version {
                         V1 => ResponseIncludesVersion::No,
-                        V2 | V3 => ResponseIncludesVersion::Yes(fork_name),
+                        V2 => ResponseIncludesVersion::Yes(fork_name),
                         _ => return Err(unsupported_version_rejection(endpoint_version)),
                     };
 
@@ -2184,7 +2184,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                         let require_version = match endpoint_version {
                             V1 => ResponseIncludesVersion::No,
-                            V2 | V3 => ResponseIncludesVersion::Yes(fork_name),
+                            V2 => ResponseIncludesVersion::Yes(fork_name),
                             _ => return Err(unsupported_version_rejection(endpoint_version)),
                         };
 

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -47,9 +47,9 @@ use bytes::Bytes;
 use directory::DEFAULT_ROOT_DIR;
 use either::Either;
 use eth2::types::{
-    self as api_types, BroadcastValidation, EndpointVersion, ForkChoice, ForkChoiceNode,
-    LightClientUpdatesQuery, PublishBlockRequest, ValidatorBalancesRequestBody, ValidatorId,
-    ValidatorStatus, ValidatorsRequestBody,
+    self as api_types, BroadcastValidation, ContextDeserialize, EndpointVersion, ForkChoice,
+    ForkChoiceNode, LightClientUpdatesQuery, PublishBlockRequest, ValidatorBalancesRequestBody,
+    ValidatorId, ValidatorStatus, ValidatorsRequestBody,
 };
 use eth2::{CONSENSUS_VERSION_HEADER, CONTENT_TYPE_HEADER, SSZ_CONTENT_TYPE_HEADER};
 use health_metrics::observe::Observe;
@@ -1420,21 +1420,30 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("beacon"))
         .and(warp::path("blocks"))
         .and(warp::path::end())
-        .and(warp_utils::json::json())
+        .and(warp::body::json())
+        .and(consensus_version_header_filter)
         .and(task_spawner_filter.clone())
         .and(chain_filter.clone())
         .and(network_tx_filter.clone())
         .and(network_globals.clone())
         .then(
-            move |block_contents: PublishBlockRequest<T::EthSpec>,
+            move |value: serde_json::Value,
+                  consensus_version: ForkName,
                   task_spawner: TaskSpawner<T::EthSpec>,
                   chain: Arc<BeaconChain<T>>,
                   network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
                   network_globals: Arc<NetworkGlobals<T::EthSpec>>| {
                 task_spawner.spawn_async_with_rejection(Priority::P0, async move {
+                    let request = PublishBlockRequest::<T::EthSpec>::context_deserialize(
+                        &value,
+                        consensus_version,
+                    )
+                    .map_err(|e| {
+                        warp_utils::reject::custom_bad_request(format!("invalid JSON: {e:?}"))
+                    })?;
                     publish_blocks::publish_block(
                         None,
-                        ProvenancedBlock::local_from_publish_request(block_contents),
+                        ProvenancedBlock::local_from_publish_request(request),
                         chain,
                         &network_tx,
                         BroadcastValidation::default(),
@@ -1490,22 +1499,32 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("blocks"))
         .and(warp::query::<api_types::BroadcastValidationQuery>())
         .and(warp::path::end())
-        .and(warp_utils::json::json())
+        .and(warp::body::json())
+        .and(consensus_version_header_filter)
         .and(task_spawner_filter.clone())
         .and(chain_filter.clone())
         .and(network_tx_filter.clone())
         .and(network_globals.clone())
         .then(
             move |validation_level: api_types::BroadcastValidationQuery,
-                  block_contents: PublishBlockRequest<T::EthSpec>,
+                  value: serde_json::Value,
+                  consensus_version: ForkName,
                   task_spawner: TaskSpawner<T::EthSpec>,
                   chain: Arc<BeaconChain<T>>,
                   network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
                   network_globals: Arc<NetworkGlobals<T::EthSpec>>| {
                 task_spawner.spawn_async_with_rejection(Priority::P0, async move {
+                    let request = PublishBlockRequest::<T::EthSpec>::context_deserialize(
+                        &value,
+                        consensus_version,
+                    )
+                    .map_err(|e| {
+                        warp_utils::reject::custom_bad_request(format!("invalid JSON: {e:?}"))
+                    })?;
+
                     publish_blocks::publish_block(
                         None,
-                        ProvenancedBlock::local_from_publish_request(block_contents),
+                        ProvenancedBlock::local_from_publish_request(request),
                         chain,
                         &network_tx,
                         validation_level.broadcast_validation,

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2608,7 +2608,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     let fork_name = chain
                         .spec
-                        .fork_name_at_slot::<T::EthSpec>(*update.signature_slot());
+                        .fork_name_at_slot::<T::EthSpec>(update.get_slot());
                     match accept_header {
                         Some(api_types::Accept::Ssz) => Response::builder()
                             .status(200)

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -9,7 +9,7 @@ use types::{
         ExecutionOptimisticFinalizedBeaconResponse, ExecutionOptimisticFinalizedMetadata,
     },
     BeaconResponse, ForkName, ForkVersionedResponse, InconsistentFork, Uint256,
-    UnVersionedResponse,
+    UnversionedResponse,
 };
 use warp::reply::{self, Reply, Response};
 
@@ -35,7 +35,7 @@ pub fn beacon_response<T: Serialize>(
                 data,
             })
         }
-        ResponseIncludesVersion::No => BeaconResponse::UnVersioned(UnVersionedResponse {
+        ResponseIncludesVersion::No => BeaconResponse::Unversioned(UnversionedResponse {
             metadata: Default::default(),
             data,
         }),
@@ -60,7 +60,7 @@ pub fn execution_optimistic_finalized_beacon_response<T: Serialize>(
                 data,
             }))
         }
-        ResponseIncludesVersion::No => Ok(BeaconResponse::UnVersioned(UnVersionedResponse {
+        ResponseIncludesVersion::No => Ok(BeaconResponse::Unversioned(UnversionedResponse {
             metadata,
             data,
         })),

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -6,9 +6,10 @@ use eth2::{
 use serde::Serialize;
 use types::{
     fork_versioned_response::{
-        ExecutionOptimisticFinalizedForkVersionedResponse, ExecutionOptimisticFinalizedMetadata,
+        ExecutionOptimisticFinalizedBeaconResponse, ExecutionOptimisticFinalizedMetadata,
     },
-    ForkName, ForkVersionedResponse, InconsistentFork, Uint256,
+    BeaconResponse, ForkName, ForkVersionedResponse, InconsistentFork, Uint256,
+    UnVersionedResponse,
 };
 use warp::reply::{self, Reply, Response};
 
@@ -16,47 +17,54 @@ pub const V1: EndpointVersion = EndpointVersion(1);
 pub const V2: EndpointVersion = EndpointVersion(2);
 pub const V3: EndpointVersion = EndpointVersion(3);
 
-pub fn fork_versioned_response<T: Serialize>(
-    endpoint_version: EndpointVersion,
-    fork_name: ForkName,
-    data: T,
-) -> Result<ForkVersionedResponse<T>, warp::reject::Rejection> {
-    let fork_name = if endpoint_version == V1 {
-        None
-    } else if endpoint_version == V2 || endpoint_version == V3 {
-        Some(fork_name)
-    } else {
-        return Err(unsupported_version_rejection(endpoint_version));
-    };
-    Ok(ForkVersionedResponse {
-        version: fork_name,
-        metadata: Default::default(),
-        data,
-    })
+#[derive(Debug, PartialEq, Clone, Serialize)]
+pub enum ResponseIncludesVersion {
+    Yes(ForkName),
+    No,
 }
 
-pub fn execution_optimistic_finalized_fork_versioned_response<T: Serialize>(
-    endpoint_version: EndpointVersion,
-    fork_name: ForkName,
+pub fn beacon_response<T: Serialize>(
+    require_version: ResponseIncludesVersion,
+    data: T,
+) -> BeaconResponse<T> {
+    match require_version {
+        ResponseIncludesVersion::Yes(fork_name) => {
+            BeaconResponse::ForkVersioned(ForkVersionedResponse {
+                version: fork_name,
+                metadata: Default::default(),
+                data,
+            })
+        }
+        ResponseIncludesVersion::No => BeaconResponse::UnVersioned(UnVersionedResponse {
+            metadata: Default::default(),
+            data,
+        }),
+    }
+}
+
+pub fn execution_optimistic_finalized_beacon_response<T: Serialize>(
+    require_version: ResponseIncludesVersion,
     execution_optimistic: bool,
     finalized: bool,
     data: T,
-) -> Result<ExecutionOptimisticFinalizedForkVersionedResponse<T>, warp::reject::Rejection> {
-    let fork_name = if endpoint_version == V1 {
-        None
-    } else if endpoint_version == V2 {
-        Some(fork_name)
-    } else {
-        return Err(unsupported_version_rejection(endpoint_version));
+) -> Result<ExecutionOptimisticFinalizedBeaconResponse<T>, warp::reject::Rejection> {
+    let metadata = ExecutionOptimisticFinalizedMetadata {
+        execution_optimistic: Some(execution_optimistic),
+        finalized: Some(finalized),
     };
-    Ok(ExecutionOptimisticFinalizedForkVersionedResponse {
-        version: fork_name,
-        metadata: ExecutionOptimisticFinalizedMetadata {
-            execution_optimistic: Some(execution_optimistic),
-            finalized: Some(finalized),
-        },
-        data,
-    })
+    match require_version {
+        ResponseIncludesVersion::Yes(fork_name) => {
+            Ok(BeaconResponse::ForkVersioned(ForkVersionedResponse {
+                version: fork_name,
+                metadata,
+                data,
+            }))
+        }
+        ResponseIncludesVersion::No => Ok(BeaconResponse::UnVersioned(UnVersionedResponse {
+            metadata,
+            data,
+        })),
+    }
 }
 
 /// Add the 'Content-Type application/octet-stream` header to a response.

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -5,7 +5,7 @@ use eth2::{
 };
 use serde::Serialize;
 use types::{
-    fork_versioned_response::{
+    beacon_response::{
         ExecutionOptimisticFinalizedBeaconResponse, ExecutionOptimisticFinalizedMetadata,
     },
     BeaconResponse, ForkName, ForkVersionedResponse, InconsistentFork, Uint256,

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -115,10 +115,10 @@ async fn state_by_root_pruned_from_fork_choice() {
             .unwrap()
             .unwrap();
 
-        assert!(response.metadata.finalized.unwrap());
-        assert!(!response.metadata.execution_optimistic.unwrap());
+        assert!(response.metadata().finalized.unwrap());
+        assert!(!response.metadata().execution_optimistic.unwrap());
 
-        let mut state = response.data;
+        let mut state = response.into_data();
         assert_eq!(state.update_tree_hash_cache().unwrap(), state_root);
     }
 }
@@ -846,7 +846,7 @@ pub async fn fork_choice_before_proposal() {
         .get_validator_blocks::<E>(slot_d, &randao_reveal, None)
         .await
         .unwrap()
-        .data
+        .into_data()
         .deconstruct()
         .0;
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1598,10 +1598,7 @@ impl ApiTester {
 
             if let (Some(json), Some(expected)) = (&json_result, &expected) {
                 assert_eq!(&json.data, expected.as_ref(), "{:?}", block_id);
-                assert_eq!(
-                    json.version,
-                    Some(expected.fork_name(&self.chain.spec).unwrap())
-                );
+                assert_eq!(json.version, expected.fork_name(&self.chain.spec).unwrap());
             } else {
                 assert_eq!(json_result, None);
                 assert_eq!(expected, None);
@@ -1623,8 +1620,8 @@ impl ApiTester {
             // Check that the legacy v1 API still works but doesn't return a version field.
             let v1_result = self.client.get_beacon_blocks_v1(block_id.0).await.unwrap();
             if let (Some(v1_result), Some(expected)) = (&v1_result, &expected) {
-                assert_eq!(v1_result.version, None);
-                assert_eq!(&v1_result.data, expected.as_ref());
+                assert_eq!(v1_result.version(), None);
+                assert_eq!(v1_result.data(), expected.as_ref());
             } else {
                 assert_eq!(v1_result, None);
                 assert_eq!(expected, None);
@@ -1686,10 +1683,7 @@ impl ApiTester {
 
             if let (Some(json), Some(expected)) = (&json_result, &expected) {
                 assert_eq!(&json.data, expected, "{:?}", block_id);
-                assert_eq!(
-                    json.version,
-                    Some(expected.fork_name(&self.chain.spec).unwrap())
-                );
+                assert_eq!(json.version, expected.fork_name(&self.chain.spec).unwrap());
             } else {
                 assert_eq!(json_result, None);
                 assert_eq!(expected, None);
@@ -2650,10 +2644,7 @@ impl ApiTester {
 
             if let (Some(json), Some(expected)) = (&result_json, &expected) {
                 assert_eq!(json.data, *expected, "{:?}", state_id);
-                assert_eq!(
-                    json.version,
-                    Some(expected.fork_name(&self.chain.spec).unwrap())
-                );
+                assert_eq!(json.version, expected.fork_name(&self.chain.spec).unwrap());
             } else {
                 assert_eq!(result_json, None);
                 assert_eq!(expected, None);
@@ -3254,7 +3245,7 @@ impl ApiTester {
     ) {
         // Compare fork name to ForkVersionedResponse rather than metadata consensus_version, which
         // is deserialized to a dummy value.
-        assert_eq!(Some(metadata.consensus_version), response.version);
+        assert_eq!(metadata.consensus_version, response.version);
         assert_eq!(ForkName::Base, response.metadata.consensus_version);
         assert_eq!(
             metadata.execution_payload_blinded,

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1750,7 +1750,11 @@ impl ApiTester {
         };
         let result = match self
             .client
-            .get_blobs::<E>(CoreBlockId::Root(block_root), blob_indices.as_deref())
+            .get_blobs::<E>(
+                CoreBlockId::Root(block_root),
+                blob_indices.as_deref(),
+                &self.chain.spec,
+            )
             .await
         {
             Ok(result) => result.unwrap().into_data(),
@@ -1806,7 +1810,7 @@ impl ApiTester {
 
         match self
             .client
-            .get_blobs::<E>(CoreBlockId::Slot(test_slot), None)
+            .get_blobs::<E>(CoreBlockId::Slot(test_slot), None, &self.chain.spec)
             .await
         {
             Ok(result) => {
@@ -1844,7 +1848,7 @@ impl ApiTester {
 
         match self
             .client
-            .get_blobs::<E>(CoreBlockId::Slot(test_slot), None)
+            .get_blobs::<E>(CoreBlockId::Slot(test_slot), None, &self.chain.spec)
             .await
         {
             Ok(result) => panic!("queries for pre-Deneb slots should fail. got: {result:?}"),

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -682,7 +682,7 @@ impl ApiTester {
                 .await
                 .unwrap()
                 .unwrap()
-                .metadata
+                .metadata()
                 .finalized
                 .unwrap();
 
@@ -719,7 +719,7 @@ impl ApiTester {
                 .await
                 .unwrap()
                 .unwrap()
-                .metadata
+                .metadata()
                 .finalized
                 .unwrap();
 
@@ -757,7 +757,7 @@ impl ApiTester {
                 .await
                 .unwrap()
                 .unwrap()
-                .metadata
+                .metadata()
                 .finalized
                 .unwrap();
 
@@ -1597,8 +1597,11 @@ impl ApiTester {
             let json_result = self.client.get_beacon_blocks(block_id.0).await.unwrap();
 
             if let (Some(json), Some(expected)) = (&json_result, &expected) {
-                assert_eq!(&json.data, expected.as_ref(), "{:?}", block_id);
-                assert_eq!(json.version, expected.fork_name(&self.chain.spec).unwrap());
+                assert_eq!(json.data(), expected.as_ref(), "{:?}", block_id);
+                assert_eq!(
+                    json.version(),
+                    Some(expected.fork_name(&self.chain.spec).unwrap())
+                );
             } else {
                 assert_eq!(json_result, None);
                 assert_eq!(expected, None);
@@ -1682,8 +1685,11 @@ impl ApiTester {
                 .unwrap();
 
             if let (Some(json), Some(expected)) = (&json_result, &expected) {
-                assert_eq!(&json.data, expected, "{:?}", block_id);
-                assert_eq!(json.version, expected.fork_name(&self.chain.spec).unwrap());
+                assert_eq!(json.data(), expected, "{:?}", block_id);
+                assert_eq!(
+                    json.version(),
+                    Some(expected.fork_name(&self.chain.spec).unwrap())
+                );
             } else {
                 assert_eq!(json_result, None);
                 assert_eq!(expected, None);
@@ -1747,7 +1753,7 @@ impl ApiTester {
             .get_blobs::<E>(CoreBlockId::Root(block_root), blob_indices.as_deref())
             .await
         {
-            Ok(result) => result.unwrap().data,
+            Ok(result) => result.unwrap().into_data(),
             Err(e) => panic!("query failed incorrectly: {e:?}"),
         };
 
@@ -1806,7 +1812,7 @@ impl ApiTester {
             Ok(result) => {
                 if zero_blobs {
                     assert_eq!(
-                        &result.unwrap().data[..],
+                        &result.unwrap().into_data()[..],
                         &[],
                         "empty blobs are always available"
                     );
@@ -1855,7 +1861,7 @@ impl ApiTester {
                 .get_beacon_blocks_attestations_v2(block_id.0)
                 .await
                 .unwrap()
-                .map(|res| res.data);
+                .map(|res| res.into_data());
 
             let expected = block_id.full_block(&self.chain).await.ok().map(
                 |(block, _execution_optimistic, _finalized)| {
@@ -2065,7 +2071,7 @@ impl ApiTester {
             .get_light_client_bootstrap(&self.chain.store, &block_root, 1u64, &self.chain.spec);
 
         assert!(expected.is_ok());
-        assert_eq!(result.unwrap().data, expected.unwrap().unwrap().0);
+        assert_eq!(result.unwrap().data(), &expected.unwrap().unwrap().0);
 
         self
     }
@@ -2077,7 +2083,7 @@ impl ApiTester {
             .get_beacon_light_client_optimistic_update::<E>()
             .await
         {
-            Ok(result) => result.map(|res| res.data),
+            Ok(result) => result.map(|res| res.into_data()),
             Err(e) => panic!("query failed incorrectly: {e:?}"),
         };
 
@@ -2096,7 +2102,7 @@ impl ApiTester {
             .get_beacon_light_client_finality_update::<E>()
             .await
         {
-            Ok(result) => result.map(|res| res.data),
+            Ok(result) => result.map(|res| res.into_data()),
             Err(e) => panic!("query failed incorrectly: {e:?}"),
         };
 
@@ -2127,7 +2133,7 @@ impl ApiTester {
             .get_beacon_pool_attestations_v2(None, None)
             .await
             .unwrap()
-            .data;
+            .into_data();
 
         assert_eq!(result, expected);
 
@@ -2189,7 +2195,7 @@ impl ApiTester {
                 .get_beacon_pool_attestations_v2(None, Some(0))
                 .await
                 .unwrap()
-                .data;
+                .into_data();
             let mut expected = self.chain.op_pool.get_all_attestations();
             expected.extend(self.chain.naive_aggregation_pool.read().iter().cloned());
             let expected_committee_index_filtered = expected
@@ -2305,7 +2311,7 @@ impl ApiTester {
             .get_beacon_pool_attester_slashings_v2()
             .await
             .unwrap()
-            .data;
+            .into_data();
         assert_eq!(result, expected);
 
         self
@@ -2643,8 +2649,11 @@ impl ApiTester {
             expected.as_mut().map(|state| state.drop_all_caches());
 
             if let (Some(json), Some(expected)) = (&result_json, &expected) {
-                assert_eq!(json.data, *expected, "{:?}", state_id);
-                assert_eq!(json.version, expected.fork_name(&self.chain.spec).unwrap());
+                assert_eq!(json.data(), expected, "{:?}", state_id);
+                assert_eq!(
+                    json.version(),
+                    Some(expected.fork_name(&self.chain.spec).unwrap())
+                );
             } else {
                 assert_eq!(result_json, None);
                 assert_eq!(expected, None);
@@ -3148,7 +3157,7 @@ impl ApiTester {
                 .get_validator_blocks::<E>(slot, &randao_reveal, None)
                 .await
                 .unwrap()
-                .data
+                .into_data()
                 .deconstruct()
                 .0;
 
@@ -3371,7 +3380,7 @@ impl ApiTester {
                 )
                 .await
                 .unwrap()
-                .data
+                .into_data()
                 .deconstruct()
                 .0;
             assert_eq!(block.slot(), slot);
@@ -3485,7 +3494,7 @@ impl ApiTester {
                 .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
                 .await
                 .unwrap()
-                .data;
+                .into_data();
 
             let signed_block = block.sign(&sk, &fork, genesis_validators_root, &self.chain.spec);
 
@@ -3500,7 +3509,7 @@ impl ApiTester {
                 .await
                 .unwrap()
                 .unwrap()
-                .data;
+                .into_data();
 
             assert_eq!(head_block.clone_as_blinded(), signed_block);
 
@@ -3573,7 +3582,7 @@ impl ApiTester {
                 .await
                 .unwrap()
                 .unwrap()
-                .data;
+                .into_data();
 
             let signed_block = signed_block_contents.signed_block();
             assert_eq!(head_block, **signed_block);
@@ -3596,7 +3605,7 @@ impl ApiTester {
                 )
                 .await
                 .unwrap()
-                .data;
+                .into_data();
             assert_eq!(blinded_block.slot(), slot);
             self.chain.slot_clock.set_slot(slot.as_u64() + 1);
         }
@@ -3740,7 +3749,7 @@ impl ApiTester {
                 .await
                 .unwrap()
                 .unwrap()
-                .data;
+                .into_data();
             let expected = attestation;
 
             assert_eq!(result, expected);
@@ -4314,7 +4323,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -4360,7 +4369,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -4404,7 +4413,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -4478,7 +4487,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -4564,7 +4573,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -4656,7 +4665,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -4746,7 +4755,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -4835,7 +4844,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -4910,7 +4919,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -4973,7 +4982,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -5049,7 +5058,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(next_slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -5080,7 +5089,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(next_slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -5188,7 +5197,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(next_slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -5229,7 +5238,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(next_slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -5345,7 +5354,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -5426,7 +5435,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -5494,7 +5503,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -5562,7 +5571,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -5629,7 +5638,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()
@@ -5700,7 +5709,7 @@ impl ApiTester {
             .get_validator_blinded_blocks::<E>(slot, &randao_reveal, None)
             .await
             .unwrap()
-            .data
+            .into_data()
             .body()
             .execution_payload()
             .unwrap()

--- a/beacon_node/tests/test.rs
+++ b/beacon_node/tests/test.rs
@@ -41,7 +41,7 @@ fn http_server_genesis_state() {
         .block_on(remote_node.get_debug_beacon_states(StateId::Slot(Slot::new(0))))
         .expect("should fetch state from http api")
         .unwrap()
-        .data;
+        .into_data();
 
     let mut db_state = node
         .client

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -2392,7 +2392,6 @@ impl BeaconNodeHttpClient {
             )
             .await?;
 
-        // TODO: verify this is fork versioned.. couldn't find API docs for this endpoint
         self.get(path).await.map(BeaconResponse::ForkVersioned)
     }
 

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -16,7 +16,7 @@ pub mod types;
 
 use self::mixin::{RequestAccept, ResponseOptional};
 use self::types::{Error as ResponseError, *};
-use ::types::fork_versioned_response::ExecutionOptimisticFinalizedForkVersionedResponse;
+use ::types::beacon_response::ExecutionOptimisticFinalizedBeaconResponse;
 use derivative::Derivative;
 use either::Either;
 use futures::Stream;
@@ -850,7 +850,7 @@ impl BeaconNodeHttpClient {
         &self,
         start_period: u64,
         count: u64,
-    ) -> Result<Option<Vec<ForkVersionedResponse<LightClientUpdate<E>>>>, Error> {
+    ) -> Result<Option<Vec<BeaconResponse<LightClientUpdate<E>>>>, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()
@@ -865,7 +865,14 @@ impl BeaconNodeHttpClient {
         path.query_pairs_mut()
             .append_pair("count", &count.to_string());
 
-        self.get_opt(path).await
+        self.get_opt(path).await.map(|opt| {
+            opt.map(|updates: Vec<_>| {
+                updates
+                    .into_iter()
+                    .map(BeaconResponse::ForkVersioned)
+                    .collect()
+            })
+        })
     }
 
     /// `GET beacon/light_client/bootstrap`
@@ -874,7 +881,7 @@ impl BeaconNodeHttpClient {
     pub async fn get_light_client_bootstrap<E: EthSpec>(
         &self,
         block_root: Hash256,
-    ) -> Result<Option<ForkVersionedResponse<LightClientBootstrap<E>>>, Error> {
+    ) -> Result<Option<BeaconResponse<LightClientBootstrap<E>>>, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()
@@ -884,7 +891,9 @@ impl BeaconNodeHttpClient {
             .push("bootstrap")
             .push(&format!("{:?}", block_root));
 
-        self.get_opt(path).await
+        self.get_opt(path)
+            .await
+            .map(|opt| opt.map(BeaconResponse::ForkVersioned))
     }
 
     /// `GET beacon/light_client/optimistic_update`
@@ -892,7 +901,7 @@ impl BeaconNodeHttpClient {
     /// Returns `Ok(None)` on a 404 error.
     pub async fn get_beacon_light_client_optimistic_update<E: EthSpec>(
         &self,
-    ) -> Result<Option<ForkVersionedResponse<LightClientOptimisticUpdate<E>>>, Error> {
+    ) -> Result<Option<BeaconResponse<LightClientOptimisticUpdate<E>>>, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()
@@ -901,7 +910,9 @@ impl BeaconNodeHttpClient {
             .push("light_client")
             .push("optimistic_update");
 
-        self.get_opt(path).await
+        self.get_opt(path)
+            .await
+            .map(|opt| opt.map(BeaconResponse::ForkVersioned))
     }
 
     /// `GET beacon/light_client/finality_update`
@@ -909,7 +920,7 @@ impl BeaconNodeHttpClient {
     /// Returns `Ok(None)` on a 404 error.
     pub async fn get_beacon_light_client_finality_update<E: EthSpec>(
         &self,
-    ) -> Result<Option<ForkVersionedResponse<LightClientFinalityUpdate<E>>>, Error> {
+    ) -> Result<Option<BeaconResponse<LightClientFinalityUpdate<E>>>, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()
@@ -918,7 +929,9 @@ impl BeaconNodeHttpClient {
             .push("light_client")
             .push("finality_update");
 
-        self.get_opt(path).await
+        self.get_opt(path)
+            .await
+            .map(|opt| opt.map(BeaconResponse::ForkVersioned))
     }
 
     /// `GET beacon/headers?slot,parent_root`
@@ -1200,16 +1213,12 @@ impl BeaconNodeHttpClient {
     pub async fn get_beacon_blocks<E: EthSpec>(
         &self,
         block_id: BlockId,
-    ) -> Result<
-        Option<ExecutionOptimisticFinalizedForkVersionedResponse<SignedBeaconBlock<E>>>,
-        Error,
-    > {
+    ) -> Result<Option<ExecutionOptimisticFinalizedBeaconResponse<SignedBeaconBlock<E>>>, Error>
+    {
         let path = self.get_beacon_blocks_path(block_id)?;
-        let Some(response) = self.get_response(path, |b| b).await.optional()? else {
-            return Ok(None);
-        };
-
-        Ok(Some(response.json().await?))
+        self.get_opt(path)
+            .await
+            .map(|opt| opt.map(BeaconResponse::ForkVersioned))
     }
 
     /// `GET v1/beacon/blob_sidecars/{block_id}`
@@ -1219,8 +1228,7 @@ impl BeaconNodeHttpClient {
         &self,
         block_id: BlockId,
         indices: Option<&[u64]>,
-    ) -> Result<Option<ExecutionOptimisticFinalizedForkVersionedResponse<BlobSidecarList<E>>>, Error>
-    {
+    ) -> Result<Option<ExecutionOptimisticFinalizedBeaconResponse<BlobSidecarList<E>>>, Error> {
         let mut path = self.get_blobs_path(block_id)?;
         if let Some(indices) = indices {
             let indices_string = indices
@@ -1232,11 +1240,9 @@ impl BeaconNodeHttpClient {
                 .append_pair("indices", &indices_string);
         }
 
-        let Some(response) = self.get_response(path, |b| b).await.optional()? else {
-            return Ok(None);
-        };
-
-        Ok(Some(response.json().await?))
+        self.get_opt(path)
+            .await
+            .map(|opt| opt.map(BeaconResponse::ForkVersioned))
     }
 
     /// `GET v1/beacon/blinded_blocks/{block_id}`
@@ -1246,15 +1252,13 @@ impl BeaconNodeHttpClient {
         &self,
         block_id: BlockId,
     ) -> Result<
-        Option<ExecutionOptimisticFinalizedForkVersionedResponse<SignedBlindedBeaconBlock<E>>>,
+        Option<ExecutionOptimisticFinalizedBeaconResponse<SignedBlindedBeaconBlock<E>>>,
         Error,
     > {
         let path = self.get_beacon_blinded_blocks_path(block_id)?;
-        let Some(response) = self.get_response(path, |b| b).await.optional()? else {
-            return Ok(None);
-        };
-
-        Ok(Some(response.json().await?))
+        self.get_opt(path)
+            .await
+            .map(|opt| opt.map(BeaconResponse::ForkVersioned))
     }
 
     /// `GET v1/beacon/blocks` (LEGACY)
@@ -1355,7 +1359,7 @@ impl BeaconNodeHttpClient {
     pub async fn get_beacon_blocks_attestations_v2<E: EthSpec>(
         &self,
         block_id: BlockId,
-    ) -> Result<Option<ExecutionOptimisticFinalizedForkVersionedResponse<Vec<Attestation<E>>>>, Error>
+    ) -> Result<Option<ExecutionOptimisticFinalizedBeaconResponse<Vec<Attestation<E>>>>, Error>
     {
         let mut path = self.eth_path(V2)?;
 
@@ -1366,7 +1370,9 @@ impl BeaconNodeHttpClient {
             .push(&block_id.to_string())
             .push("attestations");
 
-        self.get_opt(path).await
+        self.get_opt(path)
+            .await
+            .map(|opt| opt.map(BeaconResponse::ForkVersioned))
     }
 
     /// `POST v1/beacon/pool/attestations`
@@ -1458,7 +1464,7 @@ impl BeaconNodeHttpClient {
         &self,
         slot: Option<Slot>,
         committee_index: Option<u64>,
-    ) -> Result<ForkVersionedResponse<Vec<Attestation<E>>>, Error> {
+    ) -> Result<BeaconResponse<Vec<Attestation<E>>>, Error> {
         let mut path = self.eth_path(V2)?;
 
         path.path_segments_mut()
@@ -1477,7 +1483,7 @@ impl BeaconNodeHttpClient {
                 .append_pair("committee_index", &index.to_string());
         }
 
-        self.get(path).await
+        self.get(path).await.map(BeaconResponse::ForkVersioned)
     }
 
     /// `POST v1/beacon/pool/attester_slashings`
@@ -1536,7 +1542,7 @@ impl BeaconNodeHttpClient {
     /// `GET v2/beacon/pool/attester_slashings`
     pub async fn get_beacon_pool_attester_slashings_v2<E: EthSpec>(
         &self,
-    ) -> Result<ForkVersionedResponse<Vec<AttesterSlashing<E>>>, Error> {
+    ) -> Result<BeaconResponse<Vec<AttesterSlashing<E>>>, Error> {
         let mut path = self.eth_path(V2)?;
 
         path.path_segments_mut()
@@ -1545,7 +1551,7 @@ impl BeaconNodeHttpClient {
             .push("pool")
             .push("attester_slashings");
 
-        self.get(path).await
+        self.get(path).await.map(BeaconResponse::ForkVersioned)
     }
 
     /// `POST beacon/pool/proposer_slashings`
@@ -1966,10 +1972,11 @@ impl BeaconNodeHttpClient {
     pub async fn get_debug_beacon_states<E: EthSpec>(
         &self,
         state_id: StateId,
-    ) -> Result<Option<ExecutionOptimisticFinalizedForkVersionedResponse<BeaconState<E>>>, Error>
-    {
+    ) -> Result<Option<ExecutionOptimisticFinalizedBeaconResponse<BeaconState<E>>>, Error> {
         let path = self.get_debug_beacon_states_path(state_id)?;
-        self.get_opt(path).await
+        self.get_opt(path)
+            .await
+            .map(|opt| opt.map(BeaconResponse::ForkVersioned))
     }
 
     /// `GET debug/beacon/states/{state_id}`
@@ -2053,7 +2060,7 @@ impl BeaconNodeHttpClient {
         slot: Slot,
         randao_reveal: &SignatureBytes,
         graffiti: Option<&Graffiti>,
-    ) -> Result<ForkVersionedResponse<FullBlockContents<E>>, Error> {
+    ) -> Result<BeaconResponse<FullBlockContents<E>>, Error> {
         self.get_validator_blocks_modular(slot, randao_reveal, graffiti, SkipRandaoVerification::No)
             .await
     }
@@ -2065,12 +2072,12 @@ impl BeaconNodeHttpClient {
         randao_reveal: &SignatureBytes,
         graffiti: Option<&Graffiti>,
         skip_randao_verification: SkipRandaoVerification,
-    ) -> Result<ForkVersionedResponse<FullBlockContents<E>>, Error> {
+    ) -> Result<BeaconResponse<FullBlockContents<E>>, Error> {
         let path = self
             .get_validator_blocks_path::<E>(slot, randao_reveal, graffiti, skip_randao_verification)
             .await?;
 
-        self.get(path).await
+        self.get(path).await.map(BeaconResponse::ForkVersioned)
     }
 
     /// returns `GET v2/validator/blocks/{slot}` URL path
@@ -2326,7 +2333,7 @@ impl BeaconNodeHttpClient {
         slot: Slot,
         randao_reveal: &SignatureBytes,
         graffiti: Option<&Graffiti>,
-    ) -> Result<ForkVersionedResponse<BlindedBeaconBlock<E>>, Error> {
+    ) -> Result<BeaconResponse<BlindedBeaconBlock<E>>, Error> {
         self.get_validator_blinded_blocks_modular(
             slot,
             randao_reveal,
@@ -2375,7 +2382,7 @@ impl BeaconNodeHttpClient {
         randao_reveal: &SignatureBytes,
         graffiti: Option<&Graffiti>,
         skip_randao_verification: SkipRandaoVerification,
-    ) -> Result<ForkVersionedResponse<BlindedBeaconBlock<E>>, Error> {
+    ) -> Result<BeaconResponse<BlindedBeaconBlock<E>>, Error> {
         let path = self
             .get_validator_blinded_blocks_path::<E>(
                 slot,
@@ -2385,7 +2392,8 @@ impl BeaconNodeHttpClient {
             )
             .await?;
 
-        self.get(path).await
+        // TODO: verify this is fork versioned.. couldn't find API docs for this endpoint
+        self.get(path).await.map(BeaconResponse::ForkVersioned)
     }
 
     /// `GET v2/validator/blinded_blocks/{slot}` in ssz format
@@ -2474,7 +2482,7 @@ impl BeaconNodeHttpClient {
         slot: Slot,
         attestation_data_root: Hash256,
         committee_index: CommitteeIndex,
-    ) -> Result<Option<ForkVersionedResponse<Attestation<E>>>, Error> {
+    ) -> Result<Option<BeaconResponse<Attestation<E>>>, Error> {
         let mut path = self.eth_path(V2)?;
 
         path.path_segments_mut()
@@ -2492,6 +2500,7 @@ impl BeaconNodeHttpClient {
 
         self.get_opt_with_timeout(path, self.timeouts.attestation)
             .await
+            .map(|opt| opt.map(BeaconResponse::ForkVersioned))
     }
 
     /// `GET validator/sync_committee_contribution`

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1278,7 +1278,7 @@ impl BeaconNodeHttpClient {
 
         self.get_opt(path)
             .await
-            .map(|opt| opt.map(BeaconResponse::UnVersioned))
+            .map(|opt| opt.map(BeaconResponse::Unversioned))
     }
 
     /// `GET beacon/blocks` as SSZ

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1263,7 +1263,7 @@ impl BeaconNodeHttpClient {
     pub async fn get_beacon_blocks_v1<E: EthSpec>(
         &self,
         block_id: BlockId,
-    ) -> Result<Option<ForkVersionedResponse<SignedBeaconBlock<E>>>, Error> {
+    ) -> Result<Option<BeaconResponse<SignedBeaconBlock<E>>>, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()
@@ -1272,7 +1272,9 @@ impl BeaconNodeHttpClient {
             .push("blocks")
             .push(&block_id.to_string());
 
-        self.get_opt(path).await
+        self.get_opt(path)
+            .await
+            .map(|opt| opt.map(BeaconResponse::UnVersioned))
     }
 
     /// `GET beacon/blocks` as SSZ

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1040,8 +1040,14 @@ impl BeaconNodeHttpClient {
             .push("beacon")
             .push("blocks");
 
-        self.post_with_timeout(path, block_contents, self.timeouts.proposal)
-            .await?;
+        let fork_name = block_contents.signed_block().fork_name_unchecked();
+        self.post_generic_with_consensus_version(
+            path,
+            block_contents,
+            Some(self.timeouts.proposal),
+            fork_name,
+        )
+        .await?;
 
         Ok(())
     }

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -283,6 +283,52 @@ impl BeaconNodeHttpClient {
         }
     }
 
+    pub async fn get_fork_contextual<T, U, Ctx, Meta>(
+        &self,
+        url: U,
+        ctx_constructor: impl Fn(ForkName) -> Ctx,
+    ) -> Result<Option<ForkVersionedResponse<T, Meta>>, Error>
+    where
+        U: IntoUrl,
+        T: ContextDeserialize<'static, Ctx>,
+        Meta: DeserializeOwned,
+        Ctx: Clone,
+    {
+        let response = self
+            .get_response(url, |b| b.accept(Accept::Json))
+            .await
+            .optional()?;
+
+        let Some(resp) = response else {
+            return Ok(None);
+        };
+
+        let bytes = resp.bytes().await?;
+
+        #[derive(serde::Deserialize)]
+        struct Helper {
+            version: ForkName,
+            #[serde(flatten)]
+            metadata: serde_json::Value,
+            data: serde_json::Value,
+        }
+
+        let helper: Helper = serde_json::from_slice(&bytes).map_err(Error::InvalidJson)?;
+
+        let metadata: Meta = serde_json::from_value(helper.metadata).map_err(Error::InvalidJson)?;
+
+        let ctx = ctx_constructor(helper.version);
+
+        let data: T = ContextDeserialize::context_deserialize(helper.data, ctx)
+            .map_err(Error::InvalidJson)?;
+
+        Ok(Some(ForkVersionedResponse {
+            version: helper.version,
+            metadata,
+            data,
+        }))
+    }
+
     /// Perform a HTTP GET request using an 'accept' header, returning `None` on a 404 error.
     pub async fn get_bytes_opt_accept_header<U: IntoUrl>(
         &self,
@@ -1228,6 +1274,7 @@ impl BeaconNodeHttpClient {
         &self,
         block_id: BlockId,
         indices: Option<&[u64]>,
+        spec: &ChainSpec,
     ) -> Result<Option<ExecutionOptimisticFinalizedBeaconResponse<BlobSidecarList<E>>>, Error> {
         let mut path = self.get_blobs_path(block_id)?;
         if let Some(indices) = indices {
@@ -1240,9 +1287,11 @@ impl BeaconNodeHttpClient {
                 .append_pair("indices", &indices_string);
         }
 
-        self.get_opt(path)
-            .await
-            .map(|opt| opt.map(BeaconResponse::ForkVersioned))
+        self.get_fork_contextual(path, |fork| {
+            (fork, spec.max_blobs_per_block_by_fork(fork) as usize)
+        })
+        .await
+        .map(|opt| opt.map(BeaconResponse::ForkVersioned))
     }
 
     /// `GET v1/beacon/blinded_blocks/{block_id}`

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1085,17 +1085,8 @@ impl<'de> ContextDeserialize<'de, ForkName> for SseExtendedPayloadAttributes {
     where
         D: Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        struct Helper {
-            proposal_slot: Slot,
-            proposer_index: u64,
-            parent_block_root: Hash256,
-            parent_block_number: u64,
-            parent_block_hash: ExecutionBlockHash,
-            payload_attributes: serde_json::Value,
-        }
-
-        let helper = Helper::deserialize(deserializer)?;
+        let helper =
+            SseExtendedPayloadAttributesGeneric::<serde_json::Value>::deserialize(deserializer)?;
 
         Ok(Self {
             proposal_slot: helper.proposal_slot,

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1131,8 +1131,8 @@ pub enum EventKind<E: EthSpec> {
     ChainReorg(SseChainReorg),
     ContributionAndProof(Box<SignedContributionAndProof<E>>),
     LateHead(SseLateHead),
-    LightClientFinalityUpdate(Box<LightClientFinalityUpdate<E>>),
-    LightClientOptimisticUpdate(Box<LightClientOptimisticUpdate<E>>),
+    LightClientFinalityUpdate(Box<BeaconResponse<LightClientFinalityUpdate<E>>>),
+    LightClientOptimisticUpdate(Box<BeaconResponse<LightClientOptimisticUpdate<E>>>),
     #[cfg(feature = "lighthouse")]
     BlockReward(BlockReward),
     PayloadAttributes(VersionedSsePayloadAttributes),
@@ -1212,22 +1212,24 @@ impl<E: EthSpec> EventKind<E> {
                     ServerError::InvalidServerSentEvent(format!("Payload Attributes: {:?}", e))
                 })?,
             )),
-            "light_client_finality_update" => Ok(EventKind::LightClientFinalityUpdate(
-                serde_json::from_str(data).map_err(|e| {
+            "light_client_finality_update" => Ok(EventKind::LightClientFinalityUpdate(Box::new(
+                BeaconResponse::ForkVersioned(serde_json::from_str(data).map_err(|e| {
                     ServerError::InvalidServerSentEvent(format!(
                         "Light Client Finality Update: {:?}",
                         e
                     ))
-                })?,
-            )),
-            "light_client_optimistic_update" => Ok(EventKind::LightClientOptimisticUpdate(
-                serde_json::from_str(data).map_err(|e| {
-                    ServerError::InvalidServerSentEvent(format!(
-                        "Light Client Optimistic Update: {:?}",
-                        e
-                    ))
-                })?,
-            )),
+                })?),
+            ))),
+            "light_client_optimistic_update" => {
+                Ok(EventKind::LightClientOptimisticUpdate(Box::new(
+                    BeaconResponse::ForkVersioned(serde_json::from_str(data).map_err(|e| {
+                        ServerError::InvalidServerSentEvent(format!(
+                            "Light Client Optimistic Update: {:?}",
+                            e
+                        ))
+                    })?),
+                )))
+            }
             #[cfg(feature = "lighthouse")]
             "block_reward" => Ok(EventKind::BlockReward(serde_json::from_str(data).map_err(
                 |e| ServerError::InvalidServerSentEvent(format!("Block Reward: {:?}", e)),

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -10,7 +10,6 @@ use mediatype::{names, MediaType, MediaTypeList};
 use multiaddr::Multiaddr;
 use reqwest::header::HeaderMap;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::Value;
 use serde_utils::quoted_u64::Quoted;
 use ssz::{Decode, DecodeError};
 use ssz_derive::{Decode, Encode};
@@ -1050,51 +1049,71 @@ pub struct SseExtendedPayloadAttributesGeneric<T> {
 pub type SseExtendedPayloadAttributes = SseExtendedPayloadAttributesGeneric<SsePayloadAttributes>;
 pub type VersionedSsePayloadAttributes = ForkVersionedResponse<SseExtendedPayloadAttributes>;
 
-impl ForkVersionDeserialize for SsePayloadAttributes {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::value::Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        match fork_name {
-            ForkName::Bellatrix => serde_json::from_value(value)
-                .map(Self::V1)
-                .map_err(serde::de::Error::custom),
-            ForkName::Capella => serde_json::from_value(value)
-                .map(Self::V2)
-                .map_err(serde::de::Error::custom),
-            ForkName::Deneb => serde_json::from_value(value)
-                .map(Self::V3)
-                .map_err(serde::de::Error::custom),
-            ForkName::Electra => serde_json::from_value(value)
-                .map(Self::V3)
-                .map_err(serde::de::Error::custom),
-            ForkName::Fulu => serde_json::from_value(value)
-                .map(Self::V3)
-                .map_err(serde::de::Error::custom),
-            ForkName::Base | ForkName::Altair => Err(serde::de::Error::custom(format!(
-                "SsePayloadAttributes deserialization for {fork_name} not implemented"
-            ))),
-        }
+impl<'de> ContextDeserialize<'de, ForkName> for SsePayloadAttributes {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let convert_err = |e| {
+            serde::de::Error::custom(format!(
+                "SsePayloadAttributes failed to deserialize: {:?}",
+                e
+            ))
+        };
+        Ok(match context {
+            ForkName::Base | ForkName::Altair => {
+                return Err(serde::de::Error::custom(format!(
+                    "SsePayloadAttributes failed to deserialize: unsupported fork '{}'",
+                    context
+                )))
+            }
+            ForkName::Bellatrix => {
+                Self::V1(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Capella => {
+                Self::V2(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Deneb => {
+                Self::V3(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Electra => {
+                Self::V3(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Fulu => {
+                Self::V3(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+        })
     }
 }
 
-impl ForkVersionDeserialize for SseExtendedPayloadAttributes {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::value::Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        let helper: SseExtendedPayloadAttributesGeneric<serde_json::Value> =
-            serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+impl<'de> ContextDeserialize<'de, ForkName> for SseExtendedPayloadAttributes {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper {
+            proposal_slot: Slot,
+            proposer_index: u64,
+            parent_block_root: Hash256,
+            parent_block_number: u64,
+            parent_block_hash: ExecutionBlockHash,
+            payload_attributes: serde_json::Value,
+        }
+
+        let helper = Helper::deserialize(deserializer)?;
+
         Ok(Self {
             proposal_slot: helper.proposal_slot,
             proposer_index: helper.proposer_index,
             parent_block_root: helper.parent_block_root,
             parent_block_number: helper.parent_block_number,
             parent_block_hash: helper.parent_block_hash,
-            payload_attributes: SsePayloadAttributes::deserialize_by_fork::<D>(
+            payload_attributes: SsePayloadAttributes::context_deserialize(
                 helper.payload_attributes,
-                fork_name,
-            )?,
+                context,
+            )
+            .map_err(serde::de::Error::custom)?,
         })
     }
 }
@@ -1724,18 +1743,18 @@ impl<E: EthSpec> FullBlockContents<E> {
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for FullBlockContents<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::value::Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        if fork_name.deneb_enabled() {
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for FullBlockContents<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if context.deneb_enabled() {
             Ok(FullBlockContents::BlockContents(
-                BlockContents::deserialize_by_fork::<'de, D>(value, fork_name)?,
+                BlockContents::context_deserialize::<D>(deserializer, context)?,
             ))
         } else {
             Ok(FullBlockContents::Block(
-                BeaconBlock::deserialize_by_fork::<'de, D>(value, fork_name)?,
+                BeaconBlock::context_deserialize::<D>(deserializer, context)?,
             ))
         }
     }
@@ -1905,11 +1924,11 @@ pub struct BlockContents<E: EthSpec> {
     pub blobs: BlobsList<E>,
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for BlockContents<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::value::Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for BlockContents<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         #[derive(Deserialize)]
         #[serde(bound = "E: EthSpec")]
         struct Helper<E: EthSpec> {
@@ -1918,10 +1937,13 @@ impl<E: EthSpec> ForkVersionDeserialize for BlockContents<E> {
             #[serde(with = "ssz_types::serde_utils::list_of_hex_fixed_vec")]
             blobs: BlobsList<E>,
         }
-        let helper: Helper<E> = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        let helper = Helper::<E>::deserialize(deserializer).map_err(serde::de::Error::custom)?;
+
+        let block = BeaconBlock::context_deserialize(helper.block, context)
+            .map_err(serde::de::Error::custom)?;
 
         Ok(Self {
-            block: BeaconBlock::deserialize_by_fork::<'de, D>(helper.block, fork_name)?,
+            block,
             kzg_proofs: helper.kzg_proofs,
             blobs: helper.blobs,
         })
@@ -1993,22 +2015,22 @@ impl<E: EthSpec> FullPayloadContents<E> {
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for FullPayloadContents<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
-        value: Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        if fork_name.deneb_enabled() {
-            ExecutionPayloadAndBlobs::deserialize_by_fork::<'de, D>(value, fork_name)
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for FullPayloadContents<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if context.deneb_enabled() {
+            ExecutionPayloadAndBlobs::context_deserialize::<D>(deserializer, context)
                 .map(Self::PayloadAndBlobs)
                 .map_err(serde::de::Error::custom)
-        } else if fork_name.bellatrix_enabled() {
-            ExecutionPayload::deserialize_by_fork::<'de, D>(value, fork_name)
+        } else if context.bellatrix_enabled() {
+            ExecutionPayload::context_deserialize::<D>(deserializer, context)
                 .map(Self::Payload)
                 .map_err(serde::de::Error::custom)
         } else {
             Err(serde::de::Error::custom(format!(
-                "FullPayloadContents deserialization for {fork_name} not implemented"
+                "FullPayloadContents deserialization for {context} not implemented"
             )))
         }
     }
@@ -2021,23 +2043,25 @@ pub struct ExecutionPayloadAndBlobs<E: EthSpec> {
     pub blobs_bundle: BlobsBundle<E>,
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for ExecutionPayloadAndBlobs<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
-        value: Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for ExecutionPayloadAndBlobs<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         #[derive(Deserialize)]
         #[serde(bound = "E: EthSpec")]
         struct Helper<E: EthSpec> {
             execution_payload: serde_json::Value,
             blobs_bundle: BlobsBundle<E>,
         }
-        let helper: Helper<E> = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        let helper = Helper::<E>::deserialize(deserializer).map_err(serde::de::Error::custom)?;
+
         Ok(Self {
-            execution_payload: ExecutionPayload::deserialize_by_fork::<'de, D>(
+            execution_payload: ExecutionPayload::context_deserialize(
                 helper.execution_payload,
-                fork_name,
-            )?,
+                context,
+            )
+            .map_err(serde::de::Error::custom)?,
             blobs_bundle: helper.blobs_bundle,
         })
     }
@@ -2278,14 +2302,13 @@ mod test {
     fn generic_deserialize_by_fork<
         'de,
         D: Deserializer<'de>,
-        O: ForkVersionDeserialize + PartialEq + Debug,
+        O: ContextDeserialize<'de, ForkName> + PartialEq + Debug,
     >(
         deserializer: D,
         original: O,
         fork_name: ForkName,
     ) {
-        let val = Value::deserialize(deserializer).unwrap();
-        let roundtrip = O::deserialize_by_fork::<'de, D>(val, fork_name).unwrap();
+        let roundtrip = O::context_deserialize::<D>(deserializer, fork_name).unwrap();
         assert_eq!(original, roundtrip);
     }
 }

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1603,7 +1603,7 @@ mod tests {
     }
 }
 
-#[derive(Debug, Encode, Serialize, Deserialize)]
+#[derive(Debug, Encode, Serialize)]
 #[serde(untagged)]
 #[serde(bound = "E: EthSpec")]
 #[ssz(enum_behaviour = "transparent")]
@@ -1616,7 +1616,7 @@ pub type JsonProduceBlockV3Response<E> =
     ForkVersionedResponse<ProduceBlockV3Response<E>, ProduceBlockV3Metadata>;
 
 /// A wrapper over a [`BeaconBlock`] or a [`BlockContents`].
-#[derive(Debug, Encode, Serialize, Deserialize)]
+#[derive(Debug, Encode, Serialize)]
 #[serde(untagged)]
 #[serde(bound = "E: EthSpec")]
 #[ssz(enum_behaviour = "transparent")]
@@ -1808,13 +1808,33 @@ impl TryFrom<&HeaderMap> for ProduceBlockV3Metadata {
 }
 
 /// A wrapper over a [`SignedBeaconBlock`] or a [`SignedBlockContents`].
-#[derive(Clone, Debug, Encode, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Encode, Serialize)]
 #[serde(untagged)]
 #[serde(bound = "E: EthSpec")]
 #[ssz(enum_behaviour = "transparent")]
 pub enum PublishBlockRequest<E: EthSpec> {
     BlockContents(SignedBlockContents<E>),
     Block(Arc<SignedBeaconBlock<E>>),
+}
+
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for PublishBlockRequest<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value =
+            serde_json::Value::deserialize(deserializer).map_err(serde::de::Error::custom)?;
+
+        SignedBlockContents::<E>::context_deserialize(&value, context)
+            .map(PublishBlockRequest::BlockContents)
+            .or_else(|_| {
+                Arc::<SignedBeaconBlock<E>>::context_deserialize(&value, context)
+                    .map(PublishBlockRequest::Block)
+            })
+            .map_err(|_| {
+                serde::de::Error::custom("could not match any variant of PublishBlockRequest")
+            })
+    }
 }
 
 impl<E: EthSpec> PublishBlockRequest<E> {
@@ -1893,7 +1913,7 @@ impl<E: EthSpec> From<SignedBlockContentsTuple<E>> for PublishBlockRequest<E> {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Encode)]
+#[derive(Debug, Clone, PartialEq, Serialize, Encode)]
 #[serde(bound = "E: EthSpec")]
 pub struct SignedBlockContents<E: EthSpec> {
     pub signed_block: Arc<SignedBeaconBlock<E>>,
@@ -1902,7 +1922,33 @@ pub struct SignedBlockContents<E: EthSpec> {
     pub blobs: BlobsList<E>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Encode)]
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for SignedBlockContents<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(bound = "E: EthSpec")]
+        struct Helper<E: EthSpec> {
+            signed_block: serde_json::Value,
+            kzg_proofs: KzgProofs<E>,
+            #[serde(with = "ssz_types::serde_utils::list_of_hex_fixed_vec")]
+            blobs: BlobsList<E>,
+        }
+        let helper = Helper::<E>::deserialize(deserializer).map_err(serde::de::Error::custom)?;
+
+        let block = SignedBeaconBlock::context_deserialize(helper.signed_block, context)
+            .map_err(serde::de::Error::custom)?;
+
+        Ok(Self {
+            signed_block: Arc::new(block),
+            kzg_proofs: helper.kzg_proofs,
+            blobs: helper.blobs,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Encode)]
 #[serde(bound = "E: EthSpec")]
 pub struct BlockContents<E: EthSpec> {
     pub block: BeaconBlock<E>,
@@ -2195,6 +2241,73 @@ mod test {
         let pubkey_str = "\"0xb824b5ede33a7b05a378a84b183b4bc7e7db894ce48b659f150c97d359edca2f503081d6678d1200f582ec7cafa9caf2\"";
         let y: ValidatorId = serde_json::from_str(pubkey_str).unwrap();
         assert_eq!(serde_json::to_string(&y).unwrap(), pubkey_str);
+    }
+
+    #[test]
+    fn test_publish_block_request_context_deserialize() {
+        let round_trip_test = |request: PublishBlockRequest<MainnetEthSpec>| {
+            let fork_name = request.signed_block().fork_name_unchecked();
+            let json_str = serde_json::to_string(&request).unwrap();
+            let mut de = serde_json::Deserializer::from_str(&json_str);
+            let deserialized_request =
+                PublishBlockRequest::<MainnetEthSpec>::context_deserialize(&mut de, fork_name)
+                    .unwrap();
+            assert_eq!(request, deserialized_request);
+        };
+
+        let rng = &mut XorShiftRng::from_seed([42; 16]);
+        for fork_name in ForkName::list_all() {
+            let signed_beacon_block =
+                map_fork_name!(fork_name, SignedBeaconBlock, <_>::random_for_test(rng));
+            let request = if fork_name.deneb_enabled() {
+                let kzg_proofs = KzgProofs::<MainnetEthSpec>::random_for_test(rng);
+                let blobs = BlobsList::<MainnetEthSpec>::random_for_test(rng);
+                let block_contents = SignedBlockContents {
+                    signed_block: Arc::new(signed_beacon_block),
+                    kzg_proofs,
+                    blobs,
+                };
+                PublishBlockRequest::BlockContents(block_contents)
+            } else {
+                PublishBlockRequest::Block(Arc::new(signed_beacon_block))
+            };
+            round_trip_test(request);
+            println!("fork_name: {:?} PASSED", fork_name);
+        }
+    }
+
+    #[test]
+    fn test_signed_block_contents_context_deserialize() {
+        let round_trip_test = |contents: SignedBlockContents<MainnetEthSpec>| {
+            let fork_name = contents.signed_block.fork_name_unchecked();
+            let json_str = serde_json::to_string(&contents).unwrap();
+            let mut de = serde_json::Deserializer::from_str(&json_str);
+            let deserialized_contents =
+                SignedBlockContents::<MainnetEthSpec>::context_deserialize(&mut de, fork_name)
+                    .unwrap();
+            assert_eq!(contents, deserialized_contents);
+        };
+
+        let mut fork_name = ForkName::Deneb;
+        let rng = &mut XorShiftRng::from_seed([42; 16]);
+        loop {
+            let signed_beacon_block =
+                map_fork_name!(fork_name, SignedBeaconBlock, <_>::random_for_test(rng));
+            let kzg_proofs = KzgProofs::<MainnetEthSpec>::random_for_test(rng);
+            let blobs = BlobsList::<MainnetEthSpec>::random_for_test(rng);
+            let block_contents = SignedBlockContents {
+                signed_block: Arc::new(signed_beacon_block),
+                kzg_proofs,
+                blobs,
+            };
+            round_trip_test(block_contents);
+            println!("fork_name: {:?} PASSED", fork_name);
+            if let Some(next_fork_name) = fork_name.next_fork() {
+                fork_name = next_fork_name;
+            } else {
+                break;
+            }
+        }
     }
 
     #[test]

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1073,13 +1073,7 @@ impl<'de> ContextDeserialize<'de, ForkName> for SsePayloadAttributes {
             ForkName::Capella => {
                 Self::V2(Deserialize::deserialize(deserializer).map_err(convert_err)?)
             }
-            ForkName::Deneb => {
-                Self::V3(Deserialize::deserialize(deserializer).map_err(convert_err)?)
-            }
-            ForkName::Electra => {
-                Self::V3(Deserialize::deserialize(deserializer).map_err(convert_err)?)
-            }
-            ForkName::Fulu => {
+            ForkName::Deneb | ForkName::Electra | ForkName::Fulu => {
                 Self::V3(Deserialize::deserialize(deserializer).map_err(convert_err)?)
             }
         })

--- a/consensus/context_deserialize/Cargo.toml
+++ b/consensus/context_deserialize/Cargo.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+milhouse = { workspace = true }
 serde = { workspace = true }
+ssz_types = { workspace = true }

--- a/consensus/context_deserialize/Cargo.toml
+++ b/consensus/context_deserialize/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "context_deserialize"
 version = "0.1.0"
-edition.workspace = true
+edition = "2021"
 
 [dependencies]
 serde = { workspace = true }

--- a/consensus/context_deserialize/Cargo.toml
+++ b/consensus/context_deserialize/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "context_deserialize"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+serde = { workspace = true }

--- a/consensus/context_deserialize/src/impls.rs
+++ b/consensus/context_deserialize/src/impls.rs
@@ -2,6 +2,7 @@ use crate::ContextDeserialize;
 use serde::de::{Deserialize, DeserializeSeed, Deserializer, SeqAccess, Visitor};
 use std::marker::PhantomData;
 use std::sync::Arc;
+
 impl<'de, C, T> ContextDeserialize<'de, T> for Arc<C>
 where
     C: ContextDeserialize<'de, T>,

--- a/consensus/context_deserialize/src/impls.rs
+++ b/consensus/context_deserialize/src/impls.rs
@@ -15,12 +15,12 @@ where
     }
 }
 
-impl<'de, C, T> ContextDeserialize<'de, T> for Vec<C>
+impl<'de, T, C> ContextDeserialize<'de, C> for Vec<T>
 where
-    C: ContextDeserialize<'de, T>,
-    T: Clone,
+    T: ContextDeserialize<'de, C>,
+    C: Clone,
 {
-    fn context_deserialize<D>(deserializer: D, context: T) -> Result<Self, D::Error>
+    fn context_deserialize<D>(deserializer: D, context: C) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -58,23 +58,23 @@ where
         }
 
         // A little seed that hands the deserializer + context into C::context_deserialize
-        struct ContextSeed<C, T> {
-            context: T,
-            _marker: PhantomData<C>,
+        struct ContextSeed<T, C> {
+            context: C,
+            _marker: PhantomData<T>,
         }
 
-        impl<'de, C, T> DeserializeSeed<'de> for ContextSeed<C, T>
+        impl<'de, T, C> DeserializeSeed<'de> for ContextSeed<T, C>
         where
-            C: ContextDeserialize<'de, T>,
-            T: Clone,
+            T: ContextDeserialize<'de, C>,
+            C: Clone,
         {
-            type Value = C;
+            type Value = T;
 
-            fn deserialize<D>(self, deserializer: D) -> Result<C, D::Error>
+            fn deserialize<D>(self, deserializer: D) -> Result<T, D::Error>
             where
                 D: Deserializer<'de>,
             {
-                C::context_deserialize(deserializer, self.context)
+                T::context_deserialize(deserializer, self.context)
             }
         }
 

--- a/consensus/context_deserialize/src/impls.rs
+++ b/consensus/context_deserialize/src/impls.rs
@@ -1,0 +1,102 @@
+use crate::ContextDeserialize;
+use serde::de::{Deserialize, DeserializeSeed, Deserializer, SeqAccess, Visitor};
+use std::marker::PhantomData;
+use std::sync::Arc;
+impl<'de, C, T> ContextDeserialize<'de, T> for Arc<C>
+where
+    C: ContextDeserialize<'de, T>,
+{
+    fn context_deserialize<D>(deserializer: D, context: T) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Arc::new(C::context_deserialize(deserializer, context)?))
+    }
+}
+
+impl<'de, C, T> ContextDeserialize<'de, T> for Vec<C>
+where
+    C: ContextDeserialize<'de, T>,
+    T: Clone,
+{
+    fn context_deserialize<D>(deserializer: D, context: T) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Our Visitor, which owns one copy of the context T
+        struct ContextVisitor<C, T> {
+            context: T,
+            _marker: PhantomData<C>,
+        }
+
+        impl<'de, C, T> Visitor<'de> for ContextVisitor<C, T>
+        where
+            C: ContextDeserialize<'de, T>,
+            T: Clone,
+        {
+            type Value = Vec<C>;
+
+            fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+                fmt.write_str("a sequence of context‐deserialized elements")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Vec<C>, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                // for each element, we clone the context and hand it to the seed
+                while let Some(elem) = seq.next_element_seed(ContextSeed {
+                    context: self.context.clone(),
+                    _marker: PhantomData,
+                })? {
+                    out.push(elem);
+                }
+                Ok(out)
+            }
+        }
+
+        // A little seed that hands the deserializer + context into C::context_deserialize
+        struct ContextSeed<C, T> {
+            context: T,
+            _marker: PhantomData<C>,
+        }
+
+        impl<'de, C, T> DeserializeSeed<'de> for ContextSeed<C, T>
+        where
+            C: ContextDeserialize<'de, T>,
+            T: Clone,
+        {
+            type Value = C;
+
+            fn deserialize<D>(self, deserializer: D) -> Result<C, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                C::context_deserialize(deserializer, self.context)
+            }
+        }
+
+        deserializer.deserialize_seq(ContextVisitor {
+            context,
+            _marker: PhantomData,
+        })
+    }
+}
+
+macro_rules! trivial_deserialize {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl<'de, T> ContextDeserialize<'de, T> for $t {
+                fn context_deserialize<D>(deserializer: D, _context: T) -> Result<Self, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    <$t>::deserialize(deserializer)
+                }
+            }
+        )*
+    };
+}
+
+trivial_deserialize!(bool, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64);

--- a/consensus/context_deserialize/src/lib.rs
+++ b/consensus/context_deserialize/src/lib.rs
@@ -1,93 +1,13 @@
-extern crate serde;
+pub mod impls;
+pub mod milhouse;
+pub mod ssz_impls;
 
-use serde::de::{DeserializeSeed, Deserializer, SeqAccess, Visitor};
-use std::marker::PhantomData;
-use std::sync::Arc;
+extern crate serde;
+use serde::de::Deserializer;
+
 /// General-purpose deserialization trait that accepts extra context `C`.
 pub trait ContextDeserialize<'de, C>: Sized {
     fn context_deserialize<D>(deserializer: D, context: C) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>;
-}
-
-impl<'de, C, T> ContextDeserialize<'de, T> for Arc<C>
-where
-    C: ContextDeserialize<'de, T>,
-{
-    fn context_deserialize<D>(deserializer: D, context: T) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(Arc::new(C::context_deserialize(deserializer, context)?))
-    }
-}
-
-impl<'de, C, T> ContextDeserialize<'de, T> for Vec<C>
-where
-    C: ContextDeserialize<'de, T>,
-    T: Clone,
-{
-    fn context_deserialize<D>(deserializer: D, context: T) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        // Our Visitor, which owns one copy of the context T
-        struct ContextVisitor<C, T> {
-            context: T,
-            _marker: PhantomData<C>,
-        }
-
-        impl<'de, C, T> Visitor<'de> for ContextVisitor<C, T>
-        where
-            C: ContextDeserialize<'de, T>,
-            T: Clone,
-        {
-            type Value = Vec<C>;
-
-            fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-                fmt.write_str("a sequence of context‐deserialized elements")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Vec<C>, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
-                let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0));
-                // for each element, we clone the context and hand it to the seed
-                while let Some(elem) = seq.next_element_seed(ContextSeed {
-                    context: self.context.clone(),
-                    _marker: PhantomData,
-                })? {
-                    out.push(elem);
-                }
-                Ok(out)
-            }
-        }
-
-        // A little seed that hands the deserializer + context into C::context_deserialize
-        struct ContextSeed<C, T> {
-            context: T,
-            _marker: PhantomData<C>,
-        }
-
-        impl<'de, C, T> DeserializeSeed<'de> for ContextSeed<C, T>
-        where
-            C: ContextDeserialize<'de, T>,
-            T: Clone,
-        {
-            type Value = C;
-
-            fn deserialize<D>(self, deserializer: D) -> Result<C, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                C::context_deserialize(deserializer, self.context)
-            }
-        }
-
-        deserializer.deserialize_seq(ContextVisitor {
-            context,
-            _marker: PhantomData,
-        })
-    }
 }

--- a/consensus/context_deserialize/src/lib.rs
+++ b/consensus/context_deserialize/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate serde;
+
 use serde::de::{DeserializeSeed, Deserializer, SeqAccess, Visitor};
 use std::marker::PhantomData;
 use std::sync::Arc;

--- a/consensus/context_deserialize/src/lib.rs
+++ b/consensus/context_deserialize/src/lib.rs
@@ -1,28 +1,91 @@
-use serde::de::Deserializer;
-
+use serde::de::{DeserializeSeed, Deserializer, SeqAccess, Visitor};
+use std::marker::PhantomData;
+use std::sync::Arc;
 /// General-purpose deserialization trait that accepts extra context `C`.
 pub trait ContextDeserialize<'de, C>: Sized {
-    fn context_deserialize<D>(
-        deserializer: D,
-        context: C,
-    ) -> Result<Self, D::Error>
+    fn context_deserialize<D>(deserializer: D, context: C) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>;
 }
 
-/// Blanket impl for ordinary `serde::Deserialize` types
-/// when `Context = ()`.
-impl<'de, T> ContextDeserialize<'de, ()> for T
+impl<'de, C, T> ContextDeserialize<'de, T> for Arc<C>
 where
-    T: serde::Deserialize<'de>,
+    C: ContextDeserialize<'de, T>,
 {
-    fn context_deserialize<D>(
-        deserializer: D,
-        _context: (),
-    ) -> Result<Self, D::Error>
+    fn context_deserialize<D>(deserializer: D, context: T) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        T::deserialize(deserializer)
+        Ok(Arc::new(C::context_deserialize(deserializer, context)?))
+    }
+}
+
+impl<'de, C, T> ContextDeserialize<'de, T> for Vec<C>
+where
+    C: ContextDeserialize<'de, T>,
+    T: Clone,
+{
+    fn context_deserialize<D>(deserializer: D, context: T) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Our Visitor, which owns one copy of the context T
+        struct ContextVisitor<C, T> {
+            context: T,
+            _marker: PhantomData<C>,
+        }
+
+        impl<'de, C, T> Visitor<'de> for ContextVisitor<C, T>
+        where
+            C: ContextDeserialize<'de, T>,
+            T: Clone,
+        {
+            type Value = Vec<C>;
+
+            fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+                fmt.write_str("a sequence of context‐deserialized elements")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Vec<C>, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                // for each element, we clone the context and hand it to the seed
+                while let Some(elem) = seq.next_element_seed(ContextSeed {
+                    context: self.context.clone(),
+                    _marker: PhantomData,
+                })? {
+                    out.push(elem);
+                }
+                Ok(out)
+            }
+        }
+
+        // A little seed that hands the deserializer + context into C::context_deserialize
+        struct ContextSeed<C, T> {
+            context: T,
+            _marker: PhantomData<C>,
+        }
+
+        impl<'de, C, T> DeserializeSeed<'de> for ContextSeed<C, T>
+        where
+            C: ContextDeserialize<'de, T>,
+            T: Clone,
+        {
+            type Value = C;
+
+            fn deserialize<D>(self, deserializer: D) -> Result<C, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                C::context_deserialize(deserializer, self.context)
+            }
+        }
+
+        deserializer.deserialize_seq(ContextVisitor {
+            context,
+            _marker: PhantomData,
+        })
     }
 }

--- a/consensus/context_deserialize/src/lib.rs
+++ b/consensus/context_deserialize/src/lib.rs
@@ -1,0 +1,28 @@
+use serde::de::Deserializer;
+
+/// General-purpose deserialization trait that accepts extra context `C`.
+pub trait ContextDeserialize<'de, C>: Sized {
+    fn context_deserialize<D>(
+        deserializer: D,
+        context: C,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>;
+}
+
+/// Blanket impl for ordinary `serde::Deserialize` types
+/// when `Context = ()`.
+impl<'de, T> ContextDeserialize<'de, ()> for T
+where
+    T: serde::Deserialize<'de>,
+{
+    fn context_deserialize<D>(
+        deserializer: D,
+        _context: (),
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        T::deserialize(deserializer)
+    }
+}

--- a/consensus/context_deserialize/src/milhouse.rs
+++ b/consensus/context_deserialize/src/milhouse.rs
@@ -1,0 +1,101 @@
+use crate::ContextDeserialize;
+use milhouse::{List, Value, Vector};
+use serde::de::{DeserializeSeed, Deserializer, SeqAccess, Visitor};
+use ssz_types::typenum::Unsigned;
+use std::marker::PhantomData;
+
+impl<'de, C, T, N> ContextDeserialize<'de, C> for List<T, N>
+where
+    T: ContextDeserialize<'de, C> + Value,
+    N: Unsigned,
+    C: Clone,
+{
+    fn context_deserialize<D>(deserializer: D, context: C) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Our Visitor, which owns one copy of the context C
+        struct ListVisitor<C, T, N> {
+            context: C,
+            _marker: PhantomData<(T, N)>,
+        }
+
+        impl<'de, C, T, N> Visitor<'de> for ListVisitor<C, T, N>
+        where
+            C: Clone,
+            T: ContextDeserialize<'de, C> + Value,
+            N: Unsigned,
+        {
+            type Value = List<T, N>;
+
+            fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+                fmt.write_str("a sequence of context‐deserialized elements")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<List<T, N>, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+
+                // for each element, we clone the context and hand it to the seed
+                while let Some(elem) = seq.next_element_seed(ContextSeed {
+                    context: self.context.clone(),
+                    _marker: PhantomData,
+                })? {
+                    out.push(elem);
+                }
+
+                List::new(out).map_err(|e| {
+                    serde::de::Error::custom(format!("Failed to create List: {:?}", e))
+                })
+            }
+        }
+
+        // A little seed that hands the deserializer + context into T::context_deserialize
+        struct ContextSeed<C, T> {
+            context: C,
+            _marker: PhantomData<T>,
+        }
+
+        impl<'de, C, T> DeserializeSeed<'de> for ContextSeed<C, T>
+        where
+            C: Clone,
+            T: ContextDeserialize<'de, C>,
+        {
+            type Value = T;
+
+            fn deserialize<D>(self, deserializer: D) -> Result<T, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                T::context_deserialize(deserializer, self.context)
+            }
+        }
+
+        deserializer.deserialize_seq(ListVisitor {
+            context,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<'de, C, T, N> ContextDeserialize<'de, C> for Vector<T, N>
+where
+    T: ContextDeserialize<'de, C> + Value,
+    N: Unsigned,
+    C: Clone,
+{
+    fn context_deserialize<D>(deserializer: D, context: C) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // First deserialize as a List
+        let list = List::<T, N>::context_deserialize(deserializer, context)?;
+
+        // Then convert to Vector, which will check the length
+        Vector::try_from(list).map_err(|e| {
+            serde::de::Error::custom(format!("Failed to convert List to Vector: {:?}", e))
+        })
+    }
+}

--- a/consensus/context_deserialize/src/milhouse.rs
+++ b/consensus/context_deserialize/src/milhouse.rs
@@ -1,8 +1,7 @@
 use crate::ContextDeserialize;
 use milhouse::{List, Value, Vector};
-use serde::de::{DeserializeSeed, Deserializer, SeqAccess, Visitor};
+use serde::de::Deserializer;
 use ssz_types::typenum::Unsigned;
-use std::marker::PhantomData;
 
 impl<'de, C, T, N> ContextDeserialize<'de, C> for List<T, N>
 where
@@ -14,69 +13,14 @@ where
     where
         D: Deserializer<'de>,
     {
-        // Our Visitor, which owns one copy of the context C
-        struct ListVisitor<C, T, N> {
-            context: C,
-            _marker: PhantomData<(T, N)>,
-        }
+        // First deserialize as a Vec.
+        // This is not the most efficient implementation as it allocates a temporary Vec. In future
+        // we could write a more performant implementation using `List::builder()`.
+        let vec = Vec::<T>::context_deserialize(deserializer, context)?;
 
-        impl<'de, C, T, N> Visitor<'de> for ListVisitor<C, T, N>
-        where
-            C: Clone,
-            T: ContextDeserialize<'de, C> + Value,
-            N: Unsigned,
-        {
-            type Value = List<T, N>;
-
-            fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-                fmt.write_str("a sequence of context‐deserialized elements")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<List<T, N>, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
-                let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0));
-
-                // for each element, we clone the context and hand it to the seed
-                while let Some(elem) = seq.next_element_seed(ContextSeed {
-                    context: self.context.clone(),
-                    _marker: PhantomData,
-                })? {
-                    out.push(elem);
-                }
-
-                List::new(out).map_err(|e| {
-                    serde::de::Error::custom(format!("Failed to create List: {:?}", e))
-                })
-            }
-        }
-
-        // A little seed that hands the deserializer + context into T::context_deserialize
-        struct ContextSeed<C, T> {
-            context: C,
-            _marker: PhantomData<T>,
-        }
-
-        impl<'de, C, T> DeserializeSeed<'de> for ContextSeed<C, T>
-        where
-            C: Clone,
-            T: ContextDeserialize<'de, C>,
-        {
-            type Value = T;
-
-            fn deserialize<D>(self, deserializer: D) -> Result<T, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                T::context_deserialize(deserializer, self.context)
-            }
-        }
-
-        deserializer.deserialize_seq(ListVisitor {
-            context,
-            _marker: PhantomData,
-        })
+        // Then convert to List, which will check the length.
+        List::new(vec)
+            .map_err(|e| serde::de::Error::custom(format!("Failed to create List: {:?}", e)))
     }
 }
 

--- a/consensus/context_deserialize/src/ssz_impls.rs
+++ b/consensus/context_deserialize/src/ssz_impls.rs
@@ -1,0 +1,48 @@
+use crate::serde::de::Error;
+use crate::ContextDeserialize;
+use serde::de::Deserializer;
+use serde::Deserialize;
+use ssz_types::length::{Fixed, Variable};
+use ssz_types::typenum::Unsigned;
+use ssz_types::{Bitfield, FixedVector};
+
+impl<'de, C, T, N> ContextDeserialize<'de, C> for FixedVector<T, N>
+where
+    T: ContextDeserialize<'de, C>,
+    N: Unsigned,
+    C: Clone,
+{
+    fn context_deserialize<D>(deserializer: D, context: C) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let vec = Vec::<T>::context_deserialize(deserializer, context)?;
+        FixedVector::new(vec).map_err(|e| D::Error::custom(format!("{:?}", e)))
+    }
+}
+
+impl<'de, C, N> ContextDeserialize<'de, C> for Bitfield<Variable<N>>
+where
+    N: Unsigned + Clone,
+{
+    fn context_deserialize<D>(deserializer: D, _context: C) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Bitfield::<Variable<N>>::deserialize(deserializer)
+            .map_err(|e| D::Error::custom(format!("{:?}", e)))
+    }
+}
+
+impl<'de, C, N> ContextDeserialize<'de, C> for Bitfield<Fixed<N>>
+where
+    N: Unsigned + Clone,
+{
+    fn context_deserialize<D>(deserializer: D, _context: C) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Bitfield::<Fixed<N>>::deserialize(deserializer)
+            .map_err(|e| D::Error::custom(format!("{:?}", e)))
+    }
+}

--- a/consensus/context_deserialize_derive/Cargo.toml
+++ b/consensus/context_deserialize_derive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "context_deserialize_derive"
+version = "0.1.0"
+edition.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { workspace = true }
+quote = { workspace = true }
+serde = { workspace = true }

--- a/consensus/context_deserialize_derive/Cargo.toml
+++ b/consensus/context_deserialize_derive/Cargo.toml
@@ -8,5 +8,4 @@ proc-macro = true
 
 [dependencies]
 quote = { workspace = true }
-serde = { workspace = true }
 syn = { workspace = true }

--- a/consensus/context_deserialize_derive/Cargo.toml
+++ b/consensus/context_deserialize_derive/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "context_deserialize_derive"
 version = "0.1.0"
-edition.workspace = true
+edition = "2021"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-syn = { workspace = true }
 quote = { workspace = true }
 serde = { workspace = true }
+syn = { workspace = true }

--- a/consensus/context_deserialize_derive/Cargo.toml
+++ b/consensus/context_deserialize_derive/Cargo.toml
@@ -9,3 +9,8 @@ proc-macro = true
 [dependencies]
 quote = { workspace = true }
 syn = { workspace = true }
+
+[dev-dependencies]
+context_deserialize = { path = "../context_deserialize" }
+serde = { workspace = true }
+serde_json = "1.0"

--- a/consensus/context_deserialize_derive/src/lib.rs
+++ b/consensus/context_deserialize_derive/src/lib.rs
@@ -1,0 +1,77 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse_macro_input, AttributeArgs, DeriveInput, Meta, NestedMeta, Path,
+    LifetimeDef,
+};
+
+/// `#[context_deserialize(Foo, Bar, ...)]`
+/// generates `ContextDeserialize<'de, Foo>` and `ContextDeserialize<'de, Bar>`
+/// forwarding impls for the given struct.
+#[proc_macro_attribute]
+pub fn context_deserialize(attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Parse attribute and input struct
+    let args  = parse_macro_input!(attr  as AttributeArgs);
+    let input = parse_macro_input!(item  as DeriveInput);
+    let ident = &input.ident;
+
+    // Context types provided in macro
+    let ctx_types: Vec<Path> = args
+        .iter()
+        .filter_map(|meta| match meta {
+            NestedMeta::Meta(Meta::Path(p)) => Some(p.clone()),
+            _ => None,
+        })
+        .collect();
+
+    if ctx_types.is_empty() {
+        return quote! {
+            compile_error!("Usage: #[context_deserialize(Type1, Type2, ...)]");
+        }
+        .into();
+    }
+
+    // Generic handling
+    let generics = &input.generics;
+    let params   = &generics.params;
+    let (_, ty_generics, where_clause) = generics.split_for_impl();
+
+    let has_de = generics
+        .lifetimes()
+        .any(|LifetimeDef { lifetime, .. }| lifetime.ident == "de");
+
+    let base_generics = if has_de {
+        quote! { #params }
+    } else if params.is_empty() {
+        quote! { 'de }
+    } else {
+        quote! { 'de, #params }
+    };
+
+    // Generate impls per context type
+    let mut impls = quote! {};
+    for ctx in ctx_types {
+        impls.extend(quote! {
+            impl<#base_generics> context_deserialize::ContextDeserialize<'de, #ctx>
+                for #ident #ty_generics #where_clause
+            {
+                fn context_deserialize<D>(
+                    deserializer: D,
+                    _context: #ctx,
+                ) -> Result<Self, D::Error>
+                where
+                    D: serde::de::Deserializer<'de>,
+                {
+                    <Self as serde::Deserialize>::deserialize(deserializer)
+                }
+            }
+        });
+    }
+
+    // Final output: input struct + impl blocks
+    quote! {
+        #input
+        #impls
+    }
+    .into()
+}

--- a/consensus/context_deserialize_derive/src/lib.rs
+++ b/consensus/context_deserialize_derive/src/lib.rs
@@ -1,9 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{
-    parse_macro_input, AttributeArgs, DeriveInput, Meta, NestedMeta, Path,
-    LifetimeDef,
-};
+use syn::{parse_macro_input, AttributeArgs, DeriveInput, LifetimeDef, Meta, NestedMeta, Path};
 
 /// `#[context_deserialize(Foo, Bar, ...)]`
 /// generates `ContextDeserialize<'de, Foo>` and `ContextDeserialize<'de, Bar>`
@@ -11,8 +8,8 @@ use syn::{
 #[proc_macro_attribute]
 pub fn context_deserialize(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Parse attribute and input struct
-    let args  = parse_macro_input!(attr  as AttributeArgs);
-    let input = parse_macro_input!(item  as DeriveInput);
+    let args = parse_macro_input!(attr as AttributeArgs);
+    let input = parse_macro_input!(item as DeriveInput);
     let ident = &input.ident;
 
     // Context types provided in macro
@@ -33,7 +30,7 @@ pub fn context_deserialize(attr: TokenStream, item: TokenStream) -> TokenStream 
 
     // Generic handling
     let generics = &input.generics;
-    let params   = &generics.params;
+    let params = &generics.params;
     let (_, ty_generics, where_clause) = generics.split_for_impl();
 
     let has_de = generics

--- a/consensus/context_deserialize_derive/src/lib.rs
+++ b/consensus/context_deserialize_derive/src/lib.rs
@@ -1,3 +1,7 @@
+extern crate proc_macro;
+extern crate quote;
+extern crate syn;
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, AttributeArgs, DeriveInput, LifetimeDef, Meta, NestedMeta, Path};

--- a/consensus/context_deserialize_derive/src/lib.rs
+++ b/consensus/context_deserialize_derive/src/lib.rs
@@ -4,57 +4,98 @@ extern crate syn;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, AttributeArgs, DeriveInput, LifetimeDef, Meta, NestedMeta, Path};
+use syn::{
+    parse_macro_input, AttributeArgs, DeriveInput, GenericParam, LifetimeDef, Meta, NestedMeta,
+    WhereClause,
+};
 
-/// `#[context_deserialize(Foo, Bar, ...)]`
-/// generates `ContextDeserialize<'de, Foo>` and `ContextDeserialize<'de, Bar>`
-/// forwarding impls for the given struct.
 #[proc_macro_attribute]
 pub fn context_deserialize(attr: TokenStream, item: TokenStream) -> TokenStream {
-    // Parse attribute and input struct
     let args = parse_macro_input!(attr as AttributeArgs);
     let input = parse_macro_input!(item as DeriveInput);
     let ident = &input.ident;
 
-    // Context types provided in macro
-    let ctx_types: Vec<Path> = args
-        .iter()
-        .filter_map(|meta| match meta {
-            NestedMeta::Meta(Meta::Path(p)) => Some(p.clone()),
-            _ => None,
-        })
-        .collect();
+    let mut ctx_types = Vec::new();
+    let mut explicit_where: Option<WhereClause> = None;
+
+    for meta in args {
+        match meta {
+            NestedMeta::Meta(Meta::Path(p)) => {
+                ctx_types.push(p);
+            }
+            NestedMeta::Meta(Meta::NameValue(nv)) if nv.path.is_ident("bound") => {
+                if let syn::Lit::Str(lit_str) = &nv.lit {
+                    let where_string = format!("where {}", lit_str.value());
+                    match syn::parse_str::<WhereClause>(&where_string) {
+                        Ok(where_clause) => {
+                            explicit_where = Some(where_clause);
+                        }
+                        Err(err) => {
+                            return syn::Error::new_spanned(
+                                lit_str,
+                                format!("Invalid where clause '{}': {}", lit_str.value(), err),
+                            )
+                            .to_compile_error()
+                            .into();
+                        }
+                    }
+                } else {
+                    return syn::Error::new_spanned(
+                        &nv,
+                        "Expected a string literal for `bound` value",
+                    )
+                    .to_compile_error()
+                    .into();
+                }
+            }
+            _ => {
+                return syn::Error::new_spanned(
+                    &meta,
+                    "Expected paths or `bound = \"...\"` in #[context_deserialize(...)]",
+                )
+                .to_compile_error()
+                .into();
+            }
+        }
+    }
 
     if ctx_types.is_empty() {
         return quote! {
-            compile_error!("Usage: #[context_deserialize(Type1, Type2, ...)]");
+            compile_error!("Usage: #[context_deserialize(Type1, Type2, ..., bound = \"...\")]");
         }
         .into();
     }
 
-    // Generic handling
-    let generics = &input.generics;
-    let params = &generics.params;
-    let (_, ty_generics, where_clause) = generics.split_for_impl();
+    let original_generics = input.generics.clone();
 
-    let has_de = generics
+    // Clone and clean generics for impl use (remove default params)
+    let mut impl_generics = input.generics.clone();
+    for param in impl_generics.params.iter_mut() {
+        if let GenericParam::Type(ty) = param {
+            ty.eq_token = None;
+            ty.default = None;
+        }
+    }
+
+    // Ensure 'de lifetime exists in impl generics
+    let has_de = impl_generics
         .lifetimes()
         .any(|LifetimeDef { lifetime, .. }| lifetime.ident == "de");
 
-    let base_generics = if has_de {
-        quote! { #params }
-    } else if params.is_empty() {
-        quote! { 'de }
-    } else {
-        quote! { 'de, #params }
-    };
+    if !has_de {
+        impl_generics.params.insert(0, syn::parse_quote! { 'de });
+    }
 
-    // Generate impls per context type
+    let (_, ty_generics, _) = original_generics.split_for_impl();
+    let (impl_gens, _, _) = impl_generics.split_for_impl();
+
+    // Generate: no `'de` applied to the type name
     let mut impls = quote! {};
     for ctx in ctx_types {
         impls.extend(quote! {
-            impl<#base_generics> context_deserialize::ContextDeserialize<'de, #ctx>
-                for #ident #ty_generics #where_clause
+            impl #impl_gens context_deserialize::ContextDeserialize<'de, #ctx>
+                for #ident #ty_generics
+                #explicit_where
             {
                 fn context_deserialize<D>(
                     deserializer: D,
@@ -69,7 +110,6 @@ pub fn context_deserialize(attr: TokenStream, item: TokenStream) -> TokenStream 
         });
     }
 
-    // Final output: input struct + impl blocks
     quote! {
         #input
         #impls

--- a/consensus/context_deserialize_derive/tests/context_deserialize_derive.rs
+++ b/consensus/context_deserialize_derive/tests/context_deserialize_derive.rs
@@ -1,0 +1,94 @@
+use context_deserialize::ContextDeserialize;
+use context_deserialize_derive::context_deserialize;
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn test_context_deserialize_derive() {
+    type TestContext = ();
+
+    #[context_deserialize(TestContext)]
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Test {
+        field: String,
+    }
+
+    let test = Test {
+        field: "test".to_string(),
+    };
+    let serialized = serde_json::to_string(&test).unwrap();
+    let deserialized =
+        Test::context_deserialize(&mut serde_json::Deserializer::from_str(&serialized), ())
+            .unwrap();
+    assert_eq!(test, deserialized);
+}
+
+#[test]
+fn test_context_deserialize_derive_multiple_types() {
+    #[allow(dead_code)]
+    struct TestContext1(u64);
+    #[allow(dead_code)]
+    struct TestContext2(String);
+
+    // This will derive:
+    // - ContextDeserialize<TestContext1> for Test
+    // - ContextDeserialize<TestContext2> for Test
+    // by just leveraging the Deserialize impl
+    #[context_deserialize(TestContext1, TestContext2)]
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Test {
+        field: String,
+    }
+
+    let test = Test {
+        field: "test".to_string(),
+    };
+    let serialized = serde_json::to_string(&test).unwrap();
+    let deserialized = Test::context_deserialize(
+        &mut serde_json::Deserializer::from_str(&serialized),
+        TestContext1(1),
+    )
+    .unwrap();
+    assert_eq!(test, deserialized);
+
+    let deserialized = Test::context_deserialize(
+        &mut serde_json::Deserializer::from_str(&serialized),
+        TestContext2("2".to_string()),
+    )
+    .unwrap();
+
+    assert_eq!(test, deserialized);
+}
+
+#[test]
+fn test_context_deserialize_derive_bound() {
+    use std::fmt::Debug;
+
+    struct TestContext;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Inner {
+        value: u64,
+    }
+
+    #[context_deserialize(
+        TestContext,
+        bound = "T: Serialize + for<'a> Deserialize<'a> + Debug + PartialEq"
+    )]
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Wrapper<T> {
+        inner: T,
+    }
+
+    let val = Wrapper {
+        inner: Inner { value: 42 },
+    };
+
+    let serialized = serde_json::to_string(&val).unwrap();
+    let deserialized = Wrapper::<Inner>::context_deserialize(
+        &mut serde_json::Deserializer::from_str(&serialized),
+        TestContext,
+    )
+    .unwrap();
+
+    assert_eq!(val, deserialized);
+}

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -17,6 +17,8 @@ arbitrary = { workspace = true, features = ["derive"] }
 bls = { workspace = true, features = ["arbitrary"] }
 compare_fields = { workspace = true }
 compare_fields_derive = { workspace = true }
+context_deserialize = { path = "../context_deserialize" }
+context_deserialize_derive = { path = "../context_deserialize_derive" }
 derivative = { workspace = true }
 eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
 ethereum_hashing = { workspace = true }

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -17,8 +17,8 @@ arbitrary = { workspace = true, features = ["derive"] }
 bls = { workspace = true, features = ["arbitrary"] }
 compare_fields = { workspace = true }
 compare_fields_derive = { workspace = true }
-context_deserialize = { path = "../context_deserialize" }
-context_deserialize_derive = { path = "../context_deserialize_derive" }
+context_deserialize = { workspace = true }
+context_deserialize_derive = { workspace = true }
 derivative = { workspace = true }
 eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
 ethereum_hashing = { workspace = true }

--- a/consensus/types/src/aggregate_and_proof.rs
+++ b/consensus/types/src/aggregate_and_proof.rs
@@ -1,8 +1,9 @@
 use super::{AttestationBase, AttestationElectra, AttestationRef};
 use super::{
-    ChainSpec, Domain, EthSpec, Fork, Hash256, PublicKey, SecretKey, SelectionProof, Signature,
-    SignedRoot,
+    ChainSpec, Domain, EthSpec, Fork, ForkName, Hash256, PublicKey, SecretKey, SelectionProof,
+    Signature, SignedRoot,
 };
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
 use crate::Attestation;
 use serde::{Deserialize, Serialize};
@@ -26,6 +27,7 @@ use tree_hash_derive::TreeHash;
             TestRandom,
             TreeHash,
         ),
+        context_deserialize(ForkName),
         serde(bound = "E: EthSpec"),
         arbitrary(bound = "E: EthSpec"),
     ),

--- a/consensus/types/src/attestation.rs
+++ b/consensus/types/src/attestation.rs
@@ -1,8 +1,8 @@
 use crate::slot_data::SlotData;
 use crate::{test_utils::TestRandom, Hash256, Slot};
-use crate::{Checkpoint, ForkVersionDeserialize};
+use crate::{Checkpoint, ContextDeserialize, ForkName};
 use derivative::Derivative;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::BitVector;
 use std::collections::HashSet;
@@ -532,45 +532,44 @@ impl<'a, E: EthSpec> From<AttestationRefOnDisk<'a, E>> for AttestationRef<'a, E>
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for Attestation<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::Value,
-        fork_name: crate::ForkName,
-    ) -> Result<Self, D::Error> {
-        if fork_name.electra_enabled() {
-            let attestation: AttestationElectra<E> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
-            Ok(Attestation::Electra(attestation))
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for Attestation<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if context.electra_enabled() {
+            AttestationElectra::<E>::deserialize(deserializer)
+                .map_err(serde::de::Error::custom)
+                .map(Attestation::Electra)
         } else {
-            let attestation: AttestationBase<E> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
-            Ok(Attestation::Base(attestation))
+            AttestationBase::<E>::deserialize(deserializer)
+                .map_err(serde::de::Error::custom)
+                .map(Attestation::Base)
         }
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for Vec<Attestation<E>> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::Value,
-        fork_name: crate::ForkName,
-    ) -> Result<Self, D::Error> {
-        if fork_name.electra_enabled() {
-            let attestations: Vec<AttestationElectra<E>> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
-            Ok(attestations
-                .into_iter()
-                .map(Attestation::Electra)
-                .collect::<Vec<_>>())
+/*
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for Vec<Attestation<E>> {
+    fn context_deserialize<D>(
+        deserializer: D,
+        context: ForkName,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if context.electra_enabled() {
+            <Vec<AttestationElectra<E>>>::deserialize(deserializer)
+                .map_err(serde::de::Error::custom)
+                .map(|vec| vec.into_iter().map(Attestation::Electra).collect::<Vec<_>>())
         } else {
-            let attestations: Vec<AttestationBase<E>> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
-            Ok(attestations
-                .into_iter()
-                .map(Attestation::Base)
-                .collect::<Vec<_>>())
+            <Vec<AttestationBase<E>>>::deserialize(deserializer)
+                .map_err(serde::de::Error::custom)
+                .map(|vec| vec.into_iter().map(Attestation::Base).collect::<Vec<_>>())
         }
     }
 }
+*/
 
 #[derive(
     Debug,

--- a/consensus/types/src/attestation.rs
+++ b/consensus/types/src/attestation.rs
@@ -1,3 +1,4 @@
+use crate::context_deserialize;
 use crate::slot_data::SlotData;
 use crate::{test_utils::TestRandom, Hash256, Slot};
 use crate::{Checkpoint, ContextDeserialize, ForkName};
@@ -47,6 +48,7 @@ impl From<ssz_types::Error> for Error {
             arbitrary::Arbitrary,
             TreeHash,
         ),
+        context_deserialize(ForkName),
         derivative(PartialEq, Hash(bound = "E: EthSpec")),
         serde(bound = "E: EthSpec", deny_unknown_fields),
         arbitrary(bound = "E: EthSpec"),
@@ -584,6 +586,7 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for Vec<Attestation<E>> 
     TreeHash,
     PartialEq,
 )]
+#[context_deserialize(ForkName)]
 pub struct SingleAttestation {
     #[serde(with = "serde_utils::quoted_u64")]
     pub committee_index: u64,

--- a/consensus/types/src/attestation_data.rs
+++ b/consensus/types/src/attestation_data.rs
@@ -1,12 +1,11 @@
-use crate::test_utils::TestRandom;
-use crate::{Checkpoint, Hash256, SignedRoot, Slot};
-
 use crate::slot_data::SlotData;
+use crate::test_utils::TestRandom;
+use crate::{Checkpoint, ForkName, Hash256, SignedRoot, Slot};
+use context_deserialize_derive::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
-
 /// The data upon which an attestation is based.
 ///
 /// Spec v0.12.1
@@ -25,6 +24,7 @@ use tree_hash_derive::TreeHash;
     TestRandom,
     Default,
 )]
+#[context_deserialize(ForkName)]
 pub struct AttestationData {
     pub slot: Slot,
     #[serde(with = "serde_utils::quoted_u64")]

--- a/consensus/types/src/attester_slashing.rs
+++ b/consensus/types/src/attester_slashing.rs
@@ -1,3 +1,4 @@
+use crate::context_deserialize;
 use crate::indexed_attestation::{
     IndexedAttestationBase, IndexedAttestationElectra, IndexedAttestationRef,
 };
@@ -26,6 +27,7 @@ use tree_hash_derive::TreeHash;
             TestRandom,
             arbitrary::Arbitrary
         ),
+        context_deserialize(ForkName),
         derivative(PartialEq, Eq, Hash(bound = "E: EthSpec")),
         serde(bound = "E: EthSpec"),
         arbitrary(bound = "E: EthSpec")

--- a/consensus/types/src/attester_slashing.rs
+++ b/consensus/types/src/attester_slashing.rs
@@ -2,9 +2,10 @@ use crate::indexed_attestation::{
     IndexedAttestationBase, IndexedAttestationElectra, IndexedAttestationRef,
 };
 use crate::{test_utils::TestRandom, EthSpec};
+use crate::{ContextDeserialize, ForkName};
 use derivative::Derivative;
 use rand::{Rng, RngCore};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
 use test_random_derive::TestRandom;
@@ -171,25 +172,27 @@ impl<E: EthSpec> TestRandom for AttesterSlashing<E> {
     }
 }
 
-impl<E: EthSpec> crate::ForkVersionDeserialize for Vec<AttesterSlashing<E>> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::Value,
-        fork_name: crate::ForkName,
-    ) -> Result<Self, D::Error> {
-        if fork_name.electra_enabled() {
-            let slashings: Vec<AttesterSlashingElectra<E>> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
-            Ok(slashings
-                .into_iter()
-                .map(AttesterSlashing::Electra)
-                .collect::<Vec<_>>())
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for Vec<AttesterSlashing<E>> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if context.electra_enabled() {
+            <Vec<AttesterSlashingElectra<E>>>::deserialize(deserializer)
+                .map_err(serde::de::Error::custom)
+                .map(|vec| {
+                    vec.into_iter()
+                        .map(AttesterSlashing::Electra)
+                        .collect::<Vec<_>>()
+                })
         } else {
-            let slashings: Vec<AttesterSlashingBase<E>> =
-                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
-            Ok(slashings
-                .into_iter()
-                .map(AttesterSlashing::Base)
-                .collect::<Vec<_>>())
+            <Vec<AttesterSlashingBase<E>>>::deserialize(deserializer)
+                .map_err(serde::de::Error::custom)
+                .map(|vec| {
+                    vec.into_iter()
+                        .map(AttesterSlashing::Base)
+                        .collect::<Vec<_>>()
+                })
         }
     }
 }

--- a/consensus/types/src/beacon_block_header.rs
+++ b/consensus/types/src/beacon_block_header.rs
@@ -1,6 +1,7 @@
 use crate::test_utils::TestRandom;
 use crate::*;
 
+use context_deserialize_derive::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -24,6 +25,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct BeaconBlockHeader {
     pub slot: Slot,
     #[serde(with = "serde_utils::quoted_u64")]

--- a/consensus/types/src/beacon_response.rs
+++ b/consensus/types/src/beacon_response.rs
@@ -70,9 +70,6 @@ pub struct EmptyMetadata {}
 pub type ExecutionOptimisticFinalizedBeaconResponse<T> =
     BeaconResponse<T, ExecutionOptimisticFinalizedMetadata>;
 
-pub type ExecutionOptimisticFinalizedForkVersionedResponse<T> =
-    ForkVersionedResponse<T, ExecutionOptimisticFinalizedMetadata>;
-
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ExecutionOptimisticFinalizedMetadata {
     pub execution_optimistic: Option<bool>,
@@ -147,6 +144,13 @@ impl<T, M> BeaconResponse<T, M> {
             BeaconResponse::UnVersioned(response) => {
                 BeaconResponse::UnVersioned(response.map_data(f))
             }
+        }
+    }
+
+    pub fn into_data(self) -> T {
+        match self {
+            BeaconResponse::ForkVersioned(response) => response.data,
+            BeaconResponse::UnVersioned(response) => response.data,
         }
     }
 }

--- a/consensus/types/src/beacon_response.rs
+++ b/consensus/types/src/beacon_response.rs
@@ -24,7 +24,7 @@ pub struct ForkVersionedResponse<T, M = EmptyMetadata> {
 /// version. If you *do* care about adding other fields you can mix in any type that implements
 /// `Deserialize`.
 #[derive(Debug, PartialEq, Clone, Serialize)]
-pub struct UnVersionedResponse<T, M = EmptyMetadata> {
+pub struct UnversionedResponse<T, M = EmptyMetadata> {
     pub metadata: M,
     pub data: T,
 }
@@ -33,28 +33,28 @@ pub struct UnVersionedResponse<T, M = EmptyMetadata> {
 #[serde(untagged)]
 pub enum BeaconResponse<T, M = EmptyMetadata> {
     ForkVersioned(ForkVersionedResponse<T, M>),
-    UnVersioned(UnVersionedResponse<T, M>),
+    Unversioned(UnversionedResponse<T, M>),
 }
 
 impl<T, M> BeaconResponse<T, M> {
     pub fn version(&self) -> Option<ForkName> {
         match self {
             BeaconResponse::ForkVersioned(response) => Some(response.version),
-            BeaconResponse::UnVersioned(_) => None,
+            BeaconResponse::Unversioned(_) => None,
         }
     }
 
     pub fn data(&self) -> &T {
         match self {
             BeaconResponse::ForkVersioned(response) => &response.data,
-            BeaconResponse::UnVersioned(response) => &response.data,
+            BeaconResponse::Unversioned(response) => &response.data,
         }
     }
 
     pub fn metadata(&self) -> &M {
         match self {
             BeaconResponse::ForkVersioned(response) => &response.metadata,
-            BeaconResponse::UnVersioned(response) => &response.metadata,
+            BeaconResponse::Unversioned(response) => &response.metadata,
         }
     }
 }
@@ -110,7 +110,7 @@ where
     }
 }
 
-impl<'de, T, M> Deserialize<'de> for UnVersionedResponse<T, M>
+impl<'de, T, M> Deserialize<'de> for UnversionedResponse<T, M>
 where
     T: DeserializeOwned,
     M: DeserializeOwned,
@@ -128,7 +128,7 @@ where
 
         let helper = Helper::deserialize(deserializer)?;
 
-        Ok(UnVersionedResponse {
+        Ok(UnversionedResponse {
             metadata: helper.metadata,
             data: helper.data,
         })
@@ -141,8 +141,8 @@ impl<T, M> BeaconResponse<T, M> {
             BeaconResponse::ForkVersioned(response) => {
                 BeaconResponse::ForkVersioned(response.map_data(f))
             }
-            BeaconResponse::UnVersioned(response) => {
-                BeaconResponse::UnVersioned(response.map_data(f))
+            BeaconResponse::Unversioned(response) => {
+                BeaconResponse::Unversioned(response.map_data(f))
             }
         }
     }
@@ -150,15 +150,15 @@ impl<T, M> BeaconResponse<T, M> {
     pub fn into_data(self) -> T {
         match self {
             BeaconResponse::ForkVersioned(response) => response.data,
-            BeaconResponse::UnVersioned(response) => response.data,
+            BeaconResponse::Unversioned(response) => response.data,
         }
     }
 }
 
-impl<T, M> UnVersionedResponse<T, M> {
-    pub fn map_data<U>(self, f: impl FnOnce(T) -> U) -> UnVersionedResponse<U, M> {
-        let UnVersionedResponse { metadata, data } = self;
-        UnVersionedResponse {
+impl<T, M> UnversionedResponse<T, M> {
+    pub fn map_data<U>(self, f: impl FnOnce(T) -> U) -> UnversionedResponse<U, M> {
+        let UnversionedResponse { metadata, data } = self;
+        UnversionedResponse {
             metadata,
             data: f(data),
         }
@@ -187,9 +187,9 @@ impl<T, M> From<ForkVersionedResponse<T, M>> for BeaconResponse<T, M> {
     }
 }
 
-impl<T, M> From<UnVersionedResponse<T, M>> for BeaconResponse<T, M> {
-    fn from(response: UnVersionedResponse<T, M>) -> Self {
-        BeaconResponse::UnVersioned(response)
+impl<T, M> From<UnversionedResponse<T, M>> for BeaconResponse<T, M> {
+    fn from(response: UnversionedResponse<T, M>) -> Self {
+        BeaconResponse::Unversioned(response)
     }
 }
 

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1,7 +1,7 @@
 use self::committee_cache::get_active_validator_indices;
 use crate::historical_summary::HistoricalSummary;
-use crate::ContextDeserialize;
 use crate::test_utils::TestRandom;
+use crate::ContextDeserialize;
 use crate::FixedBytesExtended;
 use crate::*;
 use compare_fields::CompareFields;
@@ -2749,32 +2749,13 @@ impl<E: EthSpec> CompareFields for BeaconState<E> {
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for BeaconState<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::value::Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        Ok(map_fork_name!(
-            fork_name,
-            Self,
-            serde_json::from_value(value).map_err(|e| serde::de::Error::custom(format!(
-                "BeaconState failed to deserialize: {:?}",
-                e
-            )))?
-        ))
-    }
-}
-
 impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for BeaconState<E> {
-    fn context_deserialize<D>(
-        deserializer: D,
-        ctx: ForkName,
-    ) -> Result<Self, D::Error>
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         Ok(map_fork_name!(
-            ctx,
+            context,
             Self,
             serde::Deserialize::deserialize(deserializer)?
         ))

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1,5 +1,6 @@
 use self::committee_cache::get_active_validator_indices;
 use crate::historical_summary::HistoricalSummary;
+use crate::ContextDeserialize;
 use crate::test_utils::TestRandom;
 use crate::FixedBytesExtended;
 use crate::*;
@@ -11,7 +12,7 @@ use int_to_bytes::{int_to_bytes4, int_to_bytes8};
 use metastruct::{metastruct, NumFields};
 pub use pubkey_cache::PubkeyCache;
 use safe_arith::{ArithError, SafeArith};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use ssz::{ssz_encode, Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
 use std::hash::Hash;
@@ -2760,6 +2761,22 @@ impl<E: EthSpec> ForkVersionDeserialize for BeaconState<E> {
                 "BeaconState failed to deserialize: {:?}",
                 e
             )))?
+        ))
+    }
+}
+
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for BeaconState<E> {
+    fn context_deserialize<D>(
+        deserializer: D,
+        ctx: ForkName,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(map_fork_name!(
+            ctx,
+            Self,
+            serde::Deserialize::deserialize(deserializer)?
         ))
     }
 }

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -26,6 +26,7 @@ use tree_hash_derive::TreeHash;
 #[derive(
     Serialize, Deserialize, Encode, Decode, TreeHash, Copy, Clone, Debug, PartialEq, Eq, Hash,
 )]
+#[context_deserialize(ForkName)]
 pub struct BlobIdentifier {
     pub block_root: Hash256,
     pub index: u64,

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -1,9 +1,10 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
 use crate::{
     beacon_block_body::BLOB_KZG_COMMITMENTS_INDEX, AbstractExecPayload, BeaconBlockHeader,
-    BeaconStateError, Blob, ChainSpec, Epoch, EthSpec, FixedVector, ForkName,
-    ForkVersionDeserialize, Hash256, KzgProofs, RuntimeFixedVector, RuntimeVariableList,
-    SignedBeaconBlock, SignedBeaconBlockHeader, Slot, VariableList,
+    BeaconStateError, Blob, ChainSpec, Epoch, EthSpec, FixedVector, ForkName, Hash256, KzgProofs,
+    RuntimeFixedVector, RuntimeVariableList, SignedBeaconBlock, SignedBeaconBlockHeader, Slot,
+    VariableList,
 };
 use bls::Signature;
 use derivative::Derivative;
@@ -54,6 +55,7 @@ impl Ord for BlobIdentifier {
     Derivative,
     arbitrary::Arbitrary,
 )]
+#[context_deserialize(ForkName)]
 #[serde(bound = "E: EthSpec")]
 #[arbitrary(bound = "E: EthSpec")]
 #[derivative(PartialEq, Eq, Hash(bound = "E: EthSpec"))]
@@ -296,12 +298,3 @@ pub type BlobSidecarList<E> = RuntimeVariableList<Arc<BlobSidecar<E>>>;
 /// Alias for a non length-constrained list of `BlobSidecar`s.
 pub type FixedBlobSidecarList<E> = RuntimeFixedVector<Option<Arc<BlobSidecar<E>>>>;
 pub type BlobsList<E> = VariableList<Blob<E>, <E as EthSpec>::MaxBlobCommitmentsPerBlock>;
-
-impl<E: EthSpec> ForkVersionDeserialize for BlobSidecarList<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::value::Value,
-        _: ForkName,
-    ) -> Result<Self, D::Error> {
-        serde_json::from_value::<BlobSidecarList<E>>(value).map_err(serde::de::Error::custom)
-    }
-}

--- a/consensus/types/src/bls_to_execution_change.rs
+++ b/consensus/types/src/bls_to_execution_change.rs
@@ -19,6 +19,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct BlsToExecutionChange {
     #[serde(with = "serde_utils::quoted_u64")]
     pub validator_index: u64,

--- a/consensus/types/src/checkpoint.rs
+++ b/consensus/types/src/checkpoint.rs
@@ -1,5 +1,6 @@
 use crate::test_utils::TestRandom;
-use crate::{Epoch, Hash256};
+use crate::{Epoch, ForkName, Hash256};
+use context_deserialize_derive::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -24,6 +25,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct Checkpoint {
     pub epoch: Epoch,
     pub root: Hash256,

--- a/consensus/types/src/consolidation_request.rs
+++ b/consensus/types/src/consolidation_request.rs
@@ -1,4 +1,5 @@
-use crate::{test_utils::TestRandom, Address, PublicKeyBytes, SignedRoot};
+use crate::context_deserialize;
+use crate::{test_utils::TestRandom, Address, ForkName, PublicKeyBytes, SignedRoot};
 use serde::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
@@ -19,6 +20,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct ConsolidationRequest {
     pub source_address: Address,
     pub source_pubkey: PublicKeyBytes,

--- a/consensus/types/src/contribution_and_proof.rs
+++ b/consensus/types/src/contribution_and_proof.rs
@@ -1,7 +1,8 @@
 use super::{
-    ChainSpec, EthSpec, Fork, Hash256, SecretKey, Signature, SignedRoot, SyncCommitteeContribution,
-    SyncSelectionProof,
+    ChainSpec, EthSpec, Fork, ForkName, Hash256, SecretKey, Signature, SignedRoot,
+    SyncCommitteeContribution, SyncSelectionProof,
 };
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -23,6 +24,7 @@ use tree_hash_derive::TreeHash;
 )]
 #[serde(bound = "E: EthSpec")]
 #[arbitrary(bound = "E: EthSpec")]
+#[context_deserialize(ForkName)]
 pub struct ContributionAndProof<E: EthSpec> {
     /// The index of the validator that created the sync contribution.
     #[serde(with = "serde_utils::quoted_u64")]

--- a/consensus/types/src/data_column_sidecar.rs
+++ b/consensus/types/src/data_column_sidecar.rs
@@ -1,7 +1,8 @@
 use crate::beacon_block_body::{KzgCommitments, BLOB_KZG_COMMITMENTS_INDEX};
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
 use crate::{
-    BeaconBlockHeader, BeaconStateError, Epoch, EthSpec, Hash256, RuntimeVariableList,
+    BeaconBlockHeader, BeaconStateError, Epoch, EthSpec, ForkName, Hash256, RuntimeVariableList,
     SignedBeaconBlockHeader, Slot,
 };
 use bls::Signature;
@@ -84,6 +85,7 @@ pub type DataColumnSidecarList<E> = Vec<Arc<DataColumnSidecar<E>>>;
 #[serde(bound = "E: EthSpec")]
 #[arbitrary(bound = "E: EthSpec")]
 #[derivative(PartialEq, Eq, Hash(bound = "E: EthSpec"))]
+#[context_deserialize(ForkName)]
 pub struct DataColumnSidecar<E: EthSpec> {
     #[serde(with = "serde_utils::quoted_u64")]
     pub index: ColumnIndex,

--- a/consensus/types/src/deposit.rs
+++ b/consensus/types/src/deposit.rs
@@ -1,3 +1,4 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
 use crate::*;
 use serde::{Deserialize, Serialize};
@@ -24,6 +25,7 @@ pub const DEPOSIT_TREE_DEPTH: usize = 32;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct Deposit {
     pub proof: FixedVector<Hash256, U33>,
     pub data: DepositData,

--- a/consensus/types/src/deposit_data.rs
+++ b/consensus/types/src/deposit_data.rs
@@ -1,6 +1,5 @@
 use crate::test_utils::TestRandom;
 use crate::*;
-
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -22,6 +21,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct DepositData {
     pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,

--- a/consensus/types/src/deposit_message.rs
+++ b/consensus/types/src/deposit_message.rs
@@ -21,6 +21,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct DepositMessage {
     pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,

--- a/consensus/types/src/deposit_request.rs
+++ b/consensus/types/src/deposit_request.rs
@@ -1,5 +1,6 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::{Hash256, PublicKeyBytes};
+use crate::{ForkName, Hash256, PublicKeyBytes};
 use bls::SignatureBytes;
 use serde::{Deserialize, Serialize};
 use ssz::Encode;
@@ -20,6 +21,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct DepositRequest {
     pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,

--- a/consensus/types/src/eth1_data.rs
+++ b/consensus/types/src/eth1_data.rs
@@ -1,6 +1,7 @@
 use super::Hash256;
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-
+use crate::ForkName;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -24,6 +25,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct Eth1Data {
     pub deposit_root: Hash256,
     #[serde(with = "serde_utils::quoted_u64")]

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -1,6 +1,6 @@
 use crate::{test_utils::TestRandom, *};
 use derivative::Derivative;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -133,28 +133,35 @@ impl<E: EthSpec> ExecutionPayload<E> {
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for ExecutionPayload<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::value::Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for ExecutionPayload<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         let convert_err = |e| {
             serde::de::Error::custom(format!("ExecutionPayload failed to deserialize: {:?}", e))
         };
-
-        Ok(match fork_name {
-            ForkName::Bellatrix => {
-                Self::Bellatrix(serde_json::from_value(value).map_err(convert_err)?)
-            }
-            ForkName::Capella => Self::Capella(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Deneb => Self::Deneb(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Electra => Self::Electra(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Fulu => Self::Fulu(serde_json::from_value(value).map_err(convert_err)?),
+        Ok(match context {
             ForkName::Base | ForkName::Altair => {
                 return Err(serde::de::Error::custom(format!(
                     "ExecutionPayload failed to deserialize: unsupported fork '{}'",
-                    fork_name
-                )));
+                    context
+                )))
+            }
+            ForkName::Bellatrix => {
+                Self::Bellatrix(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Capella => {
+                Self::Capella(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Deneb => {
+                Self::Deneb(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Electra => {
+                Self::Electra(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Fulu => {
+                Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
             }
         })
     }

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -30,6 +30,7 @@ pub type Withdrawals<E> = VariableList<Withdrawal, <E as EthSpec>::MaxWithdrawal
             Derivative,
             arbitrary::Arbitrary
         ),
+        context_deserialize(ForkName),
         derivative(PartialEq, Hash(bound = "E: EthSpec")),
         serde(bound = "E: EthSpec", deny_unknown_fields),
         arbitrary(bound = "E: EthSpec")

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -1,6 +1,6 @@
 use crate::{test_utils::TestRandom, *};
 use derivative::Derivative;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -472,31 +472,38 @@ impl<E: EthSpec> TryFrom<ExecutionPayloadHeader<E>> for ExecutionPayloadHeaderFu
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for ExecutionPayloadHeader<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::value::Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for ExecutionPayloadHeader<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         let convert_err = |e| {
             serde::de::Error::custom(format!(
                 "ExecutionPayloadHeader failed to deserialize: {:?}",
                 e
             ))
         };
-
-        Ok(match fork_name {
-            ForkName::Bellatrix => {
-                Self::Bellatrix(serde_json::from_value(value).map_err(convert_err)?)
-            }
-            ForkName::Capella => Self::Capella(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Deneb => Self::Deneb(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Electra => Self::Electra(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Fulu => Self::Fulu(serde_json::from_value(value).map_err(convert_err)?),
+        Ok(match context {
             ForkName::Base | ForkName::Altair => {
                 return Err(serde::de::Error::custom(format!(
                     "ExecutionPayloadHeader failed to deserialize: unsupported fork '{}'",
-                    fork_name
-                )));
+                    context
+                )))
+            }
+            ForkName::Bellatrix => {
+                Self::Bellatrix(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Capella => {
+                Self::Capella(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Deneb => {
+                Self::Deneb(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Electra => {
+                Self::Electra(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Fulu => {
+                Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
             }
         })
     }

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -25,7 +25,8 @@ use tree_hash_derive::TreeHash;
         ),
         derivative(PartialEq, Hash(bound = "E: EthSpec")),
         serde(bound = "E: EthSpec", deny_unknown_fields),
-        arbitrary(bound = "E: EthSpec")
+        arbitrary(bound = "E: EthSpec"),
+        context_deserialize(ForkName),
     ),
     ref_attributes(
         derive(PartialEq, TreeHash, Debug),

--- a/consensus/types/src/execution_requests.rs
+++ b/consensus/types/src/execution_requests.rs
@@ -1,5 +1,6 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::{ConsolidationRequest, DepositRequest, EthSpec, Hash256, WithdrawalRequest};
+use crate::{ConsolidationRequest, DepositRequest, EthSpec, ForkName, Hash256, WithdrawalRequest};
 use alloy_primitives::Bytes;
 use derivative::Derivative;
 use ethereum_hashing::{DynamicContext, Sha256Context};
@@ -33,6 +34,7 @@ pub type ConsolidationRequests<E> =
 #[serde(bound = "E: EthSpec")]
 #[arbitrary(bound = "E: EthSpec")]
 #[derivative(PartialEq, Eq, Hash(bound = "E: EthSpec"))]
+#[context_deserialize(ForkName)]
 pub struct ExecutionRequests<E: EthSpec> {
     pub deposits: DepositRequests<E>,
     pub withdrawals: WithdrawalRequests<E>,

--- a/consensus/types/src/fork.rs
+++ b/consensus/types/src/fork.rs
@@ -1,5 +1,6 @@
 use crate::test_utils::TestRandom;
-use crate::Epoch;
+use crate::{Epoch, ForkName};
+use context_deserialize_derive::context_deserialize;
 
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -23,6 +24,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct Fork {
     #[serde(with = "serde_utils::bytes_4_hex")]
     pub previous_version: [u8; 4],

--- a/consensus/types/src/fork_data.rs
+++ b/consensus/types/src/fork_data.rs
@@ -1,5 +1,6 @@
 use crate::test_utils::TestRandom;
-use crate::{Hash256, SignedRoot};
+use crate::{ForkName, Hash256, SignedRoot};
+use context_deserialize_derive::context_deserialize;
 
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -22,6 +23,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct ForkData {
     #[serde(with = "serde_utils::bytes_4_hex")]
     pub current_version: [u8; 4],

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -1,33 +1,62 @@
-use crate::ForkName;
+use crate::{ContextDeserialize, ForkName};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::value::Value;
-use std::sync::Arc;
 
 pub trait ForkVersionDecode: Sized {
     /// SSZ decode with explicit fork variant.
     fn from_ssz_bytes_by_fork(bytes: &[u8], fork_name: ForkName) -> Result<Self, ssz::DecodeError>;
 }
 
-pub trait ForkVersionDeserialize: Sized + DeserializeOwned {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
-        value: Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error>;
-}
-
-/// Deserialize is only implemented for types that implement ForkVersionDeserialize.
-///
 /// The metadata of type M should be set to `EmptyMetadata` if you don't care about adding fields other than
 /// version. If you *do* care about adding other fields you can mix in any type that implements
 /// `Deserialize`.
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct ForkVersionedResponse<T, M = EmptyMetadata> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<ForkName>,
+    pub version: ForkName,
     #[serde(flatten)]
     pub metadata: M,
     pub data: T,
+}
+
+// Used for responses to V1 endpoints that don't have a version field.
+/// The metadata of type M should be set to `EmptyMetadata` if you don't care about adding fields other than
+/// version. If you *do* care about adding other fields you can mix in any type that implements
+/// `Deserialize`.
+#[derive(Debug, PartialEq, Clone, Serialize)]
+pub struct UnVersionedResponse<T, M = EmptyMetadata> {
+    pub metadata: M,
+    pub data: T,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize)]
+#[serde(untagged)]
+pub enum BeaconResponse<T, M = EmptyMetadata> {
+    ForkVersioned(ForkVersionedResponse<T, M>),
+    UnVersioned(UnVersionedResponse<T, M>),
+}
+
+impl<T, M> BeaconResponse<T, M> {
+    pub fn version(&self) -> Option<ForkName> {
+        match self {
+            BeaconResponse::ForkVersioned(response) => Some(response.version),
+            BeaconResponse::UnVersioned(_) => None,
+        }
+    }
+
+    pub fn data(&self) -> &T {
+        match self {
+            BeaconResponse::ForkVersioned(response) => &response.data,
+            BeaconResponse::UnVersioned(response) => &response.data,
+        }
+    }
+
+    pub fn metadata(&self) -> &M {
+        match self {
+            BeaconResponse::ForkVersioned(response) => &response.metadata,
+            BeaconResponse::UnVersioned(response) => &response.metadata,
+        }
+    }
 }
 
 /// Metadata type similar to unit (i.e. `()`) but deserializes from a map (`serde_json::Value`).
@@ -38,6 +67,9 @@ pub struct ForkVersionedResponse<T, M = EmptyMetadata> {
 pub struct EmptyMetadata {}
 
 /// Fork versioned response with extra information about finalization & optimistic execution.
+pub type ExecutionOptimisticFinalizedBeaconResponse<T> =
+    BeaconResponse<T, ExecutionOptimisticFinalizedMetadata>;
+
 pub type ExecutionOptimisticFinalizedForkVersionedResponse<T> =
     ForkVersionedResponse<T, ExecutionOptimisticFinalizedMetadata>;
 
@@ -47,9 +79,9 @@ pub struct ExecutionOptimisticFinalizedMetadata {
     pub finalized: Option<bool>,
 }
 
-impl<'de, F, M> serde::Deserialize<'de> for ForkVersionedResponse<F, M>
+impl<'de, T, M> Deserialize<'de> for ForkVersionedResponse<T, M>
 where
-    F: ForkVersionDeserialize,
+    T: ContextDeserialize<'de, ForkName>,
     M: DeserializeOwned,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -58,18 +90,20 @@ where
     {
         #[derive(Deserialize)]
         struct Helper {
-            version: Option<ForkName>,
+            version: ForkName,
             #[serde(flatten)]
-            metadata: serde_json::Value,
-            data: serde_json::Value,
+            metadata: Value,
+            data: Value,
         }
 
         let helper = Helper::deserialize(deserializer)?;
-        let data = match helper.version {
-            Some(fork_name) => F::deserialize_by_fork::<'de, D>(helper.data, fork_name)?,
-            None => serde_json::from_value(helper.data).map_err(serde::de::Error::custom)?,
-        };
+
+        // Deserialize metadata
         let metadata = serde_json::from_value(helper.metadata).map_err(serde::de::Error::custom)?;
+
+        // Deserialize `data` using ContextDeserialize
+        let data = T::context_deserialize(helper.data, helper.version)
+            .map_err(serde::de::Error::custom)?;
 
         Ok(ForkVersionedResponse {
             version: helper.version,
@@ -79,14 +113,51 @@ where
     }
 }
 
-impl<F: ForkVersionDeserialize> ForkVersionDeserialize for Arc<F> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
-        value: Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        Ok(Arc::new(F::deserialize_by_fork::<'de, D>(
-            value, fork_name,
-        )?))
+impl<'de, T, M> Deserialize<'de> for UnVersionedResponse<T, M>
+where
+    T: DeserializeOwned,
+    M: DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper<T, M> {
+            #[serde(flatten)]
+            metadata: M,
+            data: T,
+        }
+
+        let helper = Helper::deserialize(deserializer)?;
+
+        Ok(UnVersionedResponse {
+            metadata: helper.metadata,
+            data: helper.data,
+        })
+    }
+}
+
+impl<T, M> BeaconResponse<T, M> {
+    pub fn map_data<U>(self, f: impl FnOnce(T) -> U) -> BeaconResponse<U, M> {
+        match self {
+            BeaconResponse::ForkVersioned(response) => {
+                BeaconResponse::ForkVersioned(response.map_data(f))
+            }
+            BeaconResponse::UnVersioned(response) => {
+                BeaconResponse::UnVersioned(response.map_data(f))
+            }
+        }
+    }
+}
+
+impl<T, M> UnVersionedResponse<T, M> {
+    pub fn map_data<U>(self, f: impl FnOnce(T) -> U) -> UnVersionedResponse<U, M> {
+        let UnVersionedResponse { metadata, data } = self;
+        UnVersionedResponse {
+            metadata,
+            data: f(data),
+        }
     }
 }
 
@@ -106,6 +177,18 @@ impl<T, M> ForkVersionedResponse<T, M> {
     }
 }
 
+impl<T, M> From<ForkVersionedResponse<T, M>> for BeaconResponse<T, M> {
+    fn from(response: ForkVersionedResponse<T, M>) -> Self {
+        BeaconResponse::ForkVersioned(response)
+    }
+}
+
+impl<T, M> From<UnVersionedResponse<T, M>> for BeaconResponse<T, M> {
+    fn from(response: UnVersionedResponse<T, M>) -> Self {
+        BeaconResponse::UnVersioned(response)
+    }
+}
+
 #[cfg(test)]
 mod fork_version_response_tests {
     use crate::{
@@ -120,7 +203,7 @@ mod fork_version_response_tests {
 
         let response_json =
             serde_json::to_string(&json!(ForkVersionedResponse::<ExecutionPayload<E>> {
-                version: Some(ForkName::Bellatrix),
+                version: ForkName::Bellatrix,
                 metadata: Default::default(),
                 data: ExecutionPayload::Bellatrix(ExecutionPayloadBellatrix::default()),
             }))
@@ -138,7 +221,7 @@ mod fork_version_response_tests {
 
         let response_json =
             serde_json::to_string(&json!(ForkVersionedResponse::<ExecutionPayload<E>> {
-                version: Some(ForkName::Capella),
+                version: ForkName::Capella,
                 metadata: Default::default(),
                 data: ExecutionPayload::Bellatrix(ExecutionPayloadBellatrix::default()),
             }))

--- a/consensus/types/src/historical_batch.rs
+++ b/consensus/types/src/historical_batch.rs
@@ -22,6 +22,7 @@ use tree_hash_derive::TreeHash;
     arbitrary::Arbitrary,
 )]
 #[arbitrary(bound = "E: EthSpec")]
+#[context_deserialize(ForkName)]
 pub struct HistoricalBatch<E: EthSpec> {
     #[test_random(default)]
     pub block_roots: Vector<Hash256, E::SlotsPerHistoricalRoot>,

--- a/consensus/types/src/historical_summary.rs
+++ b/consensus/types/src/historical_summary.rs
@@ -1,5 +1,6 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::{BeaconState, EthSpec, Hash256};
+use crate::{BeaconState, EthSpec, ForkName, Hash256};
 use compare_fields_derive::CompareFields;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -28,6 +29,7 @@ use tree_hash_derive::TreeHash;
     Default,
     arbitrary::Arbitrary,
 )]
+#[context_deserialize(ForkName)]
 pub struct HistoricalSummary {
     block_summary_root: Hash256,
     state_summary_root: Hash256,

--- a/consensus/types/src/indexed_attestation.rs
+++ b/consensus/types/src/indexed_attestation.rs
@@ -1,4 +1,7 @@
-use crate::{test_utils::TestRandom, AggregateSignature, AttestationData, EthSpec, VariableList};
+use crate::context_deserialize;
+use crate::{
+    test_utils::TestRandom, AggregateSignature, AttestationData, EthSpec, ForkName, VariableList,
+};
 use core::slice::Iter;
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
@@ -29,6 +32,7 @@ use tree_hash_derive::TreeHash;
             arbitrary::Arbitrary,
             TreeHash,
         ),
+        context_deserialize(ForkName),
         derivative(PartialEq, Hash(bound = "E: EthSpec")),
         serde(bound = "E: EthSpec", deny_unknown_fields),
         arbitrary(bound = "E: EthSpec"),

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -291,3 +291,5 @@ pub use kzg::{KzgCommitment, KzgProof, VERSIONED_HASH_VERSION_KZG};
 pub use milhouse::{self, List, Vector};
 pub use ssz_types::{typenum, typenum::Unsigned, BitList, BitVector, FixedVector, VariableList};
 pub use superstruct::superstruct;
+pub use context_deserialize_derive::context_deserialize;
+pub use context_deserialize::ContextDeserialize;

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -22,6 +22,7 @@ pub mod beacon_block;
 pub mod beacon_block_body;
 pub mod beacon_block_header;
 pub mod beacon_committee;
+pub mod beacon_response;
 pub mod beacon_state;
 pub mod bls_to_execution_change;
 pub mod builder_bid;
@@ -44,7 +45,6 @@ pub mod execution_payload_header;
 pub mod fork;
 pub mod fork_data;
 pub mod fork_name;
-pub mod fork_versioned_response;
 pub mod graffiti;
 pub mod historical_batch;
 pub mod historical_summary;
@@ -138,6 +138,9 @@ pub use crate::beacon_block_body::{
 };
 pub use crate::beacon_block_header::BeaconBlockHeader;
 pub use crate::beacon_committee::{BeaconCommittee, OwnedBeaconCommittee};
+pub use crate::beacon_response::{
+    BeaconResponse, ForkVersionDecode, ForkVersionedResponse, UnVersionedResponse,
+};
 pub use crate::beacon_state::{Error as BeaconStateError, *};
 pub use crate::blob_sidecar::{BlobIdentifier, BlobSidecar, BlobSidecarList, BlobsList};
 pub use crate::bls_to_execution_change::BlsToExecutionChange;
@@ -178,9 +181,6 @@ pub use crate::fork::Fork;
 pub use crate::fork_context::ForkContext;
 pub use crate::fork_data::ForkData;
 pub use crate::fork_name::{ForkName, InconsistentFork};
-pub use crate::fork_versioned_response::{
-    BeaconResponse, ForkVersionDecode, ForkVersionedResponse, UnVersionedResponse,
-};
 pub use crate::graffiti::{Graffiti, GRAFFITI_BYTES_LEN};
 pub use crate::historical_batch::HistoricalBatch;
 pub use crate::indexed_attestation::{

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -139,7 +139,7 @@ pub use crate::beacon_block_body::{
 pub use crate::beacon_block_header::BeaconBlockHeader;
 pub use crate::beacon_committee::{BeaconCommittee, OwnedBeaconCommittee};
 pub use crate::beacon_response::{
-    BeaconResponse, ForkVersionDecode, ForkVersionedResponse, UnVersionedResponse,
+    BeaconResponse, ForkVersionDecode, ForkVersionedResponse, UnversionedResponse,
 };
 pub use crate::beacon_state::{Error as BeaconStateError, *};
 pub use crate::blob_sidecar::{BlobIdentifier, BlobSidecar, BlobSidecarList, BlobsList};

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -179,7 +179,7 @@ pub use crate::fork_context::ForkContext;
 pub use crate::fork_data::ForkData;
 pub use crate::fork_name::{ForkName, InconsistentFork};
 pub use crate::fork_versioned_response::{
-    ForkVersionDecode, ForkVersionDeserialize, ForkVersionedResponse,
+    BeaconResponse, ForkVersionDecode, ForkVersionedResponse, UnVersionedResponse,
 };
 pub use crate::graffiti::{Graffiti, GRAFFITI_BYTES_LEN};
 pub use crate::historical_batch::HistoricalBatch;
@@ -287,9 +287,9 @@ pub use bls::{
     AggregatePublicKey, AggregateSignature, Keypair, PublicKey, PublicKeyBytes, SecretKey,
     Signature, SignatureBytes,
 };
+pub use context_deserialize::ContextDeserialize;
+pub use context_deserialize_derive::context_deserialize;
 pub use kzg::{KzgCommitment, KzgProof, VERSIONED_HASH_VERSION_KZG};
 pub use milhouse::{self, List, Vector};
 pub use ssz_types::{typenum, typenum::Unsigned, BitList, BitVector, FixedVector, VariableList};
 pub use superstruct::superstruct;
-pub use context_deserialize_derive::context_deserialize;
-pub use context_deserialize::ContextDeserialize;

--- a/consensus/types/src/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client_bootstrap.rs
@@ -1,12 +1,11 @@
 use crate::{
-    light_client_update::*, test_utils::TestRandom, BeaconState, ChainSpec, EthSpec, FixedVector,
-    ForkName, ForkVersionDeserialize, Hash256, LightClientHeader, LightClientHeaderAltair,
+    light_client_update::*, test_utils::TestRandom, BeaconState, ChainSpec, ContextDeserialize,
+    EthSpec, FixedVector, ForkName, Hash256, LightClientHeader, LightClientHeaderAltair,
     LightClientHeaderCapella, LightClientHeaderDeneb, LightClientHeaderElectra,
     LightClientHeaderFulu, SignedBlindedBeaconBlock, Slot, SyncCommittee,
 };
 use derivative::Derivative;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::Value;
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use std::sync::Arc;
@@ -213,20 +212,40 @@ impl<E: EthSpec> LightClientBootstrap<E> {
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for LightClientBootstrap<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
-        value: Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        if fork_name.altair_enabled() {
-            Ok(serde_json::from_value::<LightClientBootstrap<E>>(value)
-                .map_err(serde::de::Error::custom))?
-        } else {
-            Err(serde::de::Error::custom(format!(
-                "LightClientBootstrap failed to deserialize: unsupported fork '{}'",
-                fork_name
-            )))
-        }
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientBootstrap<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let convert_err = |e| {
+            serde::de::Error::custom(format!(
+                "LightClientBootstrap failed to deserialize: {:?}",
+                e
+            ))
+        };
+        Ok(match context {
+            ForkName::Base => {
+                return Err(serde::de::Error::custom(format!(
+                    "LightClientBootstrap failed to deserialize: unsupported fork '{}'",
+                    context
+                )))
+            }
+            ForkName::Altair | ForkName::Bellatrix => {
+                Self::Altair(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Capella => {
+                Self::Capella(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Deneb => {
+                Self::Deneb(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Electra => {
+                Self::Electra(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Fulu => {
+                Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+        })
     }
 }
 

--- a/consensus/types/src/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client_bootstrap.rs
@@ -1,3 +1,4 @@
+use crate::context_deserialize;
 use crate::{
     light_client_update::*, test_utils::TestRandom, BeaconState, ChainSpec, ContextDeserialize,
     EthSpec, FixedVector, ForkName, Hash256, LightClientHeader, LightClientHeaderAltair,
@@ -33,6 +34,7 @@ use tree_hash_derive::TreeHash;
         ),
         serde(bound = "E: EthSpec", deny_unknown_fields),
         arbitrary(bound = "E: EthSpec"),
+        context_deserialize(ForkName),
     )
 )]
 #[derive(

--- a/consensus/types/src/light_client_finality_update.rs
+++ b/consensus/types/src/light_client_finality_update.rs
@@ -1,4 +1,5 @@
 use super::{EthSpec, FixedVector, Hash256, LightClientHeader, Slot, SyncAggregate};
+use crate::context_deserialize;
 use crate::ChainSpec;
 use crate::{
     light_client_update::*, test_utils::TestRandom, ContextDeserialize, ForkName,
@@ -32,6 +33,7 @@ use tree_hash_derive::TreeHash;
         ),
         serde(bound = "E: EthSpec", deny_unknown_fields),
         arbitrary(bound = "E: EthSpec"),
+        context_deserialize(ForkName),
     )
 )]
 #[derive(Debug, Clone, Serialize, Encode, TreeHash, arbitrary::Arbitrary, PartialEq)]

--- a/consensus/types/src/light_client_finality_update.rs
+++ b/consensus/types/src/light_client_finality_update.rs
@@ -34,9 +34,7 @@ use tree_hash_derive::TreeHash;
         arbitrary(bound = "E: EthSpec"),
     )
 )]
-#[derive(
-    Debug, Clone, Serialize, Encode, TreeHash, Deserialize, arbitrary::Arbitrary, PartialEq,
-)]
+#[derive(Debug, Clone, Serialize, Encode, TreeHash, arbitrary::Arbitrary, PartialEq)]
 #[serde(untagged)]
 #[tree_hash(enum_behaviour = "transparent")]
 #[ssz(enum_behaviour = "transparent")]

--- a/consensus/types/src/light_client_finality_update.rs
+++ b/consensus/types/src/light_client_finality_update.rs
@@ -1,13 +1,12 @@
 use super::{EthSpec, FixedVector, Hash256, LightClientHeader, Slot, SyncAggregate};
 use crate::ChainSpec;
 use crate::{
-    light_client_update::*, test_utils::TestRandom, ForkName, ForkVersionDeserialize,
+    light_client_update::*, test_utils::TestRandom, ContextDeserialize, ForkName,
     LightClientHeaderAltair, LightClientHeaderCapella, LightClientHeaderDeneb,
     LightClientHeaderElectra, LightClientHeaderFulu, SignedBlindedBeaconBlock,
 };
 use derivative::Derivative;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::Value;
 use ssz::{Decode, Encode};
 use ssz_derive::Decode;
 use ssz_derive::Encode;
@@ -233,20 +232,40 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for LightClientFinalityUpdate<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
-        value: Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        if fork_name.altair_enabled() {
-            serde_json::from_value::<LightClientFinalityUpdate<E>>(value)
-                .map_err(serde::de::Error::custom)
-        } else {
-            Err(serde::de::Error::custom(format!(
-                "LightClientFinalityUpdate failed to deserialize: unsupported fork '{}'",
-                fork_name
-            )))
-        }
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientFinalityUpdate<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let convert_err = |e| {
+            serde::de::Error::custom(format!(
+                "LightClientFinalityUpdate failed to deserialize: {:?}",
+                e
+            ))
+        };
+        Ok(match context {
+            ForkName::Base => {
+                return Err(serde::de::Error::custom(format!(
+                    "LightClientFinalityUpdate failed to deserialize: unsupported fork '{}'",
+                    context
+                )))
+            }
+            ForkName::Altair | ForkName::Bellatrix => {
+                Self::Altair(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Capella => {
+                Self::Capella(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Deneb => {
+                Self::Deneb(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Electra => {
+                Self::Electra(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Fulu => {
+                Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+        })
     }
 }
 

--- a/consensus/types/src/light_client_header.rs
+++ b/consensus/types/src/light_client_header.rs
@@ -1,3 +1,4 @@
+use crate::context_deserialize;
 use crate::ChainSpec;
 use crate::{light_client_update::*, BeaconBlockBody};
 use crate::{
@@ -34,6 +35,7 @@ use tree_hash_derive::TreeHash;
         ),
         serde(bound = "E: EthSpec", deny_unknown_fields),
         arbitrary(bound = "E: EthSpec"),
+        context_deserialize(ForkName),
     )
 )]
 #[derive(Debug, Clone, Serialize, TreeHash, Encode, arbitrary::Arbitrary, PartialEq)]

--- a/consensus/types/src/light_client_header.rs
+++ b/consensus/types/src/light_client_header.rs
@@ -1,6 +1,4 @@
 use crate::ChainSpec;
-use crate::ForkName;
-use crate::ForkVersionDeserialize;
 use crate::{light_client_update::*, BeaconBlockBody};
 use crate::{
     test_utils::TestRandom, EthSpec, ExecutionPayloadHeaderCapella, ExecutionPayloadHeaderDeneb,
@@ -8,8 +6,9 @@ use crate::{
     SignedBlindedBeaconBlock,
 };
 use crate::{BeaconBlockHeader, ExecutionPayloadHeader};
+use crate::{ContextDeserialize, ForkName};
 use derivative::Derivative;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use ssz::Decode;
 use ssz_derive::{Decode, Encode};
 use std::marker::PhantomData;
@@ -334,31 +333,40 @@ impl<E: EthSpec> Default for LightClientHeaderFulu<E> {
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for LightClientHeader<E> {
-    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
-        value: serde_json::value::Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        match fork_name {
-            ForkName::Altair | ForkName::Bellatrix => serde_json::from_value(value)
-                .map(|light_client_header| Self::Altair(light_client_header))
-                .map_err(serde::de::Error::custom),
-            ForkName::Capella => serde_json::from_value(value)
-                .map(|light_client_header| Self::Capella(light_client_header))
-                .map_err(serde::de::Error::custom),
-            ForkName::Deneb => serde_json::from_value(value)
-                .map(|light_client_header| Self::Deneb(light_client_header))
-                .map_err(serde::de::Error::custom),
-            ForkName::Electra => serde_json::from_value(value)
-                .map(|light_client_header| Self::Electra(light_client_header))
-                .map_err(serde::de::Error::custom),
-            ForkName::Fulu => serde_json::from_value(value)
-                .map(|light_client_header| Self::Fulu(light_client_header))
-                .map_err(serde::de::Error::custom),
-            ForkName::Base => Err(serde::de::Error::custom(format!(
-                "LightClientHeader deserialization for {fork_name} not implemented"
-            ))),
-        }
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientHeader<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let convert_err = |e| {
+            serde::de::Error::custom(format!(
+                "LightClientFinalityUpdate failed to deserialize: {:?}",
+                e
+            ))
+        };
+        Ok(match context {
+            ForkName::Base => {
+                return Err(serde::de::Error::custom(format!(
+                    "LightClientFinalityUpdate failed to deserialize: unsupported fork '{}'",
+                    context
+                )))
+            }
+            ForkName::Altair | ForkName::Bellatrix => {
+                Self::Altair(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Capella => {
+                Self::Capella(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Deneb => {
+                Self::Deneb(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Electra => {
+                Self::Electra(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Fulu => {
+                Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+        })
     }
 }
 

--- a/consensus/types/src/light_client_header.rs
+++ b/consensus/types/src/light_client_header.rs
@@ -36,9 +36,7 @@ use tree_hash_derive::TreeHash;
         arbitrary(bound = "E: EthSpec"),
     )
 )]
-#[derive(
-    Debug, Clone, Serialize, TreeHash, Encode, Deserialize, arbitrary::Arbitrary, PartialEq,
-)]
+#[derive(Debug, Clone, Serialize, TreeHash, Encode, arbitrary::Arbitrary, PartialEq)]
 #[serde(untagged)]
 #[tree_hash(enum_behaviour = "transparent")]
 #[ssz(enum_behaviour = "transparent")]

--- a/consensus/types/src/light_client_optimistic_update.rs
+++ b/consensus/types/src/light_client_optimistic_update.rs
@@ -1,4 +1,5 @@
 use super::{ContextDeserialize, EthSpec, ForkName, LightClientHeader, Slot, SyncAggregate};
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
 use crate::{
     light_client_update::*, ChainSpec, LightClientHeaderAltair, LightClientHeaderCapella,
@@ -35,6 +36,7 @@ use tree_hash_derive::TreeHash;
         ),
         serde(bound = "E: EthSpec", deny_unknown_fields),
         arbitrary(bound = "E: EthSpec"),
+        context_deserialize(ForkName),
     )
 )]
 #[derive(Debug, Clone, Serialize, Encode, TreeHash, arbitrary::Arbitrary, PartialEq)]

--- a/consensus/types/src/light_client_optimistic_update.rs
+++ b/consensus/types/src/light_client_optimistic_update.rs
@@ -1,4 +1,4 @@
-use super::{EthSpec, ForkName, ForkVersionDeserialize, LightClientHeader, Slot, SyncAggregate};
+use super::{ContextDeserialize, EthSpec, ForkName, LightClientHeader, Slot, SyncAggregate};
 use crate::test_utils::TestRandom;
 use crate::{
     light_client_update::*, ChainSpec, LightClientHeaderAltair, LightClientHeaderCapella,
@@ -7,7 +7,6 @@ use crate::{
 };
 use derivative::Derivative;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::Value;
 use ssz::{Decode, Encode};
 use ssz_derive::Decode;
 use ssz_derive::Encode;
@@ -206,22 +205,40 @@ impl<E: EthSpec> LightClientOptimisticUpdate<E> {
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for LightClientOptimisticUpdate<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
-        value: Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        if fork_name.altair_enabled() {
-            Ok(
-                serde_json::from_value::<LightClientOptimisticUpdate<E>>(value)
-                    .map_err(serde::de::Error::custom),
-            )?
-        } else {
-            Err(serde::de::Error::custom(format!(
-                "LightClientOptimisticUpdate failed to deserialize: unsupported fork '{}'",
-                fork_name
-            )))
-        }
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientOptimisticUpdate<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let convert_err = |e| {
+            serde::de::Error::custom(format!(
+                "LightClientOptimisticUpdate failed to deserialize: {:?}",
+                e
+            ))
+        };
+        Ok(match context {
+            ForkName::Base => {
+                return Err(serde::de::Error::custom(format!(
+                    "LightClientOptimisticUpdate failed to deserialize: unsupported fork '{}'",
+                    context
+                )))
+            }
+            ForkName::Altair | ForkName::Bellatrix => {
+                Self::Altair(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Capella => {
+                Self::Capella(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Deneb => {
+                Self::Deneb(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Electra => {
+                Self::Electra(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Fulu => {
+                Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+        })
     }
 }
 

--- a/consensus/types/src/light_client_optimistic_update.rs
+++ b/consensus/types/src/light_client_optimistic_update.rs
@@ -37,9 +37,7 @@ use tree_hash_derive::TreeHash;
         arbitrary(bound = "E: EthSpec"),
     )
 )]
-#[derive(
-    Debug, Clone, Serialize, Encode, TreeHash, Deserialize, arbitrary::Arbitrary, PartialEq,
-)]
+#[derive(Debug, Clone, Serialize, Encode, TreeHash, arbitrary::Arbitrary, PartialEq)]
 #[serde(untagged)]
 #[tree_hash(enum_behaviour = "transparent")]
 #[ssz(enum_behaviour = "transparent")]

--- a/consensus/types/src/light_client_update.rs
+++ b/consensus/types/src/light_client_update.rs
@@ -2,7 +2,7 @@ use super::{EthSpec, FixedVector, Hash256, Slot, SyncAggregate, SyncCommittee};
 use crate::light_client_header::LightClientHeaderElectra;
 use crate::LightClientHeader;
 use crate::{
-    beacon_state, test_utils::TestRandom, ChainSpec, Epoch, ForkName, ForkVersionDeserialize,
+    beacon_state, test_utils::TestRandom, ChainSpec, ContextDeserialize, Epoch, ForkName,
     LightClientHeaderAltair, LightClientHeaderCapella, LightClientHeaderDeneb,
     LightClientHeaderFulu, SignedBlindedBeaconBlock,
 };
@@ -10,7 +10,6 @@ use derivative::Derivative;
 use safe_arith::ArithError;
 use safe_arith::SafeArith;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::Value;
 use ssz::{Decode, Encode};
 use ssz_derive::Decode;
 use ssz_derive::Encode;
@@ -180,19 +179,37 @@ pub struct LightClientUpdate<E: EthSpec> {
     pub signature_slot: Slot,
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for LightClientUpdate<E> {
-    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
-        value: Value,
-        fork_name: ForkName,
-    ) -> Result<Self, D::Error> {
-        match fork_name {
-            ForkName::Base => Err(serde::de::Error::custom(format!(
-                "LightClientUpdate failed to deserialize: unsupported fork '{}'",
-                fork_name
-            ))),
-            _ => Ok(serde_json::from_value::<LightClientUpdate<E>>(value)
-                .map_err(serde::de::Error::custom))?,
-        }
+impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientUpdate<E> {
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let convert_err = |e| {
+            serde::de::Error::custom(format!("LightClientUpdate failed to deserialize: {:?}", e))
+        };
+        Ok(match context {
+            ForkName::Base => {
+                return Err(serde::de::Error::custom(format!(
+                    "LightClientUpdate failed to deserialize: unsupported fork '{}'",
+                    context
+                )))
+            }
+            ForkName::Altair | ForkName::Bellatrix => {
+                Self::Altair(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Capella => {
+                Self::Capella(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Deneb => {
+                Self::Deneb(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Electra => {
+                Self::Electra(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Fulu => {
+                Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+        })
     }
 }
 

--- a/consensus/types/src/light_client_update.rs
+++ b/consensus/types/src/light_client_update.rs
@@ -1,4 +1,5 @@
 use super::{EthSpec, FixedVector, Hash256, Slot, SyncAggregate, SyncCommittee};
+use crate::context_deserialize;
 use crate::light_client_header::LightClientHeaderElectra;
 use crate::LightClientHeader;
 use crate::{
@@ -116,6 +117,7 @@ impl From<milhouse::Error> for Error {
         ),
         serde(bound = "E: EthSpec", deny_unknown_fields),
         arbitrary(bound = "E: EthSpec"),
+        context_deserialize(ForkName),
     )
 )]
 #[derive(Debug, Clone, Serialize, Encode, TreeHash, arbitrary::Arbitrary, PartialEq)]

--- a/consensus/types/src/light_client_update.rs
+++ b/consensus/types/src/light_client_update.rs
@@ -118,9 +118,7 @@ impl From<milhouse::Error> for Error {
         arbitrary(bound = "E: EthSpec"),
     )
 )]
-#[derive(
-    Debug, Clone, Serialize, Encode, TreeHash, Deserialize, arbitrary::Arbitrary, PartialEq,
-)]
+#[derive(Debug, Clone, Serialize, Encode, TreeHash, arbitrary::Arbitrary, PartialEq)]
 #[serde(untagged)]
 #[tree_hash(enum_behaviour = "transparent")]
 #[ssz(enum_behaviour = "transparent")]

--- a/consensus/types/src/pending_attestation.rs
+++ b/consensus/types/src/pending_attestation.rs
@@ -1,6 +1,6 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::{AttestationData, BitList, EthSpec};
-
+use crate::{AttestationData, BitList, EthSpec, ForkName};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -22,6 +22,7 @@ use tree_hash_derive::TreeHash;
     arbitrary::Arbitrary,
 )]
 #[arbitrary(bound = "E: EthSpec")]
+#[context_deserialize(ForkName)]
 pub struct PendingAttestation<E: EthSpec> {
     pub aggregation_bits: BitList<E::MaxValidatorsPerCommittee>,
     pub data: AttestationData,

--- a/consensus/types/src/pending_consolidation.rs
+++ b/consensus/types/src/pending_consolidation.rs
@@ -1,4 +1,6 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
+use crate::ForkName;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -18,6 +20,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct PendingConsolidation {
     #[serde(with = "serde_utils::quoted_u64")]
     pub source_index: u64,

--- a/consensus/types/src/pending_deposit.rs
+++ b/consensus/types/src/pending_deposit.rs
@@ -18,6 +18,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct PendingDeposit {
     pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,

--- a/consensus/types/src/pending_partial_withdrawal.rs
+++ b/consensus/types/src/pending_partial_withdrawal.rs
@@ -1,5 +1,6 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::Epoch;
+use crate::{Epoch, ForkName};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -19,6 +20,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct PendingPartialWithdrawal {
     #[serde(with = "serde_utils::quoted_u64")]
     pub validator_index: u64,

--- a/consensus/types/src/proposer_slashing.rs
+++ b/consensus/types/src/proposer_slashing.rs
@@ -1,5 +1,6 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::SignedBeaconBlockHeader;
+use crate::{ForkName, SignedBeaconBlockHeader};
 
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -23,6 +24,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct ProposerSlashing {
     pub signed_header_1: SignedBeaconBlockHeader,
     pub signed_header_2: SignedBeaconBlockHeader,

--- a/consensus/types/src/runtime_var_list.rs
+++ b/consensus/types/src/runtime_var_list.rs
@@ -1,5 +1,6 @@
+use crate::{ContextDeserialize, ForkName};
 use derivative::Derivative;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use ssz::Decode;
 use ssz_types::Error;
 use std::ops::{Deref, Index, IndexMut};
@@ -214,6 +215,21 @@ where
 
     fn ssz_bytes_len(&self) -> usize {
         self.vec.ssz_bytes_len()
+    }
+}
+
+impl<'de, C> ContextDeserialize<'de, ForkName> for RuntimeVariableList<C>
+where
+    C: ContextDeserialize<'de, ForkName>,
+{
+    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // first parse out a Vec<C> using the Vec<C> impl you already have
+        let vec: Vec<C> = Vec::context_deserialize(deserializer, context)?;
+        let len = vec.len();
+        Ok(RuntimeVariableList::from_vec(vec, len))
     }
 }
 

--- a/consensus/types/src/runtime_var_list.rs
+++ b/consensus/types/src/runtime_var_list.rs
@@ -1,5 +1,6 @@
-use crate::{ContextDeserialize, ForkName};
+use crate::ContextDeserialize;
 use derivative::Derivative;
+use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize};
 use ssz::Decode;
 use ssz_types::Error;
@@ -218,18 +219,25 @@ where
     }
 }
 
-impl<'de, C> ContextDeserialize<'de, ForkName> for RuntimeVariableList<C>
+impl<'de, C, T> ContextDeserialize<'de, (C, usize)> for RuntimeVariableList<T>
 where
-    C: ContextDeserialize<'de, ForkName>,
+    T: ContextDeserialize<'de, C>,
+    C: Clone,
 {
-    fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
+    fn context_deserialize<D>(deserializer: D, context: (C, usize)) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         // first parse out a Vec<C> using the Vec<C> impl you already have
-        let vec: Vec<C> = Vec::context_deserialize(deserializer, context)?;
-        let len = vec.len();
-        Ok(RuntimeVariableList::from_vec(vec, len))
+        let vec: Vec<T> = Vec::context_deserialize(deserializer, context.0)?;
+        if vec.len() > context.1 {
+            return Err(DeError::custom(format!(
+                "RuntimeVariableList lengh {} exceeds max_len {}",
+                vec.len(),
+                context.1
+            )));
+        }
+        Ok(RuntimeVariableList::from_vec(vec, context.1))
     }
 }
 

--- a/consensus/types/src/signed_aggregate_and_proof.rs
+++ b/consensus/types/src/signed_aggregate_and_proof.rs
@@ -2,11 +2,11 @@ use super::{
     AggregateAndProof, AggregateAndProofBase, AggregateAndProofElectra, AggregateAndProofRef,
 };
 use super::{
-    AttestationRef, ChainSpec, Domain, EthSpec, Fork, Hash256, SecretKey, SelectionProof,
-    Signature, SignedRoot,
+    Attestation, AttestationRef, ChainSpec, Domain, EthSpec, Fork, ForkName, Hash256, SecretKey,
+    SelectionProof, Signature, SignedRoot,
 };
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::Attestation;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
@@ -32,6 +32,7 @@ use tree_hash_derive::TreeHash;
             TestRandom,
             TreeHash,
         ),
+        context_deserialize(ForkName),
         serde(bound = "E: EthSpec"),
         arbitrary(bound = "E: EthSpec"),
     ),

--- a/consensus/types/src/signed_beacon_block_header.rs
+++ b/consensus/types/src/signed_beacon_block_header.rs
@@ -1,5 +1,6 @@
+use crate::context_deserialize;
 use crate::{
-    test_utils::TestRandom, BeaconBlockHeader, ChainSpec, Domain, EthSpec, Fork, Hash256,
+    test_utils::TestRandom, BeaconBlockHeader, ChainSpec, Domain, EthSpec, Fork, ForkName, Hash256,
     PublicKey, Signature, SignedRoot,
 };
 use serde::{Deserialize, Serialize};
@@ -24,6 +25,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct SignedBeaconBlockHeader {
     pub message: BeaconBlockHeader,
     pub signature: Signature,

--- a/consensus/types/src/signed_bls_to_execution_change.rs
+++ b/consensus/types/src/signed_bls_to_execution_change.rs
@@ -19,6 +19,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct SignedBlsToExecutionChange {
     pub message: BlsToExecutionChange,
     pub signature: Signature,

--- a/consensus/types/src/signed_contribution_and_proof.rs
+++ b/consensus/types/src/signed_contribution_and_proof.rs
@@ -1,7 +1,8 @@
 use super::{
-    ChainSpec, ContributionAndProof, Domain, EthSpec, Fork, Hash256, SecretKey, Signature,
-    SignedRoot, SyncCommitteeContribution, SyncSelectionProof,
+    ChainSpec, ContributionAndProof, Domain, EthSpec, Fork, ForkName, Hash256, SecretKey,
+    Signature, SignedRoot, SyncCommitteeContribution, SyncSelectionProof,
 };
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -24,6 +25,7 @@ use tree_hash_derive::TreeHash;
 )]
 #[serde(bound = "E: EthSpec")]
 #[arbitrary(bound = "E: EthSpec")]
+#[context_deserialize(ForkName)]
 pub struct SignedContributionAndProof<E: EthSpec> {
     /// The `ContributionAndProof` that was signed.
     pub message: ContributionAndProof<E>,

--- a/consensus/types/src/signed_voluntary_exit.rs
+++ b/consensus/types/src/signed_voluntary_exit.rs
@@ -1,4 +1,5 @@
-use crate::{test_utils::TestRandom, VoluntaryExit};
+use crate::context_deserialize;
+use crate::{test_utils::TestRandom, ForkName, VoluntaryExit};
 use bls::Signature;
 
 use serde::{Deserialize, Serialize};
@@ -22,6 +23,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct SignedVoluntaryExit {
     pub message: VoluntaryExit,
     pub signature: Signature,

--- a/consensus/types/src/signing_data.rs
+++ b/consensus/types/src/signing_data.rs
@@ -1,5 +1,6 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::Hash256;
+use crate::{ForkName, Hash256};
 
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -19,6 +20,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct SigningData {
     pub object_root: Hash256,
     pub domain: Hash256,

--- a/consensus/types/src/sync_aggregate.rs
+++ b/consensus/types/src/sync_aggregate.rs
@@ -1,6 +1,7 @@
 use crate::consts::altair::SYNC_COMMITTEE_SUBNET_COUNT;
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::{AggregateSignature, BitVector, EthSpec, SyncCommitteeContribution};
+use crate::{AggregateSignature, BitVector, EthSpec, ForkName, SyncCommitteeContribution};
 use derivative::Derivative;
 use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
@@ -36,6 +37,7 @@ impl From<ArithError> for Error {
 #[derivative(PartialEq, Hash(bound = "E: EthSpec"))]
 #[serde(bound = "E: EthSpec")]
 #[arbitrary(bound = "E: EthSpec")]
+#[context_deserialize(ForkName)]
 pub struct SyncAggregate<E: EthSpec> {
     pub sync_committee_bits: BitVector<E::SyncCommitteeSize>,
     pub sync_committee_signature: AggregateSignature,

--- a/consensus/types/src/sync_aggregator_selection_data.rs
+++ b/consensus/types/src/sync_aggregator_selection_data.rs
@@ -1,6 +1,6 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::{SignedRoot, Slot};
-
+use crate::{ForkName, SignedRoot, Slot};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -19,6 +19,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct SyncAggregatorSelectionData {
     pub slot: Slot,
     #[serde(with = "serde_utils::quoted_u64")]

--- a/consensus/types/src/sync_committee.rs
+++ b/consensus/types/src/sync_committee.rs
@@ -1,5 +1,6 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::{EthSpec, FixedVector, SyncSubnetId};
+use crate::{EthSpec, FixedVector, ForkName, SyncSubnetId};
 use bls::PublicKeyBytes;
 use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
@@ -38,6 +39,7 @@ impl From<ArithError> for Error {
 )]
 #[serde(bound = "E: EthSpec")]
 #[arbitrary(bound = "E: EthSpec")]
+#[context_deserialize(ForkName)]
 pub struct SyncCommittee<E: EthSpec> {
     pub pubkeys: FixedVector<PublicKeyBytes, E::SyncCommitteeSize>,
     pub aggregate_pubkey: PublicKeyBytes,

--- a/consensus/types/src/sync_committee_contribution.rs
+++ b/consensus/types/src/sync_committee_contribution.rs
@@ -1,4 +1,5 @@
-use super::{AggregateSignature, EthSpec, SignedRoot};
+use super::{AggregateSignature, EthSpec, ForkName, SignedRoot};
+use crate::context_deserialize;
 use crate::slot_data::SlotData;
 use crate::{test_utils::TestRandom, BitVector, Hash256, Slot, SyncCommitteeMessage};
 use serde::{Deserialize, Serialize};
@@ -28,6 +29,7 @@ pub enum Error {
 )]
 #[serde(bound = "E: EthSpec")]
 #[arbitrary(bound = "E: EthSpec")]
+#[context_deserialize(ForkName)]
 pub struct SyncCommitteeContribution<E: EthSpec> {
     pub slot: Slot,
     pub beacon_block_root: Hash256,

--- a/consensus/types/src/sync_committee_message.rs
+++ b/consensus/types/src/sync_committee_message.rs
@@ -1,7 +1,9 @@
-use crate::test_utils::TestRandom;
-use crate::{ChainSpec, Domain, EthSpec, Fork, Hash256, SecretKey, Signature, SignedRoot, Slot};
-
+use crate::context_deserialize;
 use crate::slot_data::SlotData;
+use crate::test_utils::TestRandom;
+use crate::{
+    ChainSpec, Domain, EthSpec, Fork, ForkName, Hash256, SecretKey, Signature, SignedRoot, Slot,
+};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -20,6 +22,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct SyncCommitteeMessage {
     pub slot: Slot,
     pub beacon_block_root: Hash256,

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -1,3 +1,4 @@
+use crate::context_deserialize;
 use crate::{
     test_utils::TestRandom, Address, BeaconState, ChainSpec, Checkpoint, Epoch, EthSpec,
     FixedBytesExtended, ForkName, Hash256, PublicKeyBytes,
@@ -23,6 +24,7 @@ use tree_hash_derive::TreeHash;
     TestRandom,
     TreeHash,
 )]
+#[context_deserialize(ForkName)]
 pub struct Validator {
     pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,

--- a/consensus/types/src/voluntary_exit.rs
+++ b/consensus/types/src/voluntary_exit.rs
@@ -1,3 +1,4 @@
+use crate::context_deserialize;
 use crate::{
     test_utils::TestRandom, ChainSpec, Domain, Epoch, ForkName, Hash256, SecretKey, SignedRoot,
     SignedVoluntaryExit,
@@ -24,6 +25,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct VoluntaryExit {
     /// Earliest epoch when voluntary exit can be processed.
     pub epoch: Epoch,

--- a/consensus/types/src/withdrawal.rs
+++ b/consensus/types/src/withdrawal.rs
@@ -19,6 +19,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct Withdrawal {
     #[serde(with = "serde_utils::quoted_u64")]
     pub index: u64,

--- a/consensus/types/src/withdrawal_request.rs
+++ b/consensus/types/src/withdrawal_request.rs
@@ -1,5 +1,6 @@
+use crate::context_deserialize;
 use crate::test_utils::TestRandom;
-use crate::{Address, PublicKeyBytes};
+use crate::{Address, ForkName, PublicKeyBytes};
 use serde::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
@@ -20,6 +21,7 @@ use tree_hash_derive::TreeHash;
     TreeHash,
     TestRandom,
 )]
+#[context_deserialize(ForkName)]
 pub struct WithdrawalRequest {
     #[serde(with = "serde_utils::address_hex")]
     pub source_address: Address,

--- a/lcli/src/block_root.rs
+++ b/lcli/src/block_root.rs
@@ -79,7 +79,7 @@ pub fn run<E: EthSpec>(
                         .await
                         .map_err(|e| format!("Failed to download block: {:?}", e))?
                         .ok_or_else(|| format!("Unable to locate block at {:?}", block_id))?
-                        .data;
+                        .into_data();
                     Ok::<_, String>(block)
                 })
                 .map_err(|e| format!("Failed to complete task: {:?}", e))?

--- a/lcli/src/http_sync.rs
+++ b/lcli/src/http_sync.rs
@@ -127,7 +127,7 @@ async fn get_block_from_source<T: EthSpec>(
             .await
             .unwrap()
             .unwrap()
-            .data;
+            .into_data();
 
         let (kzg_proofs, blobs): (Vec<_>, Vec<_>) = blobs_from_source
             .iter()

--- a/lcli/src/http_sync.rs
+++ b/lcli/src/http_sync.rs
@@ -123,7 +123,7 @@ async fn get_block_from_source<T: EthSpec>(
             .unwrap()
             .unwrap();
         let blobs_from_source = source
-            .get_blobs::<T>(block_id, None)
+            .get_blobs::<T>(block_id, None, spec)
             .await
             .unwrap()
             .unwrap()

--- a/lcli/src/skip_slots.rs
+++ b/lcli/src/skip_slots.rs
@@ -102,7 +102,7 @@ pub fn run<E: EthSpec>(
                 })
                 .map_err(|e| format!("Failed to complete task: {:?}", e))?
                 .ok_or_else(|| format!("Unable to locate state at {:?}", state_id))?
-                .data;
+                .into_data();
             let state_root = match state_id {
                 StateId::Root(root) => Some(root),
                 _ => None,

--- a/lcli/src/state_root.rs
+++ b/lcli/src/state_root.rs
@@ -50,7 +50,7 @@ pub fn run<E: EthSpec>(
                 })
                 .map_err(|e| format!("Failed to complete task: {:?}", e))?
                 .ok_or_else(|| format!("Unable to locate state at {:?}", state_id))?
-                .data
+                .into_data()
         }
         _ => return Err("must supply either --state-path or --beacon-url".into()),
     };

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -154,7 +154,7 @@ pub fn run<E: EthSpec>(
                         .await
                         .map_err(|e| format!("Failed to download block: {:?}", e))?
                         .ok_or_else(|| format!("Unable to locate block at {:?}", block_id))?
-                        .data;
+                        .into_data();
 
                     if block.slot() == inner_spec.genesis_slot {
                         return Err("Cannot run on the genesis block".to_string());
@@ -165,7 +165,7 @@ pub fn run<E: EthSpec>(
                         .await
                         .map_err(|e| format!("Failed to download parent block: {:?}", e))?
                         .ok_or_else(|| format!("Unable to locate parent block at {:?}", block_id))?
-                        .data;
+                        .into_data();
 
                     let state_root = parent_block.state_root();
                     let state_id = StateId::Root(state_root);
@@ -174,7 +174,7 @@ pub fn run<E: EthSpec>(
                         .await
                         .map_err(|e| format!("Failed to download state: {:?}", e))?
                         .ok_or_else(|| format!("Unable to locate state at {:?}", state_id))?
-                        .data;
+                        .into_data();
 
                     Ok((pre_state, Some(state_root), block))
                 })

--- a/testing/ef_tests/src/cases/light_client_verify_is_better_update.rs
+++ b/testing/ef_tests/src/cases/light_client_verify_is_better_update.rs
@@ -3,8 +3,7 @@ use decode::ssz_decode_light_client_update;
 use serde::Deserialize;
 use types::{LightClientUpdate, Slot};
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone)]
 pub struct LightClientVerifyIsBetterUpdate<E: EthSpec> {
     light_client_updates: Vec<LightClientUpdate<E>>,
 }

--- a/testing/simulator/src/checks.rs
+++ b/testing/simulator/src/checks.rs
@@ -97,7 +97,7 @@ async fn verify_validator_count<E: EthSpec>(
             let vc = remote_node
                 .get_debug_beacon_states::<E>(StateId::Head)
                 .await
-                .map(|body| body.unwrap().data)
+                .map(|body| body.unwrap().into_data())
                 .map_err(|e| format!("Get state root via http failed: {:?}", e))?
                 .validators()
                 .len();
@@ -197,7 +197,7 @@ pub async fn verify_full_sync_aggregates_up_to<E: EthSpec>(
                         slot
                     )
                 })
-                .data
+                .data()
                 .message()
                 .body()
                 .sync_aggregate()
@@ -235,7 +235,7 @@ pub async fn verify_transition_block_finalized<E: EthSpec>(
         let execution_block_hash: ExecutionBlockHash = remote_node
             .get_beacon_blocks::<E>(BlockId::Finalized)
             .await
-            .map(|body| body.unwrap().data)
+            .map(|body| body.unwrap().into_data())
             .map_err(|e| format!("Get state root via http failed: {:?}", e))?
             .message()
             .execution_payload()
@@ -308,7 +308,7 @@ pub(crate) async fn verify_light_client_updates<E: EthSpec>(
             .await
             .map_err(|e| format!("Error while getting light client updates: {:?}", e))?
             .ok_or(format!("Light client optimistic update not found {slot:?}"))?
-            .data
+            .data()
             .signature_slot();
         let signature_slot_distance = slot - signature_slot;
         if signature_slot_distance > light_client_update_slot_tolerance {
@@ -337,7 +337,7 @@ pub(crate) async fn verify_light_client_updates<E: EthSpec>(
             .await
             .map_err(|e| format!("Error while getting light client updates: {:?}", e))?
             .ok_or(format!("Light client finality update not found {slot:?}"))?
-            .data
+            .data()
             .signature_slot();
         let signature_slot_distance = slot - signature_slot;
         if signature_slot_distance > light_client_update_slot_tolerance {
@@ -385,7 +385,7 @@ pub async fn ensure_node_synced_up_to_slot<E: EthSpec>(
         .ok()
         .flatten()
         .ok_or(format!("No head block exists on node {node_index}"))?
-        .data;
+        .into_data();
 
     // Check the head block is synced with the rest of the network.
     if head.slot() >= upto_slot {

--- a/testing/simulator/src/checks.rs
+++ b/testing/simulator/src/checks.rs
@@ -422,7 +422,7 @@ pub async fn verify_full_blob_production_up_to<E: EthSpec>(
         // the `verify_full_block_production_up_to` function.
         if block.is_some() {
             remote_node
-                .get_blobs::<E>(BlockId::Slot(Slot::new(slot)), None)
+                .get_blobs::<E>(BlockId::Slot(Slot::new(slot)), None, &E::default_spec())
                 .await
                 .map_err(|e| format!("Failed to get blobs at slot {slot:?}: {e:?}"))?
                 .ok_or_else(|| format!("No blobs available at slot {slot:?}"))?;

--- a/validator_client/validator_services/src/attestation_service.rs
+++ b/validator_client/validator_services/src/attestation_service.rs
@@ -569,7 +569,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
                             format!("Failed to produce an aggregate attestation: {:?}", e)
                         })?
                         .ok_or_else(|| format!("No aggregate available for {:?}", attestation_data))
-                        .map(|result| result.data)
+                        .map(|result| result.into_data())
                 } else {
                     beacon_node
                         .get_validator_aggregate_attestation_v1(


### PR DESCRIPTION
## Issue Addressed

* #7286 
* BeaconAPI is not returning a versioned response when it should for some V1 endpoints
* these [strange functions with vX in the name that still accept `endpoint_version` arguments](https://github.com/sigp/lighthouse/blob/stable/beacon_node/http_api/src/produce_block.rs#L192)

This refactor is a prerequisite to get the fulu EF tests running.