### PR TITLE
Fix incorrect `waker` update condition

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -377,7 +377,7 @@ where
         ConnectionHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::ToBehaviour>,
     > {
         if let Some(waker) = &self.waker {
-            if waker.will_wake(cx.waker()) {
+            if !waker.will_wake(cx.waker()) {
                 self.waker = Some(cx.waker().clone());
             }
         } else {

--- a/beacon_node/network/src/subnet_service/attestation_subnets.rs
+++ b/beacon_node/network/src/subnet_service/attestation_subnets.rs
@@ -600,7 +600,7 @@ impl<T: BeaconChainTypes> Stream for AttestationService<T> {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // Update the waker if needed.
         if let Some(waker) = &self.waker {
-            if waker.will_wake(cx.waker()) {
+            if !waker.will_wake(cx.waker()) {
                 self.waker = Some(cx.waker().clone());
             }
         } else {

--- a/beacon_node/network/src/subnet_service/mod.rs
+++ b/beacon_node/network/src/subnet_service/mod.rs
@@ -663,7 +663,7 @@ impl<T: BeaconChainTypes> Stream for SubnetService<T> {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // Update the waker if needed.
         if let Some(waker) = &self.waker {
-            if waker.will_wake(cx.waker()) {
+            if !waker.will_wake(cx.waker()) {
                 self.waker = Some(cx.waker().clone());
             }
         } else {

--- a/beacon_node/network/src/subnet_service/sync_subnets.rs
+++ b/beacon_node/network/src/subnet_service/sync_subnets.rs
@@ -319,7 +319,7 @@ impl<T: BeaconChainTypes> Stream for SyncCommitteeService<T> {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // update the waker if needed
         if let Some(waker) = &self.waker {
-            if waker.will_wake(cx.waker()) {
+            if !waker.will_wake(cx.waker()) {
                 self.waker = Some(cx.waker().clone());
             }
         } else {


### PR DESCRIPTION
## Issue Addressed

This bug was first found and partially fixed by @VolodymyrBg in #7317 - this PR applies the same fix everywhere else.

The old logic updated the waker when it already matched the context, and did nothing when it was stale:

```rust
if waker.will_wake(cx.waker()) {
    self.waker = Some(cx.waker().clone());
}
```

This is the wrong way around. We only want to update the waker if it doesn't match the current context:

```rust
if !waker.will_wake(cx.waker()) {
    self.waker = Some(cx.waker().clone());
}
```

I don't think we've ever noticed any issues, but it’s a subtle bug that could lead to missed wakeups.
