### PR TITLE
Adjust DA checker cache size

### DIFF
--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -38,12 +38,19 @@ use crate::observed_data_sidecars::ObservationStrategy;
 pub use error::{Error as AvailabilityCheckError, ErrorCategory as AvailabilityCheckErrorCategory};
 use types::non_zero_usize::new_non_zero_usize;
 
-/// The LRU Cache stores `PendingComponents` which can store up to
-/// `MAX_BLOBS_PER_BLOCK = 6` blobs each. A `BlobSidecar` is 0.131256 MB. So
-/// the maximum size of a `PendingComponents` is ~ 0.787536 MB. Setting this
-/// to 1024 means the maximum size of the cache is ~ 0.8 GB. But the cache
-/// will target a size of less than 75% of capacity.
-pub const OVERFLOW_LRU_CAPACITY: NonZeroUsize = new_non_zero_usize(1024);
+/// The LRU Cache stores `PendingComponents`, which can store up to `MAX_BLOBS_PER_BLOCK` blobs each.
+///
+/// * Deneb blobs are 128 kb each and are stored in the form of `BlobSidecar`.
+/// * From Fulu (PeerDAS), blobs are erasure-coded and are 256 kb each, stored in the form of 128 `DataColumnSidecar`s.
+///
+/// With `MAX_BLOBS_PER_BLOCK` = 48 (expected in the next year), the maximum size of data columns
+/// in `PendingComponents` is ~12.29 MB. Setting this to 64 means the maximum size of the cache is
+/// approximately 0.8 GB.
+///
+/// Under normal conditions, the cache should only store the current pending block, but could
+///  occasionally spike to 2-4 for various reasons e.g. components arriving late, but would very
+/// rarely go above this, unless there are many concurrent forks.
+pub const OVERFLOW_LRU_CAPACITY: NonZeroUsize = new_non_zero_usize(64);
 /// Until tree-states is implemented, we can't store very many states in memory :(
 pub const STATE_LRU_CAPACITY_NON_ZERO: NonZeroUsize = new_non_zero_usize(2);
 pub const STATE_LRU_CAPACITY: usize = STATE_LRU_CAPACITY_NON_ZERO.get();

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -51,8 +51,7 @@ use types::non_zero_usize::new_non_zero_usize;
 ///  occasionally spike to 2-4 for various reasons e.g. components arriving late, but would very
 /// rarely go above this, unless there are many concurrent forks.
 pub const OVERFLOW_LRU_CAPACITY: NonZeroUsize = new_non_zero_usize(64);
-/// Until tree-states is implemented, we can't store very many states in memory :(
-pub const STATE_LRU_CAPACITY_NON_ZERO: NonZeroUsize = new_non_zero_usize(2);
+pub const STATE_LRU_CAPACITY_NON_ZERO: NonZeroUsize = new_non_zero_usize(32);
 pub const STATE_LRU_CAPACITY: usize = STATE_LRU_CAPACITY_NON_ZERO.get();
 
 /// Cache to hold fully valid data that can't be imported to fork-choice yet. After Dencun hard-fork


### PR DESCRIPTION
## Issue Addressed

The current `OVERFLOW_LRU_CAPACITY` of `1024` seems a bit excessive now we rarely store more than 1 `PendingComponents` (under normal networking components). Additionally given the blob count increases, the max size of `PendingComponents` has also increased and is expected to increase further. 

This PR brings the max capacity of the cache down to `64`, which should be more than enough headroom but also give us  better protection from the network.