### PR TITLE
Mitigate flakiness in test_delayed_rpc_response

### DIFF
--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -1246,10 +1246,12 @@ fn test_delayed_rpc_response() {
                                 // The second and subsequent responses are delayed due to the response rate-limiter on the receiver side.
                                 // Adding a slight margin to the elapsed time check to account for potential timing issues caused by system
                                 // scheduling or execution delays during testing.
+                                // https://github.com/sigp/lighthouse/issues/7466
+                                let margin = 500;
                                 assert!(
                                     request_sent_at.elapsed()
                                         > (Duration::from_secs(QUOTA_SEC)
-                                            - Duration::from_millis(100))
+                                            - Duration::from_millis(margin))
                                 );
                                 if request_id == 5 {
                                     // End the test


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/7466

## Proposed Changes

Expanded the margin from 100ms to 500ms.

<!--
## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->