### PR TITLE
Fix `http-api` tests not getting run on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ test-beacon-chain-%:
 test-http-api: $(patsubst %,test-http-api-%,$(RECENT_FORKS))
 
 test-http-api-%:
-	env FORK_NAME=$* cargo nextest run --release --features "beacon_chain/fork_from_env,$(TEST_FEATURES)" -p http_api
+	env FORK_NAME=$* cargo nextest run --release --features "beacon_chain/fork_from_env" -p http_api
 
 
 # Run the tests in the `operation_pool` crate for all known forks.

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ test-beacon-chain: $(patsubst %,test-beacon-chain-%,$(FORKS))
 test-beacon-chain-%:
 	env FORK_NAME=$* cargo nextest run --release --features "fork_from_env,slasher/lmdb,$(TEST_FEATURES)" -p beacon_chain
 
-# Run the tests in the `http_api` crate for all known forks.
+# Run the tests in the `http_api` crate for recent forks.
 test-http-api: $(patsubst %,test-http-api-%,$(RECENT_FORKS))
 
 test-http-api-%:

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ test-beacon-chain-%:
 test-http-api: $(patsubst %,test-http-api-%,$(RECENT_FORKS))
 
 test-http-api-%:
-	env FORK_NAME=$* cargo nextest run --release --features "fork_from_env,slasher/lmdb,$(TEST_FEATURES)" -p http_api
+	env FORK_NAME=$* cargo nextest run --release --features "beacon_chain/fork_from_env,$(TEST_FEATURES)" -p http_api
 
 
 # Run the tests in the `operation_pool` crate for all known forks.

--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,8 @@ test-beacon-chain: $(patsubst %,test-beacon-chain-%,$(FORKS))
 test-beacon-chain-%:
 	env FORK_NAME=$* cargo nextest run --release --features "fork_from_env,slasher/lmdb,$(TEST_FEATURES)" -p beacon_chain
 
-# Run the tests in the `beacon_chain` crate for all known forks.
-test-http-api: $(patsubst %,test-beacon-chain-%,$(RECENT_FORKS))
+# Run the tests in the `http_api` crate for all known forks.
+test-http-api: $(patsubst %,test-http-api-%,$(RECENT_FORKS))
 
 test-http-api-%:
 	env FORK_NAME=$* cargo nextest run --release --features "fork_from_env,slasher/lmdb,$(TEST_FEATURES)" -p http_api

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -96,7 +96,7 @@ pub enum GossipBlobError {
     /// ## Peer scoring
     ///
     /// We cannot process the blob without validating its parent, the peer isn't necessarily faulty.
-    BlobParentUnknown { parent_root: Hash256 },
+    ParentUnknown { parent_root: Hash256 },
 
     /// Invalid kzg commitment inclusion proof
     /// ## Peer scoring
@@ -473,7 +473,7 @@ pub fn validate_blob_sidecar_for_gossip<T: BeaconChainTypes, O: ObservationStrat
     // We have already verified that the blob is past finalization, so we can
     // just check fork choice for the block's parent.
     let Some(parent_block) = fork_choice.get_block(&block_parent_root) else {
-        return Err(GossipBlobError::BlobParentUnknown {
+        return Err(GossipBlobError::ParentUnknown {
             parent_root: block_parent_root,
         });
     };

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -906,8 +906,62 @@ where
         state: BeaconState<E>,
         slot: Slot,
     ) -> (SignedBlindedBeaconBlock<E>, BeaconState<E>) {
-        let (unblinded, new_state) = self.make_block(state, slot).await;
-        ((*unblinded.0).clone().into(), new_state)
+        self.make_blinded_block_with_modifier(state, slot, |_| {})
+            .await
+    }
+
+    pub async fn make_blinded_block_with_modifier(
+        &self,
+        mut state: BeaconState<E>,
+        slot: Slot,
+        block_modifier: impl FnOnce(&mut BlindedBeaconBlock<E>),
+    ) -> (SignedBlindedBeaconBlock<E>, BeaconState<E>) {
+        assert_ne!(slot, 0, "can't produce a block at slot 0");
+        assert!(slot >= state.slot());
+
+        complete_state_advance(&mut state, None, slot, &self.spec)
+            .expect("should be able to advance state to slot");
+
+        state.build_caches(&self.spec).expect("should build caches");
+
+        let proposer_index = state.get_beacon_proposer_index(slot, &self.spec).unwrap();
+
+        // If we produce two blocks for the same slot, they hash up to the same value and
+        // BeaconChain errors out with `DuplicateFullyImported`.  Vary the graffiti so that we produce
+        // different blocks each time.
+        let graffiti = Graffiti::from(self.rng.lock().gen::<[u8; 32]>());
+
+        let randao_reveal = self.sign_randao_reveal(&state, proposer_index, slot);
+
+        let BeaconBlockResponseWrapper::Blinded(block_response) = self
+            .chain
+            .produce_block_on_state(
+                state,
+                None,
+                slot,
+                randao_reveal,
+                Some(graffiti),
+                ProduceBlockVerification::VerifyRandao,
+                None,
+                BlockProductionVersion::BlindedV2,
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("Should always be a blinded payload response");
+        };
+
+        let mut block = block_response.block;
+        block_modifier(&mut block);
+
+        let signed_block = block.sign(
+            &self.validator_keypairs[proposer_index].sk,
+            &block_response.state.fork(),
+            block_response.state.genesis_validators_root(),
+            &self.spec,
+        );
+
+        (signed_block, block_response.state)
     }
 
     /// Returns a newly created block, signed by the proposer for the given slot.

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -713,6 +713,8 @@ where
     pub fn set_mock_builder(
         &mut self,
         beacon_url: SensitiveUrl,
+        strict_registrations: bool,
+        apply_operations: bool,
     ) -> impl futures::Future<Output = ()> {
         let mock_el = self
             .mock_execution_layer
@@ -725,6 +727,8 @@ where
         let (mock_builder, (addr, mock_builder_server)) = MockBuilder::new_for_testing(
             mock_el_url,
             beacon_url,
+            strict_registrations,
+            apply_operations,
             self.spec.clone(),
             self.runtime.task_executor.clone(),
         );

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -715,6 +715,7 @@ where
         beacon_url: SensitiveUrl,
         strict_registrations: bool,
         apply_operations: bool,
+        broadcast_to_bn: bool,
     ) -> impl futures::Future<Output = ()> {
         let mock_el = self
             .mock_execution_layer
@@ -729,6 +730,7 @@ where
             beacon_url,
             strict_registrations,
             apply_operations,
+            broadcast_to_bn,
             self.spec.clone(),
             self.runtime.task_executor.clone(),
         );
@@ -937,6 +939,9 @@ where
 
         let randao_reveal = self.sign_randao_reveal(&state, proposer_index, slot);
 
+        // Always use the builder, so that we produce a "real" blinded payload.
+        let builder_boost_factor = Some(u64::MAX);
+
         let BeaconBlockResponseWrapper::Blinded(block_response) = self
             .chain
             .produce_block_on_state(
@@ -946,8 +951,8 @@ where
                 randao_reveal,
                 Some(graffiti),
                 ProduceBlockVerification::VerifyRandao,
-                None,
-                BlockProductionVersion::BlindedV2,
+                builder_boost_factor,
+                BlockProductionVersion::V3,
             )
             .await
             .unwrap()

--- a/beacon_node/builder_client/src/lib.rs
+++ b/beacon_node/builder_client/src/lib.rs
@@ -7,7 +7,7 @@ use eth2::types::{
 use eth2::types::{FullPayloadContents, SignedBlindedBeaconBlock};
 pub use eth2::Error;
 use eth2::{
-    ok_or_error, StatusCode, CONSENSUS_VERSION_HEADER, CONTENT_TYPE_HEADER,
+    ok_or_error, success_or_error, StatusCode, CONSENSUS_VERSION_HEADER, CONTENT_TYPE_HEADER,
     JSON_CONTENT_TYPE_HEADER, SSZ_CONTENT_TYPE_HEADER,
 };
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT};
@@ -249,7 +249,7 @@ impl BuilderHttpClient {
             .send()
             .await
             .map_err(Error::from)?;
-        ok_or_error(response).await
+        success_or_error(response).await
     }
 
     async fn post_with_raw_response<T: Serialize, U: IntoUrl>(
@@ -270,7 +270,7 @@ impl BuilderHttpClient {
             .send()
             .await
             .map_err(Error::from)?;
-        ok_or_error(response).await
+        success_or_error(response).await
     }
 
     /// `POST /eth/v1/builder/validators`

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2020,7 +2020,9 @@ impl<E: EthSpec> ExecutionLayer<E> {
                         relay_response_ms = duration.as_millis(),
                         ?block_root,
                         "Successfully submitted blinded block to the builder"
-                    )
+                    );
+
+                    Ok(())
                 }
                 Err(e) => {
                     metrics::inc_counter_vec(
@@ -2033,11 +2035,10 @@ impl<E: EthSpec> ExecutionLayer<E> {
                         relay_response_ms = duration.as_millis(),
                         ?block_root,
                         "Failed to submit blinded block to the builder"
-                    )
+                    );
+                    Err(e)
                 }
             }
