### PR TITLE
simulator: Write dependency logs to separate files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8384,6 +8384,7 @@ dependencies = [
  "sensitive_url",
  "serde_json",
  "tokio",
+ "tracing",
  "tracing-subscriber",
  "types",
 ]

--- a/lighthouse/environment/src/tracing_common.rs
+++ b/lighthouse/environment/src/tracing_common.rs
@@ -40,6 +40,7 @@ pub fn construct_logger<E: EthSpec>(
         if subcommand_name == "beacon_node"
             || subcommand_name == "boot_node"
             || subcommand_name == "basic-sim"
+            || subcommand_name == "fallback-sim"
         {
             if logger_config.max_log_size == 0 || logger_config.max_log_number == 0 {
                 // User has explicitly disabled logging to file.

--- a/lighthouse/environment/src/tracing_common.rs
+++ b/lighthouse/environment/src/tracing_common.rs
@@ -37,7 +37,10 @@ pub fn construct_logger<E: EthSpec>(
         environment_builder.init_tracing(logger_config.clone(), logfile_prefix);
 
     let libp2p_discv5_layer = if let Some(subcommand_name) = subcommand_name {
-        if subcommand_name == "beacon_node" || subcommand_name == "boot_node" {
+        if subcommand_name == "beacon_node"
+            || subcommand_name == "boot_node"
+            || subcommand_name == "basic-sim"
+        {
             if logger_config.max_log_size == 0 || logger_config.max_log_number == 0 {
                 // User has explicitly disabled logging to file.
                 None

--- a/testing/simulator/Cargo.toml
+++ b/testing/simulator/Cargo.toml
@@ -20,5 +20,6 @@ rayon = { workspace = true }
 sensitive_url  = { path = "../../common/sensitive_url" }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 types = { workspace = true }

--- a/testing/simulator/src/main.rs
+++ b/testing/simulator/src/main.rs
@@ -29,21 +29,23 @@ fn main() {
     Builder::from_env(Env::default()).init();
 
     let matches = cli_app().get_matches();
-    match matches.subcommand() {
-        Some(("basic-sim", matches)) => match basic_sim::run_basic_sim(matches) {
+    match matches.subcommand_name() {
+        Some("basic-sim") => match basic_sim::run_basic_sim(&matches) {
             Ok(()) => println!("Simulation exited successfully"),
             Err(e) => {
                 eprintln!("Simulation exited with error: {}", e);
                 std::process::exit(1)
             }
         },
-        Some(("fallback-sim", matches)) => match fallback_sim::run_fallback_sim(matches) {
-            Ok(()) => println!("Simulation exited successfully"),
-            Err(e) => {
-                eprintln!("Simulation exited with error: {}", e);
-                std::process::exit(1)
+        Some("fallback-sim") => {
+            match fallback_sim::run_fallback_sim(&matches.subcommand().unwrap().1) {
+                Ok(()) => println!("Simulation exited successfully"),
+                Err(e) => {
+                    eprintln!("Simulation exited with error: {}", e);
+                    std::process::exit(1)
+                }
             }
-        },
+        }
         _ => {
             eprintln!("Invalid subcommand. Use --help to see available options");
             std::process::exit(1)

--- a/testing/simulator/src/main.rs
+++ b/testing/simulator/src/main.rs
@@ -37,15 +37,13 @@ fn main() {
                 std::process::exit(1)
             }
         },
-        Some("fallback-sim") => {
-            match fallback_sim::run_fallback_sim(&matches.subcommand().unwrap().1) {
-                Ok(()) => println!("Simulation exited successfully"),
-                Err(e) => {
-                    eprintln!("Simulation exited with error: {}", e);
-                    std::process::exit(1)
-                }
+        Some("fallback-sim") => match fallback_sim::run_fallback_sim(&matches) {
+            Ok(()) => println!("Simulation exited successfully"),
+            Err(e) => {
+                eprintln!("Simulation exited with error: {}", e);
+                std::process::exit(1)
             }
-        }
+        },
         _ => {
             eprintln!("Invalid subcommand. Use --help to see available options");
             std::process::exit(1)


### PR DESCRIPTION
<!--
## Issue Addressed

Which issue # does this PR address?
-->
## Proposed Changes

This PR relates to:
- https://github.com/sigp/lighthouse/pull/7199
  - -> workspace_filter has been enabled (dependency logging has been disabled)
- https://github.com/sigp/lighthouse/pull/7394
  - -> file logging has been optionally enabled

Building on these, this PR enables dependency logging for the simulators. The logs are written to separate files.

The libp2p/discv5 logs:
- are saved to the directory  specified with `--log-dir`
- respects the `RUST_LOG` environment variable for log level configuration


## Additional Info

<!--
Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->

The logs can be downloaded as follows:

<img width="1518" alt="image" src="https://github.com/user-attachments/assets/1a2a7e0a-b26f-48d9-b697-cb3615cbde14" />

<img width="491" alt="image" src="https://github.com/user-attachments/assets/68b59f79-546a-4340-967e-cc9d0806c059" />
