### PR TITLE
Don't publish data columns reconstructed from RPC columns to the gossip network

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1160,7 +1160,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "Processed data column, waiting for other components"
                     );
 
-                    self.attempt_data_column_reconstruction(block_root).await;
+                    self.attempt_data_column_reconstruction(block_root, true)
+                        .await;
                 }
             },
             Err(BlockError::DuplicateFullyImported(_)) => {

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -383,8 +383,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     );
                     // Attempt reconstruction here before notifying sync, to avoid sending out more requests
                     // that we may no longer need.
-                    if let Some(availability) =
-                        self.attempt_data_column_reconstruction(block_root).await
+                    // We don't publish columns reconstructed from rpc columns to the gossip network,
+                    // as these are likely historic columns.
+                    let publish_columns = false;
+                    if let Some(availability) = self
+                        .attempt_data_column_reconstruction(block_root, publish_columns)
+                        .await
                     {
                         result = Ok(availability)
                     }


### PR DESCRIPTION
## Issue Addressed

Don't publish data columns reconstructed from RPC columns to the gossip network, as this may result in peer downscoring if we're sending columns from past slots.