### PR TITLE
Allow /validator apis to work pre-genesis

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -3790,7 +3790,11 @@ pub fn serve<T: BeaconChainTypes>(
                         .ok_or(BeaconChainError::ExecutionLayerMissing)
                         .map_err(warp_utils::reject::unhandled_error)?;
 
-                    let current_slot = chain.slot().map_err(warp_utils::reject::unhandled_error)?;
+                    let current_slot = chain
+                        .slot_clock
+                        .now_or_genesis()
+                        .ok_or(BeaconChainError::UnableToReadSlot)
+                        .map_err(warp_utils::reject::unhandled_error)?;
                     let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
 
                     debug!(


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Lighthouse BN http endpoint would return a server error pre-genesis on the `validator/duties/attester` and `validator/prepare_beacon_proposer` because `slot_clock.now()` would return a `None` pre-genesis. 

The prysm VC depends on the endpoints pre-genesis and was having issues interoping with the lighthouse bn because of this reason.

The proposer duties endpoint explicitly handles the pre-genesis case here
https://github.com/sigp/lighthouse/blob/538067f1ff9840d44e3c2ea60581e18aba8c4143/beacon_node/http_api/src/proposer_duties.rs#L23-L28

I see no reason why we can't make the other endpoints more flexible to work pre-genesis. This PR handles the pre-genesis case on the attester and prepare_beacon_proposer endpoints as well.

Thanks for raising @james-prysm. 
