### PR TITLE
Update minimal spec to v1.5.0 version

### DIFF
--- a/consensus/types/presets/minimal/electra.yaml
+++ b/consensus/types/presets/minimal/electra.yaml
@@ -32,10 +32,10 @@ MAX_ATTESTATIONS_ELECTRA: 8
 
 # Execution
 # ---------------------------------------------------------------
-# [customized] 2**2 (= 4) deposit requests
-MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: 4
-# [customized] 2**1 (= 2) withdrawal requests
-MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 2
+# 2**13 (= 8,192) deposit requests
+MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: 8192
+# 2**4 (= 16) withdrawal requests
+MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: 16
 # 2**1 (= 2) consolidation requests
 MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: 2
 

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -476,8 +476,6 @@ impl EthSpec for MinimalEthSpec {
     type KzgCommitmentInclusionProofDepth = U10;
     type PendingPartialWithdrawalsLimit = U64;
     type PendingConsolidationsLimit = U64;
-    type MaxDepositRequestsPerPayload = U4;
-    type MaxWithdrawalRequestsPerPayload = U2;
     type FieldElementsPerCell = U64;
     type FieldElementsPerExtBlob = U8192;
     type MaxCellsPerBlock = U33554432;
@@ -509,7 +507,9 @@ impl EthSpec for MinimalEthSpec {
         MaxPendingDepositsPerEpoch,
         MaxConsolidationRequestsPerPayload,
         MaxAttesterSlashingsElectra,
-        MaxAttestationsElectra
+        MaxAttestationsElectra,
+        MaxDepositRequestsPerPayload,
+        MaxWithdrawalRequestsPerPayload
     });
 
     fn default_spec() -> ChainSpec {

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.5.0-beta.4
+TESTS_TAG := v1.5.0
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 


### PR DESCRIPTION
## Issue Addressed

Closes:

- https://github.com/sigp/lighthouse/issues/7383

## Proposed Changes

- Update `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD` to 8192 for the minimal spec (same as mainnet)
- Update `MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD` to 16 for the minimal spec (same as mainnet)
- Update test vectors to v1.5.0

## Additional Info

I'm hoping CI will pass without too much fussing around. If it doesn't, maybe we just roll this into @ethDreamer's upcoming PR that will enable the Fulu spec tests.
