### PR TITLE
Fix leak in range sync `components_by_range_requests`

### DIFF
--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -80,7 +80,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
     /// request for some columns.
     pub fn reinsert_failed_column_requests(
         &mut self,
-        failed_column_requests: Vec<(DataColumnsByRangeRequestId, Vec<u64>)>,
+        failed_column_requests: Vec<(DataColumnsByRangeRequestId, Vec<ColumnIndex>)>,
     ) -> Result<(), String> {
         match &mut self.block_data_request {
             RangeBlockDataRequest::DataColumns {
@@ -195,6 +195,9 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                     spec,
                 );
 
+                // FIXME: If a peer provided _some_ useful columns but not all, do we end up
+                // removing the entire requests, including the useful columns? These columns won't
+                // be in the error and may not be retried?
                 if let Err(err) = &resp {
                     if let Some((peers, _)) = &err.column_and_peer {
                         for (_, peer) in peers.iter() {
@@ -300,6 +303,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                 .insert(index, column)
                 .is_some()
             {
+                // FIXME: we could probably ignore and continue? instead of failing the whole batch?
                 return Err(CouplingError {
                     msg: format!("Repeated column block_root {block_root:?} index {index}"),
                     column_and_peer: None,

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -677,6 +677,21 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         Ok(columns_to_request_by_peer)
     }
 
+    /// Remove the range request before attempting a retry.
+    pub(crate) fn remove_range_request_by_id(&mut self, id: Id) {
+        if let Some(request_id) = self
+            .components_by_range_requests
+            .keys()
+            .find(|r| r.id == id)
+        {
+            let request_id = ComponentsByRangeRequestId {
+                id,
+                requester: request_id.requester,
+            };
+            self.components_by_range_requests.remove(&request_id);
+        };
+    }
+
     /// Received a blocks by range or blobs by range response for a request that couples blocks '
     /// and blobs.
     pub fn range_block_component_response(
@@ -727,21 +742,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         }
 
         if let Some(blocks_result) = entry.get_mut().responses(&self.chain.spec) {
-            match blocks_result.as_ref() {
-                Ok(_) => {
-                    // remove the entry only if it coupled successfully with
-                    // no errors
-                    entry.remove();
-                }
-                Err(&CouplingError {
-                    msg: _,
-                    column_and_peer: None,
-                }) => {
-                    // remove the entry only if the coupling error has no columns specified, as the
-                    // entire batch will be retried
-                    entry.remove();
-                }
-                _ => {}
+            if blocks_result.is_ok() {
+                // remove the entry only if it coupled successfully with
+                // no errors
+                entry.remove();
             }
             // If the request is finished, dequeue everything
             Some(blocks_result.map_err(RpcResponseError::BlockComponentCouplingError))

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -727,10 +727,21 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         }
 
         if let Some(blocks_result) = entry.get_mut().responses(&self.chain.spec) {
-            if blocks_result.is_ok() {
-                // remove the entry only if it coupled successfully with
-                // no errors
-                entry.remove();
+            match blocks_result.as_ref() {
+                Ok(_) => {
+                    // remove the entry only if it coupled successfully with
+                    // no errors
+                    entry.remove();
+                }
+                Err(&CouplingError {
+                    msg: _,
+                    column_and_peer: None,
+                }) => {
+                    // remove the entry only if the coupling error has no columns specified, as the
+                    // entire batch will be retried
+                    entry.remove();
+                }
+                _ => {}
             }
             // If the request is finished, dequeue everything
             Some(blocks_result.map_err(RpcResponseError::BlockComponentCouplingError))

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -885,6 +885,8 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                     failing_batch: batch_id,
                 });
             }
+            // FIXME: hack to remove range request before a retry
+            network.remove_range_request_by_id(request_id);
             self.send_batch(network, batch_id)
         } else {
             debug!(


### PR DESCRIPTION
## Issue Addressed

When a data column range sync fails with coupling error returned below, if the coupling error does not contain a column and peer (i.e. `column_and_peer == None`)

https://github.com/sigp/lighthouse/blob/9181ff43f623481c7c4d154a4b6dcb0f833ef75c/beacon_node/network/src/sync/block_sidecar_coupling.rs#L286-L292

The entire batch gets retried, without the previous `context.components_by_range_requests` entry being removed, this result in unbounded memory usage increase as shown in the metric:

<img width="1889" height="583" alt="image" src="https://github.com/user-attachments/assets/f03b0405-9d77-4654-a70f-8297d2694a6b" />

Note: this PR is not tested and I'm not sure if the fix is good - but just wanted to illustrate the issue.