### PR TITLE
Reduce number of basic sim test nodes from 7 to 4

### DIFF
--- a/testing/simulator/src/cli.rs
+++ b/testing/simulator/src/cli.rs
@@ -28,7 +28,7 @@ pub fn cli_app() -> Command {
                         .short('p')
                         .long("proposer-nodes")
                         .action(ArgAction::Set)
-                        .default_value("2")
+                        .default_value("1")
                         .help("Number of proposer-only beacon nodes"),
                 )
                 .arg(

--- a/testing/simulator/src/cli.rs
+++ b/testing/simulator/src/cli.rs
@@ -20,7 +20,7 @@ pub fn cli_app() -> Command {
                         .short('n')
                         .long("nodes")
                         .action(ArgAction::Set)
-                        .default_value("3")
+                        .default_value("2")
                         .help("Number of beacon nodes"),
                 )
                 .arg(
@@ -28,7 +28,7 @@ pub fn cli_app() -> Command {
                         .short('p')
                         .long("proposer-nodes")
                         .action(ArgAction::Set)
-                        .default_value("3")
+                        .default_value("2")
                         .help("Number of proposer-only beacon nodes"),
                 )
                 .arg(


### PR DESCRIPTION
## Issue Addressed

Our basic sim test has been [flaky](https://github.com/sigp/lighthouse/actions/runs/15458818777/job/43515966229) for some time, and seems like it has gotten worse since electra fork was added to it in #7199.

It looks like the github runner is struggling with the load, currently it runs 7 nodes on a 4 CPU runner, which is definitely too much. We could consider moving this to run on our self hosted runner - but I think running 7 nodes is unnecessary and we can probably trim test this down.

## Proposed Changes

Reduce number of basic sim test nodes from 7 (3 BN + 3 Proposer BN + 1 extra)  to 4 (2 BN + 1 Proposer BN + 1 extra).

If we want to run more nodes, we'd have to consider running on self hosted runners.
