### PR TITLE
Allow for  constructing light client data across fork boundaries

### DIFF
--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -290,9 +290,12 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
 
             let fork_name = chain_spec.fork_name_at_epoch(epoch.into());
 
-            let light_client_update =
-                LightClientUpdate::from_ssz_bytes(&light_client_update_bytes, &fork_name)
-                    .map_err(store::errors::Error::SszDecodeError)?;
+            let light_client_update = LightClientUpdate::from_ssz_bytes_by_fork_and_spec(
+                &light_client_update_bytes,
+                fork_name,
+                chain_spec,
+            )
+            .map_err(store::errors::Error::SszDecodeError)?;
 
             light_client_updates.push(light_client_update);
         }

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -174,11 +174,11 @@ async fn light_client_bootstrap_test() {
         .unwrap();
 
     let bootstrap_slot = match lc_bootstrap {
-        LightClientBootstrap::Altair(lc_bootstrap) => lc_bootstrap.header.beacon.slot,
-        LightClientBootstrap::Capella(lc_bootstrap) => lc_bootstrap.header.beacon.slot,
-        LightClientBootstrap::Deneb(lc_bootstrap) => lc_bootstrap.header.beacon.slot,
-        LightClientBootstrap::Electra(lc_bootstrap) => lc_bootstrap.header.beacon.slot,
-        LightClientBootstrap::Fulu(lc_bootstrap) => lc_bootstrap.header.beacon.slot,
+        LightClientBootstrap::Altair(lc_bootstrap) => lc_bootstrap.header.beacon().slot,
+        LightClientBootstrap::Capella(lc_bootstrap) => lc_bootstrap.header.beacon().slot,
+        LightClientBootstrap::Deneb(lc_bootstrap) => lc_bootstrap.header.beacon().slot,
+        LightClientBootstrap::Electra(lc_bootstrap) => lc_bootstrap.header.beacon().slot,
+        LightClientBootstrap::Fulu(lc_bootstrap) => lc_bootstrap.header.beacon().slot,
     };
 
     assert_eq!(

--- a/beacon_node/lighthouse_network/src/rpc/codec.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use tokio_util::codec::{Decoder, Encoder};
 use types::{
     BlobSidecar, ChainSpec, DataColumnSidecar, DataColumnsByRootIdentifier, EthSpec, ForkContext,
-    ForkName, Hash256, LightClientBootstrap, LightClientFinalityUpdate,
+    ForkName, ForkVersionDecode, Hash256, LightClientBootstrap, LightClientFinalityUpdate,
     LightClientOptimisticUpdate, LightClientUpdate, RuntimeVariableList, SignedBeaconBlock,
     SignedBeaconBlockAltair, SignedBeaconBlockBase, SignedBeaconBlockBellatrix,
     SignedBeaconBlockCapella, SignedBeaconBlockDeneb, SignedBeaconBlockElectra,
@@ -282,7 +282,12 @@ impl<E: EthSpec> SSZSnappyOutboundCodec<E> {
                 // Safe to `take` from `self.fork_name` as we have all the bytes we need to
                 // decode an ssz object at this point.
                 let fork_name = self.fork_name.take();
-                handle_rpc_response(self.protocol.versioned_protocol, &decoded_buffer, fork_name)
+                handle_rpc_response(
+                    self.protocol.versioned_protocol,
+                    &decoded_buffer,
+                    fork_name,
+                    &self.fork_context.spec,
+                )
             }
             Err(e) => handle_error(e, reader.get_ref().get_ref().position(), max_compressed_len),
         }
@@ -664,6 +669,7 @@ fn handle_rpc_response<E: EthSpec>(
     versioned_protocol: SupportedProtocol,
     decoded_buffer: &[u8],
     fork_name: Option<ForkName>,
+    spec: &ChainSpec,
 ) -> Result<Option<RpcSuccessResponse<E>>, RPCError> {
     match versioned_protocol {
         SupportedProtocol::StatusV1 => Ok(Some(RpcSuccessResponse::Status(
@@ -773,7 +779,7 @@ fn handle_rpc_response<E: EthSpec>(
         )))),
         SupportedProtocol::LightClientBootstrapV1 => match fork_name {
             Some(fork_name) => Ok(Some(RpcSuccessResponse::LightClientBootstrap(Arc::new(
-                LightClientBootstrap::from_ssz_bytes(decoded_buffer, fork_name)?,
+                LightClientBootstrap::from_ssz_bytes_by_fork(decoded_buffer, fork_name)?,
             )))),
             None => Err(RPCError::ErrorResponse(
                 RpcErrorResponse::InvalidRequest,
@@ -785,7 +791,7 @@ fn handle_rpc_response<E: EthSpec>(
         },
         SupportedProtocol::LightClientOptimisticUpdateV1 => match fork_name {
             Some(fork_name) => Ok(Some(RpcSuccessResponse::LightClientOptimisticUpdate(
-                Arc::new(LightClientOptimisticUpdate::from_ssz_bytes(
+                Arc::new(LightClientOptimisticUpdate::from_ssz_bytes_by_fork(
                     decoded_buffer,
                     fork_name,
                 )?),
@@ -800,7 +806,7 @@ fn handle_rpc_response<E: EthSpec>(
         },
         SupportedProtocol::LightClientFinalityUpdateV1 => match fork_name {
             Some(fork_name) => Ok(Some(RpcSuccessResponse::LightClientFinalityUpdate(
-                Arc::new(LightClientFinalityUpdate::from_ssz_bytes(
+                Arc::new(LightClientFinalityUpdate::from_ssz_bytes_by_fork(
                     decoded_buffer,
                     fork_name,
                 )?),
@@ -815,9 +821,10 @@ fn handle_rpc_response<E: EthSpec>(
         },
         SupportedProtocol::LightClientUpdatesByRangeV1 => match fork_name {
             Some(fork_name) => Ok(Some(RpcSuccessResponse::LightClientUpdatesByRange(
-                Arc::new(LightClientUpdate::from_ssz_bytes(
+                Arc::new(LightClientUpdate::from_ssz_bytes_by_fork_and_spec(
                     decoded_buffer,
-                    &fork_name,
+                    fork_name,
+                    spec,
                 )?),
             ))),
             None => Err(RPCError::ErrorResponse(

--- a/beacon_node/lighthouse_network/src/types/pubsub.rs
+++ b/beacon_node/lighthouse_network/src/types/pubsub.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use types::{
     Attestation, AttestationBase, AttesterSlashing, AttesterSlashingBase, AttesterSlashingElectra,
     BlobSidecar, DataColumnSidecar, DataColumnSubnetId, EthSpec, ForkContext, ForkName,
-    LightClientFinalityUpdate, LightClientOptimisticUpdate, ProposerSlashing,
+    ForkVersionDecode, LightClientFinalityUpdate, LightClientOptimisticUpdate, ProposerSlashing,
     SignedAggregateAndProof, SignedAggregateAndProofBase, SignedAggregateAndProofElectra,
     SignedBeaconBlock, SignedBeaconBlockAltair, SignedBeaconBlockBase, SignedBeaconBlockBellatrix,
     SignedBeaconBlockCapella, SignedBeaconBlockDeneb, SignedBeaconBlockElectra,
@@ -370,7 +370,7 @@ impl<E: EthSpec> PubsubMessage<E> {
                     GossipKind::LightClientFinalityUpdate => {
                         let light_client_finality_update = match fork_context.from_context_bytes(gossip_topic.fork_digest) {
                             Some(&fork_name) => {
-                                    LightClientFinalityUpdate::from_ssz_bytes(data, fork_name)
+                                    LightClientFinalityUpdate::from_ssz_bytes_by_fork(data, fork_name)
                                     .map_err(|e| format!("{:?}", e))?
                             },
                             None => return Err(format!(
@@ -385,7 +385,7 @@ impl<E: EthSpec> PubsubMessage<E> {
                     GossipKind::LightClientOptimisticUpdate => {
                         let light_client_optimistic_update = match fork_context.from_context_bytes(gossip_topic.fork_digest) {
                             Some(&fork_name) => {
-                                LightClientOptimisticUpdate::from_ssz_bytes(data, fork_name)
+                                LightClientOptimisticUpdate::from_ssz_bytes_by_fork(data, fork_name)
                                 .map_err(|e| format!("{:?}", e))?
                             },
                             None => return Err(format!(

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -755,8 +755,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
             let fork_name = self.spec.fork_name_at_epoch(epoch.into());
 
-            let light_client_update =
-                LightClientUpdate::from_ssz_bytes(&light_client_update_bytes, &fork_name)?;
+            let light_client_update = LightClientUpdate::from_ssz_bytes_by_fork_and_spec(
+                &light_client_update_bytes,
+                fork_name,
+                &self.spec,
+            )?;
 
             return Ok(Some(light_client_update));
         }
@@ -782,8 +785,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
             let fork_name = self.spec.fork_name_at_epoch(epoch.into());
 
-            let light_client_update =
-                LightClientUpdate::from_ssz_bytes(&light_client_update_bytes, &fork_name)?;
+            let light_client_update = LightClientUpdate::from_ssz_bytes_by_fork_and_spec(
+                &light_client_update_bytes,
+                fork_name,
+                &self.spec,
+            )?;
 
             light_client_updates.push(light_client_update);
 

--- a/consensus/types/src/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client_bootstrap.rs
@@ -1,17 +1,15 @@
 use crate::context_deserialize;
+use crate::ForkVersionDecode;
 use crate::{
-    light_client_update::*, test_utils::TestRandom, BeaconState, ChainSpec, ContextDeserialize,
-    EthSpec, FixedVector, ForkName, Hash256, LightClientHeader, LightClientHeaderAltair,
-    LightClientHeaderCapella, LightClientHeaderDeneb, LightClientHeaderElectra,
-    LightClientHeaderFulu, SignedBlindedBeaconBlock, Slot, SyncCommittee,
+    light_client_update::*, BeaconState, ChainSpec, ContextDeserialize, EthSpec, FixedVector,
+    ForkName, Hash256, LightClientHeader, SignedBlindedBeaconBlock, Slot, SyncCommittee,
 };
 use derivative::Derivative;
 use serde::{Deserialize, Deserializer, Serialize};
-use ssz::{Decode, Encode};
-use ssz_derive::{Decode, Encode};
+use ssz::{DecodeError, Encode};
+use ssz_derive::Encode;
 use std::sync::Arc;
 use superstruct::superstruct;
-use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
 /// A LightClientBootstrap is the initializer we send over to light_client nodes
@@ -26,9 +24,7 @@ use tree_hash_derive::TreeHash;
             Serialize,
             Deserialize,
             Derivative,
-            Decode,
             Encode,
-            TestRandom,
             arbitrary::Arbitrary,
             TreeHash,
         ),
@@ -47,16 +43,7 @@ use tree_hash_derive::TreeHash;
 #[arbitrary(bound = "E: EthSpec")]
 pub struct LightClientBootstrap<E: EthSpec> {
     /// The requested beacon block header.
-    #[superstruct(only(Altair), partial_getter(rename = "header_altair"))]
-    pub header: LightClientHeaderAltair<E>,
-    #[superstruct(only(Capella), partial_getter(rename = "header_capella"))]
-    pub header: LightClientHeaderCapella<E>,
-    #[superstruct(only(Deneb), partial_getter(rename = "header_deneb"))]
-    pub header: LightClientHeaderDeneb<E>,
-    #[superstruct(only(Electra), partial_getter(rename = "header_electra"))]
-    pub header: LightClientHeaderElectra<E>,
-    #[superstruct(only(Fulu), partial_getter(rename = "header_fulu"))]
-    pub header: LightClientHeaderFulu<E>,
+    pub header: LightClientHeader<E>,
     /// The `SyncCommittee` used in the requested period.
     pub current_sync_committee: Arc<SyncCommittee<E>>,
     /// Merkle proof for sync committee
@@ -89,27 +76,8 @@ impl<E: EthSpec> LightClientBootstrap<E> {
     pub fn get_slot<'a>(&'a self) -> Slot {
         map_light_client_bootstrap_ref!(&'a _, self.to_ref(), |inner, cons| {
             cons(inner);
-            inner.header.beacon.slot
+            inner.header.beacon().slot
         })
-    }
-
-    pub fn from_ssz_bytes(bytes: &[u8], fork_name: ForkName) -> Result<Self, ssz::DecodeError> {
-        let bootstrap = match fork_name {
-            ForkName::Altair | ForkName::Bellatrix => {
-                Self::Altair(LightClientBootstrapAltair::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Capella => Self::Capella(LightClientBootstrapCapella::from_ssz_bytes(bytes)?),
-            ForkName::Deneb => Self::Deneb(LightClientBootstrapDeneb::from_ssz_bytes(bytes)?),
-            ForkName::Electra => Self::Electra(LightClientBootstrapElectra::from_ssz_bytes(bytes)?),
-            ForkName::Fulu => Self::Fulu(LightClientBootstrapFulu::from_ssz_bytes(bytes)?),
-            ForkName::Base => {
-                return Err(ssz::DecodeError::BytesInvalid(format!(
-                    "LightClientBootstrap decoding for {fork_name} not implemented"
-                )))
-            }
-        };
-
-        Ok(bootstrap)
     }
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -133,33 +101,34 @@ impl<E: EthSpec> LightClientBootstrap<E> {
         current_sync_committee_branch: Vec<Hash256>,
         chain_spec: &ChainSpec,
     ) -> Result<Self, Error> {
+        let header = LightClientHeader::block_to_light_client_header(block, chain_spec)?;
         let light_client_bootstrap = match block
             .fork_name(chain_spec)
             .map_err(|_| Error::InconsistentFork)?
         {
             ForkName::Base => return Err(Error::AltairForkNotActive),
             ForkName::Altair | ForkName::Bellatrix => Self::Altair(LightClientBootstrapAltair {
-                header: LightClientHeaderAltair::block_to_light_client_header(block)?,
+                header,
                 current_sync_committee,
                 current_sync_committee_branch: current_sync_committee_branch.into(),
             }),
             ForkName::Capella => Self::Capella(LightClientBootstrapCapella {
-                header: LightClientHeaderCapella::block_to_light_client_header(block)?,
+                header,
                 current_sync_committee,
                 current_sync_committee_branch: current_sync_committee_branch.into(),
             }),
             ForkName::Deneb => Self::Deneb(LightClientBootstrapDeneb {
-                header: LightClientHeaderDeneb::block_to_light_client_header(block)?,
+                header,
                 current_sync_committee,
                 current_sync_committee_branch: current_sync_committee_branch.into(),
             }),
             ForkName::Electra => Self::Electra(LightClientBootstrapElectra {
-                header: LightClientHeaderElectra::block_to_light_client_header(block)?,
+                header,
                 current_sync_committee,
                 current_sync_committee_branch: current_sync_committee_branch.into(),
             }),
             ForkName::Fulu => Self::Fulu(LightClientBootstrapFulu {
-                header: LightClientHeaderFulu::block_to_light_client_header(block)?,
+                header,
                 current_sync_committee,
                 current_sync_committee_branch: current_sync_committee_branch.into(),
             }),
@@ -178,33 +147,35 @@ impl<E: EthSpec> LightClientBootstrap<E> {
         let current_sync_committee_branch = beacon_state.compute_current_sync_committee_proof()?;
         let current_sync_committee = beacon_state.current_sync_committee()?.clone();
 
+        let header = LightClientHeader::block_to_light_client_header(block, chain_spec)?;
+
         let light_client_bootstrap = match block
             .fork_name(chain_spec)
             .map_err(|_| Error::InconsistentFork)?
         {
             ForkName::Base => return Err(Error::AltairForkNotActive),
             ForkName::Altair | ForkName::Bellatrix => Self::Altair(LightClientBootstrapAltair {
-                header: LightClientHeaderAltair::block_to_light_client_header(block)?,
+                header,
                 current_sync_committee,
                 current_sync_committee_branch: current_sync_committee_branch.into(),
             }),
             ForkName::Capella => Self::Capella(LightClientBootstrapCapella {
-                header: LightClientHeaderCapella::block_to_light_client_header(block)?,
+                header,
                 current_sync_committee,
                 current_sync_committee_branch: current_sync_committee_branch.into(),
             }),
             ForkName::Deneb => Self::Deneb(LightClientBootstrapDeneb {
-                header: LightClientHeaderDeneb::block_to_light_client_header(block)?,
+                header,
                 current_sync_committee,
                 current_sync_committee_branch: current_sync_committee_branch.into(),
             }),
             ForkName::Electra => Self::Electra(LightClientBootstrapElectra {
-                header: LightClientHeaderElectra::block_to_light_client_header(block)?,
+                header,
                 current_sync_committee,
                 current_sync_committee_branch: current_sync_committee_branch.into(),
             }),
             ForkName::Fulu => Self::Fulu(LightClientBootstrapFulu {
-                header: LightClientHeaderFulu::block_to_light_client_header(block)?,
+                header,
                 current_sync_committee,
                 current_sync_committee_branch: current_sync_committee_branch.into(),
             }),
@@ -251,36 +222,71 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientBootstrap
     }
 }
 
-#[cfg(test)]
-mod tests {
-    // `ssz_tests!` can only be defined once per namespace
-    #[cfg(test)]
-    mod altair {
-        use crate::{LightClientBootstrapAltair, MainnetEthSpec};
-        ssz_tests!(LightClientBootstrapAltair<MainnetEthSpec>);
-    }
+impl<E: EthSpec> ForkVersionDecode for LightClientBootstrap<E> {
+    fn from_ssz_bytes_by_fork(bytes: &[u8], fork_name: ForkName) -> Result<Self, DecodeError> {
+        let mut builder = ssz::SszDecoderBuilder::new(bytes);
+        // header
+        builder.register_anonymous_variable_length_item()?;
+        builder.register_type::<SyncCommittee<E>>()?;
 
-    #[cfg(test)]
-    mod capella {
-        use crate::{LightClientBootstrapCapella, MainnetEthSpec};
-        ssz_tests!(LightClientBootstrapCapella<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod deneb {
-        use crate::{LightClientBootstrapDeneb, MainnetEthSpec};
-        ssz_tests!(LightClientBootstrapDeneb<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod electra {
-        use crate::{LightClientBootstrapElectra, MainnetEthSpec};
-        ssz_tests!(LightClientBootstrapElectra<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod fulu {
-        use crate::{LightClientBootstrapFulu, MainnetEthSpec};
-        ssz_tests!(LightClientBootstrapFulu<MainnetEthSpec>);
+        if fork_name.electra_enabled() {
+            builder.register_type::<FixedVector<Hash256, CurrentSyncCommitteeProofLenElectra>>()?;
+        } else {
+            builder.register_type::<FixedVector<Hash256, CurrentSyncCommitteeProofLen>>()?;
+        }
+        let mut decoder = builder.build()?;
+        let header = decoder.decode_next_with(|bytes| {
+            LightClientHeader::from_ssz_bytes_by_fork(bytes, fork_name)
+        })?;
+        match fork_name {
+            ForkName::Base => Err(ssz::DecodeError::BytesInvalid(format!(
+                "unsupported fork for LightClientBootstrap: {fork_name}",
+            ))),
+            ForkName::Altair | ForkName::Bellatrix => {
+                let current_sync_committee = decoder.decode_next()?;
+                let current_sync_committee_branch = decoder.decode_next()?;
+                Ok(Self::Altair(LightClientBootstrapAltair {
+                    header,
+                    current_sync_committee,
+                    current_sync_committee_branch,
+                }))
+            }
+            ForkName::Capella => {
+                let current_sync_committee = decoder.decode_next()?;
+                let current_sync_committee_branch = decoder.decode_next()?;
+                Ok(Self::Capella(LightClientBootstrapCapella {
+                    header,
+                    current_sync_committee,
+                    current_sync_committee_branch,
+                }))
+            }
+            ForkName::Deneb => {
+                let current_sync_committee = decoder.decode_next()?;
+                let current_sync_committee_branch = decoder.decode_next()?;
+                Ok(Self::Deneb(LightClientBootstrapDeneb {
+                    header,
+                    current_sync_committee,
+                    current_sync_committee_branch,
+                }))
+            }
+            ForkName::Electra => {
+                let current_sync_committee = decoder.decode_next()?;
+                let current_sync_committee_branch = decoder.decode_next()?;
+                Ok(Self::Electra(LightClientBootstrapElectra {
+                    header,
+                    current_sync_committee,
+                    current_sync_committee_branch,
+                }))
+            }
+            ForkName::Fulu => {
+                let current_sync_committee = decoder.decode_next()?;
+                let current_sync_committee_branch = decoder.decode_next()?;
+                Ok(Self::Fulu(LightClientBootstrapFulu {
+                    header,
+                    current_sync_committee,
+                    current_sync_committee_branch,
+                }))
+            }
+        }
     }
 }

--- a/consensus/types/src/light_client_finality_update.rs
+++ b/consensus/types/src/light_client_finality_update.rs
@@ -2,17 +2,14 @@ use super::{EthSpec, FixedVector, Hash256, LightClientHeader, Slot, SyncAggregat
 use crate::context_deserialize;
 use crate::ChainSpec;
 use crate::{
-    light_client_update::*, test_utils::TestRandom, ContextDeserialize, ForkName,
-    LightClientHeaderAltair, LightClientHeaderCapella, LightClientHeaderDeneb,
-    LightClientHeaderElectra, LightClientHeaderFulu, SignedBlindedBeaconBlock,
+    light_client_update::*, ContextDeserialize, ForkName, ForkVersionDecode,
+    SignedBlindedBeaconBlock,
 };
 use derivative::Derivative;
 use serde::{Deserialize, Deserializer, Serialize};
-use ssz::{Decode, Encode};
-use ssz_derive::Decode;
+use ssz::{DecodeError, Encode};
 use ssz_derive::Encode;
 use superstruct::superstruct;
-use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
 #[superstruct(
@@ -25,9 +22,7 @@ use tree_hash_derive::TreeHash;
             Serialize,
             Deserialize,
             Derivative,
-            Decode,
             Encode,
-            TestRandom,
             arbitrary::Arbitrary,
             TreeHash,
         ),
@@ -44,27 +39,9 @@ use tree_hash_derive::TreeHash;
 #[arbitrary(bound = "E: EthSpec")]
 pub struct LightClientFinalityUpdate<E: EthSpec> {
     /// The last `BeaconBlockHeader` from the last attested block by the sync committee.
-    #[superstruct(only(Altair), partial_getter(rename = "attested_header_altair"))]
-    pub attested_header: LightClientHeaderAltair<E>,
-    #[superstruct(only(Capella), partial_getter(rename = "attested_header_capella"))]
-    pub attested_header: LightClientHeaderCapella<E>,
-    #[superstruct(only(Deneb), partial_getter(rename = "attested_header_deneb"))]
-    pub attested_header: LightClientHeaderDeneb<E>,
-    #[superstruct(only(Electra), partial_getter(rename = "attested_header_electra"))]
-    pub attested_header: LightClientHeaderElectra<E>,
-    #[superstruct(only(Fulu), partial_getter(rename = "attested_header_fulu"))]
-    pub attested_header: LightClientHeaderFulu<E>,
+    pub attested_header: LightClientHeader<E>,
     /// The last `BeaconBlockHeader` from the last attested finalized block (end of epoch).
-    #[superstruct(only(Altair), partial_getter(rename = "finalized_header_altair"))]
-    pub finalized_header: LightClientHeaderAltair<E>,
-    #[superstruct(only(Capella), partial_getter(rename = "finalized_header_capella"))]
-    pub finalized_header: LightClientHeaderCapella<E>,
-    #[superstruct(only(Deneb), partial_getter(rename = "finalized_header_deneb"))]
-    pub finalized_header: LightClientHeaderDeneb<E>,
-    #[superstruct(only(Electra), partial_getter(rename = "finalized_header_electra"))]
-    pub finalized_header: LightClientHeaderElectra<E>,
-    #[superstruct(only(Fulu), partial_getter(rename = "finalized_header_fulu"))]
-    pub finalized_header: LightClientHeaderFulu<E>,
+    pub finalized_header: LightClientHeader<E>,
     /// Merkle proof attesting finalized header.
     #[superstruct(
         only(Altair, Capella, Deneb),
@@ -91,63 +68,47 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
         signature_slot: Slot,
         chain_spec: &ChainSpec,
     ) -> Result<Self, Error> {
+        let attested_header =
+            LightClientHeader::block_to_light_client_header(attested_block, chain_spec)?;
+        let finalized_header =
+            LightClientHeader::block_to_light_client_header(finalized_block, chain_spec)?;
         let finality_update = match attested_block
             .fork_name(chain_spec)
             .map_err(|_| Error::InconsistentFork)?
         {
             ForkName::Altair | ForkName::Bellatrix => {
                 Self::Altair(LightClientFinalityUpdateAltair {
-                    attested_header: LightClientHeaderAltair::block_to_light_client_header(
-                        attested_block,
-                    )?,
-                    finalized_header: LightClientHeaderAltair::block_to_light_client_header(
-                        finalized_block,
-                    )?,
+                    attested_header,
+                    finalized_header,
                     finality_branch: finality_branch.into(),
                     sync_aggregate,
                     signature_slot,
                 })
             }
             ForkName::Capella => Self::Capella(LightClientFinalityUpdateCapella {
-                attested_header: LightClientHeaderCapella::block_to_light_client_header(
-                    attested_block,
-                )?,
-                finalized_header: LightClientHeaderCapella::block_to_light_client_header(
-                    finalized_block,
-                )?,
+                attested_header,
+                finalized_header,
                 finality_branch: finality_branch.into(),
                 sync_aggregate,
                 signature_slot,
             }),
             ForkName::Deneb => Self::Deneb(LightClientFinalityUpdateDeneb {
-                attested_header: LightClientHeaderDeneb::block_to_light_client_header(
-                    attested_block,
-                )?,
-                finalized_header: LightClientHeaderDeneb::block_to_light_client_header(
-                    finalized_block,
-                )?,
+                attested_header,
+                finalized_header,
                 finality_branch: finality_branch.into(),
                 sync_aggregate,
                 signature_slot,
             }),
             ForkName::Electra => Self::Electra(LightClientFinalityUpdateElectra {
-                attested_header: LightClientHeaderElectra::block_to_light_client_header(
-                    attested_block,
-                )?,
-                finalized_header: LightClientHeaderElectra::block_to_light_client_header(
-                    finalized_block,
-                )?,
+                attested_header,
+                finalized_header,
                 finality_branch: finality_branch.into(),
                 sync_aggregate,
                 signature_slot,
             }),
             ForkName::Fulu => Self::Fulu(LightClientFinalityUpdateFulu {
-                attested_header: LightClientHeaderFulu::block_to_light_client_header(
-                    attested_block,
-                )?,
-                finalized_header: LightClientHeaderFulu::block_to_light_client_header(
-                    finalized_block,
-                )?,
+                attested_header,
+                finalized_header,
                 finality_branch: finality_branch.into(),
                 sync_aggregate,
                 signature_slot,
@@ -175,31 +136,8 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
     pub fn get_attested_header_slot<'a>(&'a self) -> Slot {
         map_light_client_finality_update_ref!(&'a _, self.to_ref(), |inner, cons| {
             cons(inner);
-            inner.attested_header.beacon.slot
+            inner.attested_header.beacon().slot
         })
-    }
-
-    pub fn from_ssz_bytes(bytes: &[u8], fork_name: ForkName) -> Result<Self, ssz::DecodeError> {
-        let finality_update = match fork_name {
-            ForkName::Altair | ForkName::Bellatrix => {
-                Self::Altair(LightClientFinalityUpdateAltair::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Capella => {
-                Self::Capella(LightClientFinalityUpdateCapella::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Deneb => Self::Deneb(LightClientFinalityUpdateDeneb::from_ssz_bytes(bytes)?),
-            ForkName::Electra => {
-                Self::Electra(LightClientFinalityUpdateElectra::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Fulu => Self::Fulu(LightClientFinalityUpdateFulu::from_ssz_bytes(bytes)?),
-            ForkName::Base => {
-                return Err(ssz::DecodeError::BytesInvalid(format!(
-                    "LightClientFinalityUpdate decoding for {fork_name} not implemented"
-                )))
-            }
-        };
-
-        Ok(finality_update)
     }
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -269,36 +207,97 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientFinalityU
     }
 }
 
-#[cfg(test)]
-mod tests {
-    // `ssz_tests!` can only be defined once per namespace
-    #[cfg(test)]
-    mod altair {
-        use crate::{LightClientFinalityUpdateAltair, MainnetEthSpec};
-        ssz_tests!(LightClientFinalityUpdateAltair<MainnetEthSpec>);
-    }
+impl<E: EthSpec> ForkVersionDecode for LightClientFinalityUpdate<E> {
+    fn from_ssz_bytes_by_fork(bytes: &[u8], fork_name: ForkName) -> Result<Self, DecodeError> {
+        let mut builder = ssz::SszDecoderBuilder::new(bytes);
+        // attested header
+        builder.register_anonymous_variable_length_item()?;
+        // finalized header
+        builder.register_anonymous_variable_length_item()?;
+        if fork_name.electra_enabled() {
+            builder.register_type::<FixedVector<Hash256, FinalizedRootProofLenElectra>>()?;
+        } else {
+            builder.register_type::<FixedVector<Hash256, FinalizedRootProofLen>>()?;
+        }
+        builder.register_type::<SyncAggregate<E>>()?;
+        builder.register_type::<Slot>()?;
 
-    #[cfg(test)]
-    mod capella {
-        use crate::{LightClientFinalityUpdateCapella, MainnetEthSpec};
-        ssz_tests!(LightClientFinalityUpdateCapella<MainnetEthSpec>);
-    }
+        let mut decoder = builder.build()?;
+        let attested_header = decoder.decode_next_with(|bytes| {
+            LightClientHeader::from_ssz_bytes_by_fork(bytes, fork_name)
+        })?;
+        let finalized_header = decoder.decode_next_with(|bytes| {
+            LightClientHeader::from_ssz_bytes_by_fork(bytes, fork_name)
+        })?;
+        match fork_name {
+            ForkName::Base => Err(ssz::DecodeError::BytesInvalid(format!(
+                "unsupported fork for LightClientFinalityUpdate: {fork_name}",
+            ))),
+            ForkName::Altair | ForkName::Bellatrix => {
+                let finality_branch = decoder.decode_next()?;
+                let sync_aggregate = decoder.decode_next()?;
+                let signature_slot = decoder.decode_next()?;
 
-    #[cfg(test)]
-    mod deneb {
-        use crate::{LightClientFinalityUpdateDeneb, MainnetEthSpec};
-        ssz_tests!(LightClientFinalityUpdateDeneb<MainnetEthSpec>);
-    }
+                Ok(Self::Altair(LightClientFinalityUpdateAltair {
+                    attested_header,
+                    finalized_header,
+                    finality_branch,
+                    sync_aggregate,
+                    signature_slot,
+                }))
+            }
+            ForkName::Capella => {
+                let finality_branch = decoder.decode_next()?;
+                let sync_aggregate = decoder.decode_next()?;
+                let signature_slot = decoder.decode_next()?;
 
-    #[cfg(test)]
-    mod electra {
-        use crate::{LightClientFinalityUpdateElectra, MainnetEthSpec};
-        ssz_tests!(LightClientFinalityUpdateElectra<MainnetEthSpec>);
-    }
+                Ok(Self::Capella(LightClientFinalityUpdateCapella {
+                    attested_header,
+                    finalized_header,
+                    finality_branch,
+                    sync_aggregate,
+                    signature_slot,
+                }))
+            }
+            ForkName::Deneb => {
+                let finality_branch = decoder.decode_next()?;
+                let sync_aggregate = decoder.decode_next()?;
+                let signature_slot = decoder.decode_next()?;
 
-    #[cfg(test)]
-    mod fulu {
-        use crate::{LightClientFinalityUpdateFulu, MainnetEthSpec};
-        ssz_tests!(LightClientFinalityUpdateFulu<MainnetEthSpec>);
+                Ok(Self::Deneb(LightClientFinalityUpdateDeneb {
+                    attested_header,
+                    finalized_header,
+                    finality_branch,
+                    sync_aggregate,
+                    signature_slot,
+                }))
+            }
+            ForkName::Electra => {
+                let finality_branch = decoder.decode_next()?;
+                let sync_aggregate = decoder.decode_next()?;
+                let signature_slot = decoder.decode_next()?;
+
+                Ok(Self::Electra(LightClientFinalityUpdateElectra {
+                    attested_header,
+                    finalized_header,
+                    finality_branch,
+                    sync_aggregate,
+                    signature_slot,
+                }))
+            }
+            ForkName::Fulu => {
+                let finality_branch = decoder.decode_next()?;
+                let sync_aggregate = decoder.decode_next()?;
+                let signature_slot = decoder.decode_next()?;
+
+                Ok(Self::Fulu(LightClientFinalityUpdateFulu {
+                    attested_header,
+                    finalized_header,
+                    finality_branch,
+                    sync_aggregate,
+                    signature_slot,
+                }))
+            }
+        }
     }
 }

--- a/consensus/types/src/light_client_header.rs
+++ b/consensus/types/src/light_client_header.rs
@@ -1,20 +1,19 @@
 use crate::context_deserialize;
 use crate::ChainSpec;
 use crate::{light_client_update::*, BeaconBlockBody};
+use crate::{BeaconBlockHeader, ExecutionPayloadHeader};
+use crate::{ContextDeserialize, ForkName, ForkVersionDecode};
 use crate::{
-    test_utils::TestRandom, EthSpec, ExecutionPayloadHeaderCapella, ExecutionPayloadHeaderDeneb,
+    EthSpec, ExecutionPayloadHeaderCapella, ExecutionPayloadHeaderDeneb,
     ExecutionPayloadHeaderElectra, ExecutionPayloadHeaderFulu, FixedVector, Hash256,
     SignedBlindedBeaconBlock,
 };
-use crate::{BeaconBlockHeader, ExecutionPayloadHeader};
-use crate::{ContextDeserialize, ForkName};
 use derivative::Derivative;
 use serde::{Deserialize, Deserializer, Serialize};
-use ssz::Decode;
-use ssz_derive::{Decode, Encode};
+use ssz::DecodeError;
+use ssz_derive::Encode;
 use std::marker::PhantomData;
 use superstruct::superstruct;
-use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
 #[superstruct(
@@ -27,9 +26,7 @@ use tree_hash_derive::TreeHash;
             Serialize,
             Deserialize,
             Derivative,
-            Decode,
             Encode,
-            TestRandom,
             arbitrary::Arbitrary,
             TreeHash,
         ),
@@ -38,7 +35,9 @@ use tree_hash_derive::TreeHash;
         context_deserialize(ForkName),
     )
 )]
-#[derive(Debug, Clone, Serialize, TreeHash, Encode, arbitrary::Arbitrary, PartialEq)]
+#[derive(
+    Debug, Deserialize, Clone, Serialize, TreeHash, Encode, arbitrary::Arbitrary, PartialEq,
+)]
 #[serde(untagged)]
 #[tree_hash(enum_behaviour = "transparent")]
 #[ssz(enum_behaviour = "transparent")]
@@ -46,22 +45,8 @@ use tree_hash_derive::TreeHash;
 #[arbitrary(bound = "E: EthSpec")]
 pub struct LightClientHeader<E: EthSpec> {
     pub beacon: BeaconBlockHeader,
-
-    #[superstruct(
-        only(Capella),
-        partial_getter(rename = "execution_payload_header_capella")
-    )]
-    pub execution: ExecutionPayloadHeaderCapella<E>,
-    #[superstruct(only(Deneb), partial_getter(rename = "execution_payload_header_deneb"))]
-    pub execution: ExecutionPayloadHeaderDeneb<E>,
-    #[superstruct(
-        only(Electra),
-        partial_getter(rename = "execution_payload_header_electra")
-    )]
-    pub execution: ExecutionPayloadHeaderElectra<E>,
-    #[superstruct(only(Fulu), partial_getter(rename = "execution_payload_header_fulu"))]
-    pub execution: ExecutionPayloadHeaderFulu<E>,
-
+    #[superstruct(only(Capella, Deneb, Electra, Fulu))]
+    pub execution: ExecutionPayloadHeader<E>,
     #[superstruct(only(Capella, Deneb, Electra, Fulu))]
     pub execution_branch: FixedVector<Hash256, ExecutionPayloadProofLen>,
 
@@ -101,47 +86,21 @@ impl<E: EthSpec> LightClientHeader<E> {
         Ok(header)
     }
 
-    pub fn from_ssz_bytes(bytes: &[u8], fork_name: ForkName) -> Result<Self, ssz::DecodeError> {
-        let header = match fork_name {
-            ForkName::Altair | ForkName::Bellatrix => {
-                LightClientHeader::Altair(LightClientHeaderAltair::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Capella => {
-                LightClientHeader::Capella(LightClientHeaderCapella::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Deneb => {
-                LightClientHeader::Deneb(LightClientHeaderDeneb::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Electra => {
-                LightClientHeader::Electra(LightClientHeaderElectra::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Fulu => {
-                LightClientHeader::Fulu(LightClientHeaderFulu::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Base => {
-                return Err(ssz::DecodeError::BytesInvalid(format!(
-                    "LightClientHeader decoding for {fork_name} not implemented"
-                )))
-            }
-        };
-
-        Ok(header)
-    }
-
-    /// Custom SSZ decoder that takes a `ForkName` as context.
-    pub fn from_ssz_bytes_for_fork(
-        bytes: &[u8],
-        fork_name: ForkName,
-    ) -> Result<Self, ssz::DecodeError> {
-        Self::from_ssz_bytes(bytes, fork_name)
-    }
-
     pub fn ssz_max_var_len_for_fork(fork_name: ForkName) -> usize {
         if fork_name.capella_enabled() {
             ExecutionPayloadHeader::<E>::ssz_max_var_len_for_fork(fork_name)
         } else {
             0
         }
+    }
+
+    pub fn from_ssz_bytes_dynamic(bytes: &[u8], spec: &ChainSpec) -> Result<Self, DecodeError> {
+        let mut builder = ssz::SszDecoderBuilder::new(bytes);
+        builder.register_type::<BeaconBlockHeader>()?;
+        let mut decoder = builder.build()?;
+        let beacon: BeaconBlockHeader = decoder.decode_next()?;
+        let fork_name = spec.fork_name_at_slot::<E>(beacon.slot);
+        Self::from_ssz_bytes_by_fork(bytes, fork_name)
     }
 }
 
@@ -189,7 +148,7 @@ impl<E: EthSpec> LightClientHeaderCapella<E> {
 
         Ok(LightClientHeaderCapella {
             beacon: block.message().block_header(),
-            execution: header,
+            execution: ExecutionPayloadHeader::Capella(header),
             execution_branch: FixedVector::new(execution_branch)?,
             _phantom_data: PhantomData,
         })
@@ -200,7 +159,7 @@ impl<E: EthSpec> Default for LightClientHeaderCapella<E> {
     fn default() -> Self {
         Self {
             beacon: BeaconBlockHeader::empty(),
-            execution: ExecutionPayloadHeaderCapella::default(),
+            execution: ExecutionPayloadHeader::Capella(ExecutionPayloadHeaderCapella::default()),
             execution_branch: FixedVector::default(),
             _phantom_data: PhantomData,
         }
@@ -231,7 +190,7 @@ impl<E: EthSpec> LightClientHeaderDeneb<E> {
 
         Ok(LightClientHeaderDeneb {
             beacon: block.message().block_header(),
-            execution: header,
+            execution: ExecutionPayloadHeader::Deneb(header),
             execution_branch: FixedVector::new(execution_branch)?,
             _phantom_data: PhantomData,
         })
@@ -242,7 +201,7 @@ impl<E: EthSpec> Default for LightClientHeaderDeneb<E> {
     fn default() -> Self {
         Self {
             beacon: BeaconBlockHeader::empty(),
-            execution: ExecutionPayloadHeaderDeneb::default(),
+            execution: ExecutionPayloadHeader::Deneb(ExecutionPayloadHeaderDeneb::default()),
             execution_branch: FixedVector::default(),
             _phantom_data: PhantomData,
         }
@@ -273,7 +232,7 @@ impl<E: EthSpec> LightClientHeaderElectra<E> {
 
         Ok(LightClientHeaderElectra {
             beacon: block.message().block_header(),
-            execution: header,
+            execution: ExecutionPayloadHeader::Electra(header),
             execution_branch: FixedVector::new(execution_branch)?,
             _phantom_data: PhantomData,
         })
@@ -284,7 +243,7 @@ impl<E: EthSpec> Default for LightClientHeaderElectra<E> {
     fn default() -> Self {
         Self {
             beacon: BeaconBlockHeader::empty(),
-            execution: ExecutionPayloadHeaderElectra::default(),
+            execution: ExecutionPayloadHeader::Electra(ExecutionPayloadHeaderElectra::default()),
             execution_branch: FixedVector::default(),
             _phantom_data: PhantomData,
         }
@@ -315,7 +274,7 @@ impl<E: EthSpec> LightClientHeaderFulu<E> {
 
         Ok(LightClientHeaderFulu {
             beacon: block.message().block_header(),
-            execution: header,
+            execution: ExecutionPayloadHeader::Fulu(header),
             execution_branch: FixedVector::new(execution_branch)?,
             _phantom_data: PhantomData,
         })
@@ -326,7 +285,7 @@ impl<E: EthSpec> Default for LightClientHeaderFulu<E> {
     fn default() -> Self {
         Self {
             beacon: BeaconBlockHeader::empty(),
-            execution: ExecutionPayloadHeaderFulu::default(),
+            execution: ExecutionPayloadHeader::Fulu(ExecutionPayloadHeaderFulu::default()),
             execution_branch: FixedVector::default(),
             _phantom_data: PhantomData,
         }
@@ -370,30 +329,79 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientHeader<E>
     }
 }
 
-#[cfg(test)]
-mod tests {
-    // `ssz_tests!` can only be defined once per namespace
-    #[cfg(test)]
-    mod altair {
-        use crate::{LightClientHeaderAltair, MainnetEthSpec};
-        ssz_tests!(LightClientHeaderAltair<MainnetEthSpec>);
-    }
+impl<E: EthSpec> ForkVersionDecode for LightClientHeader<E> {
+    fn from_ssz_bytes_by_fork(bytes: &[u8], fork_name: ForkName) -> Result<Self, DecodeError> {
+        let mut builder = ssz::SszDecoderBuilder::new(bytes);
+        builder.register_type::<BeaconBlockHeader>()?;
 
-    #[cfg(test)]
-    mod capella {
-        use crate::{LightClientHeaderCapella, MainnetEthSpec};
-        ssz_tests!(LightClientHeaderCapella<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod deneb {
-        use crate::{LightClientHeaderDeneb, MainnetEthSpec};
-        ssz_tests!(LightClientHeaderDeneb<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod electra {
-        use crate::{LightClientHeaderElectra, MainnetEthSpec};
-        ssz_tests!(LightClientHeaderElectra<MainnetEthSpec>);
+        match fork_name {
+            ForkName::Base => Err(ssz::DecodeError::BytesInvalid(format!(
+                "unsupported fork for LightClientHeader: {fork_name}",
+            ))),
+            ForkName::Altair | ForkName::Bellatrix => {
+                let mut decoder = builder.build()?;
+                let beacon = decoder.decode_next()?;
+                Ok(Self::Altair(LightClientHeaderAltair {
+                    beacon,
+                    _phantom_data: PhantomData,
+                }))
+            }
+            ForkName::Capella => {
+                builder.register_type::<ExecutionPayloadHeaderCapella<E>>()?;
+                builder.register_type::<FixedVector<Hash256, ExecutionPayloadProofLen>>()?;
+                let mut decoder = builder.build()?;
+                let beacon = decoder.decode_next()?;
+                let execution = ExecutionPayloadHeader::Capella(decoder.decode_next()?);
+                let execution_branch = decoder.decode_next()?;
+                Ok(Self::Capella(LightClientHeaderCapella {
+                    beacon,
+                    execution,
+                    execution_branch,
+                    _phantom_data: PhantomData,
+                }))
+            }
+            ForkName::Deneb => {
+                builder.register_type::<ExecutionPayloadHeaderDeneb<E>>()?;
+                builder.register_type::<FixedVector<Hash256, ExecutionPayloadProofLen>>()?;
+                let mut decoder = builder.build()?;
+                let beacon = decoder.decode_next()?;
+                let execution = ExecutionPayloadHeader::Deneb(decoder.decode_next()?);
+                let execution_branch = decoder.decode_next()?;
+                Ok(Self::Deneb(LightClientHeaderDeneb {
+                    beacon,
+                    execution,
+                    execution_branch,
+                    _phantom_data: PhantomData,
+                }))
+            }
+            ForkName::Electra => {
+                builder.register_type::<ExecutionPayloadHeaderElectra<E>>()?;
+                builder.register_type::<FixedVector<Hash256, ExecutionPayloadProofLen>>()?;
+                let mut decoder = builder.build()?;
+                let beacon = decoder.decode_next()?;
+                let execution = ExecutionPayloadHeader::Electra(decoder.decode_next()?);
+                let execution_branch = decoder.decode_next()?;
+                Ok(Self::Electra(LightClientHeaderElectra {
+                    beacon,
+                    execution,
+                    execution_branch,
+                    _phantom_data: PhantomData,
+                }))
+            }
+            ForkName::Fulu => {
+                builder.register_type::<ExecutionPayloadHeaderFulu<E>>()?;
+                builder.register_type::<FixedVector<Hash256, ExecutionPayloadProofLen>>()?;
+                let mut decoder = builder.build()?;
+                let beacon = decoder.decode_next()?;
+                let execution = ExecutionPayloadHeader::Fulu(decoder.decode_next()?);
+                let execution_branch = decoder.decode_next()?;
+                Ok(Self::Fulu(LightClientHeaderFulu {
+                    beacon,
+                    execution,
+                    execution_branch,
+                    _phantom_data: PhantomData,
+                }))
+            }
+        }
     }
 }

--- a/consensus/types/src/light_client_optimistic_update.rs
+++ b/consensus/types/src/light_client_optimistic_update.rs
@@ -1,18 +1,11 @@
 use super::{ContextDeserialize, EthSpec, ForkName, LightClientHeader, Slot, SyncAggregate};
 use crate::context_deserialize;
-use crate::test_utils::TestRandom;
-use crate::{
-    light_client_update::*, ChainSpec, LightClientHeaderAltair, LightClientHeaderCapella,
-    LightClientHeaderDeneb, LightClientHeaderElectra, LightClientHeaderFulu,
-    SignedBlindedBeaconBlock,
-};
+use crate::{light_client_update::*, ChainSpec, ForkVersionDecode, SignedBlindedBeaconBlock};
 use derivative::Derivative;
 use serde::{Deserialize, Deserializer, Serialize};
-use ssz::{Decode, Encode};
-use ssz_derive::Decode;
+use ssz::{DecodeError, Encode};
 use ssz_derive::Encode;
 use superstruct::superstruct;
-use test_random_derive::TestRandom;
 use tree_hash::Hash256;
 use tree_hash_derive::TreeHash;
 
@@ -28,9 +21,7 @@ use tree_hash_derive::TreeHash;
             Serialize,
             Deserialize,
             Derivative,
-            Decode,
             Encode,
-            TestRandom,
             arbitrary::Arbitrary,
             TreeHash,
         ),
@@ -47,16 +38,7 @@ use tree_hash_derive::TreeHash;
 #[arbitrary(bound = "E: EthSpec")]
 pub struct LightClientOptimisticUpdate<E: EthSpec> {
     /// The last `BeaconBlockHeader` from the last attested block by the sync committee.
-    #[superstruct(only(Altair), partial_getter(rename = "attested_header_altair"))]
-    pub attested_header: LightClientHeaderAltair<E>,
-    #[superstruct(only(Capella), partial_getter(rename = "attested_header_capella"))]
-    pub attested_header: LightClientHeaderCapella<E>,
-    #[superstruct(only(Deneb), partial_getter(rename = "attested_header_deneb"))]
-    pub attested_header: LightClientHeaderDeneb<E>,
-    #[superstruct(only(Electra), partial_getter(rename = "attested_header_electra"))]
-    pub attested_header: LightClientHeaderElectra<E>,
-    #[superstruct(only(Fulu), partial_getter(rename = "attested_header_fulu"))]
-    pub attested_header: LightClientHeaderFulu<E>,
+    pub attested_header: LightClientHeader<E>,
     /// current sync aggregate
     pub sync_aggregate: SyncAggregate<E>,
     /// Slot of the sync aggregated signature
@@ -70,44 +52,36 @@ impl<E: EthSpec> LightClientOptimisticUpdate<E> {
         signature_slot: Slot,
         chain_spec: &ChainSpec,
     ) -> Result<Self, Error> {
+        let attested_header =
+            LightClientHeader::block_to_light_client_header(attested_block, chain_spec)?;
         let optimistic_update = match attested_block
             .fork_name(chain_spec)
             .map_err(|_| Error::InconsistentFork)?
         {
             ForkName::Altair | ForkName::Bellatrix => {
                 Self::Altair(LightClientOptimisticUpdateAltair {
-                    attested_header: LightClientHeaderAltair::block_to_light_client_header(
-                        attested_block,
-                    )?,
+                    attested_header,
                     sync_aggregate,
                     signature_slot,
                 })
             }
             ForkName::Capella => Self::Capella(LightClientOptimisticUpdateCapella {
-                attested_header: LightClientHeaderCapella::block_to_light_client_header(
-                    attested_block,
-                )?,
+                attested_header,
                 sync_aggregate,
                 signature_slot,
             }),
             ForkName::Deneb => Self::Deneb(LightClientOptimisticUpdateDeneb {
-                attested_header: LightClientHeaderDeneb::block_to_light_client_header(
-                    attested_block,
-                )?,
+                attested_header,
                 sync_aggregate,
                 signature_slot,
             }),
             ForkName::Electra => Self::Electra(LightClientOptimisticUpdateElectra {
-                attested_header: LightClientHeaderElectra::block_to_light_client_header(
-                    attested_block,
-                )?,
+                attested_header,
                 sync_aggregate,
                 signature_slot,
             }),
             ForkName::Fulu => Self::Fulu(LightClientOptimisticUpdateFulu {
-                attested_header: LightClientHeaderFulu::block_to_light_client_header(
-                    attested_block,
-                )?,
+                attested_header,
                 sync_aggregate,
                 signature_slot,
             }),
@@ -133,47 +107,22 @@ impl<E: EthSpec> LightClientOptimisticUpdate<E> {
     pub fn get_slot<'a>(&'a self) -> Slot {
         map_light_client_optimistic_update_ref!(&'a _, self.to_ref(), |inner, cons| {
             cons(inner);
-            inner.attested_header.beacon.slot
+            inner.attested_header.beacon().slot
         })
     }
 
     pub fn get_canonical_root<'a>(&'a self) -> Hash256 {
         map_light_client_optimistic_update_ref!(&'a _, self.to_ref(), |inner, cons| {
             cons(inner);
-            inner.attested_header.beacon.canonical_root()
+            inner.attested_header.beacon().canonical_root()
         })
     }
 
     pub fn get_parent_root<'a>(&'a self) -> Hash256 {
         map_light_client_optimistic_update_ref!(&'a _, self.to_ref(), |inner, cons| {
             cons(inner);
-            inner.attested_header.beacon.parent_root
+            inner.attested_header.beacon().parent_root
         })
-    }
-
-    pub fn from_ssz_bytes(bytes: &[u8], fork_name: ForkName) -> Result<Self, ssz::DecodeError> {
-        let optimistic_update = match fork_name {
-            ForkName::Altair | ForkName::Bellatrix => {
-                Self::Altair(LightClientOptimisticUpdateAltair::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Capella => {
-                Self::Capella(LightClientOptimisticUpdateCapella::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Deneb => {
-                Self::Deneb(LightClientOptimisticUpdateDeneb::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Electra => {
-                Self::Electra(LightClientOptimisticUpdateElectra::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Fulu => Self::Fulu(LightClientOptimisticUpdateFulu::from_ssz_bytes(bytes)?),
-            ForkName::Base => {
-                return Err(ssz::DecodeError::BytesInvalid(format!(
-                    "LightClientOptimisticUpdate decoding for {fork_name} not implemented"
-                )))
-            }
-        };
-
-        Ok(optimistic_update)
     }
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -242,36 +191,51 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientOptimisti
     }
 }
 
-#[cfg(test)]
-mod tests {
-    // `ssz_tests!` can only be defined once per namespace
-    #[cfg(test)]
-    mod altair {
-        use crate::{LightClientOptimisticUpdateAltair, MainnetEthSpec};
-        ssz_tests!(LightClientOptimisticUpdateAltair<MainnetEthSpec>);
-    }
+impl<E: EthSpec> ForkVersionDecode for LightClientOptimisticUpdate<E> {
+    fn from_ssz_bytes_by_fork(bytes: &[u8], fork_name: ForkName) -> Result<Self, DecodeError> {
+        let mut builder = ssz::SszDecoderBuilder::new(bytes);
+        // attested header
+        builder.register_anonymous_variable_length_item()?;
+        builder.register_type::<SyncAggregate<E>>()?;
+        builder.register_type::<Slot>()?;
 
-    #[cfg(test)]
-    mod capella {
-        use crate::{LightClientOptimisticUpdateCapella, MainnetEthSpec};
-        ssz_tests!(LightClientOptimisticUpdateCapella<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod deneb {
-        use crate::{LightClientOptimisticUpdateDeneb, MainnetEthSpec};
-        ssz_tests!(LightClientOptimisticUpdateDeneb<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod electra {
-        use crate::{LightClientOptimisticUpdateElectra, MainnetEthSpec};
-        ssz_tests!(LightClientOptimisticUpdateElectra<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod fulu {
-        use crate::{LightClientOptimisticUpdateFulu, MainnetEthSpec};
-        ssz_tests!(LightClientOptimisticUpdateFulu<MainnetEthSpec>);
+        let mut decoder = builder.build()?;
+        let attested_header = decoder.decode_next_with(|bytes| {
+            LightClientHeader::from_ssz_bytes_by_fork(bytes, fork_name)
+        })?;
+        let sync_aggregate = decoder.decode_next()?;
+        let signature_slot = decoder.decode_next()?;
+        match fork_name {
+            ForkName::Base => Err(ssz::DecodeError::BytesInvalid(format!(
+                "unsupported fork for LightClientFinalityUpdate: {fork_name}",
+            ))),
+            ForkName::Altair | ForkName::Bellatrix => {
+                Ok(Self::Altair(LightClientOptimisticUpdateAltair {
+                    attested_header,
+                    sync_aggregate,
+                    signature_slot,
+                }))
+            }
+            ForkName::Capella => Ok(Self::Capella(LightClientOptimisticUpdateCapella {
+                attested_header,
+                sync_aggregate,
+                signature_slot,
+            })),
+            ForkName::Deneb => Ok(Self::Deneb(LightClientOptimisticUpdateDeneb {
+                attested_header,
+                sync_aggregate,
+                signature_slot,
+            })),
+            ForkName::Electra => Ok(Self::Electra(LightClientOptimisticUpdateElectra {
+                attested_header,
+                sync_aggregate,
+                signature_slot,
+            })),
+            ForkName::Fulu => Ok(Self::Fulu(LightClientOptimisticUpdateFulu {
+                attested_header,
+                sync_aggregate,
+                signature_slot,
+            })),
+        }
     }
 }

--- a/consensus/types/src/light_client_update.rs
+++ b/consensus/types/src/light_client_update.rs
@@ -1,23 +1,21 @@
 use super::{EthSpec, FixedVector, Hash256, Slot, SyncAggregate, SyncCommittee};
-use crate::context_deserialize;
 use crate::light_client_header::LightClientHeaderElectra;
 use crate::LightClientHeader;
 use crate::{
-    beacon_state, test_utils::TestRandom, ChainSpec, ContextDeserialize, Epoch, ForkName,
-    LightClientHeaderAltair, LightClientHeaderCapella, LightClientHeaderDeneb,
-    LightClientHeaderFulu, SignedBlindedBeaconBlock,
+    beacon_state, ChainSpec, ContextDeserialize, Epoch, ForkName, LightClientHeaderAltair,
+    LightClientHeaderCapella, LightClientHeaderDeneb, LightClientHeaderFulu,
+    SignedBlindedBeaconBlock,
 };
+use crate::{context_deserialize, ForkVersionDecode};
 use derivative::Derivative;
 use safe_arith::ArithError;
 use safe_arith::SafeArith;
 use serde::{Deserialize, Deserializer, Serialize};
-use ssz::{Decode, Encode};
-use ssz_derive::Decode;
+use ssz::{DecodeError, Encode};
 use ssz_derive::Encode;
 use ssz_types::typenum::{U4, U5, U6, U7};
 use std::sync::Arc;
 use superstruct::superstruct;
-use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
 pub const FINALIZED_ROOT_INDEX: usize = 105;
@@ -106,12 +104,10 @@ impl From<milhouse::Error> for Error {
             Debug,
             Clone,
             PartialEq,
-            Serialize,
             Deserialize,
+            Serialize,
             Derivative,
-            Decode,
             Encode,
-            TestRandom,
             arbitrary::Arbitrary,
             TreeHash,
         ),
@@ -128,16 +124,7 @@ impl From<milhouse::Error> for Error {
 #[arbitrary(bound = "E: EthSpec")]
 pub struct LightClientUpdate<E: EthSpec> {
     /// The last `BeaconBlockHeader` from the last attested block by the sync committee.
-    #[superstruct(only(Altair), partial_getter(rename = "attested_header_altair"))]
-    pub attested_header: LightClientHeaderAltair<E>,
-    #[superstruct(only(Capella), partial_getter(rename = "attested_header_capella"))]
-    pub attested_header: LightClientHeaderCapella<E>,
-    #[superstruct(only(Deneb), partial_getter(rename = "attested_header_deneb"))]
-    pub attested_header: LightClientHeaderDeneb<E>,
-    #[superstruct(only(Electra), partial_getter(rename = "attested_header_electra"))]
-    pub attested_header: LightClientHeaderElectra<E>,
-    #[superstruct(only(Fulu), partial_getter(rename = "attested_header_fulu"))]
-    pub attested_header: LightClientHeaderFulu<E>,
+    pub attested_header: LightClientHeader<E>,
     /// The `SyncCommittee` used in the next period.
     pub next_sync_committee: Arc<SyncCommittee<E>>,
     // Merkle proof for next sync committee
@@ -152,16 +139,7 @@ pub struct LightClientUpdate<E: EthSpec> {
     )]
     pub next_sync_committee_branch: NextSyncCommitteeBranchElectra,
     /// The last `BeaconBlockHeader` from the last attested finalized block (end of epoch).
-    #[superstruct(only(Altair), partial_getter(rename = "finalized_header_altair"))]
-    pub finalized_header: LightClientHeaderAltair<E>,
-    #[superstruct(only(Capella), partial_getter(rename = "finalized_header_capella"))]
-    pub finalized_header: LightClientHeaderCapella<E>,
-    #[superstruct(only(Deneb), partial_getter(rename = "finalized_header_deneb"))]
-    pub finalized_header: LightClientHeaderDeneb<E>,
-    #[superstruct(only(Electra), partial_getter(rename = "finalized_header_electra"))]
-    pub finalized_header: LightClientHeaderElectra<E>,
-    #[superstruct(only(Fulu), partial_getter(rename = "finalized_header_fulu"))]
-    pub finalized_header: LightClientHeaderFulu<E>,
+    pub finalized_header: LightClientHeader<E>,
     /// Merkle proof attesting finalized header.
     #[superstruct(
         only(Altair, Capella, Deneb),
@@ -245,10 +223,10 @@ impl<E: EthSpec> LightClientUpdate<E> {
                 };
 
                 Self::Altair(LightClientUpdateAltair {
-                    attested_header,
+                    attested_header: LightClientHeader::Altair(attested_header),
                     next_sync_committee,
                     next_sync_committee_branch: next_sync_committee_branch.into(),
-                    finalized_header,
+                    finalized_header: LightClientHeader::Altair(finalized_header),
                     finality_branch: finality_branch.into(),
                     sync_aggregate: sync_aggregate.clone(),
                     signature_slot: block_slot,
@@ -269,10 +247,10 @@ impl<E: EthSpec> LightClientUpdate<E> {
                 };
 
                 Self::Capella(LightClientUpdateCapella {
-                    attested_header,
+                    attested_header: LightClientHeader::Capella(attested_header),
                     next_sync_committee,
                     next_sync_committee_branch: next_sync_committee_branch.into(),
-                    finalized_header,
+                    finalized_header: LightClientHeader::Capella(finalized_header),
                     finality_branch: finality_branch.into(),
                     sync_aggregate: sync_aggregate.clone(),
                     signature_slot: block_slot,
@@ -293,10 +271,10 @@ impl<E: EthSpec> LightClientUpdate<E> {
                 };
 
                 Self::Deneb(LightClientUpdateDeneb {
-                    attested_header,
+                    attested_header: LightClientHeader::Deneb(attested_header),
                     next_sync_committee,
                     next_sync_committee_branch: next_sync_committee_branch.into(),
-                    finalized_header,
+                    finalized_header: LightClientHeader::Deneb(finalized_header),
                     finality_branch: finality_branch.into(),
                     sync_aggregate: sync_aggregate.clone(),
                     signature_slot: block_slot,
@@ -317,10 +295,10 @@ impl<E: EthSpec> LightClientUpdate<E> {
                 };
 
                 Self::Electra(LightClientUpdateElectra {
-                    attested_header,
+                    attested_header: LightClientHeader::Electra(attested_header),
                     next_sync_committee,
                     next_sync_committee_branch: next_sync_committee_branch.into(),
-                    finalized_header,
+                    finalized_header: LightClientHeader::Electra(finalized_header),
                     finality_branch: finality_branch.into(),
                     sync_aggregate: sync_aggregate.clone(),
                     signature_slot: block_slot,
@@ -341,10 +319,10 @@ impl<E: EthSpec> LightClientUpdate<E> {
                 };
 
                 Self::Fulu(LightClientUpdateFulu {
-                    attested_header,
+                    attested_header: LightClientHeader::Fulu(attested_header),
                     next_sync_committee,
                     next_sync_committee_branch: next_sync_committee_branch.into(),
-                    finalized_header,
+                    finalized_header: LightClientHeader::Fulu(finalized_header),
                     finality_branch: finality_branch.into(),
                     sync_aggregate: sync_aggregate.clone(),
                     signature_slot: block_slot,
@@ -357,42 +335,23 @@ impl<E: EthSpec> LightClientUpdate<E> {
         Ok(light_client_update)
     }
 
-    pub fn from_ssz_bytes(bytes: &[u8], fork_name: &ForkName) -> Result<Self, ssz::DecodeError> {
-        let update = match fork_name {
-            ForkName::Altair | ForkName::Bellatrix => {
-                Self::Altair(LightClientUpdateAltair::from_ssz_bytes(bytes)?)
-            }
-            ForkName::Capella => Self::Capella(LightClientUpdateCapella::from_ssz_bytes(bytes)?),
-            ForkName::Deneb => Self::Deneb(LightClientUpdateDeneb::from_ssz_bytes(bytes)?),
-            ForkName::Electra => Self::Electra(LightClientUpdateElectra::from_ssz_bytes(bytes)?),
-            ForkName::Fulu => Self::Fulu(LightClientUpdateFulu::from_ssz_bytes(bytes)?),
-            ForkName::Base => {
-                return Err(ssz::DecodeError::BytesInvalid(format!(
-                    "LightClientUpdate decoding for {fork_name} not implemented"
-                )))
-            }
-        };
-
-        Ok(update)
-    }
-
     pub fn attested_header_slot(&self) -> Slot {
         match self {
-            LightClientUpdate::Altair(update) => update.attested_header.beacon.slot,
-            LightClientUpdate::Capella(update) => update.attested_header.beacon.slot,
-            LightClientUpdate::Deneb(update) => update.attested_header.beacon.slot,
-            LightClientUpdate::Electra(update) => update.attested_header.beacon.slot,
-            LightClientUpdate::Fulu(update) => update.attested_header.beacon.slot,
+            LightClientUpdate::Altair(update) => update.attested_header.beacon().slot,
+            LightClientUpdate::Capella(update) => update.attested_header.beacon().slot,
+            LightClientUpdate::Deneb(update) => update.attested_header.beacon().slot,
+            LightClientUpdate::Electra(update) => update.attested_header.beacon().slot,
+            LightClientUpdate::Fulu(update) => update.attested_header.beacon().slot,
         }
     }
 
     pub fn finalized_header_slot(&self) -> Slot {
         match self {
-            LightClientUpdate::Altair(update) => update.finalized_header.beacon.slot,
-            LightClientUpdate::Capella(update) => update.finalized_header.beacon.slot,
-            LightClientUpdate::Deneb(update) => update.finalized_header.beacon.slot,
-            LightClientUpdate::Electra(update) => update.finalized_header.beacon.slot,
-            LightClientUpdate::Fulu(update) => update.finalized_header.beacon.slot,
+            LightClientUpdate::Altair(update) => update.finalized_header.beacon().slot,
+            LightClientUpdate::Capella(update) => update.finalized_header.beacon().slot,
+            LightClientUpdate::Deneb(update) => update.finalized_header.beacon().slot,
+            LightClientUpdate::Electra(update) => update.finalized_header.beacon().slot,
+            LightClientUpdate::Fulu(update) => update.finalized_header.beacon().slot,
         }
     }
 
@@ -529,6 +488,148 @@ impl<E: EthSpec> LightClientUpdate<E> {
             Self::Fulu(_) => func(ForkName::Fulu),
         }
     }
+
+    pub fn from_ssz_bytes_by_fork_and_spec(
+        bytes: &[u8],
+        fork_name: ForkName,
+        spec: &ChainSpec,
+    ) -> Result<Self, DecodeError> {
+        let mut builder = ssz::SszDecoderBuilder::new(bytes);
+        builder.register_anonymous_variable_length_item()?;
+        builder.register_type::<SyncCommittee<E>>()?;
+        if fork_name.electra_enabled() {
+            builder.register_type::<NextSyncCommitteeBranchElectra>()?;
+        } else {
+            builder.register_type::<NextSyncCommitteeBranch>()?;
+        }
+        // FINALIZED HEADER
+        builder.register_anonymous_variable_length_item()?;
+        if fork_name.electra_enabled() {
+            builder.register_type::<FinalityBranchElectra>()?;
+        } else {
+            builder.register_type::<FinalityBranch>()?;
+        }
+        builder.register_type::<SyncAggregate<E>>()?;
+        builder.register_type::<Slot>()?;
+        let mut decoder = builder.build()?;
+
+        match fork_name {
+            ForkName::Base => Err(ssz::DecodeError::BytesInvalid(format!(
+                "unsupported fork for LightClientHeader: {fork_name}",
+            ))),
+            ForkName::Altair | ForkName::Bellatrix => {
+                let attested_header = decoder.decode_next_with(|bytes| {
+                    LightClientHeader::from_ssz_bytes_by_fork(bytes, fork_name)
+                })?;
+                let next_sync_committee = decoder.decode_next()?;
+                let next_sync_committee_branch = decoder.decode_next()?;
+                let finalized_header = decoder.decode_next_with(|bytes| {
+                    LightClientHeader::from_ssz_bytes_dynamic(bytes, spec)
+                })?;
+                let finality_branch = decoder.decode_next()?;
+                let sync_aggregate = decoder.decode_next()?;
+                let signature_slot = decoder.decode_next()?;
+
+                Ok(Self::Altair(LightClientUpdateAltair {
+                    attested_header,
+                    next_sync_committee,
+                    next_sync_committee_branch,
+                    finalized_header,
+                    finality_branch,
+                    sync_aggregate,
+                    signature_slot,
+                }))
+            }
+            ForkName::Capella => {
+                let attested_header = decoder.decode_next_with(|bytes| {
+                    LightClientHeader::from_ssz_bytes_by_fork(bytes, fork_name)
+                })?;
+                let next_sync_committee = decoder.decode_next()?;
+                let next_sync_committee_branch = decoder.decode_next()?;
+                let finalized_header = decoder.decode_next_with(|bytes| {
+                    LightClientHeader::from_ssz_bytes_dynamic(bytes, spec)
+                })?;
+                let finality_branch = decoder.decode_next()?;
+                let sync_aggregate = decoder.decode_next()?;
+                let signature_slot = decoder.decode_next()?;
+                Ok(Self::Capella(LightClientUpdateCapella {
+                    attested_header,
+                    next_sync_committee,
+                    next_sync_committee_branch,
+                    finalized_header,
+                    finality_branch,
+                    sync_aggregate,
+                    signature_slot,
+                }))
+            }
+            ForkName::Deneb => {
+                let attested_header = decoder.decode_next_with(|bytes| {
+                    LightClientHeader::from_ssz_bytes_by_fork(bytes, fork_name)
+                })?;
+                let next_sync_committee = decoder.decode_next()?;
+                let next_sync_committee_branch = decoder.decode_next()?;
+                let finalized_header = decoder.decode_next_with(|bytes| {
+                    LightClientHeader::from_ssz_bytes_dynamic(bytes, spec)
+                })?;
+                let finality_branch = decoder.decode_next()?;
+                let sync_aggregate = decoder.decode_next()?;
+                let signature_slot = decoder.decode_next()?;
+                Ok(Self::Deneb(LightClientUpdateDeneb {
+                    attested_header,
+                    next_sync_committee,
+                    next_sync_committee_branch,
+                    finalized_header,
+                    finality_branch,
+                    sync_aggregate,
+                    signature_slot,
+                }))
+            }
+            ForkName::Electra => {
+                let attested_header = decoder.decode_next_with(|bytes| {
+                    LightClientHeader::from_ssz_bytes_by_fork(bytes, fork_name)
+                })?;
+                let next_sync_committee = decoder.decode_next()?;
+                let next_sync_committee_branch = decoder.decode_next()?;
+                let finalized_header = decoder.decode_next_with(|bytes| {
+                    LightClientHeader::from_ssz_bytes_dynamic(bytes, spec)
+                })?;
+                let finality_branch = decoder.decode_next()?;
+                let sync_aggregate = decoder.decode_next()?;
+                let signature_slot = decoder.decode_next()?;
+                Ok(Self::Electra(LightClientUpdateElectra {
+                    attested_header,
+                    next_sync_committee,
+                    next_sync_committee_branch,
+                    finalized_header,
+                    finality_branch,
+                    sync_aggregate,
+                    signature_slot,
+                }))
+            }
+            ForkName::Fulu => {
+                let attested_header = decoder.decode_next_with(|bytes| {
+                    LightClientHeader::from_ssz_bytes_by_fork(bytes, fork_name)
+                })?;
+                let next_sync_committee = decoder.decode_next()?;
+                let next_sync_committee_branch = decoder.decode_next()?;
+                let finalized_header = decoder.decode_next_with(|bytes| {
+                    LightClientHeader::from_ssz_bytes_dynamic(bytes, spec)
+                })?;
+                let finality_branch = decoder.decode_next()?;
+                let sync_aggregate = decoder.decode_next()?;
+                let signature_slot = decoder.decode_next()?;
+                Ok(Self::Fulu(LightClientUpdateFulu {
+                    attested_header,
+                    next_sync_committee,
+                    next_sync_committee_branch,
+                    finalized_header,
+                    finality_branch,
+                    sync_aggregate,
+                    signature_slot,
+                }))
+            }
+        }
+    }
 }
 
 fn is_empty_branch(branch: &[Hash256]) -> bool {
@@ -552,42 +653,6 @@ fn compute_sync_committee_period_at_slot<E: EthSpec>(
 mod tests {
     use super::*;
     use ssz_types::typenum::Unsigned;
-
-    // `ssz_tests!` can only be defined once per namespace
-    #[cfg(test)]
-    mod altair {
-        use super::*;
-        use crate::MainnetEthSpec;
-        ssz_tests!(LightClientUpdateAltair<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod capella {
-        use super::*;
-        use crate::MainnetEthSpec;
-        ssz_tests!(LightClientUpdateCapella<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod deneb {
-        use super::*;
-        use crate::MainnetEthSpec;
-        ssz_tests!(LightClientUpdateDeneb<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod electra {
-        use super::*;
-        use crate::MainnetEthSpec;
-        ssz_tests!(LightClientUpdateElectra<MainnetEthSpec>);
-    }
-
-    #[cfg(test)]
-    mod fulu {
-        use super::*;
-        use crate::MainnetEthSpec;
-        ssz_tests!(LightClientUpdateFulu<MainnetEthSpec>);
-    }
 
     #[test]
     fn finalized_root_params() {

--- a/testing/ef_tests/src/cases/light_client_verify_is_better_update.rs
+++ b/testing/ef_tests/src/cases/light_client_verify_is_better_update.rs
@@ -16,11 +16,13 @@ pub struct Metadata {
 impl<E: EthSpec> LoadCase for LightClientVerifyIsBetterUpdate<E> {
     fn load_from_dir(path: &Path, fork_name: ForkName) -> Result<Self, Error> {
         let mut light_client_updates = vec![];
+        let spec = &testing_spec::<E>(fork_name);
         let metadata: Metadata = decode::yaml_decode_file(path.join("meta.yaml").as_path())?;
         for index in 0..metadata.updates_count {
             let light_client_update = ssz_decode_light_client_update(
                 &path.join(format!("updates_{}.ssz_snappy", index)),
                 &fork_name,
+                spec,
             )?;
             light_client_updates.push(light_client_update);
         }

--- a/testing/ef_tests/src/decode.rs
+++ b/testing/ef_tests/src/decode.rs
@@ -99,9 +99,10 @@ pub fn ssz_decode_state<E: EthSpec>(
 pub fn ssz_decode_light_client_update<E: EthSpec>(
     path: &Path,
     fork_name: &ForkName,
+    spec: &ChainSpec,
 ) -> Result<LightClientUpdate<E>, Error> {
     log_file_access(path);
     ssz_decode_file_with(path, |bytes| {
-        LightClientUpdate::from_ssz_bytes(bytes, fork_name)
+        LightClientUpdate::from_ssz_bytes_by_fork_and_spec(bytes, *fork_name, spec)
     })
 }


### PR DESCRIPTION
## Issue Addressed

#7002

## Proposed Changes

`LightClientUpdate` data can contain an attested header and finalized header that originate from different forks. This usually happens during hardforks while an epoch in the new fork hasn't been finalized yet. This PR allows for us to construct `LightClientUpdate`s in this scenario.

