### PR TITLE
Add more context to Late Block Re-orgs

### DIFF
--- a/book/src/advanced_re-orgs.md
+++ b/book/src/advanced_re-orgs.md
@@ -4,7 +4,6 @@ Since v3.4.0 Lighthouse will opportunistically re-org late blocks when proposing
 
 When Lighthouse is about to propose a new block, it quickly checks whether the block from the previous slot landed so late that hardly anyone attested to it.
 If that late block looks weak enough, Lighthouse may decide to “re-org” it away: instead of building on it, Lighthouse builds its new block on the grand-parent block, turning the late block into an orphan.
-Because Lighthouse only does this when the opportunity presents itself and the odds of success are good, the code calls the behaviour “opportunistically re-organising late blocks when proposing.
 
 This feature is intended to disincentivise late blocks and improve network health. Proposing a
 re-orging block is also more profitable for the proposer because it increases the number of

--- a/book/src/advanced_re-orgs.md
+++ b/book/src/advanced_re-orgs.md
@@ -2,6 +2,10 @@
 
 Since v3.4.0 Lighthouse will opportunistically re-org late blocks when proposing.
 
+When Lighthouse is about to propose a new block, it quickly checks whether the block from the previous slot landed so late that hardly anyone attested to it.
+If that late block looks weak enough, Lighthouse may decide to “re-org” it away: instead of building on it, Lighthouse builds its new block on the grand-parent block, turning the late block into an orphan.
+Because Lighthouse only does this when the opportunity presents itself and the odds of success are good, the code calls the behaviour “opportunistically re-organising late blocks when proposing.
+
 This feature is intended to disincentivise late blocks and improve network health. Proposing a
 re-orging block is also more profitable for the proposer because it increases the number of
 attestations and transactions that can be included.


### PR DESCRIPTION
## Issue Addressed

Giving more context about late block re-orgs would make the concept easier to grasp for newcomers.

## Proposed Changes

Add more context to this section in the Lighthouse Book.
