### PR TITLE
Add release helper script to list PRs and breaking changes

### DIFF
--- a/scripts/print_release_diffs.py
+++ b/scripts/print_release_diffs.py
@@ -1,0 +1,72 @@
+"""
+Summarise pull requests between two Lighthouse releases.
+
+Usage:
+  export GITHUB_TOKEN=your_token
+  python -m pip install requests==2.32.4
+  python print_release_diffs.py --base v7.0.1 --head release-v7.1.0
+
+Shows commit SHA, PR number, 'backwards-incompat' label status, and PR title.
+"""
+
+import requests
+import re
+import argparse
+import os
+
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+if not GITHUB_TOKEN:
+    raise SystemExit("Error: Please set the GITHUB_TOKEN environment variable.")
+
+parser = argparse.ArgumentParser(description="Summarise PRs between two Lighthouse versions.")
+parser.add_argument("--base", required=True, help="Base tag or branch (older release)")
+parser.add_argument("--head", required=True, help="Head tag or branch (newer release)")
+args = parser.parse_args()
+
+BASE = args.base
+HEAD = args.head
+OWNER = 'sigp'
+REPO = 'lighthouse'
+
+HEADERS = {
+    'Authorization': f'token {GITHUB_TOKEN}',
+    'Accept': 'application/vnd.github+json'
+}
+
+def get_commits_between(base, head):
+    url = f'https://api.github.com/repos/{OWNER}/{REPO}/compare/{base}...{head}'
+    response = requests.get(url, headers=HEADERS)
+    response.raise_for_status()
+    return response.json()['commits']
+
+def has_backwards_incompat_label(pr_number):
+    url = f'https://api.github.com/repos/{OWNER}/{REPO}/issues/{pr_number}'
+    response = requests.get(url, headers=HEADERS)
+    if response.status_code != 200:
+        raise Exception(f"Failed to fetch PR #{pr_number}")
+    labels = response.json().get('labels', [])
+    return any(label['name'] == 'backwards-incompat' for label in labels)
+
+def main():
+    commits = get_commits_between(BASE, HEAD)
+    print(" #   Commit SHA    PR Number    Has backwards-incompat Label    PR Title")
+    print("---  ------------  -----------  ------------------------------  --------------------------------------------")
+
+    for i, commit in enumerate(commits, 1):
+        sha = commit['sha'][:12]
+        message = commit['commit']['message']
+        pr_match = re.search(r"\(#(\d+)\)", message)
+
+        if not pr_match:
+            print(f"{i:<3}  {sha}  {'-':<11}  {'-':<30}  [NO PR MATCH]: {message.splitlines()[0]}")
+            continue
+
+        pr_number = int(pr_match.group(1))
+        try:
+            has_label = has_backwards_incompat_label(pr_number)
+            print(f"{i:<3}  {sha}  {pr_number:<11}  {str(has_label):<30}  {message.splitlines()[0]}")
+        except Exception as e:
+            print(f"{i:<3}  {sha}  {pr_number:<11}  {'ERROR':<30}  [ERROR FETCHING PR]: {e}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Issue Addressed

Output for 7.1.0 release:

```
 #   Commit SHA    PR Number    Has backwards-incompat Label    PR Title
---  ------------  -----------  ------------------------------  --------------------------------------------
1    d5a03c9d86bf  6872         False                           Add more range sync tests (#6872)
2    ec2fe3812edc  -            -                               [NO PR MATCH]: Merge remote-tracking branch 'origin/release-v7.0.0-beta.0' into unstable
3    3992d6ba74c9  6862         False                           Fix misc PeerDAS todos (#6862)
4    d60388134d07  6928         False                           Add PeerDAS metrics to track subnets without peers (#6928)
5    431dd7c39828  6917         False                           Remove un-used batch sync error condition (#6917)
6    0055af56b685  6932         False                           Unsubscribe blob topics at Fulu fork (#6932)
7    6ab6eae40c0e  -            -                               [NO PR MATCH]: Merge remote-tracking branch 'origin/release-v7.0.0-beta.0' into unstable
8    193061ff7376  6634         False                           Use RpcSend on RPC::self_limiter::ready_requests (#6634)
9    e5e43ecd8129  -            -                               [NO PR MATCH]: Merge remote-tracking branch 'origin/release-v7.0.0' into unstable
10   b4be5141823f  7012         False                           Add spamoor_blob in network_params.yaml (#7012)
11   01df433dfd02  7021         False                           update codeowners, to be more specific (#7021)
12   60964fc7b530  6829         False                           Expose blst internals (#6829)
13   3fab6a2c0ba7  6866         False                           Block availability data enum (#6866)
14   6e11bddd4bd0  6947         False                           feat: adds CLI flags to delay publishing for edge case testing on PeerDAS devnets (#6947)
15   454c7d05c40b  7017         False                           Remove LC server config from HTTP API (#7017)
16   54b4150a6220  7030         False                           Add test flag to override `SYNC_TOLERANCE_EPOCHS` for range sync testing (#7030)
17   cf4104abe5e2  -            -                               [NO PR MATCH]: Merge remote-tracking branch 'origin/release-v7.0.0' into unstable
18   8a772520a50a  7034         False                           Cache validator registration only after successful publish (#7034)
19   1235d4480225  7048         False                           Remove `watch` (#7048)
20   3bc5f1f2a58b  7081         False                           Validator Registration ssz support (#7081)
21   b4e79edf2a09  -            -                               [NO PR MATCH]: Merge remote-tracking branch 'origin/release-v7.0.0' into unstable
22   8d1abce26ed5  6915         False                           Bump SSZ version for larger bitfield `SmallVec` (#6915)
23   1916a2ac5ad3  7020         False                           chore: update to rust-eth-kzg to 0.5.4 (#7020)
24   1a08e6f0a090  7109         False                           Remove duplicate sync_tolerance_epochs config (#7109)
25   f23f984f8575  7057         False                           switch to upstream gossipsub (#7057)
26   d60c24ef1cc0  6339         True                            Integrate tracing (#6339)
27   a6bdc474db01  6991         False                           Log range sync download errors (#6991)
28   574b204bdb39  6680         False                           decouple `eth2` from `store` and `lighthouse_network` (#6680)
29   c095a0a58feb  7130         False                           update gossipsub to the latest upstream revision (#7130)
30   5cda1641ea2f  7137         False                           Log `file appender` initialization errors properly (#7137)
31   d96123b02882  7149         False                           Remove unnecessary `filter_layer` in logger builder (#7149)
32   a1b1d7ae589f  7150         False                           Remove `discv5` logs from logfile output (#7150)
33   ca237652f1da  6998         False                           Track request IDs in RangeBlockComponentsRequest (#6998)
34   d323699fde01  7183         False                           Add missing `osaka-time` lcli param (#7183)
35   cbf1c04a1486  -            -                               [NO PR MATCH]: resolve merge conflicts between untstable and release-v7.0.0
36   2f37bf4de5e3  -            -                               [NO PR MATCH]: Fix more merge conflicts between unstable and release-v7.0.0
37   3f6c11db0eb6  6995         False                           Some updates to Lighthouse book (#6995)
38   9dce729cb6a0  7182         False                           Ensure sqlite and rusqlite are optional in `consensus/types` (#7182)
39   6f31d4434308  7033         False                           Remove CGC from data_availability checker (#7033)
40   ca8eaea11677  7169         True                            Remove `crit` as an option from the CLI entirely (#7169)
41   bde0f1ef0b29  -            -                               [NO PR MATCH]: Merge remote-tracking branch 'origin/release-v7.0.0' into unstable
42   fb7ec0d151d4  7112         False                           Change `genesis-state-url-timeout` (#7112)
43   4839ed620fa9  7168         False                           Tracing cleanup (#7168)
44   578db67755cb  -            -                               [NO PR MATCH]: Merge remote-tracking branch 'origin/release-v7.0.0' into backmerge-apr-2
45   80626e58d224  7244         False                           Attempt to fix flaky network tests (#7244)
46   d6cd049a453b  7238         False                           RPC RequestId Cleanup (#7238)
47   0e6da0fcafe2  -            -                               [NO PR MATCH]: Merge branch 'release-v7.0.0' into v7-backmerge
48   57abffcd997f  7240         False                           Disable log color when running in non-interactive mode (#7240)
49   6a75f24ab13e  7188         False                           Fix the `getBlobs` metric and ensure it is recorded promptly to prevent miscounts (#7188)
50   7cc64cab8352  6990         False                           Add missing error log and remove redundant id field from lookup logs (#6990)
51   591fb7df141d  -            -                               [NO PR MATCH]: Merge branch 'release-v7.0.0' into backmerge-for-openssl
52   e77fb01a063c  7265         False                           Remove CLI conflict for secrets-dir and datadir (#7265)
53   b5d40e3db06d  7256         False                           Align logs (#7256)
54   70850fe58d56  6744         True                            Drop head tracker for summaries DAG (#6744)
55   47a85cd1186d  7269         False                           Bump version to v7.1.0-beta.0 (not a release) (#7269)
56   e924264e17b8  7258         False                           Fullnodes to publish data columns from EL `getBlobs` (#7258)
57   759b0612b37f  7117         False                           Offloading KZG Proof Computation from the beacon node (#7117)
58   d96b73152e0e  7192         False                           Fix for #6296: Deterministic RNG in peer DAS publish block tests (#7192)
59   39eb8145f89e  -            -                               [NO PR MATCH]: Merge branch 'release-v7.0.0' into unstable
60   70f8ab9a6fc2  7309         False                           Add riscv64 build support (#7309)
61   be68dd24d05f  7281         False                           Fix wrong custody column count for lookup blocks (#7281)
62   08882c64cae5  6996         False                           Fix execution engine integration tests with latest geth version (#6996)
63   476f3a593c20  7161         False                           Add `MAX_BLOBS_PER_BLOCK_FULU` config (#7161)
64   c32569ab83bb  7225         False                           Restore HTTP API logging and add more metrics (#7225)
65   410af7c5f5dc  7279         False                           feat: update mainnet bootnodes (#7279)
66   80fe133d2c4c  7280         False                           Update Lighthouse Book for Electra features (#7280)
67   9f4b0cdc2855  7343         False                           Fix Kurtosis doppelganger CI (#7343)
68   e61e92b926d5  -            -                               [NO PR MATCH]: Merge remote-tracking branch 'origin/stable' into unstable
69   5527125f5e13  7340         False                           Fix GitHub releases page looks bad in GitHub dark theme (#7340)
70   c13e069c9c63  7324         False                           Revise logging when `queue is full` (#7324)
71   1dd37048b9d1  7346         False                           Enable cross-compiling for riscv64 architecture (#7346)
72   402a81cdd78e  7350         False                           Fix Kurtosis testnet (#7350)
73   1324d3d3c4c2  5923         False                           Delayed RPC Send Using Tokens (#5923)
74   6fad18644bbe  6747         False                           feat: presign for validator account (#6747)
75   2e2b0d2176e0  7351         False                           Revise consolidation info in Lighthouse book (#7351)
76   63a10eaaea62  6956         True                            Changing `boot_enr.yaml` to expect `bootstap_nodes.yaml` for pectra devnet  (#6956)
77   34a6c3a93029  6897         True                            vc: increase default gas limit (#6897)
78   94ccd7608ea8  6653         False                           Add documentation for VC API `/lighthouse/beacon/health` (#6653)
79   9779b4ba2c04  7326         False                           Optimize `validate_data_columns` (#7326)
80   93ec9df13760  7304         False                           Compute proposer shuffling only once in gossip verification (#7304)
81   2aa5d5c25e22  7359         False                           Make sure to log SyncingChain ID (#7359)
82   c8224c8d5e19  7387         False                           docs: fix broken link to voluntary exit guide (#7387)
83   43c38a6fa0cc  7378         False                           Change slog to tracing in comments (#7378)
84   beb0ce68bdf6  6922         False                           Make range sync peer loadbalancing PeerDAS-friendly (#6922)
85   3d92e3663b74  6705         False                           Modularize validator store (#6705)
86   058dae064184  7405         False                           Add requires --http when using vc subcommands --http-port (#7405)
87   0f13029c7d51  7409         False                           Don't publish data columns reconstructed from RPC columns to the gossip network (#7409)
88   8dc3d23af083  7400         False                           Add a default timeout to all `BeaconNodeHttpClient` requests (#7400)
89   e90fcbe6577c  7416         False                           Add ARM binary for macOS in release (#7416)
90   4b9c16fc7175  7199         False                           Add Electra forks to basic sim tests (#7199)
91   a497ec601cae  6975         False                           Retry custody requests after peer metadata updates (#6975)
92   e0c1f27e1303  7394         False                           simulator: Persist beacon logs (#7394)
93   92391cdac665  7284         False                           update gossipsub to the latest upstream revision (#7284)
94   593390162f47  7399         False                           `peerdas-devnet-7`: update `DataColumnSidecarsByRoot` request to use `DataColumnsByRootIdentifier` (#7399)
95   5b25a48af34b  7404         False                           Siren installation improvement (#7404)
96   e051c7ca89c8  7396         False                           Siren Pectra Feature Updates (#7396)
97   0a917989b218  7370         False                           impl test random for some types (#7370)
98   807848bc7ac4  7443         False                           Next sync committee branch bug (#7443)
99   851ee2bcedfc  7454         False                           Extract get_domain for VoluntaryExit (#7454)
100  c2c7fb87a862  7460         False                           Make DAG construction more permissive (#7460)
101  b1138c28fb94  7451         False                           Add additional mergify rules to automate triaging (#7451)
102  cc6ae9d3f09c  7463         False                           Fix mergify infinite loop. (#7463)
103  1853d836b7e4  7458         False                           Added E::slots_per_epoch() to deneb time calculation (#7458)
104  c4182e362b8f  7433         False                           simulator: Write dependency logs to separate files (#7433)
105  e0ee148d6aca  7470         False                           Prevent mergify from updating labels while CI is still running. (#7470)
106  e21198c08baa  7472         False                           One more attempt to fix mergify condition. (#7472)
107  268809a53069  7471         False                           Rust clippy 1.87 lint fixes (#7471)
108  b051a5d6cc7b  7469         False                           Delete `at-most` in `lighthouse vm create` (#7469)
109  1d27855db7be  7369         False                           impl from hash256 for `ExecutionBlockHash` (#7369)
110  23ad833747b6  7417         False                           Change default EngineState to online (#7417)
111  fcfcbf9a11b3  7481         False                           Update mdlint to disable descriptive-link-text (#7481)
112  7684d1f866ab  7372         False                           ContextDeserialize and Beacon API Improvements (#7372)
113  5393d33af823  7411         False                           Silence `Uninitialized` warn log on start-up (#7411)
114  1e6cdeb88a6a  6799         False                           feat: Add docker reproducible builds (#6799)
115  50dbfdf61243  7455         False                           Some updates to Lighthouse book (#7455)
116  af87135e3020  7484         False                           Move MD059 rule to configuration file (#7484)
117  805c2dc831e6  5047         False                           Correct reward denominator in op pool (#5047)
118  7e2df6b602a1  7474         False                           Empty list `[]` to return all validators balances (#7474)
119  f06d1d034615  7495         False                           Fix blob download from checkpointz servers (#7495)
120  0688932de28d  7497         False                           Pass blobs into `ValidatorStore::sign_block` (#7497)
121  e29b607257d8  7427         False                           Move notifier and latency service to `validator_services` (#7427)
122  7759cb8f91c0  7494         False                           Update mergify rule to not evaluate PRs that are not ready for review - to reduce noise and avoid updating stale PRs. (#7494)
123  2e96e9769b99  7507         False                           Use slice.is_sorted now that it's stable (#7507)
124  a8035d7395ea  7506         False                           Enable stdout logging in rpc_tests (#7506)
125  817f14c3491a  7500         False                           Send execution_requests in fulu (#7500)
126  537fc5bde860  7459         False                           Revive network-test logs files in CI (#7459)
127  cf0f95985540  7180         False                           Improve log readability during rpc_tests (#7180)
128  ce8d0814ad71  7246         False                           Ensure logfile permissions are maintained after rotation (#7246)
129  6af8c187e0b7  7052         False                           Publish EL Info in Metrics (#7052)
130  a2797d4bbde9  7512         False                           Fix formatting errors from cargo-sort (#7512)
131  f01dc556d157  7505         False                           Update `engine_getBlobsV2` response type and add `getBlobsV2` tests (#7505)
132  e6ef644db4e8  7493         False                           Verify `getBlobsV2` response and avoid reprocessing imported data columns (#7493)
133  7c89b970afe2  7382         False                           Handle attestation validation errors (#7382)
134  8dde5bdb4413  -            -                               [NO PR MATCH]: Update mergify rules so that I can add `waiting-on-author` on a PR that's passing CI. Remove noisy comments.
135  8989ef8fb11e  7025         False                           Enable arithmetic lint in rate-limiter (#7025)
136  b7fc03437bba  -            -                               [NO PR MATCH]: Fix condition
137  9e9c51be6fef  -            -                               [NO PR MATCH]: Remove redundant `and`
138  999b04517e35  -            -                               [NO PR MATCH]: Merge pull request #7525 from jimmygchen/mergify-again
139  0ddf9a99d64a  7332         False                           Remove support for database migrations prior to schema version v22 (#7332)
140  5cda6a6f9e4b  7522         False                           Mitigate flakiness in test_delayed_rpc_response (#7522)
141  4d21846aba6b  7533         False                           Prevent `AvailabilityCheckError` when there's no new custody columns to import (#7533)
142  39744df93f0b  7393         False                           simulator: Fix `Failed to initialize dependency logging` (#7393)
143  38a5f338fad7  7529         False                           Add `console-subscriber` feature for debugging (#7529)
144  886ceb7e25e0  6882         False                           Run Assertoor tests in CI (#6882)
145  94a1446ac955  7541         False                           Fix unexpected blob error and duplicate import in fetch blobs (#7541)
146  ae30480926b6  7521         False                           Implement EIP-7892 BPO hardforks (#7521)
147  f67068e1ec53  7518         False                           Update `staking-deposit-cli` to `ethstaker-deposit-cli` (#7518)
148  cd83d8d95ddd  7544         False                           Add a name to the Tokio task (#7544)
149  357a8ccbb996  7549         False                           Checkpoint sync without the blobs from Fulu (#7549)
150  2d9fc34d4326  7540         False                           Fulu EF tests v1.6.0-alpha.0 (#7540)
151  dcee76c0dc88  7548         False                           Update key generation in validator manager (#7548)
152  9a4972053eb5  7530         False                           Add e2e sync tests to CI (#7530)
153  d457ceeaafae  7118         False                           Don't create child lookup if parent is faulty (#7118)
154  2f807e21bede  7538         False                           Add support for nightly tests (#7538)
155  e098f667380c  7570         False                           Update kurtosis config and EL images (#7570)
156  b2e8b67e3446  7566         False                           Reduce number of basic sim test nodes from 7 to 4 (#7566)
157  170cd0f5875d  7579         False                           Store the libp2p/discv5 logs when stopping local-testnet (#7579)
158  b08d49c4cb34  7559         False                           Changes for `fusaka-devnet-1` (#7559)
159  8c6abc0b69b7  7574         False                           Optimise parallelism in compute cells operations by zipping first (#7574)
160  7416d06dce8e  7561         False                           Add genesis sync test to CI (#7561)
161  076a1c3faead  7587         False                           Data column sidecar event (#7587)
162  5f208bb85829  7578         True                            Implement basic validator custody framework (no backfill) (#7578)
163  9803d69d8045  7590         False                           Implement status v2 version (#7590)
164  5472cb85008b  7582         False                           Batch verify KZG proofs for getBlobsV2 (#7582)
165  a65f78222d69  7594         False                           Drop stale registrations without reducing CGC (#7594)
166  ccd99c138c27  7588         False                           Wait before column reconstruction (#7588)
167  dc5f5af3eb53  7595         False                           Fix flaky test_rpc_block_reprocessing (#7595)
168  4fc0665ccdd6  7592         False                           Add more context to Late Block Re-orgs (#7592)
169  6135f417a2f4  7591         False                           Add data columns sidecars debug beacon API (#7591)
170  3d2d65bf8d24  7593         False                           Advertise `--advertise-false-custody-group-count` for testing PeerDAS (#7593)
171  6786b9d12a6d  7444         True                            Single attestation "Full" implementation (#7444)
172  dd985341581f  6750         True                            Hierarchical state diffs in hot DB (#6750)
173  f67084a571d1  7437         False                           Remove reprocess channel (#7437)
174  d50924677a34  7620         False                           Remove instrumenting log level (#7620)
175  11bcccb353c0  7133         True                            Remove all prod eth1 related code (#7133)
176  e34a9a0c65d5  6551         False                           Allow the `--beacon-nodes` list to be updated at runtime (#6551)
177  3fefda68e5c1  7611         False                           Send byrange responses in the correct requested range (#7611)
178  cef04ee2ee48  7462         False                           Implement `validator_identities` Beacon API endpoint (#7462)
179  fd643c310c4e  7632         False                           Un-ignore EF test for v1.6.0-alpha.1 (#7632)
180  56b2d4b5253b  7636         False                           Remove instrumenting log level  (#7636)
181  8e3c5d152413  7644         False                           Rust 1.89 compiler lint fix (#7644)
182  a0a6b9300f11  7551         False                           Do not compute sync selection proofs for the sync duty at the current slot (#7551)
183  9b1f3ed9d1a4  7652         False                           Add gossip check (#7652)
184  83cad25d9880  7657         False                           Fix Rust 1.88 clippy errors & execution engine tests (#7657)
185  522e00f48df7  7656         False                           Fix incorrect `waker` update condition (#7656)
186  6ea5f14b3988  7597         False                           feat: better error message for light_client/bootstrap endpoint (#7597)
187  2d759f78be6c  6576         False                           Fix beacon_chain metrics descriptions (#6576)
188  6be646ca1153  7666         True                            Bump DB schema to v25 (#7666)
189  e45ba846aef5  7673         False                           Increase http client default timeout to 2s in `http-api` tests. (#7673)
190  25ea8a83b77b  7667         False                           Add Michael as codeowner for store crate (#7667)
191  c1f94d9b7bf8  7669         False                           Test database schema stability (#7669)
192  257d2707182c  6612         False                           Add voluntary exit via validator manager (#6612)
193  e305cb1b921f  7661         True                            Custody persist fix (#7661)
194  41742ce2bde9  7683         False                           Update `SAMPLES_PER_SLOT` to be number of custody groups instead of data columns (#7683)
195  69c9c7038af7  7681         False                           Use prepare_beacon_proposer endpoint for validator custody registration (#7681)
196  fcc602a7872a  7646         False                           Update fulu network configs and add `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` (#7646)
197  a459a9af98c9  7689         False                           Fix and test checkpoint sync from genesis (#7689)
198  b35854b71f04  7692         False                           Record v2 beacon blocks http api metrics separately (#7692)
199  c7bb3b00e409  7693         False                           Fix lookups of the block at `oldest_block_slot` (#7693)
200  0f895f3066a3  7695         False                           Bump default gas limit (#7695)
201  56485cc9865a  7707         False                           Remove unneeded spans that caused debug logs to appear when level is set to `info` (#7707)
202  bd8a2a8ffbaa  7023         False                           Gossip recently computed light client data (#7023)
203  7b2f138ca7e7  -            -                               [NO PR MATCH]: Merge remote-tracking branch 'origin/stable' into release-v7.1.0
204  8e55684b066f  7723         False                           Reintroduce `--logfile` with deprecation warning (#7723)
205  8b5ccacac9c0  7663         False                           Error from RPC `send_response` when request doesn't exist on the active inbound requests (#7663)
206  cfb1f7331064  7609         False                           Release v7.1.0 (#7609)
```