### PR TITLE
fix: Distinguish long chains from failed chains in block lookup sync

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -114,6 +114,9 @@ pub struct BlockLookups<T: BeaconChainTypes> {
     /// A cache of failed chain lookups to prevent duplicate searches.
     failed_chains: LRUTimeCache<Hash256>,
 
+    /// A cache of long chain lookups to prevent duplicate searches without penalizing peers.
+    long_chains: LRUTimeCache<Hash256>,
+
     // TODO: Why not index lookups by block_root?
     single_block_lookups: FnvHashMap<SingleLookupId, SingleBlockLookup<T>>,
 }
@@ -133,6 +136,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             failed_chains: LRUTimeCache::new(Duration::from_secs(
                 FAILED_CHAINS_CACHE_EXPIRY_SECONDS,
             )),
+            long_chains: LRUTimeCache::new(Duration::from_secs(FAILED_CHAINS_CACHE_EXPIRY_SECONDS)),
             single_block_lookups: Default::default(),
         }
     }
@@ -289,7 +293,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
                 // Searching for this parent would extend a parent chain over the max
                 // Insert the tip only to failed chains
-                self.failed_chains.insert(parent_chain.tip);
+                self.long_chains.insert(parent_chain.tip);
 
                 // Note: Drop only the chain that's too long until it merges with another chain
                 // that's not too long. Consider this attack: there's a chain of valid unknown
@@ -386,6 +390,13 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             for peer_id in peers {
                 cx.report_peer(*peer_id, PeerAction::MidToleranceError, "failed_chain");
             }
+            return false;
+        } else if self.long_chains.contains(&block_root) {
+            debug!(
+                ?block_root,
+                "Block is from a past long chain. Dropping without penalty"
+            );
+            // Don't penalize peers for extending long chains
             return false;
         }
 

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -170,6 +170,17 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         name = "lookup_sync",
         skip_all
     )]
+    pub(crate) fn get_long_chains(&mut self) -> Vec<Hash256> {
+        self.long_chains.keys().cloned().collect()
+    }
+
+    #[cfg(test)]
+    #[instrument(parent = None,
+        level = "info",
+        fields(service = "lookup_sync"),
+        name = "lookup_sync",
+        skip_all
+    )]
     pub(crate) fn active_single_lookups(&self) -> Vec<BlockLookupSummary> {
         self.single_block_lookups
             .iter()
@@ -761,6 +772,17 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                                     }
                                 },
                             );
+                        }
+
+                        // Check if this lookup has too many processing failures AFTER penalizing
+                        if request_state.more_failed_processing_attempts()
+                            && request_state.failed_attempts() >= SINGLE_BLOCK_LOOKUP_MAX_ATTEMPTS
+                        {
+                            // Blacklist this chain due to repeated processing failures
+                            self.failed_chains.insert(block_root);
+                            return Err(LookupRequestError::TooManyAttempts {
+                                cannot_process: true,
+                            });
                         }
 
                         Action::Retry

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -1351,6 +1351,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             }
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn get_long_chains(&mut self) -> Vec<Hash256> {
+        self.block_lookups.get_long_chains()
+    }
 }
 
 impl From<Result<AvailabilityProcessingStatus, BlockError>> for BlockProcessingResult {

--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -331,6 +331,13 @@ impl TestRig {
         }
     }
 
+    fn assert_long_chain(&mut self, chain_hash: Hash256) {
+        let long_chains = self.sync_manager.get_long_chains();
+        if !long_chains.contains(&chain_hash) {
+            panic!("expected long chains to contain {chain_hash:?}: {long_chains:?}");
+        }
+    }
+
     fn find_single_lookup_for(&self, block_root: Hash256) -> Id {
         self.active_single_lookups()
             .iter()
@@ -1679,7 +1686,8 @@ fn test_parent_lookup_too_many_processing_attempts_must_blacklist() {
         rig.expect_penalty(peer_id, "lookup_block_processing_failure");
     }
 
-    rig.assert_not_failed_chain(block_root);
+    // Tests that chains that fail due to processing errors (not just length) are blacklisted with penalties
+    rig.assert_failed_chain(parent_root);
     rig.expect_no_active_lookups_empty_network();
 }
 
@@ -1723,13 +1731,33 @@ fn test_parent_lookup_too_deep_grow_ancestor() {
     );
     // Should not penalize peer, but network is not clear because of the blocks_by_range requests
     rig.expect_no_penalty_for(peer_id);
-    rig.assert_failed_chain(chain_hash);
-    rig.assert_not_failed_chain(tip_root);
+    rig.assert_long_chain(chain_hash);
 }
 
 // Regression test for https://github.com/sigp/lighthouse/pull/7118
