### PR TITLE
Add additional mergify rules to automate triaging

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,6 +12,58 @@ pull_request_rules:
       comment:
         message: This pull request has merge conflicts. Could you please resolve them
           @{{author}}? 🙏
+      label:
+        add:
+          - waiting-on-author
+        remove:
+          - ready-for-review
+
+  - name: Ask to resolve CI failures
+    conditions:
+      - or:
+          - check-failure=test-suite-success
+          - check-skipped=test-suite-success
+          - check-failure=local-testnet-success
+          - check-skipped=local-testnet-success
+    actions:
+      comment:
+        message: Some required checks have failed. Could you please take a look @{{author}}? 🙏
+      label:
+        add:
+          - waiting-on-author
+        remove:
+          - ready-for-review
+
+  - name: Update labels when PR is unblocked
+    conditions:
+      - label=waiting-on-author
+      - -conflict
+      - check-success=test-suite-success
+      - check-success=local-testnet-success
+      - "#changes-requested-reviews-by = 0"
+    actions:
+      label:
+        remove:
+          - waiting-on-author
+        add:
+          - ready-for-review
+      comment:
+        message: >
+          All required checks have passed and there are no merge conflicts.
+          This pull request may now be ready for another review.
+
+  - name: Close stale pull request after 30 days of inactivity
+    conditions:
+      - label=waiting-on-author
+      - updated-at<=30 days ago
+    actions:
+      close:
+        message: >
+          Hi @{{author}}, this pull request has been closed automatically due to 30 days of inactivity.
+          If you’d like to continue working on it, feel free to reopen at any time.
+      label:
+        add:
+          - stale
 
   - name: Approve trivial maintainer PRs
     conditions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -38,9 +38,9 @@ pull_request_rules:
     conditions:
       - label=waiting-on-author
       - -conflict
-      - check-success=test-suite-success
-      - check-success=local-testnet-success
-      - "#changes-requested-reviews-by = 0"
+      - check-failure!=test-suite-success
+      - check-failure!=local-testnet-success
+      - "#review-requested > 0"
     actions:
       label:
         remove:


### PR DESCRIPTION
## Issue Addressed

Added a few more mergify automation rules to help improve PR management:
- Add `waiting-on-author` and remove `ready-for-review` on PRs with conflicts or failing CI checks.
- Automatically remove `waiting-on-author` and add `ready-for-review` once conflicts / failing CI checks have been resolved. (Note: this will require a "request for change" review action when asking user to make changes, i.e. if reviewer only add a regular comment, the `waiting-on-author` label may be removed by mergify)
- Close stale pull request after 30 days of inactivity, if it's in `waiting-on-author` state.