### PR TITLE
replace consensus-specs link

### DIFF
--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -292,7 +292,7 @@ pub async fn validate_merge_block<T: BeaconChainTypes>(
 }
 
 /// Validate the gossip block's execution_payload according to the checks described here:
-/// https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/p2p-interface.md#beacon_block
+/// https://github.com/ethereum/consensus-specs/blob/v1.1.0/specs/merge/p2p-interface.md#beacon_block
 pub fn validate_execution_payload_for_gossip<T: BeaconChainTypes>(
     parent_block: &ProtoBlock,
     block: BeaconBlockRef<'_, T::EthSpec>,


### PR DESCRIPTION

## Proposed Changes
Hi, I fixed broken links in the documentation and replaced them with working ones.
https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/p2p-interface.md#beacon_block - dead link
https://github.com/ethereum/consensus-specs/blob/v1.1.0/specs/merge/p2p-interface.md#beacon_block - new link