### PR TITLE
Fix unexpected blob error and duplicate import in fetch blobs

### DIFF
--- a/beacon_node/beacon_chain/src/observed_data_sidecars.rs
+++ b/beacon_node/beacon_chain/src/observed_data_sidecars.rs
@@ -161,6 +161,7 @@ pub trait ObservationStrategy {
 /// Type for messages that are observed immediately.
 pub struct Observe;
 /// Type for messages that have not been observed.
+#[derive(Debug)]
 pub struct DoNotObserve;
 
 impl ObservationStrategy for Observe {


### PR DESCRIPTION
## Issue Addressed

Getting this error on a non-PeerDAS network:

```
May 29 13:30:13.484 ERROR Error fetching or processing blobs from EL    error: BlobProcessingError(AvailabilityCheck(Unexpected("empty blobs"))), block_root: 0x98aa3927056d453614fefbc79eb1f9865666d1f119d0e8aa9e6f4d02aa9395d9
```

It appears we're passing an empty `Vec` to DA checker, because all blobs were already seen on gossip and filtered out, this causes a `AvailabilityCheckError::Unexpected("empty blobs")`.

I've added equivalent unit tests for `getBlobsV1` to cover all the scenarios we test in `getBlobsV2`. This would have caught the bug if I had added it earlier. It also caught another bug which could trigger duplicate block import.

Thanks Santito for reporting this! 🙏 