### PR TITLE
Fix enr loading from disk with cgc

### DIFF
--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -1235,6 +1235,7 @@ mod tests {
             &enr_key,
             &config,
             &EnrForkId::default(),
+            None,
             next_fork_digest,
             &spec,
         )

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -197,18 +197,21 @@ impl<E: EthSpec> Network<E> {
             .fork_context
             .next_fork_digest()
             .unwrap_or_else(|| ctx.fork_context.current_fork_digest());
+
+        let advertised_cgc = config
+            .advertise_false_custody_group_count
+            .unwrap_or(custody_group_count);
         let enr = crate::discovery::enr::build_or_load_enr::<E>(
             local_keypair.clone(),
             &config,
             &ctx.enr_fork_id,
+            Some(advertised_cgc),
             next_fork_digest,
             &ctx.chain_spec,
         )?;
 
         // Construct the metadata
-        let advertised_cgc = config
-            .advertise_false_custody_group_count
-            .unwrap_or(custody_group_count);
+
         let meta_data = utils::load_or_build_metadata(&config.network_dir, advertised_cgc);
         let seq_number = *meta_data.seq_number();
         let globals = NetworkGlobals::new(

--- a/lcli/src/generate_bootnode_enr.rs
+++ b/lcli/src/generate_bootnode_enr.rs
@@ -38,8 +38,15 @@ pub fn run<E: EthSpec>(matches: &ArgMatches, spec: &ChainSpec) -> Result<(), Str
         next_fork_version: genesis_fork_version,
         next_fork_epoch: Epoch::max_value(), // FAR_FUTURE_EPOCH
     };
-    let enr = build_enr::<E>(&enr_key, &config, &enr_fork_id, genesis_fork_digest, spec)
-        .map_err(|e| format!("Unable to create ENR: {:?}", e))?;
+    let enr = build_enr::<E>(
+        &enr_key,
+        &config,
+        &enr_fork_id,
+        None,
+        genesis_fork_digest,
+        spec,
+    )
+    .map_err(|e| format!("Unable to create ENR: {:?}", e))?;
 
     fs::create_dir_all(&output_dir).map_err(|e| format!("Unable to create output-dir: {:?}", e))?;
 


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

During building an enr on startup, we weren't using the value in the custody context. 
This was resulting in the enr value getting updated when the cgc updates, the change getting persisted, but getting set back to the default on restart.
This PR takes the value explicitly from the custody context.