### PR TITLE
Pin kurtosis version to fix local testnet errors

### DIFF
--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -7,7 +7,7 @@ set -Eeuo pipefail
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ENCLAVE_NAME=local-testnet
 NETWORK_PARAMS_FILE=$SCRIPT_DIR/network_params.yaml
-ETHEREUM_PKG_VERSION=main
+ETHEREUM_PKG_VERSION=4.6.0
 
 BUILD_IMAGE=true
 BUILDER_PROPOSALS=false


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Pin kurtosis version to 4.6.0 to avoid the bug caused by https://github.com/ethpandaops/ethereum-package/pull/1007
