### PR TITLE
Filter dependencies from SSE logging

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -650,7 +650,7 @@ fn run<E: EthSpec>(
         logging_layers.push(
             file_logging_layer
                 .with_filter(logger_config.logfile_debug_level)
-                .with_filter(workspace_filter)
+                .with_filter(workspace_filter.clone())
                 .boxed(),
         );
     }

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -656,7 +656,11 @@ fn run<E: EthSpec>(
     }
 
     if let Some(sse_logging_layer) = sse_logging_layer_opt {
-        logging_layers.push(sse_logging_layer.boxed());
+        logging_layers.push(
+            sse_logging_layer
+                .with_filter(workspace_filter.clone())
+                .boxed(),
+        );
     }
 
     if let Some(libp2p_discv5_layer) = libp2p_discv5_layer {


### PR DESCRIPTION
In the tracing upgrade we included dependency logging in the SSE logs. 

This PR removes dependencies from the SSE logs. 
