### PR TITLE
Remove instrumenting log level

### DIFF
--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -406,7 +406,6 @@ pub struct ValidatorMonitor<E: EthSpec> {
 
 impl<E: EthSpec> ValidatorMonitor<E> {
     #[instrument(parent = None,
-        level = "info",
         name = "validator_monitor",
         skip_all
     )]

--- a/beacon_node/network/src/subnet_service/mod.rs
+++ b/beacon_node/network/src/subnet_service/mod.rs
@@ -114,7 +114,6 @@ impl<T: BeaconChainTypes> SubnetService<T> {
 
     /// Establish the service based on the passed configuration.
     #[instrument(parent = None,
-        level = "info",
         fields(service = "subnet_service"),
         name = "subnet_service",
         skip_all

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -148,7 +148,6 @@ pub struct BackFillSync<T: BeaconChainTypes> {
 
 impl<T: BeaconChainTypes> BackFillSync<T> {
     #[instrument(parent = None,
-        level = "info",
         name = "backfill_sync",
         skip_all
     )]

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -139,7 +139,6 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
     #[cfg(test)]
     #[instrument(parent = None,
-        level = "info",
         fields(service = "lookup_sync"),
         name = "lookup_sync",
         skip_all

--- a/beacon_node/network/src/sync/peer_sampling.rs
+++ b/beacon_node/network/src/sync/peer_sampling.rs
@@ -39,7 +39,6 @@ impl<T: BeaconChainTypes> Sampling<T> {
 
     #[cfg(test)]
     #[instrument(parent = None,
-        level = "info",
         fields(service = "sampling"),
         name = "sampling",
         skip_all

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -153,7 +153,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
     }
 
     /// Check if the chain has peers from which to process batches.
-    #[instrument(parent = None,level = "info", fields(chain = self.id , service = "range_sync"), skip_all)]
+    #[instrument(parent = None,fields(chain = self.id , service = "range_sync"), skip_all)]
     pub fn available_peers(&self) -> usize {
         self.peers.len()
     }
@@ -211,7 +211,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
 
     /// A block has been received for a batch on this chain.
     /// If the block correctly completes the batch it will be processed if possible.
-    #[instrument(parent = None,level = "info", fields(chain = self.id , service = "range_sync"), skip_all)]
+    #[instrument(parent = None, fields(chain = self.id , service = "range_sync"), skip_all)]
     pub fn on_block_response(
         &mut self,
         network: &mut SyncNetworkContext<T>,

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -82,7 +82,6 @@ where
     T: BeaconChainTypes,
 {
     #[instrument(parent = None,
-        level = "info",
         fields(component = "range_sync"),
         name = "range_sync",
         skip_all

--- a/common/task_executor/src/lib.rs
+++ b/common/task_executor/src/lib.rs
@@ -92,7 +92,7 @@ impl TaskExecutor {
     /// This function should only be used during testing. In production, prefer to obtain an
     /// instance of `Self` via a `environment::RuntimeContext` (see the `lighthouse/environment`
     /// crate).
-    #[instrument(parent = None,level = "info", fields(service = service_name), name = "task_executor", skip_all)]
+    #[instrument(parent = None,fields(service = service_name), name = "task_executor", skip_all)]
     pub fn new<T: Into<HandleProvider>>(
         handle: T,
         exit: async_channel::Receiver<()>,


### PR DESCRIPTION
## Issue Addressed

I think this should resolve #7155


This removes the level field from the instrumenting we were doing across a range of functions. The level will now default to the level of the log. 