### PR TITLE
Make `notifier_service::notify` pub

### DIFF
--- a/validator_client/validator_services/src/notifier_service.rs
+++ b/validator_client/validator_services/src/notifier_service.rs
@@ -35,7 +35,9 @@ pub fn spawn_notifier<S: ValidatorStore + 'static, T: SlotClock + 'static>(
 }
 
 /// Performs a single notification routine.
-pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(duties_service: &DutiesService<S, T>) {
+pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
+    duties_service: &DutiesService<S, T>,
+) {
     let (candidate_info, num_available, num_synced) =
         duties_service.beacon_nodes.get_notifier_info().await;
     let num_total = candidate_info.len();

--- a/validator_client/validator_services/src/notifier_service.rs
+++ b/validator_client/validator_services/src/notifier_service.rs
@@ -35,7 +35,7 @@ pub fn spawn_notifier<S: ValidatorStore + 'static, T: SlotClock + 'static>(
 }
 
 /// Performs a single notification routine.
-async fn notify<S: ValidatorStore, T: SlotClock + 'static>(duties_service: &DutiesService<S, T>) {
+pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(duties_service: &DutiesService<S, T>) {
     let (candidate_info, num_available, num_synced) =
         duties_service.beacon_nodes.get_notifier_info().await;
     let num_total = candidate_info.len();


### PR DESCRIPTION
## Issue Addressed

Anchor wants the `notify` function to run only in certain cases - so the `spawn_notifier` function is unsuitable for us.

## Proposed Changes

Anchor uses it's own `notify` function, which then calls `notifier_service::notify` (in most circumstances). To enable that, `notify` needs to be `pub`.
