### PR TITLE
Update mergify rule to avoid unnecessarily firing some rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,6 +4,7 @@ pull_request_rules:
       - -closed
       - conflict
       - -author=dependabot[bot]
+      - label=ready-for-review
       - or:
           - -draft # Don't report conflicts on regular draft.
           - and: # Do report conflicts on draft that are scheduled for the next major release.
@@ -22,6 +23,7 @@ pull_request_rules:
   - name: Ask to resolve CI failures
     conditions:
       - -closed
+      - label=ready-for-review
       - or:
           - check-skipped=test-suite-success
           - check-skipped=local-testnet-success


### PR DESCRIPTION
I've noticed that mergify spams PRs with comments even before they're marked as reviewed. It also comments on PRs that are stale and not in the `ready-for-review` state.

This PR updates those mergify rules to not evaluate PRs that are not ready for review, so that it reduces noise and avoid updating stale PRs.