+// Test for actual failed chains (with penalty)
 #[test]
 fn test_child_lookup_not_created_for_failed_chain_parent_after_processing() {
+    // GIVEN: A parent chain that actually fails due to processing errors
+    let mut rig = TestRig::test_setup();
+    let (_, block, parent_root, _) = rig.rand_block_and_parent();
+    let peer_id = rig.new_connected_peer();
+
+    // Insert a truly failed chain (not just long)
+    rig.insert_failed_chain(parent_root);
+
+    // WHEN: Trigger a block that references the failed parent
+    rig.trigger_unknown_parent_block(peer_id, block.into());
+
+    // THEN: Should penalize peer for extending failed chain
+    rig.expect_single_penalty(peer_id, "failed_chain");
+    // AND: Should reject the lookup
+    rig.expect_no_active_lookups();
+}
+
+// Test for long chains (without penalty)
+#[test]
+fn test_child_lookup_not_created_for_long_chain_parent_after_processing() {
     // GIVEN: A parent chain longer than PARENT_DEPTH_TOLERANCE.
     let mut rig = TestRig::test_setup();
     let mut blocks = rig.rand_blockchain(PARENT_DEPTH_TOLERANCE + 1);
@@ -1758,9 +1786,9 @@ fn test_child_lookup_not_created_for_failed_chain_parent_after_processing() {
         );
     }
 
-    // At this point, the chain should have been deemed too deep and pruned.
-    // The tip root should have been inserted into failed chains.
-    rig.assert_failed_chain(tip_root);
+    // At this point, the chain should have been deemed too long and pruned.
+    // The tip root should have been inserted into long chains (not failed chains).
+    rig.assert_long_chain(tip_root);
     rig.expect_no_penalty_for(peer_id);
 
     // WHEN: Trigger the extending block that points to the tip.
@@ -1777,7 +1805,7 @@ fn test_child_lookup_not_created_for_failed_chain_parent_after_processing() {
         }),
     );
 
-    // THEN: The extending block should not create a lookup because the tip was inserted into failed chains.
+    // THEN: The extending block should not create a lookup because the tip was inserted into long chains.
     rig.expect_no_active_lookups();
     // AND: The peer should NOT be penalized for extending a long chain.
     rig.expect_no_penalty_for(peer_id);
@@ -1819,7 +1847,7 @@ fn test_parent_lookup_too_deep_grow_tip() {
     );
     // Should not penalize peer, but network is not clear because of the blocks_by_range requests
     rig.expect_no_penalty_for(peer_id);
-    rig.assert_failed_chain(tip.canonical_root());
+    rig.assert_long_chain(tip.canonical_root());
 }
 
 #[test]

--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -1691,6 +1691,7 @@ fn test_parent_lookup_too_deep_grow_ancestor() {
     let peer_id = rig.new_connected_peer();
     let trigger_block = blocks.pop().unwrap();
     let chain_hash = trigger_block.canonical_root();
+    let tip_root = trigger_block.canonical_root();
     rig.trigger_unknown_parent_block(peer_id, trigger_block);
 
     for block in blocks.into_iter().rev() {
@@ -1723,6 +1724,7 @@ fn test_parent_lookup_too_deep_grow_ancestor() {
     // Should not penalize peer, but network is not clear because of the blocks_by_range requests
     rig.expect_no_penalty_for(peer_id);
     rig.assert_failed_chain(chain_hash);
+    rig.assert_not_failed_chain(tip_root);
 }
 
 // Regression test for https://github.com/sigp/lighthouse/pull/7118
@@ -1777,8 +1779,8 @@ fn test_child_lookup_not_created_for_failed_chain_parent_after_processing() {
 
     // THEN: The extending block should not create a lookup because the tip was inserted into failed chains.
     rig.expect_no_active_lookups();
-    // AND: The peer should be penalized for extending a failed chain.
-    rig.expect_single_penalty(peer_id, "failed_chain");
+    // AND: The peer should NOT be penalized for extending a long chain.
+    rig.expect_no_penalty_for(peer_id);
     rig.expect_empty_network();
 }
 


### PR DESCRIPTION
Issue Addressed

[ticket](https://github.com/sigp/lighthouse/issues/7577#issuecomment-2959331589) 

Proposed Changes

When a chain reaches PARENT_DEPTH_TOLERANCE, the code was putting it in failed_chains and penalizing peers who reference blocks from that chain, even if the chain itself was valid

Changes:

- Add a separate long_chains for chains that are too long but not necessarily invalid
- Only penalize peers for blocks from failed_chains (actual processing failures)
- Don't penalize peers for blocks from long_chains (just drop)
- Reorganized struct field