### PR TITLE
EF tests v1.6.0-alpha.1 passing

### DIFF
--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -512,6 +512,31 @@ impl<E: EthSpec + TypeName> Handler for SanitySlotsHandler<E> {
     }
 }
 
+// This runner probably doesn't need to exist long term.
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
+pub struct SanityEffectiveBalanceIncreaseChangesLookahead<E>(PhantomData<E>);
+
+impl<E: EthSpec + TypeName> Handler for SanityEffectiveBalanceIncreaseChangesLookahead<E> {
+    type Case = cases::SanityBlocks<E>;
+
+    fn config_name() -> &'static str {
+        E::name()
+    }
+
+    fn runner_name() -> &'static str {
+        "sanity"
+    }
+
+    fn handler_name(&self) -> String {
+        "effective_balance_increase_changes_lookahead".into()
+    }
+
+    fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
+        fork_name.electra_enabled()
+    }
+}
+
 #[derive(Derivative)]
 #[derivative(Default(bound = ""))]
 pub struct RandomHandler<E>(PhantomData<E>);

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -130,6 +130,12 @@ fn sanity_slots() {
 }
 
 #[test]
+fn sanity_effective_balance_increase_changes_lookahead() {
+    SanityEffectiveBalanceIncreaseChangesLookahead::<MinimalEthSpec>::default().run();
+    SanityEffectiveBalanceIncreaseChangesLookahead::<MainnetEthSpec>::default().run();
+}
+
+#[test]
 fn random() {
     RandomHandler::<MinimalEthSpec>::default().run();
     RandomHandler::<MainnetEthSpec>::default().run();


### PR DESCRIPTION
## Proposed Changes

Simple change to get the EF tests passing on v1.6.0-alpha.1

This PR may not be necessary at all if the tarball is update to move these tests inside `sanity_blocks`, which I think might happen soon.