### PR TITLE
Add requires --http when using vc subcommands --http-port

### DIFF
--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -317,6 +317,14 @@ fn missing_unencrypted_http_transport_flag() {
         .with_config(|config| assert_eq!(config.http_api.listen_addr, addr));
 }
 #[test]
+#[should_panic]
+fn msising_http_http_port_flag() {
+    CommandLineTest::new()
+        .flag("http-port", Some("9090"))
+        .run()
+        .with_config(|config| assert_eq!(config.http_api.listen_port, 9090));
+}
+#[test]
 fn http_port_flag() {
     CommandLineTest::new()
         .flag("http", None)

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -318,7 +318,7 @@ fn missing_unencrypted_http_transport_flag() {
 }
 #[test]
 #[should_panic]
-fn msising_http_http_port_flag() {
+fn missing_http_http_port_flag() {
     CommandLineTest::new()
         .flag("http-port", Some("9090"))
         .run()

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -219,6 +219,7 @@ pub struct ValidatorClient {
 
     #[clap(
         long,
+        requires = "http",
         value_name = "PORT",
         default_value_t = 5062,
         help = "Set the listen TCP port for the RESTful HTTP API server.",


### PR DESCRIPTION
## Issue Addressed

Prevent running  `lighthouse vc --http-port <PORT>` without `--http`.
Issue: https://github.com/sigp/lighthouse/issues/7402

## Proposed Changes

Added requires `--http` when using `lighthouse vc --http-port <PORT>`.
Implemented a test code for this issue.

