### PR TITLE
Handle attestation validation errors

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -2762,6 +2762,26 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             MessageAcceptance::Ignore,
                         );
                     }
+                    BeaconChainError::AttestationValidationError(e) => {
+                        // Failures from `get_attesting_indices` end up here.
+                        debug!(
+                            %peer_id,
+                            block_root = ?beacon_block_root,
+                            attestation_slot = %failed_att.attestation_data().slot,
+                            error = ?e,
+                            "Rejecting attestation that failed validation"
+                        );
+                        self.propagate_validation_result(
+                            message_id,
+                            peer_id,
+                            MessageAcceptance::Reject,
+                        );
+                        self.gossip_penalize_peer(
+                            peer_id,
+                            PeerAction::MidToleranceError,
+                            "attn_validation_error",
+                        );
+                    }
                     _ => {
                         /*
                          * Lighthouse hit an unexpected error whilst processing the attestation. It


### PR DESCRIPTION
## Issue Addressed

Partly addresses:

- https://github.com/sigp/lighthouse/issues/7379

## Proposed Changes

Handle attestation validation errors from `get_attesting_indices` to prevent an error log, downscore the peer, and reject the message.

## Additional Info

Targeted at `release-v7.0.0` for testing but will probably rebase on `unstable`.
