### PR TITLE
Fix flaky test_rpc_block_reprocessing

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -1248,11 +1248,25 @@ async fn test_rpc_block_reprocessing() {
     tokio::time::sleep(QUEUED_RPC_BLOCK_DELAY).await;
 
     rig.assert_event_journal(&[WorkType::RpcBlock.into()]).await;
-    // Add an extra delay for block processing
-    tokio::time::sleep(Duration::from_millis(10)).await;
-    // head should update to next block now since the duplicate
-    // cache handle was dropped.
-    assert_eq!(next_block_root, rig.head_root());
+
+    let max_retries = 3;
+    let mut success = false;
+    for _ in 0..max_retries {
+        // Add an extra delay for block processing
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        // head should update to the next block now since the duplicate
+        // cache handle was dropped.
+        if next_block_root == rig.head_root() {
+            success = true;
+            break;
+        }
+    }
+    assert!(
+        success,
+        "expected head_root to be {:?} but was {:?}",
+        next_block_root,
+        rig.head_root()
+    );
 }
 
 /// Ensure that backfill batches get rate-limited and processing is scheduled at specified intervals.


### PR DESCRIPTION
## Issue Addressed

<!-- Which issue # does this PR address? -->

The test occasionally fails, likely because the 10ms fixed delay after block processing isn't insufficient when the system is under load.

https://github.com/sigp/lighthouse/pull/7522#issuecomment-2914595667

## Proposed Changes

<!-- Please list or describe the changes introduced by this PR. -->

Replace single assertion with retry loop.


<!--
## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->