### PR TITLE
fix: add exit on missing yq to prevent unclear script failures

### DIFF
--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -58,6 +58,7 @@ fi
 
 if ! command -v yq &> /dev/null; then
     echo "yq not found. Please install yq and try again."
+    exit 1
 fi
 
 if [ "$BUILDER_PROPOSALS" = true ]; then


### PR DESCRIPTION
Added an explicit exit 1 after checking for the presence of the yq utility in start_local_testnet.sh.
Previously, if yq was not installed, the script would continue and fail later with a less clear error message when attempting to use yq.
Now, if yq is missing, the script will immediately exit with a clear message to the user.
This change makes the script’s behavior more predictable and helps users quickly identify missing dependencies.