### PR TITLE
Store the libp2p/discv5 logs when stopping local-testnet

### DIFF
--- a/scripts/local_testnet/stop_local_testnet.sh
+++ b/scripts/local_testnet/stop_local_testnet.sh
@@ -6,10 +6,21 @@ ENCLAVE_NAME=${1:-local-testnet}
 LOGS_PATH=$SCRIPT_DIR/logs
 LOGS_SUBDIR=$LOGS_PATH/$ENCLAVE_NAME
 
+# Extract the service names of Lighthouse beacon nodes that start with "cl-".
+services=$(kurtosis enclave inspect "$ENCLAVE_NAME" | awk '/^=+ User Services =+$/ { in_section=1; next }
+                                              /^=+/ { in_section=0 }
+                                              in_section && /^[0-9a-f]{12}/ { print $2 }' | grep '^cl-')
+
+# Store logs (including dependency logs) to Kurtosis Files Artifacts. These are downloaded locally by `kurtosis enclave dump`.
+for service in $services; do
+  kurtosis files storeservice --name "$service-logs" local-testnet "$service" /data/lighthouse/beacon-data/beacon/logs/
+done
+
 # Delete existing logs directory and make sure parent directory exists.
 rm -rf $LOGS_SUBDIR && mkdir -p $LOGS_PATH
 kurtosis enclave dump $ENCLAVE_NAME $LOGS_SUBDIR
 echo "Local testnet logs stored to $LOGS_SUBDIR."
+echo "The lighthouse beacon nodes' logs (including dependency logs) can be found in $LOGS_SUBDIR/files/cl-*-lighthouse-geth-logs."
 
 kurtosis enclave rm -f $ENCLAVE_NAME
 kurtosis engine stop

--- a/scripts/local_testnet/stop_local_testnet.sh
+++ b/scripts/local_testnet/stop_local_testnet.sh
@@ -13,7 +13,7 @@ services=$(kurtosis enclave inspect "$ENCLAVE_NAME" | awk '/^=+ User Services =+
 
 # Store logs (including dependency logs) to Kurtosis Files Artifacts. These are downloaded locally by `kurtosis enclave dump`.
 for service in $services; do
-  kurtosis files storeservice --name "$service-logs" local-testnet "$service" /data/lighthouse/beacon-data/beacon/logs/
+  kurtosis files storeservice --name "$service-logs" "$ENCLAVE_NAME" "$service" /data/lighthouse/beacon-data/beacon/logs/
 done
 
 # Delete existing logs directory and make sure parent directory exists.


### PR DESCRIPTION
## Issue Addressed

<!-- Which issue # does this PR address? -->

The libp2p/discv5 logs are not stored when stopping local-testnet.

## Proposed Changes

<!-- Please list or describe the changes introduced by this PR. -->

Store the `beacon/logs` directory to [Kurtosis Files Artifacts](https://docs.kurtosis.com/advanced-concepts/files-artifacts/) so that they are downloaded locally by `kurtosis enclave dump`.

## Additional Info
<!--
Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->

The libp2p/discv5 logs are located in the `files` directory.

```bash
# Stop local-testnet.
$ ./stop_local_testnet.sh
INFO[2025-06-07T21:26:15+09:00] Files with artifact name 'cl-1-lighthouse-geth-logs' uploaded with artifact UUID '3bda190d6af84de999f413750b5108ef'
INFO[2025-06-07T21:26:20+09:00] Files with artifact name 'cl-2-lighthouse-geth-logs' uploaded with artifact UUID '823e31f14a974dbe83d2f6bafae508cd'
INFO[2025-06-07T21:26:24+09:00] Files with artifact name 'cl-3-lighthouse-geth-logs' uploaded with artifact UUID '1d3da899abe549689c0e154771080f19'
INFO[2025-06-07T21:26:28+09:00] Files with artifact name 'cl-4-lighthouse-geth-logs' uploaded with artifact UUID 'daaac0df98e7454db9c322d390fabc2e'
INFO[2025-06-07T21:26:30+09:00] Dumped enclave 'local-testnet' to directory '/Users/akihito/src/github.com/ackintosh/lighthouse/scripts/local_testnet/logs/local-testnet'
Local testnet logs stored to /Users/akihito/src/github.com/ackintosh/lighthouse/scripts/local_testnet/logs/local-testnet.
The lighthouse nodes logs (including dependency logs) can be found in /Users/akihito/src/github.com/ackintosh/lighthouse/scripts/local_testnet/logs/local-testnet/files/cl-*-lighthouse-geth-logs.
INFO[2025-06-07T21:26:30+09:00] Destroying enclaves...
INFO[2025-06-07T21:26:34+09:00] Enclaves successfully destroyed
INFO[2025-06-07T21:26:34+09:00] Stopping Kurtosis engine...
INFO[2025-06-07T21:26:39+09:00] Kurtosis engine successfully stopped
Local testnet stopped.

# Check the libp2p/discv5 logs.
$ ll logs/local-testnet/files/cl-1-lighthouse-geth-logs/
Permissions Size User    Date Modified Name
.rw-------  2.9M akihito  7 6  21:26   beacon.log
.rw-------  2.3M akihito  7 6  21:26   discv5.log
.rw-------   35M akihito  7 6  21:26   libp2p.log
```
