### PR TITLE
Update the not working voluntary exit URL

### DIFF
--- a/account_manager/src/validator/exit.rs
+++ b/account_manager/src/validator/exit.rs
@@ -27,7 +27,7 @@ pub const PASSWORD_PROMPT: &str = "Enter the keystore password";
 
 pub const DEFAULT_BEACON_NODE: &str = "http://localhost:5052/";
 pub const CONFIRMATION_PHRASE: &str = "Exit my validator";
-pub const WEBSITE_URL: &str = "https://lighthouse-book.sigmaprime.io/voluntary-exit.html";
+pub const WEBSITE_URL: &str = "https://lighthouse-book.sigmaprime.io/validator_voluntary_exit.html";
 
 pub fn cli_app() -> Command {
     Command::new("exit")


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/7431

## Proposed Changes

The https://lighthouse-book.sigmaprime.io/voluntary-exit.html stopped working as the docs were updated, and now returns HTTP Status 403 error.
The url is updated to https://lighthouse-book.sigmaprime.io/validator_voluntary_exit.html in this PR

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
