### PR TITLE
Update mdlint to disable descriptive-link-text

### DIFF
--- a/scripts/mdlint.sh
+++ b/scripts/mdlint.sh
@@ -5,7 +5,8 @@
 # Run `make mdlint` from the root of the repository instead.
 
 # use markdownlint-cli to check for markdown files
-docker run --rm -v ./book:/workdir ghcr.io/igorshubovych/markdownlint-cli:latest '**/*.md' --ignore node_modules
+# NOTE: we disable MD059 (descriptive-link-text) because it is too strict
+docker run --rm -v ./book:/workdir ghcr.io/igorshubovych/markdownlint-cli:latest '**/*.md' --ignore node_modules --disable MD059
 
 # exit code
 exit_code=$(echo $?)
@@ -14,7 +15,7 @@ if [[ $exit_code == 0 ]]; then
     echo "All markdown files are properly formatted."
     exit 0
 elif [[ $exit_code == 1 ]]; then
-    echo "Exiting with errors. Run 'make mdlint' locally and commit the changes. Note that not all errors can be fixed automatically, if there are still errors after running 'make mdlint', look for the errors and fix manually."    
+    echo "Exiting with errors. Run 'make mdlint' locally and commit the changes. Note that not all errors can be fixed automatically, if there are still errors after running 'make mdlint', look for the errors and fix manually."
     docker run --rm -v ./book:/workdir ghcr.io/igorshubovych/markdownlint-cli:latest '**/*.md' --ignore node_modules --fix
     exit 1
 else


### PR DESCRIPTION
## Issue Addressed

Update the mdlint CI to ignore a newly introduced lint which is overly strict (IMO).

Example failure:

https://github.com/sigp/lighthouse/actions/runs/15102688734/job/42446029011?pr=7479

## Proposed Changes

Ignore the new lint that requires link text to be descriptive. IMO it is completely fine to write links like `See docs [here](http://url.com)`.
