### PR TITLE
Fix: RPC test failures

### DIFF
--- a/beacon_node/lighthouse_network/tests/common.rs
+++ b/beacon_node/lighthouse_network/tests/common.rs
@@ -72,12 +72,18 @@ impl std::ops::DerefMut for Libp2pInstance {
 }
 
 #[allow(unused)]
-pub fn build_tracing_subscriber(level: &str, enabled: bool) {
+pub fn build_tracing_subscriber(
+    level: &str,
+    enabled: bool,
+) -> Option<tracing::subscriber::DefaultGuard> {
     if enabled {
-        tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::try_new(level).unwrap())
-            .try_init()
-            .unwrap();
+        Some(tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .with_env_filter(EnvFilter::try_new(level).unwrap())
+                .finish(),
+        ))
+    } else {
+        None
     }
 }
 

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -57,7 +57,7 @@ fn test_tcp_status_rpc() {
     // Set up the logging.
     let log_level = "debug";
     let enable_logging = true;
-    build_tracing_subscriber(log_level, enable_logging);
+    let _subscriber = build_tracing_subscriber(log_level, enable_logging);
 
     let rt = Arc::new(Runtime::new().unwrap());
 
@@ -163,7 +163,7 @@ fn test_tcp_blocks_by_range_chunked_rpc() {
     // Set up the logging.
     let log_level = "debug";
     let enable_logging = true;
-    build_tracing_subscriber(log_level, enable_logging);
+    let _subscriber = build_tracing_subscriber(log_level, enable_logging);
 
     let messages_to_send = 6;
 
@@ -310,7 +310,7 @@ fn test_blobs_by_range_chunked_rpc() {
     // Set up the logging.
     let log_level = "debug";
     let enable_logging = true;
-    build_tracing_subscriber(log_level, enable_logging);
+    let _subscriber = build_tracing_subscriber(log_level, enable_logging);
 
     let slot_count = 32;
     let messages_to_send = 34;
@@ -438,7 +438,7 @@ fn test_tcp_blocks_by_range_over_limit() {
     // Set up the logging.
     let log_level = "debug";
     let enable_logging = true;
-    build_tracing_subscriber(log_level, enable_logging);
+    let _subscriber = build_tracing_subscriber(log_level, enable_logging);
 
     let messages_to_send = 5;
 
@@ -544,7 +544,7 @@ fn test_tcp_blocks_by_range_chunked_rpc_terminates_correctly() {
     // Set up the logging.
     let log_level = "debug";
     let enable_logging = true;
-    build_tracing_subscriber(log_level, enable_logging);
+    let _subscriber = build_tracing_subscriber(log_level, enable_logging);
 
     let messages_to_send = 10;
     let extra_messages_to_send = 10;
@@ -682,7 +682,7 @@ fn test_tcp_blocks_by_range_single_empty_rpc() {
     // Set up the logging.
     let log_level = "trace";
     let enable_logging = true;
-    build_tracing_subscriber(log_level, enable_logging);
+    let _subscriber = build_tracing_subscriber(log_level, enable_logging);
 
     let rt = Arc::new(Runtime::new().unwrap());
 
@@ -805,7 +805,7 @@ fn test_tcp_blocks_by_root_chunked_rpc() {
     // Set up the logging.
     let log_level = "debug";
     let enable_logging = true;
-    build_tracing_subscriber(log_level, enable_logging);
+    let _subscriber = build_tracing_subscriber(log_level, enable_logging);
 
     let messages_to_send = 6;
 
@@ -953,7 +953,7 @@ fn test_tcp_blocks_by_root_chunked_rpc_terminates_correctly() {
     // Set up the logging.
     let log_level = "debug";
     let enable_logging = true;
-    build_tracing_subscriber(log_level, enable_logging);
+    let _subscriber = build_tracing_subscriber(log_level, enable_logging);
 
     let messages_to_send: u64 = 10;
     let extra_messages_to_send: u64 = 10;
@@ -1100,7 +1100,7 @@ fn test_tcp_blocks_by_root_chunked_rpc_terminates_correctly() {
 /// Goodbye message.
 fn goodbye_test(log_level: &str, enable_logging: bool, protocol: Protocol) {
     // Set up the logging.
-    build_tracing_subscriber(log_level, enable_logging);
+    let _subscriber = build_tracing_subscriber(log_level, enable_logging);
 
     let rt = Arc::new(Runtime::new().unwrap());
 
@@ -1184,7 +1184,7 @@ fn quic_test_goodbye_rpc() {
 #[test]
 fn test_delayed_rpc_response() {
     // Set up the logging.
-    build_tracing_subscriber("debug", true);
+    let _subscriber = build_tracing_subscriber("debug", true);
     let rt = Arc::new(Runtime::new().unwrap());
     let spec = Arc::new(spec_with_all_forks_enabled());
 
@@ -1318,7 +1318,7 @@ fn test_delayed_rpc_response() {
 #[test]
 fn test_active_requests() {
     // Set up the logging.
-    build_tracing_subscriber("debug", true);
+    let _subscriber = build_tracing_subscriber("debug", true);
     let rt = Arc::new(Runtime::new().unwrap());
     let spec = Arc::new(spec_with_all_forks_enabled());
 


### PR DESCRIPTION
## Issue Addressed

Fixes #7735 

## Proposed Changes

Use `tracing::subscriber::set_default` to ensure that each test/thread has its own subscirber.