### PR TITLE
Reintroduce `--logfile` with deprecation warning

### DIFF
--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -278,7 +278,7 @@ pub fn get_config<E: EthSpec>(
     }
 
     if clap_utils::parse_optional::<u64>(cli_args, "eth1-cache-follow-distance")?.is_some() {
-        warn!("The eth1-purge-cache flag is deprecated");
+        warn!("The eth1-cache-follow-distance flag is deprecated");
     }
 
     // `--execution-endpoint` is required now.

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -127,6 +127,16 @@ fn main() {
                 .display_order(0),
         )
         .arg(
+            Arg::new("logfile")
+                .long("logfile")
+                .value_name("PATH")
+                .help("DEPRECATED")
+                .action(ArgAction::Set)
+                .global(true)
+                .hide(true)
+                .display_order(0)
+        )
+        .arg(
             Arg::new("logfile-dir")
                 .long("logfile-dir")
                 .value_name("DIR")
@@ -700,6 +710,11 @@ fn run<E: EthSpec>(
 
     // Allow Prometheus access to the version and commit of the Lighthouse build.
     metrics::expose_lighthouse_version();
+
+    // DEPRECATED: can be removed in v7.2.0/v8.0.0.
+    if clap_utils::parse_optional::<PathBuf>(matches, "logfile")?.is_some() {
+        warn!("The --logfile flag is deprecated and replaced by --logfile-dir");
+    }
 
     #[cfg(all(feature = "modern", target_arch = "x86_64"))]
     if !std::is_x86_feature_detected!("adx") {

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2476,6 +2476,13 @@ fn logfile_format_flag() {
             )
         });
 }
+// DEPRECATED but should not crash.
+#[test]
+fn deprecated_logfile() {
+    CommandLineTest::new()
+        .flag("logfile", Some("test.txt"))
+        .run_with_zero_port();
+}
 
 // DEPRECATED but should not crash.
 #[test]


### PR DESCRIPTION
## Proposed Changes

Reintroduce the `--logfile` flag with a deprecation warning so that it doesn't prevent nodes from starting. This is considered preferable to breaking node startups so that users fix the flag, even though it means the `--logfile` flag is completely ineffective.

The flag was initially removed in:

- https://github.com/sigp/lighthouse/pull/6339
