### PR TITLE
Increase default work queue size

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -77,7 +77,7 @@ pub mod work_reprocessing_queue;
 /// The maximum size of the channel for work events to the `BeaconProcessor`.
 ///
 /// Setting this too low will cause consensus messages to be dropped.
-const DEFAULT_MAX_WORK_EVENT_QUEUE_LEN: usize = 16_384;
+const DEFAULT_MAX_WORK_EVENT_QUEUE_LEN: usize = 32_768;
 
 /// The maximum size of the channel for idle events to the `BeaconProcessor`.
 ///

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1579,7 +1579,7 @@ pub fn cli_app() -> Command {
                 .help("Specifies the length of the inbound event queue. \
                         Higher values may prevent messages from being dropped while lower values \
                         may help protect the node from becoming overwhelmed.")
-                .default_value("16384")
+                .default_value("32768")
                 .hide(true)
                 .action(ArgAction::Set)
                 .display_order(0)

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1592,7 +1592,7 @@ pub fn cli_app() -> Command {
                         Higher values may prevent messages from being dropped while lower values \
                         may help protect the node from becoming overwhelmed.")
                 .hide(true)
-                .default_value("12288")
+                .default_value("24576")
                 .action(ArgAction::Set)
                 .display_order(0)
         )


### PR DESCRIPTION
## Issue Addressed

Fix for error message seen on some nodes which are struggling slightly after Pectra:

> ERROR Unable to queue converted SingleAttestation   error: no available capacity, slot: 4230400

Because we convert `SingleAttestation`s to regular attestations in a separate work event, we are now saturating the work event queue more often. This will remain an issue until a more optimised implementation of `SingleAttestation` processing is merged (likely for v7.1.0). See:

- https://github.com/sigp/lighthouse/issues/6970

## Proposed Changes

Double the size of the generic work event queue. This isn't guaranteed to fix the issue, as nodes could be struggling to an arbitrary degree. However it should make up for the approx doubling of work events introduced by Pectra so that only nodes logging errors prior to the fork are logging errors now.

## Additional Info

I'm rolling this out to some of our Holesky nodes that exhibit this behaviour and will report back on its efficacy.
