### PR TITLE
fix: update broken Besu Merge upgrade link

### DIFF
--- a/book/src/archived_merge_migration.md
+++ b/book/src/archived_merge_migration.md
@@ -67,7 +67,7 @@ the relevant page for your execution engine for the required flags:
 - [Geth: Connecting to Consensus Clients](https://geth.ethereum.org/docs/getting-started/consensus-clients)
 - [Reth: Running the Consensus Layer](https://reth.rs/run/mainnet.html?highlight=consensus#running-the-consensus-layer)
 - [Nethermind: Running Nethermind Post Merge](https://docs.nethermind.io/nethermind/first-steps-with-nethermind/running-nethermind-post-merge)
-- [Besu: Prepare For The Merge](https://besu.hyperledger.org/en/stable/HowTo/Upgrade/Prepare-for-The-Merge/)
+- [Besu: Prepare For The Merge](https://besu.hyperledger.org/public-networks/how-to/upgrade-node)
 - [Erigon: Beacon Chain (Consensus Layer)](https://github.com/ledgerwatch/erigon#beacon-chain-consensus-layer)
 
 Once you have configured your execution engine to open up the engine API (usually on port 8551) you


### PR DESCRIPTION
Replaced broken link to Besu's "Prepare for The Merge" upgrade page with the most accurate and currently available URL:
https://besu.hyperledger.org/en/stable/public-networks/how-to/upgrade-node/

This page contains comprehensive and up-to-date information for upgrading Besu nodes, including all necessary details related to the Ethereum Merge (The Merge) preparation and node configuration. While it is a more general upgrade guide, it fully covers the Merge-related steps and is the best official resource currently available.