### PR TITLE
improve Rpc response logging

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -577,28 +577,15 @@ where
                                     self.inbound_substreams_delay.remove(delay_key);
                                 }
 
-                                // BlocksByRange is the one that typically consumes the most time.
-                                // Its useful to log when the request was completed.
-                                if matches!(info.protocol, Protocol::BlocksByRange) {
-                                    debug!(
-                                        peer_id = %self.peer_id,
-                                        connection_id = %self.connection_id,
-                                        duration = Instant::now()
-                                            .duration_since(info.request_start_time)
-                                            .as_secs(),
-                                        "BlocksByRange Response sent"
-                                    );
-                                }
-                                if matches!(info.protocol, Protocol::BlobsByRange) {
-                                    debug!(
-                                        peer_id = %self.peer_id,
-                                        connection_id = %self.connection_id,
-                                        duration = Instant::now()
-                                            .duration_since(info.request_start_time)
-                                            .as_secs(),
-                                        "BlobsByRange Response sent"
-                                    );
-                                }
+                                debug!(
+                                    peer_id = %self.peer_id,
+                                    connection_id = %self.connection_id,
+                                    duration = Instant::now()
+                                        .duration_since(info.request_start_time)
+                                        .as_secs(),
+                                    response = %info.protocol,
+                                    "Response sent"
+                                );
 
                                 // There is nothing more to process on this substream as it has
                                 // been closed. Move on to the next one.

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -239,18 +239,13 @@ impl<Id: ReqId, E: EthSpec> RPC<Id, E> {
         response: RpcResponse<E>,
     ) {
         if let Some(response_limiter) = self.response_limiter.as_mut() {
-            if !response_limiter.allows(
-                peer_id,
-                protocol,
-                request_id.connection_id,
-                request_id.substream_id,
-                response.clone(),
-            ) {
+            if !response_limiter.allows(peer_id, protocol, request_id, response.clone()) {
                 // Response is logged and queued internally in the response limiter.
                 return;
             }
         }
 
+        debug!(%peer_id, ?request_id, %response, "Queueing response to to be sent to the connection handler");
         self.events.push(ToSwarm::NotifyHandler {
             peer_id,
             handler: NotifyHandler::One(request_id.connection_id),
@@ -565,12 +560,13 @@ where
 
     fn poll(&mut self, cx: &mut Context) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(response_limiter) = self.response_limiter.as_mut() {
-            if let Poll::Ready(responses) = response_limiter.poll_ready(cx) {
-                for response in responses {
+            if let Poll::Ready(queued_responses) = response_limiter.poll_ready(cx) {
+                for ready in queued_responses {
+                    debug!(%ready.peer_id, ?ready.request_id, %ready.response, "Queueing response to to be sent to the connection handler");
                     self.events.push(ToSwarm::NotifyHandler {
-                        peer_id: response.peer_id,
-                        handler: NotifyHandler::One(response.connection_id),
-                        event: RPCSend::Response(response.substream_id, response.response),
+                        peer_id: ready.peer_id,
+                        handler: NotifyHandler::One(ready.request_id.connection_id),
+                        event: RPCSend::Response(ready.request_id.substream_id, ready.response),
                     });
                 }
             }

--- a/beacon_node/lighthouse_network/src/rpc/response_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/response_limiter.rs
@@ -1,10 +1,9 @@
 use crate::rpc::config::InboundRateLimiterConfig;
 use crate::rpc::rate_limiter::{RPCRateLimiter, RateLimitedErr};
 use crate::rpc::self_limiter::timestamp_now;
-use crate::rpc::{Protocol, RpcResponse, SubstreamId};
+use crate::rpc::{Protocol, RpcResponse};
 use crate::PeerId;
 use futures::FutureExt;
-use libp2p::swarm::ConnectionId;
 use logging::crit;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
@@ -15,13 +14,14 @@ use tokio_util::time::DelayQueue;
 use tracing::debug;
 use types::{EthSpec, ForkContext};
 
+use super::InboundRequestId;
+
 /// A response that was rate limited or waiting on rate limited responses for the same peer and
 /// protocol.
 #[derive(Clone)]
 pub(super) struct QueuedResponse<E: EthSpec> {
     pub peer_id: PeerId,
-    pub connection_id: ConnectionId,
-    pub substream_id: SubstreamId,
+    pub request_id: InboundRequestId,
     pub response: RpcResponse<E>,
     pub protocol: Protocol,
     pub queued_at: Duration,
@@ -55,8 +55,7 @@ impl<E: EthSpec> ResponseLimiter<E> {
         &mut self,
         peer_id: PeerId,
         protocol: Protocol,
-        connection_id: ConnectionId,
-        substream_id: SubstreamId,
+        request_id: InboundRequestId,
         response: RpcResponse<E>,
     ) -> bool {
         // First check that there are not already other responses waiting to be sent.
@@ -64,8 +63,7 @@ impl<E: EthSpec> ResponseLimiter<E> {
             debug!(%peer_id, %protocol, "Response rate limiting since there are already other responses waiting to be sent");
             queue.push_back(QueuedResponse {
                 peer_id,
-                connection_id,
-                substream_id,
+                request_id,
                 response,
                 protocol,
                 queued_at: timestamp_now(),
@@ -81,8 +79,7 @@ impl<E: EthSpec> ResponseLimiter<E> {
                 .or_default()
                 .push_back(QueuedResponse {
                     peer_id,
-                    connection_id,
-                    substream_id,
+                    request_id,
                     response,
                     protocol,
                     queued_at: timestamp_now(),


### PR DESCRIPTION
## Issue Addressed

This PR mainly addresses two issues with the current ConnectionHandler logging:

-  Currently, only successful `BlocksByRange` and `BlobsByRange` responses sent are logged. This PR expands logging to include all response types, providing better visibility into the full range of interactions.

- The existing `ConnectionHandler` logs lack the `SubstreamId`, making it difficult to correlate responses sent with their corresponding `InboundRequestId`. This makes it impossible to find which `InboundRequestId` was responded to . 
This PR resolves that by logging when a request is dispatched to the `ConnectionHandler`, including the associated `InboundRequestId`.

While addressing the above issues, took the opportunity to unify `SubstreamId` and `ConnectionId` to `InboundRequestId` on `QueuedResponse` as it doesn't need to have them separated, we only need that when dispatching to the `ConnectionHandler`