### PR TITLE
Silence `Uninitialized` warn log on start-up

### DIFF
--- a/validator_client/beacon_node_fallback/src/lib.rs
+++ b/validator_client/beacon_node_fallback/src/lib.rs
@@ -486,11 +486,19 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
 
         for (result, node) in results {
             if let Err(e) = result {
-                // We don't want to spam warns before Genesis and a node is only marked as
-                // Uninitialized when the slot clock has not yet been set.
-                // This will only occur at start-up so it is safe to silence them.
                 match e {
-                    CandidateError::PreGenesis | CandidateError::Uninitialized => {}
+                    // Avoid spamming warns before genesis.
+                    CandidateError::PreGenesis => {}
+                    // Uninitialized *should* only occur during start-up before the
+                    // slot clock has been initialized.
+                    // Seeing this log in any other circumstance would indicate a serious bug.
+                    CandidateError::Uninitialized => {
+                        debug!(
+                            error = ?e,
+                            endpoint = %node,
+                            "A connected beacon node is uninitialized"
+                        );
+                    }
                     _ => {
                         warn!(
                             error = ?e,

--- a/validator_client/beacon_node_fallback/src/lib.rs
+++ b/validator_client/beacon_node_fallback/src/lib.rs
@@ -486,12 +486,18 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
 
         for (result, node) in results {
             if let Err(e) = result {
-                if *e != CandidateError::PreGenesis {
-                    warn!(
-                        error = ?e,
-                        endpoint = %node,
-                        "A connected beacon node errored during routine health check"
-                    );
+                // We don't want to spam warns before Genesis and a node is only marked as
+                // Uninitialized when the slot clock has not yet been set.
+                // This will only occur at start-up so it is safe to silence them.
+                match e {
+                    CandidateError::PreGenesis | CandidateError::Uninitialized => {}
+                    _ => {
+                        warn!(
+                            error = ?e,
+                            endpoint = %node,
+                            "A connected beacon node errored during routine health check"
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Issue Addressed

#7410 

## Proposed Changes

Silences the `Uninitialized` warn log during routine beacon node health check. 

## Additional Info

`CandidateError::Uninitialized` will only ever occur during start-up during a race between the first beacon node update and the initialization of the slot clock, so we can safely silence it.