### PR TITLE
Fix blob download from checkpointz servers

### DIFF
--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -307,6 +307,8 @@ impl BeaconNodeHttpClient {
 
         #[derive(serde::Deserialize)]
         struct Helper {
+            // TODO: remove this default once checkpointz follows the spec
+            #[serde(default = "ForkName::latest_stable")]
             version: ForkName,
             #[serde(flatten)]
             metadata: serde_json::Value,


### PR DESCRIPTION
## Issue Addressed

Closes:

- https://github.com/sigp/lighthouse/issues/7489

## Proposed Changes

Use `ForkName::latest_stable`, i.e. Electra when decoding blobs from a server that does not provide `version`. This is only a temporary workaround that should be reverted once `checkpointz` is fixed. Having a default fork is potentially incorrect, and glossing over bugs in servers in general is not ideal.

However, even in the case where we update `ForkName::latest_stable` to `Fulu`, this should continue to work, as the blob limit is likely to increase and the `RuntimeVariableList` will just have a slightly higher limit than necessary (which is OK so long as the server isn't buggy enough to violate the correct lower bound: e.g. if the block is an Electra one and the server sends 10 blobs, which exceeds the Electra max (9) but not the Fulu max).

## Additional Info

I've opened an issue to revert this PR before we proceed with Fulu on mainnet, but _after_ v7.1.0:

- https://github.com/sigp/lighthouse/issues/7496