-
-            Ok(())
         } else {
             Err(Error::NoPayloadBuilder)
         }

--- a/beacon_node/execution_layer/src/payload_cache.rs
+++ b/beacon_node/execution_layer/src/payload_cache.rs
@@ -2,6 +2,7 @@ use eth2::types::FullPayloadContents;
 use lru::LruCache;
 use parking_lot::Mutex;
 use std::num::NonZeroUsize;
+use tracing::info;
 use tree_hash::TreeHash;
 use types::non_zero_usize::new_non_zero_usize;
 use types::{EthSpec, Hash256};
@@ -27,6 +28,7 @@ impl<E: EthSpec> Default for PayloadCache<E> {
 impl<E: EthSpec> PayloadCache<E> {
     pub fn put(&self, payload: FullPayloadContents<E>) -> Option<FullPayloadContents<E>> {
         let root = payload.payload_ref().tree_hash_root();
+        info!(?root, block_hash = ?payload.payload_ref().block_hash(), parent_block_hash = ?payload.payload_ref().parent_hash(), "Caching payload");
         self.payloads.lock().put(PayloadCacheId(root), payload)
     }
 

--- a/beacon_node/execution_layer/src/payload_cache.rs
+++ b/beacon_node/execution_layer/src/payload_cache.rs
@@ -2,7 +2,6 @@ use eth2::types::FullPayloadContents;
 use lru::LruCache;
 use parking_lot::Mutex;
 use std::num::NonZeroUsize;
-use tracing::info;
 use tree_hash::TreeHash;
 use types::non_zero_usize::new_non_zero_usize;
 use types::{EthSpec, Hash256};
@@ -28,7 +27,6 @@ impl<E: EthSpec> Default for PayloadCache<E> {
 impl<E: EthSpec> PayloadCache<E> {
     pub fn put(&self, payload: FullPayloadContents<E>) -> Option<FullPayloadContents<E>> {
         let root = payload.payload_ref().tree_hash_root();
-        info!(?root, block_hash = ?payload.payload_ref().block_hash(), parent_block_hash = ?payload.payload_ref().parent_hash(), "Caching payload");
         self.payloads.lock().put(PayloadCacheId(root), payload)
     }
 

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -315,6 +315,8 @@ impl<E: EthSpec> MockBuilder<E> {
     pub fn new_for_testing(
         mock_el_url: SensitiveUrl,
         beacon_url: SensitiveUrl,
+        validate_pubkey: bool,
+        apply_operations: bool,
         spec: Arc<ChainSpec>,
         executor: TaskExecutor,
     ) -> (Self, (SocketAddr, impl Future<Output = ()>)) {
@@ -332,9 +334,6 @@ impl<E: EthSpec> MockBuilder<E> {
 
         let el = ExecutionLayer::from_config(config, executor.clone()).unwrap();
 
-        // FIXME(sproul): both of these options are kind of scuffed
-        let validate_pubkey = false;
-        let apply_operations = false;
         let max_bid = false;
 
         let builder = MockBuilder::new(
@@ -525,16 +524,29 @@ impl<E: EthSpec> MockBuilder<E> {
         info!("Got payload params");
 
         let fork = self.fork_name_at_slot(slot);
+
         let payload_response_type = self
             .el
-            .get_full_payload_caching(PayloadParameters {
-                parent_hash: payload_parameters.parent_hash,
-                parent_gas_limit: payload_parameters.parent_gas_limit,
-                proposer_gas_limit: payload_parameters.proposer_gas_limit,
-                payload_attributes: &payload_parameters.payload_attributes,
-                forkchoice_update_params: &payload_parameters.forkchoice_update_params,
-                current_fork: payload_parameters.current_fork,
-            })
+            .get_full_payload_with(
+                PayloadParameters {
+                    parent_hash: payload_parameters.parent_hash,
+                    parent_gas_limit: payload_parameters.parent_gas_limit,
+                    proposer_gas_limit: payload_parameters.proposer_gas_limit,
+                    payload_attributes: &payload_parameters.payload_attributes,
+                    forkchoice_update_params: &payload_parameters.forkchoice_update_params,
+                    current_fork: payload_parameters.current_fork,
+                },
+                // If apply_operations is set, do NOT cache the payload at this point, we are about
+                // to mutate it and it would be incorrect to cache the unmutated payload.
+                //
+                // This is a flaw in apply_operations generally, if you want the mock builder to
+                // actually return payloads then this option should be turned off.
+                if self.apply_operations {
+                    |_, _| None
+                } else {
+                    ExecutionLayer::cache_payload
+                },
+            )
             .await
             .map_err(|e| format!("couldn't get payload {:?}", e))?;
 

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -963,9 +963,9 @@ pub fn serve<E: EthSpec>(
     let prefix_either = warp::path("eth")
         .and(
             warp::path::param::<EndpointVersion>().or_else(|_| async move {
-                Err(warp_utils::reject::custom_bad_request(
+                Err(warp::reject::custom(Custom(
                     "Invalid EndpointVersion".to_string(),
-                ))
+                )))
             }),
         )
         .and(warp::path("builder"));

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -332,12 +332,17 @@ impl<E: EthSpec> MockBuilder<E> {
 
         let el = ExecutionLayer::from_config(config, executor.clone()).unwrap();
 
+        // FIXME(sproul): both of these options are kind of scuffed
+        let validate_pubkey = false;
+        let apply_operations = false;
+        let max_bid = false;
+
         let builder = MockBuilder::new(
             el,
             BeaconNodeHttpClient::new(beacon_url, Timeouts::set_all(Duration::from_secs(1))),
-            true,
-            true,
-            false,
+            validate_pubkey,
+            apply_operations,
+            max_bid,
             spec,
             None,
         );
@@ -458,14 +463,20 @@ impl<E: EthSpec> MockBuilder<E> {
                 block.message.body.execution_payload.tree_hash_root()
             }
         };
+        let block_hash = block
+            .message()
+            .body()
+            .execution_payload()
+            .unwrap()
+            .block_hash();
         info!(
-            block_hash = %root,
+            execution_payload_root = %root,
+            ?block_hash,
             "Submitting blinded beacon block to builder"
         );
-        let payload = self
-            .el
-            .get_payload_by_root(&root)
-            .ok_or_else(|| "missing payload for tx root".to_string())?;
+        let payload = self.el.get_payload_by_root(&root).ok_or_else(|| {
+            format!("missing payload for root: {root:?}, block_hash: {block_hash:?}",)
+        })?;
 
         let (payload, blobs) = payload.deconstruct();
         let full_block = block

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -3,8 +3,8 @@ use crate::{Config, ExecutionLayer, PayloadAttributes, PayloadParameters};
 use bytes::Bytes;
 use eth2::types::PublishBlockRequest;
 use eth2::types::{
-    BlobsBundle, BlockId, BroadcastValidation, EventKind, EventTopic, FullPayloadContents,
-    ProposerData, StateId, ValidatorId,
+    BlobsBundle, BlockId, BroadcastValidation, EndpointVersion, EventKind, EventTopic,
+    FullPayloadContents, ProposerData, StateId, ValidatorId,
 };
 use eth2::{
     BeaconNodeHttpClient, Timeouts, CONSENSUS_VERSION_HEADER, CONTENT_TYPE_HEADER,
@@ -506,7 +506,10 @@ impl<E: EthSpec> MockBuilder<E> {
             self.beacon_client
                 .post_beacon_blocks_v2(&publish_block_request, Some(BroadcastValidation::Gossip))
                 .await
-                .map_err(|e| format!("Failed to post blinded block {:?}", e))?;
+                .map_err(|e| {
+                    // XXX: this should really be a 400 but warp makes that annoyingly difficult
+                    format!("Failed to post blinded block {e:?}")
+                })?;
         }
         Ok(FullPayloadContents::new(payload, blobs))
     }
@@ -953,11 +956,21 @@ pub fn serve<E: EthSpec>(
     let inner_ctx = builder.clone();
     let ctx_filter = warp::any().map(move || inner_ctx.clone());
 
-    let prefix = warp::path("eth")
+    let prefix_v1 = warp::path("eth")
         .and(warp::path("v1"))
         .and(warp::path("builder"));
 
-    let validators = prefix
+    let prefix_either = warp::path("eth")
+        .and(
+            warp::path::param::<EndpointVersion>().or_else(|_| async move {
+                Err(warp_utils::reject::custom_bad_request(
+                    "Invalid EndpointVersion".to_string(),
+                ))
+            }),
+        )
+        .and(warp::path("builder"));
+
+    let validators = prefix_v1
         .and(warp::path("validators"))
         .and(warp::body::json())
         .and(warp::path::end())
@@ -969,61 +982,89 @@ pub fn serve<E: EthSpec>(
                     .register_validators(registrations)
                     .await
                     .map_err(|e| warp::reject::custom(Custom(e)))?;
-                Ok::<_, Rejection>(warp::reply())
-            },
-        )
-        .boxed();
-
-    let blinded_block_ssz = prefix
-        .and(warp::path("blinded_blocks"))
-        .and(warp::body::bytes())
-        .and(warp::header::header::<ForkName>(CONSENSUS_VERSION_HEADER))
-        .and(warp::path::end())
-        .and(ctx_filter.clone())
-        .and_then(
-            |block_bytes: Bytes, fork_name: ForkName, builder: MockBuilder<E>| async move {
-                let block =
-                    SignedBlindedBeaconBlock::<E>::from_ssz_bytes_by_fork(&block_bytes, fork_name)
-                        .map_err(|e| warp::reject::custom(Custom(format!("{:?}", e))))?;
-                let payload = builder
-                    .submit_blinded_block(block)
-                    .await
-                    .map_err(|e| warp::reject::custom(Custom(e)))?;
-
-                Ok::<_, warp::reject::Rejection>(
-                    warp::http::Response::builder()
-                        .status(200)
-                        .body(payload.as_ssz_bytes())
-                        .map(add_ssz_content_type_header)
-                        .map(|res| add_consensus_version_header(res, fork_name))
-                        .unwrap(),
-                )
+                Ok::<_, Rejection>(warp::reply().into_response())
             },
         );
 
-    let blinded_block =
-        prefix
+    let blinded_block_ssz =
+        prefix_either
             .and(warp::path("blinded_blocks"))
-            .and(warp::body::json())
+            .and(warp::body::bytes())
             .and(warp::header::header::<ForkName>(CONSENSUS_VERSION_HEADER))
             .and(warp::path::end())
             .and(ctx_filter.clone())
             .and_then(
-                |block: SignedBlindedBeaconBlock<E>,
+                |endpoint_version,
+                 block_bytes: Bytes,
                  fork_name: ForkName,
                  builder: MockBuilder<E>| async move {
+                    if endpoint_version != EndpointVersion(1)
+                        && endpoint_version != EndpointVersion(2)
+                    {
+                        return Err(warp::reject::custom(Custom(format!(
+                            "Unsupported version: {endpoint_version}"
+                        ))));
+                    }
+                    let block = SignedBlindedBeaconBlock::<E>::from_ssz_bytes_by_fork(
+                        &block_bytes,
+                        fork_name,
+                    )
+                    .map_err(|e| warp::reject::custom(Custom(format!("{:?}", e))))?;
                     let payload = builder
                         .submit_blinded_block(block)
                         .await
                         .map_err(|e| warp::reject::custom(Custom(e)))?;
-                    let resp: ForkVersionedResponse<_> = ForkVersionedResponse {
-                        version: fork_name,
-                        metadata: Default::default(),
-                        data: payload,
-                    };
 
-                    let json_payload = serde_json::to_string(&resp)
-                        .map_err(|_| reject("coudn't serialize response"))?;
+                    if endpoint_version == EndpointVersion(1) {
+                        Ok::<_, warp::reject::Rejection>(
+                            warp::http::Response::builder()
+                                .status(200)
+                                .body(payload.as_ssz_bytes())
+                                .map(add_ssz_content_type_header)
+                                .map(|res| add_consensus_version_header(res, fork_name))
+                                .unwrap(),
+                        )
+                    } else {
+                        Ok(warp::http::Response::builder()
+                            .status(202)
+                            .body(&[] as &'static [u8])
+                            .map(|res| add_consensus_version_header(res, fork_name))
+                            .unwrap())
+                    }
+                },
+            );
+
+    let blinded_block = prefix_either
+        .and(warp::path("blinded_blocks"))
+        .and(warp::body::json())
+        .and(warp::header::header::<ForkName>(CONSENSUS_VERSION_HEADER))
+        .and(warp::path::end())
+        .and(ctx_filter.clone())
+        .and_then(
+            |endpoint_version,
+             block: SignedBlindedBeaconBlock<E>,
+             fork_name: ForkName,
+             builder: MockBuilder<E>| async move {
+                if endpoint_version != EndpointVersion(1) && endpoint_version != EndpointVersion(2)
+                {
+                    return Err(warp::reject::custom(Custom(format!(
+                        "Unsupported version: {endpoint_version}"
+                    ))));
+                }
+                let payload = builder
+                    .submit_blinded_block(block)
+                    .await
+                    .map_err(|e| warp::reject::custom(Custom(e)))?;
+                let resp: ForkVersionedResponse<_> = ForkVersionedResponse {
+                    version: fork_name,
+                    metadata: Default::default(),
+                    data: payload,
+                };
+
+                let json_payload = serde_json::to_string(&resp)
+                    .map_err(|_| reject("coudn't serialize response"))?;
+
+                if endpoint_version == EndpointVersion(1) {
                     Ok::<_, warp::reject::Rejection>(
                         warp::http::Response::builder()
                             .status(200)
@@ -1031,16 +1072,24 @@ pub fn serve<E: EthSpec>(
                                 serde_json::to_string(&json_payload)
                                     .map_err(|_| reject("invalid JSON"))?,
                             )
+                            .map(|res| add_consensus_version_header(res, fork_name))
                             .unwrap(),
                     )
-                },
-            );
+                } else {
+                    Ok(warp::http::Response::builder()
+                        .status(202)
+                        .body("".to_string())
+                        .map(|res| add_consensus_version_header(res, fork_name))
+                        .unwrap())
+                }
+            },
+        );
 
-    let status = prefix
+    let status = prefix_v1
         .and(warp::path("status"))
-        .then(|| async { warp::reply() });
+        .then(|| async { warp::reply().into_response() });
 
-    let header = prefix
+    let header = prefix_v1
         .and(warp::path("header"))
         .and(warp::path::param::<Slot>().or_else(|_| async { Err(reject("Invalid slot")) }))
         .and(

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -307,6 +307,10 @@ pub struct MockBuilder<E: EthSpec> {
     payload_id_cache: Arc<RwLock<HashMap<ExecutionBlockHash, PayloadParametersCloned>>>,
     /// If set to `true`, sets the bid returned by `get_header` to Uint256::MAX
     max_bid: bool,
+    /// Broadcast the full block with payload to the attached beacon node (simulating the relay).
+    ///
+    /// Turning this off is useful for testing.
+    broadcast_to_bn: bool,
     /// A cache that stores the proposers index for a given epoch
     proposers_cache: Arc<RwLock<HashMap<Epoch, Vec<ProposerData>>>>,
 }
@@ -317,6 +321,7 @@ impl<E: EthSpec> MockBuilder<E> {
         beacon_url: SensitiveUrl,
         validate_pubkey: bool,
         apply_operations: bool,
+        broadcast_to_bn: bool,
         spec: Arc<ChainSpec>,
         executor: TaskExecutor,
     ) -> (Self, (SocketAddr, impl Future<Output = ()>)) {
@@ -341,6 +346,7 @@ impl<E: EthSpec> MockBuilder<E> {
             BeaconNodeHttpClient::new(beacon_url, Timeouts::set_all(Duration::from_secs(1))),
             validate_pubkey,
             apply_operations,
+            broadcast_to_bn,
             max_bid,
             spec,
             None,
@@ -357,6 +363,7 @@ impl<E: EthSpec> MockBuilder<E> {
         beacon_client: BeaconNodeHttpClient,
         validate_pubkey: bool,
         apply_operations: bool,
+        broadcast_to_bn: bool,
         max_bid: bool,
         spec: Arc<ChainSpec>,
         sk: Option<&[u8]>,
@@ -386,6 +393,7 @@ impl<E: EthSpec> MockBuilder<E> {
             proposers_cache: Arc::new(RwLock::new(HashMap::new())),
             apply_operations,
             max_bid,
+            broadcast_to_bn,
             genesis_time: None,
         }
     }
@@ -484,16 +492,22 @@ impl<E: EthSpec> MockBuilder<E> {
         debug!(
             txs_count = payload.transactions().len(),
             blob_count = blobs.as_ref().map(|b| b.commitments.len()),
-            "Got full payload, sending to local beacon node for propagation"
+            "Got full payload"
         );
-        let publish_block_request = PublishBlockRequest::new(
-            Arc::new(full_block),
-            blobs.clone().map(|b| (b.proofs, b.blobs)),
-        );
-        self.beacon_client
-            .post_beacon_blocks_v2(&publish_block_request, Some(BroadcastValidation::Gossip))
-            .await
-            .map_err(|e| format!("Failed to post blinded block {:?}", e))?;
+        if self.broadcast_to_bn {
+            debug!(
+                block_hash = ?payload.block_hash(),
+                "Broadcasting builder block to BN"
+            );
+            let publish_block_request = PublishBlockRequest::new(
+                Arc::new(full_block),
+                blobs.clone().map(|b| (b.proofs, b.blobs)),
+            );
+            self.beacon_client
+                .post_beacon_blocks_v2(&publish_block_request, Some(BroadcastValidation::Gossip))
+                .await
+                .map_err(|e| format!("Failed to post blinded block {:?}", e))?;
+        }
         Ok(FullPayloadContents::new(payload, blobs))
     }
 

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1663,18 +1663,29 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::query::<api_types::BroadcastValidationQuery>())
         .and(warp::path::end())
         .and(warp_utils::json::json())
+        .and(consensus_version_header_filter)
         .and(task_spawner_filter.clone())
         .and(chain_filter.clone())
         .and(network_tx_filter.clone())
         .and(network_globals.clone())
         .then(
             move |validation_level: api_types::BroadcastValidationQuery,
-                  blinded_block: Arc<SignedBlindedBeaconBlock<T::EthSpec>>,
+                  blinded_block_json: serde_json::Value,
+                  consensus_version: ForkName,
                   task_spawner: TaskSpawner<T::EthSpec>,
                   chain: Arc<BeaconChain<T>>,
                   network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
                   network_globals: Arc<NetworkGlobals<T::EthSpec>>| {
                 task_spawner.spawn_async_with_rejection(Priority::P0, async move {
+                    let blinded_block =
+                        SignedBlindedBeaconBlock::<T::EthSpec>::context_deserialize(
+                            &blinded_block_json,
+                            consensus_version,
+                        )
+                        .map(Arc::new)
+                        .map_err(|e| {
+                            warp_utils::reject::custom_bad_request(format!("invalid JSON: {e:?}"))
+                        })?;
                     publish_blocks::publish_blinded_block(
                         blinded_block,
                         chain,

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -110,7 +110,17 @@ impl<E: EthSpec> InteractiveTester<E> {
         let beacon_url =
             SensitiveUrl::parse(format!("http://{beacon_api_ip}:{beacon_api_port}").as_str())
                 .unwrap();
-        let mock_builder_server = harness.set_mock_builder(beacon_url.clone());
+
+        // We disable apply_operations because it breaks the mock builder's ability to return
+        // payloads.
+        let apply_operations = false;
+
+        // We disable strict registration checks too, because it makes HTTP tests less fiddly to
+        // write.
+        let strict_registrations = false;
+
+        let mock_builder_server =
+            harness.set_mock_builder(beacon_url.clone(), strict_registrations, apply_operations);
 
         tokio::spawn(mock_builder_server);
 

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -91,7 +91,7 @@ impl<E: EthSpec> InteractiveTester<E> {
             harness_builder = harness_builder.initial_mutator(mutator);
         }
 
-        let harness = harness_builder.build();
+        let mut harness = harness_builder.build();
 
         let ApiServer {
             ctx,
@@ -103,6 +103,17 @@ impl<E: EthSpec> InteractiveTester<E> {
 
         tokio::spawn(server);
 
+        // Late-initalize the mock builder now that the mock execution node and beacon API ports
+        // have been allocated.
+        let beacon_api_ip = listening_socket.ip();
+        let beacon_api_port = listening_socket.port();
+        let beacon_url =
+            SensitiveUrl::parse(format!("http://{beacon_api_ip}:{beacon_api_port}").as_str())
+                .unwrap();
+        let mock_builder_server = harness.set_mock_builder(beacon_url.clone());
+
+        tokio::spawn(mock_builder_server);
+
         // Override the default timeout to 2s to timeouts on CI, as CI seems to require longer
         // to process. The 1s timeouts for other tasks have been working for a long time, so we'll
         // keep it as it is, as it may help identify a performance regression.
@@ -110,15 +121,7 @@ impl<E: EthSpec> InteractiveTester<E> {
             default: Duration::from_secs(2),
             ..Timeouts::set_all(Duration::from_secs(1))
         };
-        let client = BeaconNodeHttpClient::new(
-            SensitiveUrl::parse(&format!(
-                "http://{}:{}",
-                listening_socket.ip(),
-                listening_socket.port()
-            ))
-            .unwrap(),
-            timeouts,
-        );
+        let client = BeaconNodeHttpClient::new(beacon_url.clone(), timeouts);
 
         Self {
             ctx,

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -119,8 +119,16 @@ impl<E: EthSpec> InteractiveTester<E> {
         // write.
         let strict_registrations = false;
 
-        let mock_builder_server =
-            harness.set_mock_builder(beacon_url.clone(), strict_registrations, apply_operations);
+        // Broadcast validation tests expect to be able to infer things from the BN status code,
+        // so it is simpler if the builder is not also publishing blocks.
+        let broadcast_to_bn = false;
+
+        let mock_builder_server = harness.set_mock_builder(
+            beacon_url.clone(),
+            strict_registrations,
+            apply_operations,
+            broadcast_to_bn,
+        );
 
         tokio::spawn(mock_builder_server);
 

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -119,9 +119,12 @@ impl<E: EthSpec> InteractiveTester<E> {
         // write.
         let strict_registrations = false;
 
-        // Broadcast validation tests expect to be able to infer things from the BN status code,
-        // so it is simpler if the builder is not also publishing blocks.
-        let broadcast_to_bn = false;
+        // Broadcast to the BN only if Fulu is scheduled. In the broadcast validation tests we want
+        // to infer things from the builder return code, and pre-Fulu it's simpler to let the BN
+        // handle broadcast and return detailed codes. Post-Fulu the builder doesn't return the
+        // block at all, so we *need* the builder to do the broadcast and return a 400 if the block
+        // is invalid.
+        let broadcast_to_bn = ctx.chain.as_ref().unwrap().spec.is_fulu_scheduled();
 
         let mock_builder_server = harness.set_mock_builder(
             beacon_url.clone(),

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -1013,10 +1013,13 @@ pub async fn blinded_consensus_gossip() {
     let slot_a = Slot::new(num_initial);
     let slot_b = slot_a + 1;
 
+    let mut correct_state_root = Hash256::zero();
+
     let state_a = tester.harness.get_current_state();
     let (blinded_block, _) = tester
         .harness
         .make_blinded_block_with_modifier(state_a, slot_b, |b| {
+            *correct_state_root = *b.state_root();
             *b.state_root_mut() = Hash256::zero()
         })
         .await;
@@ -1031,7 +1034,14 @@ pub async fn blinded_consensus_gossip() {
 
     /* mandated by Beacon API spec */
     assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
-    assert_server_message_error(error_response, "BAD_REQUEST: Invalid block: StateRootMismatch { block: 0x0000000000000000000000000000000000000000000000000000000000000000, local: 0x3fd3d78bc99e39a7a4e643f19ff446524b405df7256f4a2f6f5f07affa0b1036 }".to_string());
+    assert_server_message_error(
+        error_response,
+        format!(
+            "BAD_REQUEST: Invalid block: StateRootMismatch {{ block: {},\
+             local: {correct_state_root} }}",
+            Hash256::ZERO
+        ),
+    );
 }
 
 /// This test checks that a block that is valid from both a gossip and consensus perspective is accepted when using `broadcast_validation=consensus`.
@@ -1259,8 +1269,7 @@ pub async fn blinded_equivocation_gossip() {
 
     /* mandated by Beacon API spec */
     assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
-
-    assert_server_message_error(error_response, "BAD_REQUEST: Invalid block: StateRootMismatch { block: 0x0000000000000000000000000000000000000000000000000000000000000000, local: 0x3fd3d78bc99e39a7a4e643f19ff446524b405df7256f4a2f6f5f07affa0b1036 }".to_string());
+    assert_server_message_error(error_response, "BAD_REQUEST: Invalid block: StateRootMismatch { block: 0x0000000000000000000000000000000000000000000000000000000000000000, local: 0xf80855e46108b1f93f2efcd61b63e29c2f718d54b1437aaa25d84ffb52b06963 }".to_string());
 }
 
 /// This test checks that a block that is valid from both a gossip and

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -1,7 +1,7 @@
 use beacon_chain::test_utils::test_spec;
 use beacon_chain::{
     test_utils::{AttestationStrategy, BlockStrategy},
-    GossipVerifiedBlock, IntoGossipVerifiedBlock,
+    GossipVerifiedBlock, IntoGossipVerifiedBlock, WhenSlotSkipped,
 };
 use eth2::reqwest::StatusCode;
 use eth2::types::{BroadcastValidation, PublishBlockRequest};
@@ -762,9 +762,9 @@ pub async fn blinded_gossip_invalid() {
 
     tester.harness.advance_slot();
 
-    let (block_contents_tuple, _) = tester
+    let (blinded_block, _) = tester
         .harness
-        .make_block_with_modifier(chain_state_before, slot, |b| {
+        .make_blinded_block_with_modifier(chain_state_before, slot, |b| {
             *b.state_root_mut() = Hash256::zero();
             *b.parent_root_mut() = Hash256::zero();
         })
@@ -772,7 +772,7 @@ pub async fn blinded_gossip_invalid() {
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blinded_blocks_v2(&block_contents_tuple.0.clone_as_blinded(), validation_level)
+        .post_beacon_blinded_blocks_v2(&blinded_block, validation_level)
         .await;
     assert!(response.is_err());
 
@@ -780,7 +780,14 @@ pub async fn blinded_gossip_invalid() {
 
     /* mandated by Beacon API spec */
     assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
-    assert_server_message_error(error_response, "BAD_REQUEST: NotFinalizedDescendant { block_parent_root: 0x0000000000000000000000000000000000000000000000000000000000000000 }".to_string());
+
+    // Since Deneb, the invalidity of the blobs will be detected prior to the invalidity of the
+    // block.
+    let pre_finalized_block_root = Hash256::zero();
+    assert_server_message_error(
+        error_response,
+        format!("BAD_REQUEST: BlobParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
+    );
 }
 
 /// This test checks that a block that is valid from a gossip perspective is accepted when using `broadcast_validation=gossip`.
@@ -811,16 +818,16 @@ pub async fn blinded_gossip_partial_pass() {
 
     tester.harness.advance_slot();
 
-    let (block_contents_tuple, _) = tester
+    let (blinded_block, _) = tester
         .harness
-        .make_block_with_modifier(chain_state_before, slot, |b| {
+        .make_blinded_block_with_modifier(chain_state_before, slot, |b| {
             *b.state_root_mut() = Hash256::zero()
         })
         .await;
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blinded_blocks_v2(&block_contents_tuple.0.clone_as_blinded(), validation_level)
+        .post_beacon_blinded_blocks_v2(&blinded_block, validation_level)
         .await;
     assert!(response.is_err());
 
@@ -921,7 +928,7 @@ pub async fn blinded_consensus_invalid() {
     // Validator count needs to be at least 32 or proposer boost gets set to 0 when computing
     // `validator_count // 32`.
     let validator_count = 64;
-    let num_initial: u64 = 31;
+    let num_initial: u64 = 256;
     let tester = InteractiveTester::<E>::new(None, validator_count).await;
 
     // Create some chain depth.
@@ -940,17 +947,29 @@ pub async fn blinded_consensus_invalid() {
 
     tester.harness.advance_slot();
 
-    let (block_contents_tuple, _) = tester
+    let finalized_slot = chain_state_before
+        .finalized_checkpoint()
+        .epoch
+        .start_slot(E::slots_per_epoch());
+    assert_ne!(finalized_slot, 0);
+    let pre_finalized_block_root = tester
         .harness
-        .make_block_with_modifier(chain_state_before, slot, |b| {
+        .chain
+        .block_root_at_slot(finalized_slot - 1, WhenSlotSkipped::Prev)
+        .unwrap()
+        .unwrap();
+
+    let (blinded_block, _) = tester
+        .harness
+        .make_blinded_block_with_modifier(chain_state_before, slot, |b| {
             *b.state_root_mut() = Hash256::zero();
-            *b.parent_root_mut() = Hash256::zero();
+            *b.parent_root_mut() = pre_finalized_block_root;
         })
         .await;
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blinded_blocks_v2(&block_contents_tuple.0.clone_as_blinded(), validation_level)
+        .post_beacon_blinded_blocks_v2(&blinded_block, validation_level)
         .await;
     assert!(response.is_err());
 
@@ -958,7 +977,13 @@ pub async fn blinded_consensus_invalid() {
 
     /* mandated by Beacon API spec */
     assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
-    assert_server_message_error(error_response, "BAD_REQUEST: NotFinalizedDescendant { block_parent_root: 0x0000000000000000000000000000000000000000000000000000000000000000 }".to_string());
+
+    // Since Deneb, the invalidity of the blobs will be detected prior to the invalidity of the
+    // block.
+    assert_server_message_error(
+        error_response,
+        format!("BAD_REQUEST: BlobParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
+    );
 }
 
 /// This test checks that a block that is only valid from a gossip perspective is rejected when using `broadcast_validation=consensus`.
@@ -989,14 +1014,16 @@ pub async fn blinded_consensus_gossip() {
     let slot_b = slot_a + 1;
 
     let state_a = tester.harness.get_current_state();
-    let (block_contents_tuple, _) = tester
+    let (blinded_block, _) = tester
         .harness
-        .make_block_with_modifier(state_a, slot_b, |b| *b.state_root_mut() = Hash256::zero())
+        .make_blinded_block_with_modifier(state_a, slot_b, |b| {
+            *b.state_root_mut() = Hash256::zero()
+        })
         .await;
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blinded_blocks_v2(&block_contents_tuple.0.clone_as_blinded(), validation_level)
+        .post_beacon_blinded_blocks_v2(&blinded_block, validation_level)
         .await;
     assert!(response.is_err());
 
@@ -1004,7 +1031,7 @@ pub async fn blinded_consensus_gossip() {
 
     /* mandated by Beacon API spec */
     assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
-    assert_server_message_error(error_response, "BAD_REQUEST: Invalid block: StateRootMismatch { block: 0x0000000000000000000000000000000000000000000000000000000000000000, local: 0x253405be9aa159bce7b276b8e1d3849c743e673118dfafe8c7d07c203ae0d80d }".to_string());
+    assert_server_message_error(error_response, "BAD_REQUEST: Invalid block: StateRootMismatch { block: 0x0000000000000000000000000000000000000000000000000000000000000000, local: 0x3fd3d78bc99e39a7a4e643f19ff446524b405df7256f4a2f6f5f07affa0b1036 }".to_string());
 }
 
 /// This test checks that a block that is valid from both a gossip and consensus perspective is accepted when using `broadcast_validation=consensus`.
@@ -1059,7 +1086,7 @@ pub async fn blinded_equivocation_invalid() {
     // Validator count needs to be at least 32 or proposer boost gets set to 0 when computing
     // `validator_count // 32`.
     let validator_count = 64;
-    let num_initial: u64 = 31;
+    let num_initial: u64 = 256;
     let tester = InteractiveTester::<E>::new(None, validator_count).await;
 
     // Create some chain depth.
@@ -1078,17 +1105,29 @@ pub async fn blinded_equivocation_invalid() {
 
     tester.harness.advance_slot();
 
-    let (block_contents_tuple, _) = tester
+    let finalized_slot = chain_state_before
+        .finalized_checkpoint()
+        .epoch
+        .start_slot(E::slots_per_epoch());
+    assert_ne!(finalized_slot, 0);
+    let pre_finalized_block_root = tester
         .harness
-        .make_block_with_modifier(chain_state_before, slot, |b| {
+        .chain
+        .block_root_at_slot(finalized_slot - 1, WhenSlotSkipped::Prev)
+        .unwrap()
+        .unwrap();
+
+    let (blinded_block, _) = tester
+        .harness
+        .make_blinded_block_with_modifier(chain_state_before, slot, |b| {
             *b.state_root_mut() = Hash256::zero();
-            *b.parent_root_mut() = Hash256::zero();
+            *b.parent_root_mut() = pre_finalized_block_root;
         })
         .await;
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blinded_blocks_v2(&block_contents_tuple.0.clone_as_blinded(), validation_level)
+        .post_beacon_blinded_blocks_v2(&blinded_block, validation_level)
         .await;
     assert!(response.is_err());
 
@@ -1096,7 +1135,12 @@ pub async fn blinded_equivocation_invalid() {
 
     /* mandated by Beacon API spec */
     assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
-    assert_server_message_error(error_response, "BAD_REQUEST: NotFinalizedDescendant { block_parent_root: 0x0000000000000000000000000000000000000000000000000000000000000000 }".to_string());
+    // Since Deneb, the invalidity of the blobs will be detected prior to the invalidity of the
+    // block.
+    assert_server_message_error(
+        error_response,
+        format!("BAD_REQUEST: BlobParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
+    );
 }
 
 /// This test checks that a block that is valid from both a gossip and consensus perspective is rejected when using `broadcast_validation=consensus_and_equivocation`.
@@ -1198,14 +1242,16 @@ pub async fn blinded_equivocation_gossip() {
     let slot_b = slot_a + 1;
 
     let state_a = tester.harness.get_current_state();
-    let (block_contents_tuple, _) = tester
+    let (blinded_block, _) = tester
         .harness
-        .make_block_with_modifier(state_a, slot_b, |b| *b.state_root_mut() = Hash256::zero())
+        .make_blinded_block_with_modifier(state_a, slot_b, |b| {
+            *b.state_root_mut() = Hash256::zero()
+        })
         .await;
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blinded_blocks_v2(&block_contents_tuple.0.clone_as_blinded(), validation_level)
+        .post_beacon_blinded_blocks_v2(&blinded_block, validation_level)
         .await;
     assert!(response.is_err());
 
@@ -1214,7 +1260,7 @@ pub async fn blinded_equivocation_gossip() {
     /* mandated by Beacon API spec */
     assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
 
-    assert_server_message_error(error_response, "BAD_REQUEST: Invalid block: StateRootMismatch { block: 0x0000000000000000000000000000000000000000000000000000000000000000, local: 0x253405be9aa159bce7b276b8e1d3849c743e673118dfafe8c7d07c203ae0d80d }".to_string());
+    assert_server_message_error(error_response, "BAD_REQUEST: Invalid block: StateRootMismatch { block: 0x0000000000000000000000000000000000000000000000000000000000000000, local: 0x3fd3d78bc99e39a7a4e643f19ff446524b405df7256f4a2f6f5f07affa0b1036 }".to_string());
 }
 
 /// This test checks that a block that is valid from both a gossip and

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -87,7 +87,13 @@ pub async fn gossip_invalid() {
     /* mandated by Beacon API spec */
     assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
 
-    assert_server_message_error(error_response, "BAD_REQUEST: NotFinalizedDescendant { block_parent_root: 0x0000000000000000000000000000000000000000000000000000000000000000 }".to_string());
+    // Since Deneb, the invalidity of the blobs will be detected prior to the invalidity of the
+    // block.
+    let pre_finalized_block_root = Hash256::zero();
+    assert_server_message_error(
+        error_response,
+        format!("BAD_REQUEST: ParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
+    );
 }
 
 /// This test checks that a block that is valid from a gossip perspective is accepted when using `broadcast_validation=gossip`.
@@ -129,11 +135,7 @@ pub async fn gossip_partial_pass() {
         .client
         .post_beacon_blocks_v2_ssz(&PublishBlockRequest::new(block, blobs), validation_level)
         .await;
-    assert!(response.is_err());
-
-    let error_response = response.unwrap_err();
-
-    assert_eq!(error_response.status(), Some(StatusCode::ACCEPTED));
+    assert!(response.is_ok());
 }
 
 // This test checks that a block that is valid from both a gossip and consensus perspective is accepted when using `broadcast_validation=gossip`.
@@ -272,7 +274,13 @@ pub async fn consensus_invalid() {
 
     /* mandated by Beacon API spec */
     assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
-    assert_server_message_error(error_response, "BAD_REQUEST: NotFinalizedDescendant { block_parent_root: 0x0000000000000000000000000000000000000000000000000000000000000000 }".to_string());
+    // Since Deneb, the invalidity of the blobs will be detected prior to the invalidity of the
+    // block.
+    let pre_finalized_block_root = Hash256::zero();
+    assert_server_message_error(
+        error_response,
+        format!("BAD_REQUEST: ParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
+    );
 }
 
 /// This test checks that a block that is only valid from a gossip perspective is rejected when using `broadcast_validation=consensus`.
@@ -500,7 +508,13 @@ pub async fn equivocation_invalid() {
 
     /* mandated by Beacon API spec */
     assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
-    assert_server_message_error(error_response, "BAD_REQUEST: NotFinalizedDescendant { block_parent_root: 0x0000000000000000000000000000000000000000000000000000000000000000 }".to_string());
+    // Since Deneb, the invalidity of the blobs will be detected prior to the invalidity of the
+    // block.
+    let pre_finalized_block_root = Hash256::zero();
+    assert_server_message_error(
+        error_response,
+        format!("BAD_REQUEST: ParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
+    );
 }
 
 /// This test checks that a block that is valid from both a gossip and consensus perspective is rejected when using `broadcast_validation=consensus_and_equivocation`.
@@ -605,11 +619,15 @@ pub async fn equivocation_gossip() {
 
     let slot_a = Slot::new(num_initial);
     let slot_b = slot_a + 1;
+    let mut correct_state_root = Hash256::zero();
 
     let state_a = tester.harness.get_current_state();
     let ((block, blobs), _) = tester
         .harness
-        .make_block_with_modifier(state_a, slot_b, |b| *b.state_root_mut() = Hash256::zero())
+        .make_block_with_modifier(state_a, slot_b, |b| {
+            *correct_state_root = *b.state_root();
+            *b.state_root_mut() = Hash256::zero()
+        })
         .await;
 
     let response: Result<(), eth2::Error> = tester
@@ -622,7 +640,7 @@ pub async fn equivocation_gossip() {
 
     /* mandated by Beacon API spec */
     assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
-    assert_server_message_error(error_response, "BAD_REQUEST: Invalid block: StateRootMismatch { block: 0x0000000000000000000000000000000000000000000000000000000000000000, local: 0x253405be9aa159bce7b276b8e1d3849c743e673118dfafe8c7d07c203ae0d80d }".to_string());
+    assert_server_message_error(error_response, format!("BAD_REQUEST: Invalid block: StateRootMismatch {{ block: {}, local: {correct_state_root} }}", Hash256::zero()));
 }
 
 /// This test checks that a block that is valid from both a gossip and consensus perspective but
@@ -800,7 +818,7 @@ pub async fn blinded_gossip_invalid() {
     let pre_finalized_block_root = Hash256::zero();
     assert_server_message_error(
         error_response,
-        format!("BAD_REQUEST: BlobParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
+        format!("BAD_REQUEST: ParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
     );
 }
 
@@ -843,11 +861,7 @@ pub async fn blinded_gossip_partial_pass() {
         .client
         .post_beacon_blinded_blocks_v2(&blinded_block, validation_level)
         .await;
-    assert!(response.is_err());
-
-    let error_response = response.unwrap_err();
-
-    assert_eq!(error_response.status(), Some(StatusCode::ACCEPTED));
+    assert!(response.is_ok());
 }
 
 // This test checks that a block that is valid from both a gossip and consensus perspective is accepted when using `broadcast_validation=gossip`.
@@ -996,7 +1010,7 @@ pub async fn blinded_consensus_invalid() {
     // block.
     assert_server_message_error(
         error_response,
-        format!("BAD_REQUEST: BlobParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
+        format!("BAD_REQUEST: ParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
     );
 }
 
@@ -1163,7 +1177,7 @@ pub async fn blinded_equivocation_invalid() {
     // block.
     assert_server_message_error(
         error_response,
-        format!("BAD_REQUEST: BlobParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
+        format!("BAD_REQUEST: ParentUnknown {{ parent_root: {pre_finalized_block_root:?} }}"),
     );
 }
 

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -302,10 +302,14 @@ pub async fn consensus_gossip() {
     let slot_a = Slot::new(num_initial);
     let slot_b = slot_a + 1;
 
+    let mut correct_state_root = Hash256::ZERO;
     let state_a = tester.harness.get_current_state();
     let ((block, blobs), _) = tester
         .harness
-        .make_block_with_modifier(state_a, slot_b, |b| *b.state_root_mut() = Hash256::zero())
+        .make_block_with_modifier(state_a, slot_b, |b| {
+            *correct_state_root = *b.state_root();
+            *b.state_root_mut() = Hash256::zero()
+        })
         .await;
 
     let response: Result<(), eth2::Error> = tester
@@ -317,8 +321,22 @@ pub async fn consensus_gossip() {
     let error_response: eth2::Error = response.err().unwrap();
 
     /* mandated by Beacon API spec */
-    assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
-    assert_server_message_error(error_response, "BAD_REQUEST: Invalid block: StateRootMismatch { block: 0x0000000000000000000000000000000000000000000000000000000000000000, local: 0x253405be9aa159bce7b276b8e1d3849c743e673118dfafe8c7d07c203ae0d80d }".to_string());
+    if tester.harness.spec.is_fulu_scheduled() {
+        assert_eq!(
+            error_response.status(),
+            Some(StatusCode::INTERNAL_SERVER_ERROR)
+        );
+    } else {
+        assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
+        assert_server_message_error(
+            error_response,
+            format!(
+                "BAD_REQUEST: Invalid block: StateRootMismatch {{ block: {}, \
+                 local: {correct_state_root:?} }}",
+                Hash256::ZERO
+            ),
+        );
+    }
 }
 
 /// This test checks that a block that is valid from both a gossip and consensus perspective, but nonetheless equivocates, is accepted when using `broadcast_validation=consensus`.
@@ -1268,8 +1286,15 @@ pub async fn blinded_equivocation_gossip() {
     let error_response: eth2::Error = response.err().unwrap();
 
     /* mandated by Beacon API spec */
-    assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
-    assert_server_message_error(error_response, "BAD_REQUEST: Invalid block: StateRootMismatch { block: 0x0000000000000000000000000000000000000000000000000000000000000000, local: 0xf80855e46108b1f93f2efcd61b63e29c2f718d54b1437aaa25d84ffb52b06963 }".to_string());
+    if tester.harness.spec.is_fulu_scheduled() {
+        assert_eq!(
+            error_response.status(),
+            Some(StatusCode::INTERNAL_SERVER_ERROR)
+        );
+    } else {
+        assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));
+        assert_server_message_error(error_response, "BAD_REQUEST: Invalid block: StateRootMismatch { block: 0x0000000000000000000000000000000000000000000000000000000000000000, local: 0xf80855e46108b1f93f2efcd61b63e29c2f718d54b1437aaa25d84ffb52b06963 }".to_string());
+    }
 }
 
 /// This test checks that a block that is valid from both a gossip and

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -1055,7 +1055,7 @@ pub async fn blinded_consensus_gossip() {
     assert_server_message_error(
         error_response,
         format!(
-            "BAD_REQUEST: Invalid block: StateRootMismatch {{ block: {},\
+            "BAD_REQUEST: Invalid block: StateRootMismatch {{ block: {}, \
              local: {correct_state_root} }}",
             Hash256::ZERO
         ),

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -1146,11 +1146,11 @@ pub async fn blinded_equivocation_consensus_early_equivocation() {
     assert_ne!(block_a.state_root(), block_b.state_root());
 
     /* submit `block_a` as valid */
-    assert!(tester
+    tester
         .client
         .post_beacon_blinded_blocks_v2(&block_a, validation_level)
         .await
-        .is_ok());
+        .unwrap();
     assert!(tester
         .harness
         .chain

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -291,7 +291,14 @@ impl ApiTester {
         let beacon_api_port = listening_socket.port();
         let beacon_url =
             SensitiveUrl::parse(format!("http://127.0.0.1:{beacon_api_port}").as_str()).unwrap();
-        let mock_builder_server = harness.set_mock_builder(beacon_url.clone());
+
+        // Be strict with validator registrations, but don't bother applying operations, that flag
+        // is only used by mock-builder tests.
+        let strict_registrations = true;
+        let apply_operations = false;
+
+        let mock_builder_server =
+            harness.set_mock_builder(beacon_url.clone(), strict_registrations, apply_operations);
 
         // Start the mock builder service prior to building the chain out.
         harness

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -296,9 +296,14 @@ impl ApiTester {
         // is only used by mock-builder tests.
         let strict_registrations = true;
         let apply_operations = false;
+        let broadcast_to_bn = true;
 
-        let mock_builder_server =
-            harness.set_mock_builder(beacon_url.clone(), strict_registrations, apply_operations);
+        let mock_builder_server = harness.set_mock_builder(
+            beacon_url.clone(),
+            strict_registrations,
+            apply_operations,
+            broadcast_to_bn,
+        );
 
         // Start the mock builder service prior to building the chain out.
         harness

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -821,7 +821,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             }
             Err(err) => {
                 match err {
-                    GossipBlobError::BlobParentUnknown { parent_root } => {
+                    GossipBlobError::ParentUnknown { parent_root } => {
                         debug!(
                             action = "requesting parent",
                             block_root = %root,

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -490,7 +490,7 @@ impl BeaconNodeHttpClient {
             .post(url)
             .timeout(timeout.unwrap_or(self.timeouts.default));
         let response = builder.json(body).send().await?;
-        ok_or_error(response).await
+        success_or_error(response).await
     }
 
     /// Generic POST function supporting arbitrary responses and timeouts.
@@ -510,7 +510,7 @@ impl BeaconNodeHttpClient {
             .json(body)
             .send()
             .await?;
-        ok_or_error(response).await
+        success_or_error(response).await
     }
 
     /// Generic POST function that includes octet-stream content type header.
@@ -527,7 +527,7 @@ impl BeaconNodeHttpClient {
             HeaderValue::from_static("application/octet-stream"),
         );
         let response = builder.headers(headers).json(body).send().await?;
-        ok_or_error(response).await
+        success_or_error(response).await
     }
 
     /// Generic POST function supporting arbitrary responses and timeouts.
@@ -552,7 +552,7 @@ impl BeaconNodeHttpClient {
             HeaderValue::from_static("application/octet-stream"),
         );
         let response = builder.headers(headers).body(body).send().await?;
-        ok_or_error(response).await
+        success_or_error(response).await
     }
 
     /// `GET beacon/genesis`
@@ -2823,6 +2823,23 @@ pub async fn ok_or_error(response: Response) -> Result<Response, Error> {
     let status = response.status();
 
     if status == StatusCode::OK {
+        Ok(response)
+    } else if let Ok(message) = response.json().await {
+        match message {
+            ResponseError::Message(message) => Err(Error::ServerMessage(message)),
+            ResponseError::Indexed(indexed) => Err(Error::ServerIndexedMessage(indexed)),
+        }
+    } else {
+        Err(Error::StatusCode(status))
+    }
+}
+
+/// Returns `Ok(response)` if the response is a success (2xx) response. Otherwise, creates an
+/// appropriate error message.
+pub async fn success_or_error(response: Response) -> Result<Response, Error> {
+    let status = response.status();
+
+    if status.is_success() {
         Ok(response)
     } else if let Ok(message) = response.json().await {
         match message {


### PR DESCRIPTION
## Issue Addressed

The `http-api` tests job incorrectly runs the `beacon_chain` tests due to an copy paste error in the `Makefile`. 