### PR TITLE
Added E::slots_per_epoch() to deneb time calculation

### DIFF
--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -310,8 +310,10 @@ where
                             .map_err(|e| format!("Unable to read system time: {e:}"))?
                             .as_secs();
                         let genesis_time = genesis_state.genesis_time();
-                        let deneb_time =
-                            genesis_time + (deneb_fork_epoch.as_u64() * spec.seconds_per_slot);
+                        let deneb_time = genesis_time
+                            + (deneb_fork_epoch.as_u64()
+                                * E::slots_per_epoch()
+                                * spec.seconds_per_slot);
 
                         // Shrink the blob availability window so users don't start
                         // a sync right before blobs start to disappear from the P2P


### PR DESCRIPTION
## Issue Addressed

Which issue # does this PR address?

Closes #7457

## Proposed Changes

Added `E::slots_per_epoch()` and now it ensures conversion from epochs to slots while calculating deneb time

## Additional Info

None