### PR TITLE
Hot hdiff buffer cache

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -808,11 +808,23 @@ pub fn cli_app() -> Command {
             Arg::new("hdiff-buffer-cache-size")
                 .long("hdiff-buffer-cache-size")
                 .value_name("SIZE")
-                .help("Number of hierarchical diff (hdiff) buffers to cache in memory. Each buffer \
-                       is around the size of a BeaconState so you should be cautious about setting \
-                       this value too high. This flag is irrelevant for most nodes, which run with \
-                       state pruning enabled.")
+                .help("Number of cold hierarchical diff (hdiff) buffers to cache in memory. Each \
+                       buffer is around the size of a BeaconState so you should be cautious about \
+                       setting this value too high. This flag is irrelevant for most nodes, which \
+                       run with state pruning enabled.")
                 .default_value("16")
+                .action(ArgAction::Set)
+                .display_order(0)
+        )
+        .arg(
+            Arg::new("hot-hdiff-buffer-cache-size")
+                .long("hot-hdiff-buffer-cache-size")
+                .value_name("SIZE")
+                .help("Number of hot hierarchical diff (hdiff) buffers to cache in memory. Each \
+                       buffer is around the size of a BeaconState so you should be cautious about \
+                       setting this value too high. Setting this value higher can reduce the time \
+                       taken to store new states on disk at the cost of higher memory usage.")
+                .default_value("1")
                 .action(ArgAction::Set)
                 .display_order(0)
         )
