### PR TITLE
Rust clippy 1.87 lint fixes

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -272,12 +272,12 @@ pub enum Error {
     ///
     /// We were unable to process this attestation due to an internal error. It's unclear if the
     /// attestation is valid.
-    BeaconChainError(BeaconChainError),
+    BeaconChainError(Box<BeaconChainError>),
 }
 
 impl From<BeaconChainError> for Error {
     fn from(e: BeaconChainError) -> Self {
-        Self::BeaconChainError(e)
+        Self::BeaconChainError(Box::new(e))
     }
 }
 
@@ -525,7 +525,7 @@ impl<'a, T: BeaconChainTypes> IndexedAggregatedAttestation<'a, T> {
             .observed_attestations
             .write()
             .is_known_subset(attestation, observed_attestation_key_root)
-            .map_err(|e| Error::BeaconChainError(e.into()))?
+            .map_err(|e| Error::BeaconChainError(Box::new(e.into())))?
         {
             metrics::inc_counter(&metrics::AGGREGATED_ATTESTATION_SUBSETS);
             return Err(Error::AttestationSupersetKnown(
@@ -628,7 +628,7 @@ impl<'a, T: BeaconChainTypes> IndexedAggregatedAttestation<'a, T> {
 
                 if !SelectionProof::from(selection_proof)
                     .is_aggregator(committee.committee.len(), &chain.spec)
-                    .map_err(|e| Error::BeaconChainError(e.into()))?
+                    .map_err(|e| Error::BeaconChainError(Box::new(e.into())))?
                 {
                     return Err(Error::InvalidSelectionProof { aggregator_index });
                 }
@@ -698,7 +698,7 @@ impl<'a, T: BeaconChainTypes> VerifiedAggregatedAttestation<'a, T> {
             .observed_attestations
             .write()
             .observe_item(attestation, Some(observed_attestation_key_root))
-            .map_err(|e| Error::BeaconChainError(e.into()))?
+            .map_err(|e| Error::BeaconChainError(Box::new(e.into())))?
         {
             metrics::inc_counter(&metrics::AGGREGATED_ATTESTATION_SUBSETS);
             return Err(Error::AttestationSupersetKnown(

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -296,7 +296,7 @@ pub enum BlockProductionError {
     MissingExecutionPayload,
     MissingKzgCommitment(String),
     TokioJoin(JoinError),
-    BeaconChain(BeaconChainError),
+    BeaconChain(Box<BeaconChainError>),
     InvalidPayloadFork,
     InvalidBlockVariant(String),
     KzgError(kzg::Error),

--- a/beacon_node/beacon_chain/src/eth1_finalization_cache.rs
+++ b/beacon_node/beacon_chain/src/eth1_finalization_cache.rs
@@ -100,20 +100,11 @@ impl CheckpointMap {
 
 /// This cache stores `Eth1CacheData` that could potentially be finalized within 4
 /// future epochs.
+#[derive(Default)]
 pub struct Eth1FinalizationCache {
     by_checkpoint: CheckpointMap,
     pending_eth1: BTreeMap<u64, Eth1Data>,
     last_finalized: Option<Eth1Data>,
-}
-
-impl Default for Eth1FinalizationCache {
-    fn default() -> Self {
-        Self {
-            by_checkpoint: CheckpointMap::new(),
-            pending_eth1: BTreeMap::new(),
-            last_finalized: None,
-        }
-    }
 }
 
 /// Provides a cache of `Eth1CacheData` at epoch boundaries. This is used to

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -319,9 +319,9 @@ pub fn validate_execution_payload_for_gossip<T: BeaconChainTypes>(
                 .slot_clock
                 .start_of(block.slot())
                 .map(|d| d.as_secs())
-                .ok_or(BlockError::BeaconChainError(
+                .ok_or(BlockError::BeaconChainError(Box::new(
                     BeaconChainError::UnableToComputeTimeAtSlot,
-                ))?;
+                )))?;
 
             // The block's execution payload timestamp is correct with respect to the slot
             if execution_payload.timestamp() != expected_timestamp {
@@ -504,7 +504,7 @@ where
             "prepare_execution_payload_forkchoice_update_params",
         )
         .await
-        .map_err(BlockProductionError::BeaconChain)?;
+        .map_err(|e| BlockProductionError::BeaconChain(Box::new(e)))?;
 
     let suggested_fee_recipient = execution_layer
         .get_suggested_fee_recipient(proposer_index)

--- a/beacon_node/beacon_chain/src/fetch_blobs.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs.rs
@@ -49,7 +49,7 @@ pub enum EngineGetBlobsOutput<E: EthSpec> {
 #[derive(Debug)]
 pub enum FetchEngineBlobError {
     BeaconStateError(BeaconStateError),
-    BeaconChainError(BeaconChainError),
+    BeaconChainError(Box<BeaconChainError>),
     BlobProcessingError(BlockError),
     BlobSidecarError(BlobSidecarError),
     DataColumnSidecarError(DataColumnSidecarError),
@@ -320,7 +320,7 @@ async fn compute_and_publish_data_columns<T: BeaconChainTypes>(
             "compute_and_publish_data_columns",
         )
         .await
-        .map_err(FetchEngineBlobError::BeaconChainError)
+        .map_err(|e| FetchEngineBlobError::BeaconChainError(Box::new(e)))
         .and_then(|r| r)
 }
 

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -44,7 +44,7 @@ const MAX_FORK_CHOICE_DISTANCE: u64 = 256;
 
 #[derive(Debug)]
 enum Error {
-    BeaconChain(BeaconChainError),
+    BeaconChain(Box<BeaconChainError>),
     // We don't use the inner value directly, but it's used in the Debug impl.
     HeadMissingFromSnapshotCache(#[allow(dead_code)] Hash256),
     BeaconState(#[allow(dead_code)] BeaconStateError),
@@ -64,7 +64,7 @@ enum Error {
 
 impl From<BeaconChainError> for Error {
     fn from(e: BeaconChainError) -> Self {
-        Self::BeaconChain(e)
+        Self::BeaconChain(e.into())
     }
 }
 

--- a/beacon_node/beacon_chain/src/sync_committee_verification.rs
+++ b/beacon_node/beacon_chain/src/sync_committee_verification.rs
@@ -189,7 +189,7 @@ pub enum Error {
     ///
     /// We were unable to process this sync committee message due to an internal error. It's unclear if the
     /// sync committee message is valid.
-    BeaconChainError(BeaconChainError),
+    BeaconChainError(Box<BeaconChainError>),
     /// There was an error whilst processing the sync contribution. It is not known if it is valid or invalid.
     ///
     /// ## Peer scoring
@@ -232,7 +232,7 @@ pub enum Error {
 
 impl From<BeaconChainError> for Error {
     fn from(e: BeaconChainError) -> Self {
-        Error::BeaconChainError(e)
+        Error::BeaconChainError(e.into())
     }
 }
 
@@ -334,7 +334,7 @@ impl<T: BeaconChainTypes> VerifiedSyncContribution<T> {
             .observed_sync_contributions
             .write()
             .is_known_subset(contribution, contribution_data_root)
-            .map_err(|e| Error::BeaconChainError(e.into()))?
+            .map_err(|e| Error::BeaconChainError(Box::new(e.into())))?
         {
             metrics::inc_counter(&metrics::SYNC_CONTRIBUTION_SUBSETS);
             return Err(Error::SyncContributionSupersetKnown(contribution_data_root));
@@ -363,7 +363,7 @@ impl<T: BeaconChainTypes> VerifiedSyncContribution<T> {
 
         if !selection_proof
             .is_aggregator::<T::EthSpec>()
-            .map_err(|e| Error::BeaconChainError(e.into()))?
+            .map_err(|e| Error::BeaconChainError(Box::new(e.into())))?
         {
             return Err(Error::InvalidSelectionProof { aggregator_index });
         }
@@ -395,7 +395,7 @@ impl<T: BeaconChainTypes> VerifiedSyncContribution<T> {
             .observed_sync_contributions
             .write()
             .observe_item(contribution, Some(contribution_data_root))
-            .map_err(|e| Error::BeaconChainError(e.into()))?
+            .map_err(|e| Error::BeaconChainError(Box::new(e.into())))?
         {
             metrics::inc_counter(&metrics::SYNC_CONTRIBUTION_SUBSETS);
             return Err(Error::SyncContributionSupersetKnown(contribution_data_root));

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -508,13 +508,11 @@ async fn justified_checkpoint_becomes_invalid() {
     let is_valid = Payload::Invalid {
         latest_valid_hash: Some(parent_hash_of_justified),
     };
-    rig.import_block_parametric(is_valid, is_valid, None, |error| {
-        matches!(
-            error,
-            // The block import should fail since the beacon chain knows the justified payload
-            // is invalid.
-            BlockError::BeaconChainError(BeaconChainError::JustifiedPayloadInvalid { .. })
-        )
+    rig.import_block_parametric(is_valid, is_valid, None, |error| match error {
+        BlockError::BeaconChainError(e) => {
+            matches!(e.as_ref(), BeaconChainError::JustifiedPayloadInvalid { .. })
+        }
+        _ => false,
     })
     .await;
 

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -3241,13 +3241,14 @@ pub fn serve<T: BeaconChainTypes>(
                                 let direction = dir.into();
                                 let state = peer_info.connection_status().clone().into();
 
-                                let state_matches = query.state.as_ref().is_none_or(|states| {
-                                    states.iter().any(|state_param| *state_param == state)
-                                });
-                                let direction_matches =
-                                    query.direction.as_ref().is_none_or(|directions| {
-                                        directions.iter().any(|dir_param| *dir_param == direction)
-                                    });
+                                let state_matches = query
+                                    .state
+                                    .as_ref()
+                                    .is_none_or(|states| states.contains(&state));
+                                let direction_matches = query
+                                    .direction
+                                    .as_ref()
+                                    .is_none_or(|directions| directions.contains(&direction));
 
                                 if state_matches && direction_matches {
                                     peers.push(api_types::PeerData {

--- a/beacon_node/http_api/src/publish_attestations.rs
+++ b/beacon_node/http_api/src/publish_attestations.rs
@@ -60,13 +60,13 @@ use types::{Attestation, EthSpec, ForkName, SingleAttestation};
 pub enum Error {
     Validation(AttestationError),
     Publication,
-    ForkChoice(#[allow(dead_code)] BeaconChainError),
+    ForkChoice(#[allow(dead_code)] Box<BeaconChainError>),
     AggregationPool(#[allow(dead_code)] AttestationError),
     ReprocessDisabled,
     ReprocessFull,
     ReprocessTimeout,
     InvalidJson(#[allow(dead_code)] serde_json::Error),
-    FailedConversion(#[allow(dead_code)] BeaconChainError),
+    FailedConversion(#[allow(dead_code)] Box<BeaconChainError>),
 }
 
 enum PublishAttestationResult {
@@ -164,7 +164,7 @@ fn verify_and_publish_attestation<T: BeaconChainTypes>(
     }
 
     if let Err(e) = fc_result {
-        Err(Error::ForkChoice(e))
+        Err(Error::ForkChoice(Box::new(e)))
     } else if let Err(e) = naive_aggregation_result {
         Err(Error::AggregationPool(e))
     } else {
@@ -213,7 +213,7 @@ fn convert_to_attestation<'a, T: BeaconChainTypes>(
                         beacon_block_root,
                     }))
                 }
-                Err(e) => Err(Error::FailedConversion(e)),
+                Err(e) => Err(Error::FailedConversion(Box::new(e))),
             }
         }
     }

--- a/beacon_node/http_api/src/validator.rs
+++ b/beacon_node/http_api/src/validator.rs
@@ -7,9 +7,10 @@ pub fn pubkey_to_validator_index<T: BeaconChainTypes>(
     chain: &BeaconChain<T>,
     state: &BeaconState<T::EthSpec>,
     pubkey: &PublicKeyBytes,
-) -> Result<Option<usize>, BeaconChainError> {
+) -> Result<Option<usize>, Box<BeaconChainError>> {
     chain
-        .validator_index(pubkey)?
+        .validator_index(pubkey)
+        .map_err(Box::new)?
         .filter(|&index| {
             state
                 .validators()

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -66,7 +66,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     fn check_peer_relevance(
         &self,
         remote: &StatusMessage,
-    ) -> Result<Option<String>, BeaconChainError> {
+    ) -> Result<Option<String>, Box<BeaconChainError>> {
         let local = self.chain.status_message();
         let start_slot = |epoch: Epoch| epoch.start_slot(T::EthSpec::slots_per_epoch());
 
@@ -112,7 +112,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 if self
                     .chain
                     .block_root_at_slot(remote_finalized_slot, WhenSlotSkipped::Prev)
-                    .map(|root_opt| root_opt != Some(remote.finalized_root))?
+                    .map(|root_opt| root_opt != Some(remote.finalized_root))
+                    .map_err(Box::new)?
                 {
                     Some("Different finalized chain".to_string())
                 } else {

--- a/beacon_node/store/src/errors.rs
+++ b/beacon_node/store/src/errors.rs
@@ -57,7 +57,7 @@ pub enum Error {
     #[cfg(feature = "leveldb")]
     LevelDbError(LevelDBError),
     #[cfg(feature = "redb")]
-    RedbError(redb::Error),
+    RedbError(Box<redb::Error>),
     CacheBuildError(EpochCacheError),
     RandaoMixOutOfBounds,
     MilhouseError(milhouse::Error),
@@ -161,49 +161,49 @@ impl From<LevelDBError> for Error {
 #[cfg(feature = "redb")]
 impl From<redb::Error> for Error {
     fn from(e: redb::Error) -> Self {
-        Error::RedbError(e)
+        Error::RedbError(Box::new(e))
     }
 }
 
 #[cfg(feature = "redb")]
 impl From<redb::TableError> for Error {
     fn from(e: redb::TableError) -> Self {
-        Error::RedbError(e.into())
+        Error::RedbError(Box::new(e.into()))
     }
 }
 
 #[cfg(feature = "redb")]
 impl From<redb::TransactionError> for Error {
     fn from(e: redb::TransactionError) -> Self {
-        Error::RedbError(e.into())
+        Error::RedbError(Box::new(e.into()))
     }
 }
 
 #[cfg(feature = "redb")]
 impl From<redb::DatabaseError> for Error {
     fn from(e: redb::DatabaseError) -> Self {
-        Error::RedbError(e.into())
+        Error::RedbError(Box::new(e.into()))
     }
 }
 
 #[cfg(feature = "redb")]
 impl From<redb::StorageError> for Error {
     fn from(e: redb::StorageError) -> Self {
-        Error::RedbError(e.into())
+        Error::RedbError(Box::new(e.into()))
     }
 }
 
 #[cfg(feature = "redb")]
 impl From<redb::CommitError> for Error {
     fn from(e: redb::CommitError) -> Self {
-        Error::RedbError(e.into())
+        Error::RedbError(Box::new(e.into()))
     }
 }
 
 #[cfg(feature = "redb")]
 impl From<redb::CompactionError> for Error {
     fn from(e: redb::CompactionError) -> Self {
-        Error::RedbError(e.into())
+        Error::RedbError(Box::new(e.into()))
     }
 }
 

--- a/consensus/state_processing/src/per_epoch_processing/altair.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair.rs
@@ -84,7 +84,7 @@ pub fn process_epoch<E: EthSpec>(
     Ok(EpochProcessingSummary::Altair {
         progressive_balances: current_epoch_progressive_balances,
         current_epoch_total_active_balance,
-        participation: participation_summary,
+        participation: participation_summary.into(),
         sync_committee,
     })
 }

--- a/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
+++ b/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
@@ -17,7 +17,7 @@ pub enum EpochProcessingSummary<E: EthSpec> {
     Altair {
         progressive_balances: ProgressiveBalancesCache,
         current_epoch_total_active_balance: u64,
-        participation: ParticipationEpochSummary<E>,
+        participation: Box<ParticipationEpochSummary<E>>,
         sync_committee: Arc<SyncCommittee<E>>,
     },
 }

--- a/testing/ef_tests/src/cases/merkle_proof_validity.rs
+++ b/testing/ef_tests/src/cases/merkle_proof_validity.rs
@@ -22,7 +22,7 @@ pub struct MerkleProof {
 
 #[derive(Debug)]
 pub enum GenericMerkleProofValidity<E: EthSpec> {
-    BeaconState(BeaconStateMerkleProofValidity<E>),
+    BeaconState(Box<BeaconStateMerkleProofValidity<E>>),
     BeaconBlockBody(Box<BeaconBlockBodyMerkleProofValidity<E>>),
 }
 
@@ -47,6 +47,7 @@ impl<E: EthSpec> LoadCase for GenericMerkleProofValidity<E> {
 
         if suite_name == "BeaconState" {
             BeaconStateMerkleProofValidity::load_from_dir(path, fork_name)
+                .map(Box::new)
                 .map(GenericMerkleProofValidity::BeaconState)
         } else if suite_name == "BeaconBlockBody" {
             BeaconBlockBodyMerkleProofValidity::load_from_dir(path, fork_name)


### PR DESCRIPTION
## Issue Addressed

Fix clippy lints for `rustc` 1.87 

## Proposed Changes

clippy complains about `BeaconChainError` being too large. I went on a bit of a boxing spree because of this. We may instead want to `Box` some of the `BeaconChainError` variants?