### PR TITLE
fix: allow BLOB_SCHEDULE: [] field

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1744,7 +1744,6 @@ pub struct Config {
     #[serde(with = "serde_utils::quoted_u64")]
     custody_requirement: u64,
     #[serde(default = "BlobSchedule::default")]
-    #[serde(skip_serializing_if = "BlobSchedule::is_empty")]
     blob_schedule: BlobSchedule,
     #[serde(default = "default_validator_custody_requirement")]
     #[serde(with = "serde_utils::quoted_u64")]

--- a/consensus/types/src/config_and_preset.rs
+++ b/consensus/types/src/config_and_preset.rs
@@ -106,8 +106,7 @@ pub fn get_extra_fields(spec: &ChainSpec) -> HashMap<String, Value> {
     let hex_string = |value: &[u8]| format!("0x{}", hex::encode(value)).into();
     let u32_hex = |v: u32| hex_string(&v.to_le_bytes());
     let u8_hex = |v: u8| hex_string(&v.to_le_bytes());
-    
-    let mut fields = hashmap! {
+    hashmap! {
         "bls_withdrawal_prefix".to_uppercase() => u8_hex(spec.bls_withdrawal_prefix_byte),
         "eth1_address_withdrawal_prefix".to_uppercase() => u8_hex(spec.eth1_address_withdrawal_prefix_byte),
         "domain_beacon_proposer".to_uppercase() => u32_hex(spec.domain_beacon_proposer),
@@ -135,16 +134,7 @@ pub fn get_extra_fields(spec: &ChainSpec) -> HashMap<String, Value> {
         "compounding_withdrawal_prefix".to_uppercase() => u8_hex(spec.compounding_withdrawal_prefix_byte),
         "unset_deposit_requests_start_index".to_uppercase() => spec.unset_deposit_requests_start_index.to_string().into(),
         "full_exit_request_amount".to_uppercase() => spec.full_exit_request_amount.to_string().into(),
-    };
-    
-    // Only include BLOB_SCHEDULE if FULU_FORK_EPOCH is not FAR_FUTURE_EPOCH
-    if spec.fulu_fork_epoch.is_some_and(|fulu_fork_epoch| fulu_fork_epoch != spec.far_future_epoch) {
-        if let Ok(blob_schedule_json) = serde_json::to_value(&spec.blob_schedule) {
-            fields.insert("BLOB_SCHEDULE".to_string(), blob_schedule_json);
-        }
     }
-    
-    fields
 }
 
 #[cfg(test)]

--- a/consensus/types/src/config_and_preset.rs
+++ b/consensus/types/src/config_and_preset.rs
@@ -106,7 +106,8 @@ pub fn get_extra_fields(spec: &ChainSpec) -> HashMap<String, Value> {
     let hex_string = |value: &[u8]| format!("0x{}", hex::encode(value)).into();
     let u32_hex = |v: u32| hex_string(&v.to_le_bytes());
     let u8_hex = |v: u8| hex_string(&v.to_le_bytes());
-    hashmap! {
+    
+    let mut fields = hashmap! {
         "bls_withdrawal_prefix".to_uppercase() => u8_hex(spec.bls_withdrawal_prefix_byte),
         "eth1_address_withdrawal_prefix".to_uppercase() => u8_hex(spec.eth1_address_withdrawal_prefix_byte),
         "domain_beacon_proposer".to_uppercase() => u32_hex(spec.domain_beacon_proposer),
@@ -134,7 +135,16 @@ pub fn get_extra_fields(spec: &ChainSpec) -> HashMap<String, Value> {
         "compounding_withdrawal_prefix".to_uppercase() => u8_hex(spec.compounding_withdrawal_prefix_byte),
         "unset_deposit_requests_start_index".to_uppercase() => spec.unset_deposit_requests_start_index.to_string().into(),
         "full_exit_request_amount".to_uppercase() => spec.full_exit_request_amount.to_string().into(),
+    };
+    
+    // Only include BLOB_SCHEDULE if FULU_FORK_EPOCH is not FAR_FUTURE_EPOCH
+    if spec.fulu_fork_epoch.is_some_and(|fulu_fork_epoch| fulu_fork_epoch != spec.far_future_epoch) {
+        if let Ok(blob_schedule_json) = serde_json::to_value(&spec.blob_schedule) {
+            fields.insert("BLOB_SCHEDULE".to_string(), blob_schedule_json);
+        }
     }
+    
+    fields
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Now empty blob schedules from config.yaml (like BLOB_SCHEDULE: []) will be preserved and included in the /eth/v1/config/spec beacon API endpoint response instead of being omitted.

## Issue Addressed

Which issue # does this PR address?

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