@@ -1645,7 +1657,7 @@ pub fn cli_app() -> Command {
         .arg(
             Arg::new("delay-data-column-publishing")
                 .long("delay-data-column-publishing")
-                .value_name("SECONDS") 
+                .value_name("SECONDS")
                 .action(ArgAction::Set)
                 .help_heading(FLAG_HEADER)
                 .help("TESTING ONLY: Artificially delay data column publishing by the specified number of seconds. \

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -418,7 +418,13 @@ pub fn get_config<E: EthSpec>(
     if let Some(hdiff_buffer_cache_size) =
         clap_utils::parse_optional(cli_args, "hdiff-buffer-cache-size")?
     {
-        client_config.store.hdiff_buffer_cache_size = hdiff_buffer_cache_size;
+        client_config.store.cold_hdiff_buffer_cache_size = hdiff_buffer_cache_size;
+    }
+
+    if let Some(hdiff_buffer_cache_size) =
+        clap_utils::parse_optional(cli_args, "hot-hdiff-buffer-cache-size")?
+    {
+        client_config.store.hot_hdiff_buffer_cache_size = hdiff_buffer_cache_size;
     }
 
     client_config.store.compact_on_init = cli_args.get_flag("compact-db");

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -24,7 +24,8 @@ pub const DEFAULT_STATE_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(128);
 pub const DEFAULT_STATE_CACHE_HEADROOM: NonZeroUsize = new_non_zero_usize(1);
 pub const DEFAULT_COMPRESSION_LEVEL: i32 = 1;
 pub const DEFAULT_HISTORIC_STATE_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(1);
-pub const DEFAULT_HDIFF_BUFFER_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(16);
+pub const DEFAULT_COLD_HDIFF_BUFFER_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(16);
+pub const DEFAULT_HOT_HDIFF_BUFFER_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(1);
 const EST_COMPRESSION_FACTOR: usize = 2;
 pub const DEFAULT_EPOCHS_PER_BLOB_PRUNE: u64 = 1;
 pub const DEFAULT_BLOB_PUNE_MARGIN_EPOCHS: u64 = 0;
@@ -42,8 +43,10 @@ pub struct StoreConfig {
     pub compression_level: i32,
     /// Maximum number of historic states to store in the in-memory historic state cache.
     pub historic_state_cache_size: NonZeroUsize,
-    /// Maximum number of `HDiffBuffer`s to store in memory.
-    pub hdiff_buffer_cache_size: NonZeroUsize,
+    /// Maximum number of cold `HDiffBuffer`s to store in memory.
+    pub cold_hdiff_buffer_cache_size: NonZeroUsize,
+    /// Maximum number of hot `HDiffBuffers` to store in memory.
+    pub hot_hdiff_buffer_cache_size: NonZeroUsize,
     /// Whether to compact the database on initialization.
     pub compact_on_init: bool,
     /// Whether to compact the database during database pruning.
@@ -106,7 +109,8 @@ impl Default for StoreConfig {
             state_cache_size: DEFAULT_STATE_CACHE_SIZE,
             state_cache_headroom: DEFAULT_STATE_CACHE_HEADROOM,
             historic_state_cache_size: DEFAULT_HISTORIC_STATE_CACHE_SIZE,
-            hdiff_buffer_cache_size: DEFAULT_HDIFF_BUFFER_CACHE_SIZE,
+            cold_hdiff_buffer_cache_size: DEFAULT_COLD_HDIFF_BUFFER_CACHE_SIZE,
+            hot_hdiff_buffer_cache_size: DEFAULT_HOT_HDIFF_BUFFER_CACHE_SIZE,
             compression_level: DEFAULT_COMPRESSION_LEVEL,
             compact_on_init: false,
             compact_on_prune: true,

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -222,9 +222,10 @@ impl<E: EthSpec> HotColdDB<E, MemoryStore<E>, MemoryStore<E>> {
             state_cache: Mutex::new(StateCache::new(
                 config.state_cache_size,
                 config.state_cache_headroom,
+                config.hot_hdiff_buffer_cache_size,
             )),
             historic_state_cache: Mutex::new(HistoricStateCache::new(
-                config.hdiff_buffer_cache_size,
+                config.cold_hdiff_buffer_cache_size,
                 config.historic_state_cache_size,
             )),
             config,
@@ -273,9 +274,10 @@ impl<E: EthSpec> HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>> {
             state_cache: Mutex::new(StateCache::new(
                 config.state_cache_size,
                 config.state_cache_headroom,
+                config.hot_hdiff_buffer_cache_size,
             )),
             historic_state_cache: Mutex::new(HistoricStateCache::new(
-                config.hdiff_buffer_cache_size,
+                config.cold_hdiff_buffer_cache_size,
                 config.historic_state_cache_size,
             )),
             config,

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -456,9 +456,16 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         block_root: Hash256,
         state: BeaconState<E>,
     ) -> Result<(), Error> {
-        self.state_cache
-            .lock()
-            .update_finalized_state(state_root, block_root, state)
+        let start_slot = self.get_anchor_info().anchor_slot;
+        let pre_finalized_slots_to_retain = self
+            .hierarchy
+            .closest_layer_points(state.slot(), start_slot);
+        self.state_cache.lock().update_finalized_state(
+            state_root,
+            block_root,
+            state,
+            &pre_finalized_slots_to_retain,
+        )
     }
 
     pub fn state_cache_len(&self) -> usize {
@@ -476,20 +483,34 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             &metrics::STORE_BEACON_BLOB_CACHE_SIZE,
             self.block_cache.lock().blob_cache.len() as i64,
         );
+        let state_cache = self.state_cache.lock();
         metrics::set_gauge(
             &metrics::STORE_BEACON_STATE_CACHE_SIZE,
-            self.state_cache.lock().len() as i64,
+            state_cache.len() as i64,
         );
+        metrics::set_gauge_vec(
+            &metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_SIZE,
+            HOT_METRIC,
+            state_cache.num_hdiff_buffers() as i64,
+        );
+        metrics::set_gauge_vec(
+            &metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_BYTE_SIZE,
+            HOT_METRIC,
+            state_cache.hdiff_buffer_mem_usage() as i64,
+        );
+        drop(state_cache);
         metrics::set_gauge(
             &metrics::STORE_BEACON_HISTORIC_STATE_CACHE_SIZE,
             hsc_metrics.num_state as i64,
         );
-        metrics::set_gauge(
+        metrics::set_gauge_vec(
             &metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_SIZE,
+            COLD_METRIC,
             hsc_metrics.num_hdiff as i64,
         );
-        metrics::set_gauge(
+        metrics::set_gauge_vec(
             &metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_BYTE_SIZE,
+            COLD_METRIC,
             hsc_metrics.hdiff_byte_size as i64,
         );
 
@@ -1455,9 +1476,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         state: &BeaconState<E>,
         ops: &mut Vec<KeyValueStoreOp>,
     ) -> Result<(), Error> {
-        // Avoid storing states in the database if they already exist in the state cache.
-        // The exception to this is the finalized state, which must exist in the cache before it
-        // is stored on disk.
         match self.state_cache.lock().put_state(
             *state_root,
             state.get_latest_block_root(*state_root),
@@ -1483,7 +1501,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 // the state summary below and rely on that instead.
             }
             // Continue to store.
-            PutStateOutcome::Finalized | PutStateOutcome::PreFinalizedIgnored => {}
+            PutStateOutcome::Finalized | PutStateOutcome::PreFinalizedHDiffBuffer => {}
         }
 
         // Computing diffs is expensive so we avoid it if we already have this state stored on
@@ -1653,6 +1671,14 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     }
 
     fn load_hot_hdiff_buffer(&self, state_root: Hash256) -> Result<HDiffBuffer, Error> {
+        if let Some(buffer) = self
+            .state_cache
+            .lock()
+            .get_hdiff_buffer_by_state_root(state_root)
+        {
+            return Ok(buffer);
+        }
+
         let Some(HotStateSummary {
             slot,
             diff_base_state,
@@ -2194,10 +2220,10 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 %slot,
                 "Hit hdiff buffer cache"
             );
-            metrics::inc_counter(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT);
+            metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, COLD_METRIC);
             return Ok((slot, buffer));
         }
-        metrics::inc_counter(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS);
+        metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, COLD_METRIC);
 
         // Load buffer for the previous state.
         // This amount of recursion (<10 levels) should be OK.

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1701,12 +1701,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     );
                     return Err(Error::MissingHotStateSnapshot(state_root, slot));
                 };
-                let buffer = HDiffBuffer::from_state(state);
-                // Add buffer to cache for future calls.
-                self.state_cache
-                    .lock()
-                    .put_hdiff_buffer(state_root, slot, &buffer);
-                buffer
+                HDiffBuffer::from_state(state)
             }
             StorageStrategy::DiffFrom(from_slot) => {
                 let from_state_root = diff_base_state.get_root(from_slot)?;
@@ -1736,6 +1731,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 })?
             }
         };
