### PR TITLE
Bump DB schema to v25

### DIFF
--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -4,7 +4,7 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use types::{Hash256, Slot};
 
-pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(24);
+pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(25);
 
 // All the keys that get stored under the `BeaconMeta` column.
 //


### PR DESCRIPTION
## Issue Addressed

When we removed the eth1 data, I wrote a v25 schema upgrade to delete the data on disk:

- https://github.com/sigp/lighthouse/pull/7133

However, I forgot to update the current schema version, so this change was never actioned.

## Proposed Changes

This PR updates the current schema version to v25 so that the migration runs.

## Additional Info

I'm getting this in before v26, which is required to fix up the persistence of validator custody data on disk before v7.1.0 is released. Presently we have introduced on-disk changes without a DB schema change in:

- https://github.com/sigp/lighthouse/pull/7578
