### PR TITLE
fix typos in validator client and manager modules

### DIFF
--- a/validator_client/beacon_node_fallback/src/lib.rs
+++ b/validator_client/beacon_node_fallback/src/lib.rs
@@ -530,7 +530,7 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
                 // require the least processing in the BN and therefore measure
                 // the connection moreso than the BNs processing speed.
                 //
-                // I imagine all clients have the version string availble as a
+                // I imagine all clients have the version string available as a
                 // pre-computed string.
                 let response_instant = candidate
                     .beacon_node

--- a/validator_client/http_api/src/remotekeys.rs
+++ b/validator_client/http_api/src/remotekeys.rs
@@ -118,7 +118,7 @@ fn import_single_remotekey<T: SlotClock + 'static, E: EthSpec>(
     }
 
     // Remotekeys are stored as web3signers.
-    // The remotekey API provides less confgiuration option than the web3signer API.
+    // The remotekey API provides less configuration option than the web3signer API.
     let web3signer_validator = ValidatorDefinition {
         enabled: true,
         voting_public_key: pubkey,

--- a/validator_manager/src/move_validators.rs
+++ b/validator_manager/src/move_validators.rs
@@ -440,7 +440,7 @@ async fn run(config: MoveConfig) -> Result<(), String> {
                             be asked to provide another password. \
                             Failing to provide the correct password now will \
                             result in the keystore being deleted from the src VC \
-                            without being transfered to the dest VC. \
+                            without being transferred to the dest VC. \
                             It is strongly recommend to provide a password now rather than exiting.",
                         pubkey_to_move
                     );


### PR DESCRIPTION


---


**Description:**  
This pull request corrects several minor typos in the following modules:
- `validator_client/beacon_node_fallback/src/lib.rs`: Fixed `availble` →`available`
- `validator_client/http_api/src/remotekeys.rs`: Fixed `confgiuration` → `configuration`
- `validator_manager/src/move_validators.rs`: Fixed `transfered` → `transferred`


---
