### PR TITLE
Update mergify to prevent incorrectly firing rule to update `ready-for-review` label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -50,7 +50,7 @@ pull_request_rules:
       - check-success=local-testnet-success
       # Update the label only if there are no more change requests from any reviewers and no unresolved threads.
       # This rule ensures that a PR with passing CI can be marked as `waiting-on-author`.
-      - or:
+      - and:
          - "#changes-requested-reviews-by = 0"
          - "#review-threads-unresolved = 0"
     actions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -48,17 +48,17 @@ pull_request_rules:
       # CI workflows approvals.
       - check-success=test-suite-success
       - check-success=local-testnet-success
-      - "#review-requested > 0"
+      # Update the label only if there are no more change requests from any reviewers and no unresolved threads.
+      # This rule ensures that a PR with passing CI can be marked as `waiting-on-author`.
+      - or:
+         - "#changes-requested-reviews-by = 0"
+         - "#review-threads-unresolved = 0"
     actions:
       label:
         remove:
           - waiting-on-author
         add:
           - ready-for-review
-      comment:
-        message: >
-          All required checks have passed and there are no merge conflicts.
-          This pull request may now be ready for another review.
 
   - name: Close stale pull request after 30 days of inactivity
     conditions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -50,9 +50,8 @@ pull_request_rules:
       - check-success=local-testnet-success
       # Update the label only if there are no more change requests from any reviewers and no unresolved threads.
       # This rule ensures that a PR with passing CI can be marked as `waiting-on-author`.
-      - and:
-         - "#changes-requested-reviews-by = 0"
-         - "#review-threads-unresolved = 0"
+      - "#changes-requested-reviews-by = 0"
+      - "#review-threads-unresolved = 0"
     actions:
       label:
         remove:


### PR DESCRIPTION
Unfortunately I think the mergify rules need to be updated again.

With the current rule, it's not possible to mark a PR with passing CI as `waiting-on-author`. Mergify will immediately remove this label and mark it as `ready-for-review` because of the following rule:
https://github.com/sigp/lighthouse/blob/7759cb8f91c01a7d335469d317b5787368656064/.github/mergify.yml#L41-L51

I've now added an additional condition, so it won't fire if there's a change request or unresolved thread:
```yaml
      - or:
         - "#changes-requested-reviews-by = 0"
         - "#review-threads-unresolved = 0"
```

I'm hoping this improves things, tested the conditions against the following PRs:
- #7521: has unresolved threads, should not label `ready-for-review`
- #7118: has requested change, should not label `ready-for-review`

If this condition proves to be painful without much benefit we can consider removing it, but I'm willing to give it another try. 

I've also removed the `comment` section of this condition, i'm getting feedback that it adds unnecessary noise.
