### PR TITLE
fix: allow validator import flags with --validators-file (fixes #7651)

### DIFF
--- a/validator_manager/src/import_validators.rs
+++ b/validator_manager/src/import_validators.rs
@@ -112,8 +112,7 @@ pub fn cli_app() -> Command {
                 .value_name("ETH1_ADDRESS")
                 .help("When provided, the imported validator will use the suggested fee recipient. Omit this flag to use the default value from the VC.")
                 .action(ArgAction::Set)
-                .display_order(0)
-                .requires(KEYSTORE_FILE_FLAG),
+                .display_order(0),
         )
         .arg(
             Arg::new(GAS_LIMIT)
@@ -122,8 +121,7 @@ pub fn cli_app() -> Command {
                 .help("When provided, the imported validator will use this gas limit. It is recommended \
                 to leave this as the default value by not specifying this flag.",)
                 .action(ArgAction::Set)
-                .display_order(0)
-                .requires(KEYSTORE_FILE_FLAG),
+                .display_order(0),
         )
         .arg(
             Arg::new(BUILDER_PROPOSALS)
@@ -132,8 +130,7 @@ pub fn cli_app() -> Command {
                 blocks via builder rather than the local EL.",)
                 .value_parser(["true","false"])
                 .action(ArgAction::Set)
-                .display_order(0)
-                .requires(KEYSTORE_FILE_FLAG),
+                .display_order(0),
         )
         .arg(
             Arg::new(BUILDER_BOOST_FACTOR)
@@ -144,8 +141,7 @@ pub fn cli_app() -> Command {
                 when choosing between a builder payload header and payload from \
                 the local execution node.",)
                 .action(ArgAction::Set)
-                .display_order(0)
-                .requires(KEYSTORE_FILE_FLAG),
+                .display_order(0),
         )
         .arg(
             Arg::new(PREFER_BUILDER_PROPOSALS)
@@ -154,8 +150,15 @@ pub fn cli_app() -> Command {
                 constructed by builders, regardless of payload value.",)
                 .value_parser(["true","false"])
                 .action(ArgAction::Set)
-                .display_order(0)
-                .requires(KEYSTORE_FILE_FLAG),
+                .display_order(0),
+        )
+        .arg(
+            Arg::new(ENABLED)
+                .long(ENABLED)
+                .help("When provided, the imported validator will be enabled or disabled. Omit this flag to use the default value from the VC.")
+                .value_parser(["true","false"])
+                .action(ArgAction::Set)
+                .display_order(0),
         )
 }
 


### PR DESCRIPTION
## Summary
This PR fixes issue #7651 by allowing validator import flags to work with both `--keystore-file` and `--validators-file` options, improving the UX for users importing validators.

## Changes Made
- **Removed `.requires(KEYSTORE_FILE_FLAG)` constraint** from the following flags:
  - `--suggested-fee-recipient`
  - `--gas-limit` 
  - `--builder-proposals`
  - `--builder-boost-factor`
  - `--prefer-builder-proposals`
- **Added missing `--enabled` flag** definition that was referenced in the `ImportConfig` struct but missing from CLI arguments

## Testing
-  Code compiles successfully
-  CLI arguments are parsed correctly
- The old error about `--password` and `--keystore-file` being required is resolved
- All flags now work with both `--keystore-file` and `--validators-file`

## Fixes
Closes #7651