### PR TITLE
Increase http client default timeout to 2s in `http-api` tests.

### DIFF
--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -103,6 +103,13 @@ impl<E: EthSpec> InteractiveTester<E> {
 
         tokio::spawn(server);
 
+        // Override the default timeout to 2s to timeouts on CI, as CI seems to require longer
+        // to process. The 1s timeouts for other tasks have been working for a long time, so we'll
+        // keep it as it is, as it may help identify a performance regression.
+        let timeouts = Timeouts {
+            default: Duration::from_secs(2),
+            ..Timeouts::set_all(Duration::from_secs(1))
+        };
         let client = BeaconNodeHttpClient::new(
             SensitiveUrl::parse(&format!(
                 "http://{}:{}",
@@ -110,7 +117,7 @@ impl<E: EthSpec> InteractiveTester<E> {
                 listening_socket.port()
             ))
             .unwrap(),
-            Timeouts::set_all(Duration::from_secs(1)),
+            timeouts,
         );
 
         Self {


### PR DESCRIPTION
## Issue Addressed

The `sync_contributions_across_fork_with_skip_slots` test have been quite flaky recently on CI, we suspect it might be caused by the recent introduction of a `default` timeout in #7400, and CI is failing to consistently process those http requests within 1s likely due to limited resources.

This PR increases the `default` timeout to 2s in tests to avoid flaky tests, but keeps the remaining timeout the same (1s).

https://github.com/sigp/lighthouse/actions/runs/15965113170/job/45023976021

```
        FAIL [   8.945s] http_api::bn_http_api_tests fork_tests::sync_contributions_across_fork_with_skip_slots
  stdout ───

    running 1 test
    test fork_tests::sync_contributions_across_fork_with_skip_slots ... FAILED

    failures:

    failures:
        fork_tests::sync_contributions_across_fork_with_skip_slots

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 175 filtered out; finished in 8.91s

  stderr ───

    thread 'fork_tests::sync_contributions_across_fork_with_skip_slots' panicked at beacon_node/http_api/tests/fork_tests.rs:239:10:
    called `Result::unwrap()` on an `Err` value: HttpClient(url: http://127.0.0.1:41793/, kind: timeout, detail: operation timed out)
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```