### PR TITLE
#3108 - set process_cpu_seconds_total to type counter

### DIFF
--- a/common/health_metrics/src/metrics.rs
+++ b/common/health_metrics/src/metrics.rs
@@ -27,8 +27,8 @@ pub static PROCESS_SHR_MEM: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
         "Shared memory used by the current process",
     )
 });
-pub static PROCESS_SECONDS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
-    try_create_int_gauge(
+pub static PROCESS_SECONDS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
         "process_cpu_seconds_total",
         "Total cpu time taken by the current process",
     )
@@ -135,8 +135,12 @@ pub fn scrape_process_health_metrics() {
         set_gauge(&PROCESS_RES_MEM, health.pid_mem_resident_set_size as i64);
         set_gauge(&PROCESS_VIRT_MEM, health.pid_mem_virtual_memory_size as i64);
         set_gauge(&PROCESS_SHR_MEM, health.pid_mem_shared_memory_size as i64);
-        set_gauge(&PROCESS_SECONDS, health.pid_process_seconds_total as i64);
-    }
+        
+        if let Ok(counter) = &*PROCESS_SECONDS {
+            let new_val = health.pid_process_seconds_total as u64;
+            counter.reset();
+            counter.inc_by(new_val);
+        }
 }
 
 pub fn scrape_system_health_metrics() {


### PR DESCRIPTION
## Issue Addressed

Closes #3108

## Proposed Changes

Changed the Prometheus metric process_cpu_seconds_total from a gauge to a counter.