+
+        // Add buffer to cache for future calls.
+        self.state_cache
+            .lock()
+            .put_hdiff_buffer(state_root, slot, &buffer);
 
         Ok(buffer)
     }

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1699,7 +1699,12 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     );
                     return Err(Error::MissingHotStateSnapshot(state_root, slot));
                 };
-                HDiffBuffer::from_state(state)
+                let buffer = HDiffBuffer::from_state(state);
+                // Add buffer to cache for future calls.
+                self.state_cache
+                    .lock()
+                    .put_hdiff_buffer(state_root, slot, &buffer);
+                buffer
             }
             StorageStrategy::DiffFrom(from_slot) => {
                 let from_state_root = diff_base_state.get_root(from_slot)?;
@@ -1729,11 +1734,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 })?
             }
         };
-
-        // Add buffer to cache for future calls.
-        self.state_cache
-            .lock()
-            .put_hdiff_buffer(state_root, slot, &buffer);
 
         Ok(buffer)
     }

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1688,7 +1688,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             return Err(Error::MissingHotStateSummary(state_root));
         };
 
-        match self.hot_storage_strategy(slot)? {
+        let buffer = match self.hot_storage_strategy(slot)? {
             StorageStrategy::Snapshot => {
                 let Some(state) = self.load_hot_state_as_snapshot(state_root)? else {
                     let existing_snapshots = self.load_hot_state_snapshot_roots()?;
@@ -1699,8 +1699,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     );
                     return Err(Error::MissingHotStateSnapshot(state_root, slot));
                 };
-                let buffer = HDiffBuffer::from_state(state);
-                Ok(buffer)
+                HDiffBuffer::from_state(state)
             }
             StorageStrategy::DiffFrom(from_slot) => {
                 let from_state_root = diff_base_state.get_root(from_slot)?;
@@ -1717,7 +1716,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         metrics::start_timer_vec(&metrics::BEACON_HDIFF_APPLY_TIME, HOT_METRIC);
                     diff.apply(&mut buffer, &self.config)?;
                 }
-                Ok(buffer)
+                buffer
             }
             StorageStrategy::ReplayFrom(from_slot) => {
                 let from_state_root = diff_base_state.get_root(from_slot)?;
@@ -1727,9 +1726,16 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         from_state_root,
                         e.into(),
                     )
-                })
+                })?
             }
-        }
+        };
+
+        // Add buffer to cache for future calls.
+        self.state_cache
+            .lock()
+            .put_hdiff_buffer(state_root, slot, &buffer);
+
+        Ok(buffer)
     }
 
     fn load_hot_hdiff(&self, state_root: Hash256) -> Result<HDiff, Error> {

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -277,17 +277,20 @@ pub static STORE_BEACON_HISTORIC_STATE_CACHE_SIZE: LazyLock<Result<IntGauge>> =
             "Current count of states in the historic state cache",
         )
     });
-pub static STORE_BEACON_HDIFF_BUFFER_CACHE_SIZE: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
-    try_create_int_gauge(
-        "store_beacon_hdiff_buffer_cache_size",
-        "Current count of hdiff buffers in the historic state cache",
-    )
-});
-pub static STORE_BEACON_HDIFF_BUFFER_CACHE_BYTE_SIZE: LazyLock<Result<IntGauge>> =
+pub static STORE_BEACON_HDIFF_BUFFER_CACHE_SIZE: LazyLock<Result<IntGaugeVec>> =
     LazyLock::new(|| {
-        try_create_int_gauge(
+        try_create_int_gauge_vec(
+            "store_beacon_hdiff_buffer_cache_size",
+            "Current count of hdiff buffers in the historic state cache",
+            &["db"],
+        )
+    });
+pub static STORE_BEACON_HDIFF_BUFFER_CACHE_BYTE_SIZE: LazyLock<Result<IntGaugeVec>> =
+    LazyLock::new(|| {
+        try_create_int_gauge_vec(
             "store_beacon_hdiff_buffer_cache_byte_size",
             "Memory consumed by hdiff buffers in the historic state cache",
+            &["db"],
         )
     });
 pub static STORE_BEACON_STATE_FREEZER_COMPRESS_TIME: LazyLock<Result<Histogram>> =
@@ -318,18 +321,20 @@ pub static STORE_BEACON_HISTORIC_STATE_CACHE_MISS: LazyLock<Result<IntCounter>> 
             "Total count of historic state cache misses for full states",
         )
     });
