### PR TITLE
Add heaptrack support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,7 +289,7 @@ panic = "abort"
 codegen-units = 1
 overflow-checks = true
 
-[profile.heaptrack]
+[profile.release-debug]
 inherits = "release"
 debug = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,5 +289,9 @@ panic = "abort"
 codegen-units = 1
 overflow-checks = true
 
+[profile.heaptrack]
+inherits = "release"
+debug = true
+
 [patch.crates-io]
 quick-protobuf = { git = "https://github.com/sigp/quick-protobuf.git", rev = "681f413312404ab6e51f0b46f39b0075c6f4ebfd" }

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -73,11 +73,11 @@ unused_port = { workspace = true }
 validator_client = { workspace = true }
 validator_manager = { path = "../validator_manager" }
 
-[target.'cfg(not(any(target_os = "windows", features = "heaptrack")))'.dependencies]
-malloc_utils = { workspace = true, features = ["jemalloc"] }
-
 [target.'cfg(any(target_os = "windows", features = "heaptrack"))'.dependencies]
 malloc_utils = { workspace = true }
+
+[target.'cfg(not(any(target_os = "windows", features = "heaptrack")))'.dependencies]
+malloc_utils = { workspace = true, features = ["jemalloc"] }
 
 [dev-dependencies]
 beacon_node_fallback = { workspace = true }

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -35,8 +35,10 @@ beacon-node-leveldb = ["store/leveldb"]
 beacon-node-redb = ["store/redb"]
 # Supports console subscriber for debugging
 console-subscriber = ["console-subscriber/default"]
+# Turns off jemalloc so that heaptrack may be used to analyse memory usage.
+heaptrack = []
 
-# Deprecated. This is now enabled by default on non windows targets.
+# Deprecated. This is now enabled by default on non windows targets (unless heaptrack is enabled).
 jemalloc = []
 
 [dependencies]
@@ -71,10 +73,10 @@ unused_port = { workspace = true }
 validator_client = { workspace = true }
 validator_manager = { path = "../validator_manager" }
 
-[target.'cfg(not(target_os = "windows"))'.dependencies]
+[target.'cfg(not(any(target_os = "windows", features = "heaptrack")))'.dependencies]
 malloc_utils = { workspace = true, features = ["jemalloc"] }
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(any(target_os = "windows", features = "heaptrack"))'.dependencies]
 malloc_utils = { workspace = true }
 
 [dev-dependencies]

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -74,11 +74,11 @@ fn bls_hardware_acceleration() -> bool {
 }
 
 fn allocator_name() -> String {
-    #[cfg(target_os = "windows")]
+    #[cfg(any(feature = "heaptrack", target_os = "windows"))]
     {
         "system".to_string()
     }
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(any(feature = "heaptrack", target_os = "windows")))]
     match malloc_utils::jemalloc::page_size() {
         Ok(page_size) => format!("jemalloc ({}K)", page_size / 1024),
         Err(e) => format!("jemalloc (error: {e:?})"),


### PR DESCRIPTION
## Proposed Changes

Although we're working on jemalloc profiler support in https://github.com/sigp/lighthouse/pull/7746, heaptrack seems to be producing more sensible results.

This PR adds a heaptrack profile and a heaptrack feature so that we no longer need to patch the code in order to use heaptrack. This may prove complementary to jemalloc profiling, so I think there is no harm in having both.

## Additional Info

Usage:

```
FEATURES=heaptrack PROFILE=release-debug make
```

Then `heaptrack lighthouse ...` using the `lighthouse` binary that was just built.
