### PR TITLE
Add Michael as codeowner for store crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 /beacon_node/network/                @jxs
 /beacon_node/lighthouse_network/     @jxs
+/beacon_node/store/                  @michaelsproul


### PR DESCRIPTION
## Proposed Changes

I'm adding myself as a codeowner for the `store` crate so that I can more easily keep track of database-related PRs.
