### PR TITLE
Bump Rust version to 1.88

### DIFF
--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -1,5 +1,5 @@
-# Define the Rust image as an argument with a default to x86_64 Rust 1.82 image based on Debian Bullseye
-ARG RUST_IMAGE="rust:1.82-bullseye@sha256:ac7fe7b0c9429313c0fe87d3a8993998d1fe2be9e3e91b5e2ec05d3a09d87128"
+# Define the Rust image as an argument with a default to x86_64 Rust 1.88 image based on Debian Bullseye
+ARG RUST_IMAGE="rust:1.88-bullseye@sha256:8e3c421122bf4cd3b2a866af41a4dd52d87ad9e315fd2cb5100e87a7187a9816"
 FROM ${RUST_IMAGE} AS builder
 
 # Install specific version of the build dependencies

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ build-lcli-riscv64:
 SOURCE_DATE := $(shell git log -1 --pretty=%ct)
 
 # Default image for x86_64
-RUST_IMAGE_AMD64 ?= rust:1.82-bullseye@sha256:ac7fe7b0c9429313c0fe87d3a8993998d1fe2be9e3e91b5e2ec05d3a09d87128
+RUST_IMAGE_AMD64 ?= rust:1.88-bullseye@sha256:8e3c421122bf4cd3b2a866af41a4dd52d87ad9e315fd2cb5100e87a7187a9816
 
 # Reproducible build for x86_64
 build-reproducible-x86_64:
@@ -101,7 +101,7 @@ build-reproducible-x86_64:
 		-t lighthouse:reproducible-amd64 .
 
 # Default image for arm64
-RUST_IMAGE_ARM64 ?= rust:1.82-bullseye@sha256:3c1b8b6487513ad4e753d008b960260f5bcc81bf110883460f6ed3cd72bf439b
+RUST_IMAGE_ARM64 ?= rust:1.88-bullseye@sha256:8b22455a7ce2adb1355067638284ee99d21cc516fab63a96c4514beaf370aa94
 
 # Reproducible build for aarch64
 build-reproducible-aarch64:

--- a/common/warp_utils/src/reject.rs
+++ b/common/warp_utils/src/reject.rs
@@ -237,15 +237,9 @@ pub async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, 
 pub async fn convert_rejection<T: Reply>(res: Result<T, warp::Rejection>) -> Response {
     match res {
         Ok(response) => response.into_response(),
-        Err(e) => match handle_rejection(e).await {
-            Ok(reply) => reply.into_response(),
-            // We can simplify this once Rust 1.82 is MSRV
-            #[allow(unreachable_patterns)]
-            Err(_) => warp::reply::with_status(
-                warp::reply::json(&"unhandled error"),
-                eth2::StatusCode::INTERNAL_SERVER_ERROR,
-            )
-            .into_response(),
-        },
+        Err(e) => {
+            let Ok(reply) = handle_rejection(e).await;
+            reply.into_response()
+        }
     }
 }

--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -1,7 +1,7 @@
 # `lcli` requires the full project to be in scope, so this should be built either:
 #  - from the `lighthouse` dir with the command: `docker build -f ./lcli/Dockerflie .`
 #  - from the current directory with the command: `docker build -f ./Dockerfile ../`
-FROM rust:1.84.0-bullseye AS builder
+FROM rust:1.88.0-bullseye AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
 COPY . lighthouse
 ARG FEATURES

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -4,7 +4,7 @@ version = "7.1.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 autotests = false
-rust-version = "1.87.0"
+rust-version = "1.88.0"
 
 # Prevent cargo-udeps from flagging the dummy package `target_check`, which exists only
 # to assert properties of the compilation target.


### PR DESCRIPTION
## Issue Addressed

In #7743, rust version was bumped:
- msrv to 1.87
- `Dockerfile` to 1.88

We also need to bump the other docker images as well, and might as well keep them all consistent at 1.88.
