### PR TITLE
Add parking_lot deadlock detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,6 +3431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5561,6 +5567,7 @@ dependencies = [
  "logging",
  "malloc_utils",
  "metrics",
+ "parking_lot 0.12.3",
  "sensitive_url",
  "serde",
  "serde_json",
@@ -6727,10 +6734,13 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
+ "backtrace",
  "cfg-if",
  "libc",
+ "petgraph",
  "redox_syscall 0.5.10",
  "smallvec",
+ "thread-id",
  "windows-targets 0.52.6",
 ]
 
@@ -6806,6 +6816,16 @@ dependencies = [
  "memchr",
  "thiserror 2.0.12",
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.8.0",
 ]
 
 [[package]]
@@ -9003,6 +9023,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "thread-id"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ milhouse = "0.5"
 mockito = "1.5.0"
 num_cpus = "1"
 once_cell = "1.17.1"
-parking_lot = "0.12"
+parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 paste = "1"
 prometheus = { version = "0.13", default-features = false }
 quickcheck = "1"
@@ -293,6 +293,7 @@ inherits = "release"
 lto = "fat"
 codegen-units = 1
 incremental = false
+debug = true
 
 [patch.crates-io]
 quick-protobuf = { git = "https://github.com/sigp/quick-protobuf.git", rev = "681f413312404ab6e51f0b46f39b0075c6f4ebfd" }

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -56,6 +56,7 @@ lighthouse_version = { workspace = true }
 logging = { workspace = true }
 malloc_utils = { workspace = true }
 metrics = { workspace = true }
+parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -110,7 +110,7 @@ fn main() {
         thread::sleep(Duration::from_secs(10));
         let deadlocks = deadlock::check_deadlock();
         if deadlocks.is_empty() {
-            continue;
+            println!("No deadlocks detected");
         }
 
         println!("{} deadlocks detected", deadlocks.len());

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -109,11 +109,12 @@ fn main() {
     thread::spawn(move || loop {
         thread::sleep(Duration::from_secs(10));
         let deadlocks = deadlock::check_deadlock();
-        if deadlocks.is_empty() {
-            println!("No deadlocks detected");
-        }
 
         println!("{} deadlocks detected", deadlocks.len());
+
+        if deadlocks.is_empty() {
+            continue;
+        }
         for (i, threads) in deadlocks.iter().enumerate() {
             println!("Deadlock #{}", i);
             for t in threads {

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -19,11 +19,14 @@ use futures::TryFutureExt;
 use lighthouse_version::VERSION;
 use logging::{build_workspace_filter, crit, MetricsLayer};
 use malloc_utils::configure_memory_allocator;
+use parking_lot::deadlock;
 use std::backtrace::Backtrace;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::exit;
 use std::sync::LazyLock;
+use std::thread;
+use std::time::Duration;
 use task_executor::ShutdownReason;
 use tracing::{info, warn, Level};
 use tracing_subscriber::{filter::EnvFilter, layer::SubscriberExt, util::SubscriberInitExt, Layer};
@@ -101,6 +104,24 @@ fn main() {
     if std::env::var("RUST_BACKTRACE").is_err() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
+
+    // Create a background thread which checks for deadlocks every 10s
+    thread::spawn(move || loop {
+        thread::sleep(Duration::from_secs(10));
+        let deadlocks = deadlock::check_deadlock();
+        if deadlocks.is_empty() {
+            continue;
+        }
+
+        println!("{} deadlocks detected", deadlocks.len());
+        for (i, threads) in deadlocks.iter().enumerate() {
+            println!("Deadlock #{}", i);
+            for t in threads {
+                println!("Thread Id {:#?}", t.thread_id());
+                println!("{:#?}", t.backtrace());
+            }
+        }
+    });
 
     // Parse the CLI parameters.
     let cli = Command::new("Lighthouse")


### PR DESCRIPTION
Adds `parking_lot` deadlock detection for debugging the freezes occuring on the VC: https://github.com/sigp/lighthouse/issues/7403

It is added outside of the tokio executor so hopefully will continue running even if the executor locks up

Based on https://github.com/sigp/lighthouse/pull/7423 to limit any unrelated deadlock scenarios.