### PR TITLE
perf: optimize regex compilation in validator keystore detection

### DIFF
--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -16,6 +16,9 @@ use types::{graffiti::GraffitiString, Address, PublicKey};
 use validator_dir::VOTING_KEYSTORE_FILE;
 use zeroize::Zeroizing;
 
+// Add LazyLock import
+use std::sync::LazyLock;
+
 /// The file name for the serialized `ValidatorDefinitions` struct.
 pub const CONFIG_FILENAME: &str = "validator_definitions.yml";
 
@@ -440,6 +443,14 @@ pub fn recursively_find_voting_keystores<P: AsRef<Path>>(
 
 /// Returns `true` if we should consider the `file_name` to represent a voting keystore.
 pub fn is_voting_keystore(file_name: &str) -> bool {
+    // Static compiled regular expressions
+    static LIGHTHOUSE_KEYSTORE_REGEX: LazyLock<Regex> = LazyLock::new(|| 
+        Regex::new("keystore-m_12381_3600_[0-9]+_0_0-[0-9]+.json").expect("regex is valid")
+    );
+    static PRYSM_KEYSTORE_REGEX: LazyLock<Regex> = LazyLock::new(|| 
+        Regex::new("keystore-[0-9]+.json").expect("regex is valid")
+    );
+
     // All formats end with `.json`.
     if !file_name.ends_with(".json") {
         return false;
@@ -462,19 +473,13 @@ pub fn is_voting_keystore(file_name: &str) -> bool {
     // Key derivation path reference:
     //
     // https://eips.ethereum.org/EIPS/eip-2334
-    if Regex::new("keystore-m_12381_3600_[0-9]+_0_0-[0-9]+.json")
-        .expect("regex is valid")
-        .is_match(file_name)
-    {
+    if LIGHTHOUSE_KEYSTORE_REGEX.is_match(file_name) {
         return true;
     }
 
     // The format exported by Prysm. I don't have a reference for this, but it was shared via
     // Discord to Paul H.
-    if Regex::new("keystore-[0-9]+.json")
-        .expect("regex is valid")
-        .is_match(file_name)
-    {
+    if PRYSM_KEYSTORE_REGEX.is_match(file_name) {
         return true;
     }
 


### PR DESCRIPTION
## Proposed Changes

- Replace repeated regex compilation in `is_voting_keystore` function with static LazyLock instances
- Add LazyLock import from std::sync
- Maintain identical functionality while improving performance

## Additional Info

This optimization is particularly important for validators managing many keystores, as the function is called repeatedly when scanning validator directories. Regex compilation is an expensive operation, and this change ensures it happens only once (on first use) rather than on every function call.

The change follows Rust best practices for handling expensive operations that can be cached and reused.