-pub static STORE_BEACON_HDIFF_BUFFER_CACHE_HIT: LazyLock<Result<IntCounter>> =
+pub static STORE_BEACON_HDIFF_BUFFER_CACHE_HIT: LazyLock<Result<IntCounterVec>> =
     LazyLock::new(|| {
-        try_create_int_counter(
+        try_create_int_counter_vec(
             "store_beacon_hdiff_buffer_cache_hit_total",
             "Total count of hdiff buffer cache hits",
+            &["db"],
         )
     });
-pub static STORE_BEACON_HDIFF_BUFFER_CACHE_MISS: LazyLock<Result<IntCounter>> =
+pub static STORE_BEACON_HDIFF_BUFFER_CACHE_MISS: LazyLock<Result<IntCounterVec>> =
     LazyLock::new(|| {
-        try_create_int_counter(
+        try_create_int_counter_vec(
             "store_beacon_hdiff_buffer_cache_miss_total",
             "Total count of hdiff buffer cache miss",
+            &["db"],
         )
     });
 pub static STORE_BEACON_HDIFF_BUFFER_INTO_STATE_TIME: LazyLock<Result<Histogram>> =

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -185,7 +185,6 @@ pub static BEACON_HDIFF_BUFFER_LOAD_TIME: LazyLock<Result<HistogramVec>> = LazyL
         &["db"],
     )
 });
