### PR TITLE
docs: update broken link

### DIFF
--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -323,7 +323,7 @@ Another possible reason for missing the head vote is due to a chain "reorg". A r
 
 ### <a name="vc-exit"></a> Can I submit a voluntary exit message without running a beacon node?
 
-Yes. Beaconcha.in provides the tool to broadcast the message. You can create the voluntary exit message file with [ethdo](https://github.com/wealdtech/ethdo/releases/tag/v1.30.0) and submit the message via the [beaconcha.in](https://beaconcha.in/tools/broadcast) website. A guide on how to use `ethdo` to perform voluntary exit can be found [here](https://github.com/eth-educators/ethstaker-guides/blob/main/voluntary-exit.md).
+Yes. Beaconcha.in provides the tool to broadcast the message. You can create the voluntary exit message file with [ethdo](https://github.com/wealdtech/ethdo/releases/tag/v1.30.0) and submit the message via the [beaconcha.in](https://beaconcha.in/tools/broadcast) website. A guide on how to use `ethdo` to perform voluntary exit can be found [here](https://github.com/eth-educators/ethstaker-guides/blob/main/docs/voluntary-exit.md).
 
 It is also noted that you can submit your BLS-to-execution-change message to update your withdrawal credentials from type `0x00` to `0x01` using the same link.
 


### PR DESCRIPTION
## Issue Addressed

Fixes a broken link in the FAQ documentation related to submitting a voluntary exit message without running a beacon node.

## Proposed Changes

- Updated the outdated link to the voluntary exit guide:
  - **Old link**: `https://github.com/eth-educators/ethstaker-guides/blob/main/voluntary-exit.md`
  - **New link**: `https://github.com/eth-educators/ethstaker-guides/blob/main/docs/voluntary-exit.md`

## Additional Info
#### before
![before](https://github.com/user-attachments/assets/d286e608-776e-4f4c-a0bf-872bf949b781)
#### after
![after](https://github.com/user-attachments/assets/3a687852-4246-4e61-9da3-c1cb0573aff4)

This change ensures that users are redirected to the correct and current guide on how to use `ethdo` to submit a voluntary exit message. No other content or logic has been modified.
