### PR TITLE
Optimise parallelism in compute cells operations by zipping first

### DIFF
--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -187,7 +187,7 @@ pub fn blobs_to_data_column_sidecars<E: EthSpec>(
         .collect::<Vec<_>>();
 
     // NOTE: assumes blob sidecars are ordered by index
-    let zipped: Vec<_> = blobs.into_iter().zip(proof_chunks.into_iter()).collect();
+    let zipped: Vec<_> = blobs.iter().zip(proof_chunks).collect();
     let blob_cells_and_proofs_vec = zipped
         .into_par_iter()
         .map(|(blob, proofs)| {

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -187,9 +187,9 @@ pub fn blobs_to_data_column_sidecars<E: EthSpec>(
         .collect::<Vec<_>>();
 
     // NOTE: assumes blob sidecars are ordered by index
-    let blob_cells_and_proofs_vec = blobs
+    let zipped: Vec<_> = blobs.into_iter().zip(proof_chunks.into_iter()).collect();
+    let blob_cells_and_proofs_vec = zipped
         .into_par_iter()
-        .zip(proof_chunks.into_par_iter())
         .map(|(blob, proofs)| {
             let blob = blob
                 .as_ref()


### PR DESCRIPTION
## Issue Addressed

We're seeing slow KZG performance on `fusaka-devnet-0` and looking for optimisations to improve performance.

Zipping the list first then `into_par_iter` shows a 10% improvement in performance benchmark, i suspect this might be even more material when running on a beacon node.

Before:
```
blobs_to_data_column_sidecars_20
                        time:   [11.583 ms 12.041 ms 12.534 ms]
Found 5 outliers among 100 measurements (5.00%)
```

After:
```
blobs_to_data_column_sidecars_20
                        time:   [10.506 ms 10.724 ms 10.982 ms]
                        change: [-14.925% -10.941% -6.5452%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
```