-// NB: the `hot` version of this metric doesn't currently exist as we don't cache hot buffers
 pub static BEACON_HDIFF_BUFFER_CLONE_TIME: LazyLock<Result<HistogramVec>> = LazyLock::new(|| {
     try_create_histogram_vec(
         "store_hdiff_buffer_clone_seconds",
@@ -281,7 +280,7 @@ pub static STORE_BEACON_HDIFF_BUFFER_CACHE_SIZE: LazyLock<Result<IntGaugeVec>> =
     LazyLock::new(|| {
         try_create_int_gauge_vec(
             "store_beacon_hdiff_buffer_cache_size",
-            "Current count of hdiff buffers in the historic state cache",
+            "Current count of hdiff buffers cached in memory",
             &["db"],
         )
     });
@@ -289,7 +288,7 @@ pub static STORE_BEACON_HDIFF_BUFFER_CACHE_BYTE_SIZE: LazyLock<Result<IntGaugeVe
     LazyLock::new(|| {
         try_create_int_gauge_vec(
             "store_beacon_hdiff_buffer_cache_byte_size",
-            "Memory consumed by hdiff buffers in the historic state cache",
+            "Memory consumed by hdiff buffers cached in memory",
             &["db"],
         )
     });

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -125,9 +125,10 @@ impl<E: EthSpec> StateCache<E> {
         // Delete states.
         for state_root in state_roots_to_prune {
             if let Some((_, state)) = self.states.pop(&state_root) {
-                // Copy hdiff buffers for states that are now aligned to the grid.
+                // Copy the hdiff buffer for the new snapshot if it is moving from after
+                // finalization to before.
                 let slot = state.slot();
-                if pre_finalized_slots_to_retain.contains(&slot) && slot != state.slot() {
+                if pre_finalized_slots_to_retain.last() == Some(&slot) {
                     let hdiff_buffer = HDiffBuffer::from_state(state);
                     self.hdiff_buffers.put(state_root, (slot, hdiff_buffer));
                 }
@@ -140,7 +141,7 @@ impl<E: EthSpec> StateCache<E> {
         let new_hdiff_cache = LruCache::new(self.hdiff_buffers.cap());
         let old_hdiff_cache = std::mem::replace(&mut self.hdiff_buffers, new_hdiff_cache);
         for (state_root, (slot, buffer)) in old_hdiff_cache {
-            if pre_finalized_slots_to_retain.contains(&slot) {
+            if pre_finalized_slots_to_retain.last() == Some(&slot) {
                 self.hdiff_buffers.put(state_root, (slot, buffer));
             }
         }

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -78,12 +78,16 @@ pub enum PutStateOutcome {
 
 #[allow(clippy::len_without_is_empty)]
 impl<E: EthSpec> StateCache<E> {
-    pub fn new(capacity: NonZeroUsize, headroom: NonZeroUsize) -> Self {
+    pub fn new(
+        state_capacity: NonZeroUsize,
+        headroom: NonZeroUsize,
+        hdiff_capacity: NonZeroUsize,
+    ) -> Self {
         StateCache {
             finalized_state: None,
-            states: LruCache::new(capacity),
+            states: LruCache::new(state_capacity),
             block_map: BlockMap::default(),
-            hdiff_buffers: HotHDiffBufferCache::new(NonZeroUsize::new(16).unwrap()),
+            hdiff_buffers: HotHDiffBufferCache::new(hdiff_capacity),
             max_epoch: Epoch::new(0),
             head_block_root: Hash256::ZERO,
             headroom,

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -127,7 +127,7 @@ impl<E: EthSpec> StateCache<E> {
             if let Some((_, state)) = self.states.pop(&state_root) {
                 // Copy hdiff buffers for states that are now aligned to the grid.
                 let slot = state.slot();
-                if pre_finalized_slots_to_retain.contains(&slot) {
+                if pre_finalized_slots_to_retain.contains(&slot) && slot != state.slot() {
                     let hdiff_buffer = HDiffBuffer::from_state(state);
                     self.hdiff_buffers.put(state_root, (slot, hdiff_buffer));
                 }
@@ -242,6 +242,17 @@ impl<E: EthSpec> StateCache<E> {
             }
         }
         self.states.get(&state_root).map(|(_, state)| state.clone())
+    }
+
+    pub fn put_hdiff_buffer(&mut self, state_root: Hash256, slot: Slot, buffer: &HDiffBuffer) {
+        // Only accept HDiffBuffers prior to finalization. Later states should be stored as proper
+        // states, not HDiffBuffers.
+        if let Some(finalized_state) = &self.finalized_state {
+            if slot >= finalized_state.state.slot() {
+                return;
+            }
+        }
+        self.hdiff_buffers.put(state_root, (slot, buffer.clone()));
     }
 
     pub fn get_hdiff_buffer_by_state_root(&mut self, state_root: Hash256) -> Option<HDiffBuffer> {

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -41,13 +41,25 @@ pub struct StateCache<E: EthSpec> {
     // the state_root
     states: LruCache<Hash256, (Hash256, BeaconState<E>)>,
     block_map: BlockMap,
+    hdiff_buffers: HotHDiffBufferCache,
+    max_epoch: Epoch,
+    head_block_root: Hash256,
+    headroom: NonZeroUsize,
+}
+
+/// Cache of hdiff buffers for hot states.
+///
+/// This cache only keeps buffers prior to the finalized state, which are required by the
+/// hierarchical state diff scheme to construct newer unfinalized states.
+///
+/// The cache always retains the hdiff buffer for the most recent snapshot so that even if the
+/// cache capacity is 1, this snapshot never needs to be loaded from disk.
+#[derive(Debug)]
+pub struct HotHDiffBufferCache {
     /// Cache of HDiffBuffers for states *prior* to the `finalized_state`.
     ///
     /// Maps state_root -> (slot, buffer).
     hdiff_buffers: LruCache<Hash256, (Slot, HDiffBuffer)>,
-    max_epoch: Epoch,
-    head_block_root: Hash256,
-    headroom: NonZeroUsize,
 }
 
 #[derive(Debug)]
@@ -71,7 +83,7 @@ impl<E: EthSpec> StateCache<E> {
             finalized_state: None,
             states: LruCache::new(capacity),
             block_map: BlockMap::default(),
-            hdiff_buffers: LruCache::new(NonZeroUsize::new(16).unwrap()),
+            hdiff_buffers: HotHDiffBufferCache::new(NonZeroUsize::new(16).unwrap()),
             max_epoch: Epoch::new(0),
             head_block_root: Hash256::ZERO,
             headroom,
@@ -91,10 +103,7 @@ impl<E: EthSpec> StateCache<E> {
     }
 
     pub fn hdiff_buffer_mem_usage(&self) -> usize {
-        self.hdiff_buffers
-            .iter()
-            .map(|(_, (_, buffer))| buffer.size())
-            .sum()
+        self.hdiff_buffers.mem_usage()
     }
 
     pub fn update_finalized_state(
@@ -122,27 +131,30 @@ impl<E: EthSpec> StateCache<E> {
         // Prune block map.
         let state_roots_to_prune = self.block_map.prune(state.slot());
 
-        // Delete states.
-        for state_root in state_roots_to_prune {
-            if let Some((_, state)) = self.states.pop(&state_root) {
-                // Copy the hdiff buffer for the new snapshot if it is moving from after
-                // finalization to before.
-                let slot = state.slot();
-                if pre_finalized_slots_to_retain.last() == Some(&slot) {
-                    let hdiff_buffer = HDiffBuffer::from_state(state);
-                    self.hdiff_buffers.put(state_root, (slot, hdiff_buffer));
-                }
+        // Prune HDiffBuffers that are no longer required by the hdiff grid of the finalized state.
+        // We need to do this prior to copying in any new hdiff buffers, because the cache
+        // preferences older slots.
+        // NOTE: This isn't perfect as it prunes by slot: there could be multiple buffers
+        // at some slots in the case of long forks without finality.
+        let new_hdiff_cache = HotHDiffBufferCache::new(self.hdiff_buffers.cap());
+        let old_hdiff_cache = std::mem::replace(&mut self.hdiff_buffers, new_hdiff_cache);
+        for (state_root, (slot, buffer)) in old_hdiff_cache.hdiff_buffers {
+            if pre_finalized_slots_to_retain.contains(&slot) {
+                self.hdiff_buffers.put(state_root, slot, buffer);
             }
         }
 
-        // Prune HDiffBuffers that are no longer required by the hdiff grid of the finalized state.
-        // NOTE: This isn't perfect as it prunes by slot: there could be multiple buffers
-        // at some slots in the case of long forks without finality.
-        let new_hdiff_cache = LruCache::new(self.hdiff_buffers.cap());
-        let old_hdiff_cache = std::mem::replace(&mut self.hdiff_buffers, new_hdiff_cache);
-        for (state_root, (slot, buffer)) in old_hdiff_cache {
-            if pre_finalized_slots_to_retain.last() == Some(&slot) {
-                self.hdiff_buffers.put(state_root, (slot, buffer));
+        // Delete states.
+        for state_root in state_roots_to_prune {
+            if let Some((_, state)) = self.states.pop(&state_root) {
+                // Add the hdiff buffer for this state to the hdiff cache if it is now part of
+                // the pre-finalized grid. The `put` method will take care of keeping the most
+                // useful buffers.
+                let slot = state.slot();
+                if pre_finalized_slots_to_retain.contains(&slot) {
+                    let hdiff_buffer = HDiffBuffer::from_state(state);
+                    self.hdiff_buffers.put(state_root, slot, hdiff_buffer);
+                }
             }
         }
 
@@ -192,7 +204,7 @@ impl<E: EthSpec> StateCache<E> {
                 // HDiffBuffer and saved.
                 let hdiff_buffer = HDiffBuffer::from_state(state.clone());
                 self.hdiff_buffers
-                    .put(state_root, (state.slot(), hdiff_buffer));
+                    .put(state_root, state.slot(), hdiff_buffer);
                 return Ok(PutStateOutcome::PreFinalizedHDiffBuffer);
             }
         }
@@ -253,11 +265,11 @@ impl<E: EthSpec> StateCache<E> {
                 return;
             }
         }
-        self.hdiff_buffers.put(state_root, (slot, buffer.clone()));
+        self.hdiff_buffers.put(state_root, slot, buffer.clone());
     }
 
     pub fn get_hdiff_buffer_by_state_root(&mut self, state_root: Hash256) -> Option<HDiffBuffer> {
-        if let Some((_, buffer)) = self.hdiff_buffers.get(&state_root) {
+        if let Some(buffer) = self.hdiff_buffers.get(&state_root) {
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
             return Some(buffer.clone());
         }
@@ -403,5 +415,82 @@ impl BlockMap {
 
     fn delete_block_states(&mut self, block_root: &Hash256) -> Option<SlotMap> {
         self.blocks.remove(block_root)
+    }
+}
+
+impl HotHDiffBufferCache {
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            hdiff_buffers: LruCache::new(capacity),
+        }
+    }
+
+    pub fn get(&mut self, state_root: &Hash256) -> Option<HDiffBuffer> {
+        self.hdiff_buffers
+            .get(state_root)
+            .map(|(_, buffer)| buffer.clone())
+    }
+
+    /// Put a value in the cache, making room for it if necessary.
+    ///
+    /// If the value was inserted then `true` is returned.
+    pub fn put(&mut self, state_root: Hash256, slot: Slot, buffer: HDiffBuffer) -> bool {
+        // If the cache is not full, simply insert the value.
+        if self.hdiff_buffers.len() != self.hdiff_buffers.cap().get() {
+            self.hdiff_buffers.put(state_root, (slot, buffer));
+            return true;
+        }
+
+        // If the cache is full, it has room for this new entry if:
+        //
+        // - The capacity is greater than 1: we can retain the snapshot and the new entry, or
+        // - The capacity is 1 and the slot of the new entry is older than the min_slot in the
+        //   cache. This is a simplified way of retaining the snapshot in the cache. We don't need
+        //   to worry about inserting/retaining states older than the snapshot because these are
+        //   pruned on finalization and never reinserted.
+        let Some(min_slot) = self.hdiff_buffers.iter().map(|(_, (slot, _))| *slot).min() else {
+            // Unreachable: cache is full so should have >0 entries.
+            return false;
+        };
+
+        if self.hdiff_buffers.cap().get() > 1 || slot < min_slot {
+            // Remove LRU value. Cache is now at size `cap - 1`.
+            let Some((removed_state_root, (removed_slot, removed_buffer))) =
+                self.hdiff_buffers.pop_lru()
+            else {
+                // Unreachable: cache is full so should have at least one entry to pop.
+                return false;
+            };
+
+            // Insert new value. Cache size is now at size `cap`.
+            self.hdiff_buffers.put(state_root, (slot, buffer));
+
+            // If the removed value had the min slot and we didn't intend to replace it (cap=1)
+            // then we reinsert it.
+            if removed_slot == min_slot && slot >= min_slot {
+                self.hdiff_buffers
+                    .put(removed_state_root, (removed_slot, removed_buffer));
+            }
+            true
+        } else {
+            // No room.
+            false
+        }
+    }
+
+    pub fn cap(&self) -> NonZeroUsize {
+        self.hdiff_buffers.cap()
+    }
+
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.hdiff_buffers.len()
+    }
+
+    pub fn mem_usage(&self) -> usize {
+        self.hdiff_buffers
+            .iter()
+            .map(|(_, (_, buffer))| buffer.size())
+            .sum()
     }
 }

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -275,14 +275,18 @@ impl<E: EthSpec> StateCache<E> {
     pub fn get_hdiff_buffer_by_state_root(&mut self, state_root: Hash256) -> Option<HDiffBuffer> {
         if let Some(buffer) = self.hdiff_buffers.get(&state_root) {
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
-            return Some(buffer.clone());
+            let timer =
+                metrics::start_timer_vec(&metrics::BEACON_HDIFF_BUFFER_CLONE_TIME, HOT_METRIC);
+            let result = Some(buffer.clone());
+            drop(timer);
+            return result;
         }
         if let Some(buffer) = self
             .get_by_state_root(state_root)
             .map(HDiffBuffer::from_state)
         {
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
-            return Some(buffer.clone());
+            return Some(buffer);
         }
         metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, HOT_METRIC);
         None

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -260,9 +260,15 @@ impl<E: EthSpec> StateCache<E> {
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
             return Some(buffer.clone());
         }
-        metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, HOT_METRIC);
-        self.get_by_state_root(state_root)
+        if let Some(buffer) = self
+            .get_by_state_root(state_root)
             .map(HDiffBuffer::from_state)
+        {
+            metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
+            return Some(buffer.clone());
+        }
+        metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, HOT_METRIC);
+        None
     }
 
     pub fn get_by_block_root(

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -1,4 +1,8 @@
-use crate::Error;
+use crate::hdiff::HDiffBuffer;
+use crate::{
+    metrics::{self, HOT_METRIC},
+    Error,
+};
 use lru::LruCache;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroUsize;
@@ -37,6 +41,10 @@ pub struct StateCache<E: EthSpec> {
     // the state_root
     states: LruCache<Hash256, (Hash256, BeaconState<E>)>,
     block_map: BlockMap,
+    /// Cache of HDiffBuffers for states *prior* to the `finalized_state`.
+    ///
+    /// Maps state_root -> (slot, buffer).
+    hdiff_buffers: LruCache<Hash256, (Slot, HDiffBuffer)>,
     max_epoch: Epoch,
     head_block_root: Hash256,
     headroom: NonZeroUsize,
@@ -44,8 +52,8 @@ pub struct StateCache<E: EthSpec> {
 
 #[derive(Debug)]
 pub enum PutStateOutcome {
-    /// State is prior to the cache's finalized state (lower slot) and was not inserted.
-    PreFinalizedIgnored,
+    /// State is prior to the cache's finalized state (lower slot) and was cached as an HDiffBuffer.
+    PreFinalizedHDiffBuffer,
     /// State is equal to the cache's finalized state and was not inserted.
     Finalized,
     /// State was already present in the cache.
@@ -63,6 +71,7 @@ impl<E: EthSpec> StateCache<E> {
             finalized_state: None,
             states: LruCache::new(capacity),
             block_map: BlockMap::default(),
+            hdiff_buffers: LruCache::new(NonZeroUsize::new(16).unwrap()),
             max_epoch: Epoch::new(0),
             head_block_root: Hash256::ZERO,
             headroom,
@@ -77,11 +86,23 @@ impl<E: EthSpec> StateCache<E> {
         self.states.cap().get()
     }
 
+    pub fn num_hdiff_buffers(&self) -> usize {
+        self.hdiff_buffers.len()
+    }
+
+    pub fn hdiff_buffer_mem_usage(&self) -> usize {
+        self.hdiff_buffers
+            .iter()
+            .map(|(_, (_, buffer))| buffer.size())
+            .sum()
+    }
+
     pub fn update_finalized_state(
         &mut self,
         state_root: Hash256,
         block_root: Hash256,
         state: BeaconState<E>,
+        pre_finalized_slots_to_retain: &[Slot],
     ) -> Result<(), Error> {
         if state.slot() % E::slots_per_epoch() != 0 {
             return Err(Error::FinalizedStateUnaligned);
@@ -103,7 +124,25 @@ impl<E: EthSpec> StateCache<E> {
 
         // Delete states.
         for state_root in state_roots_to_prune {
-            self.states.pop(&state_root);
+            if let Some((_, state)) = self.states.pop(&state_root) {
+                // Copy hdiff buffers for states that are now aligned to the grid.
+                let slot = state.slot();
+                if pre_finalized_slots_to_retain.contains(&slot) {
+                    let hdiff_buffer = HDiffBuffer::from_state(state);
+                    self.hdiff_buffers.put(state_root, (slot, hdiff_buffer));
+                }
+            }
+        }
+
+        // Prune HDiffBuffers that are no longer required by the hdiff grid of the finalized state.
+        // NOTE: This isn't perfect as it prunes by slot: there could be multiple buffers
+        // at some slots in the case of long forks without finality.
+        let new_hdiff_cache = LruCache::new(self.hdiff_buffers.cap());
+        let old_hdiff_cache = std::mem::replace(&mut self.hdiff_buffers, new_hdiff_cache);
+        for (state_root, (slot, buffer)) in old_hdiff_cache {
+            if pre_finalized_slots_to_retain.contains(&slot) {
+                self.hdiff_buffers.put(state_root, (slot, buffer));
+            }
         }
 
         // Update finalized state.
@@ -146,7 +185,14 @@ impl<E: EthSpec> StateCache<E> {
             if finalized_state.state_root == state_root {
                 return Ok(PutStateOutcome::Finalized);
             } else if state.slot() <= finalized_state.state.slot() {
-                return Ok(PutStateOutcome::PreFinalizedIgnored);
+                // We assume any state being inserted into the cache is grid-aligned (it is the
+                // caller's responsibility to not feed us garbage) as we don't want to thread the
+                // hierarchy config through here. So any state received is converted to an
+                // HDiffBuffer and saved.
+                let hdiff_buffer = HDiffBuffer::from_state(state.clone());
+                self.hdiff_buffers
+                    .put(state_root, (state.slot(), hdiff_buffer));
+                return Ok(PutStateOutcome::PreFinalizedHDiffBuffer);
             }
         }
 
@@ -196,6 +242,16 @@ impl<E: EthSpec> StateCache<E> {
             }
         }
         self.states.get(&state_root).map(|(_, state)| state.clone())
+    }
+
+    pub fn get_hdiff_buffer_by_state_root(&mut self, state_root: Hash256) -> Option<HDiffBuffer> {
+        if let Some((_, buffer)) = self.hdiff_buffers.get(&state_root) {
+            metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
+            return Some(buffer.clone());
+        }
+        metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, HOT_METRIC);
+        self.get_by_state_root(state_root)
+            .map(HDiffBuffer::from_state)
     }
 
     pub fn get_by_block_root(

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -171,10 +171,10 @@ Options:
           Specify your custom graffiti to be included in blocks. Defaults to the
           current version and commit, truncated to fit in 32 bytes.
       --hdiff-buffer-cache-size <SIZE>
-          Number of hierarchical diff (hdiff) buffers to cache in memory. Each
-          buffer is around the size of a BeaconState so you should be cautious
-          about setting this value too high. This flag is irrelevant for most
-          nodes, which run with state pruning enabled. [default: 16]
+          Number of cold hierarchical diff (hdiff) buffers to cache in memory.
+          Each buffer is around the size of a BeaconState so you should be
+          cautious about setting this value too high. This flag is irrelevant
+          for most nodes, which run with state pruning enabled. [default: 16]
       --hierarchy-exponents <EXPONENTS>
           Specifies the frequency for storing full state snapshots and
           hierarchical diffs in the freezer DB. Accepts a comma-separated list
@@ -187,6 +187,12 @@ Options:
       --historic-state-cache-size <SIZE>
           Specifies how many states from the freezer database should be cached
           in memory [default: 1]
+      --hot-hdiff-buffer-cache-size <SIZE>
+          Number of hot hierarchical diff (hdiff) buffers to cache in memory.
+          Each buffer is around the size of a BeaconState so you should be
+          cautious about setting this value too high. Setting this value higher
+          can reduce the time taken to store new states on disk at the cost of
+          higher memory usage. [default: 1]
       --http-address <ADDRESS>
           Set the listen address for the RESTful HTTP API server.
       --http-allow-origin <ORIGIN>

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1955,6 +1955,15 @@ fn hot_hdiff_buffer_cache_size_default() {
         });
 }
 #[test]
+fn hot_hdiff_buffer_cache_size_flag() {
+    CommandLineTest::new()
+        .flag("hot-hdiff-buffer-cache-size", Some("3"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(config.store.hot_hdiff_buffer_cache_size.get(), 3);
+        });
+}
+#[test]
 fn auto_compact_db_flag() {
     CommandLineTest::new()
         .flag("auto-compact-db", Some("false"))

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1927,18 +1927,30 @@ fn hdiff_buffer_cache_size_flag() {
         .flag("hdiff-buffer-cache-size", Some("1"))
         .run_with_zero_port()
         .with_config(|config| {
-            assert_eq!(config.store.hdiff_buffer_cache_size.get(), 1);
+            assert_eq!(config.store.cold_hdiff_buffer_cache_size.get(), 1);
         });
 }
 #[test]
 fn hdiff_buffer_cache_size_default() {
-    use beacon_node::beacon_chain::store::config::DEFAULT_HDIFF_BUFFER_CACHE_SIZE;
+    use beacon_node::beacon_chain::store::config::DEFAULT_COLD_HDIFF_BUFFER_CACHE_SIZE;
     CommandLineTest::new()
         .run_with_zero_port()
         .with_config(|config| {
             assert_eq!(
-                config.store.hdiff_buffer_cache_size,
-                DEFAULT_HDIFF_BUFFER_CACHE_SIZE
+                config.store.cold_hdiff_buffer_cache_size,
+                DEFAULT_COLD_HDIFF_BUFFER_CACHE_SIZE
+            );
+        });
+}
+#[test]
+fn hot_hdiff_buffer_cache_size_default() {
+    use beacon_node::beacon_chain::store::config::DEFAULT_HOT_HDIFF_BUFFER_CACHE_SIZE;
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(
+                config.store.hot_hdiff_buffer_cache_size,
+                DEFAULT_HOT_HDIFF_BUFFER_CACHE_SIZE
             );
         });
 }


### PR DESCRIPTION
## Proposed Changes

Reduce the time taken to store hot states by introducing an in-memory cache for hot `HDiffBuffer`s. This cache is attached to the `state_cache` and is simpler than the existing `HDiffBuffer` cache we have for the cold DB.

We are able to take advantage of the fact that the hot DB requires very few hdiff buffers in normal operation: just one per layer required to access the finalized state (total 7).

The memory requirement for this single buffer is 438 MB on Holesky. Presently there is no way to turn off the cache, although we could consider adding this if we want a way to avoid this 438 MB entirely. I suspect the DB cache and associated reads will use a similar amount of memory, if not more.

For users wishing to minimise _IO_ at the cost of more memory, the cache size can be increased to 8 (or higher). In practice the cache seems to hold around 4 entries when allowed to grow, for a total size of 1.68GB on Holesky (around 440 MB per buffer).
