### PR TITLE
Fix Clippy for Rust 1.90 beta

### DIFF
--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -201,7 +201,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let signature_set = signed_blocks
             .iter()
             .zip_eq(block_roots)
-            .filter(|&(_block, block_root)| (block_root != self.genesis_block_root))
+            .filter(|&(_block, block_root)| block_root != self.genesis_block_root)
             .map(|(block, block_root)| {
                 block_proposal_signature_set_from_parts(
                     block,

--- a/beacon_node/genesis/src/interop.rs
+++ b/beacon_node/genesis/src/interop.rs
@@ -169,7 +169,7 @@ fn alternating_eth1_withdrawal_credentials_fn<'a>(
     pubkey: &'a PublicKey,
     spec: &'a ChainSpec,
 ) -> Hash256 {
-    if index % 2usize == 0usize {
+    if index.is_multiple_of(2) {
         bls_withdrawal_credentials(pubkey, spec)
     } else {
         eth1_withdrawal_credentials(pubkey, spec)

--- a/beacon_node/http_api/src/aggregate_attestation.rs
+++ b/beacon_node/http_api/src/aggregate_attestation.rs
@@ -63,6 +63,6 @@ pub fn get_aggregate_attestation<T: BeaconChainTypes>(
     } else if endpoint_version == V1 {
         Ok(warp::reply::json(&GenericResponse::from(aggregate_attestation)).into_response())
     } else {
-        return Err(unsupported_version_rejection(endpoint_version));
+        Err(unsupported_version_rejection(endpoint_version))
     }
 }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -6270,7 +6270,9 @@ impl ApiTester {
 
         // Produce a BLS to execution change event
         self.client
-            .post_beacon_pool_bls_to_execution_changes(&[self.bls_to_execution_change.clone()])
+            .post_beacon_pool_bls_to_execution_changes(std::slice::from_ref(
+                &self.bls_to_execution_change,
+            ))
             .await
             .unwrap();
 

--- a/beacon_node/lighthouse_network/src/lib.rs
+++ b/beacon_node/lighthouse_network/src/lib.rs
@@ -63,7 +63,7 @@ impl<'de> Deserialize<'de> for PeerIdSerialized {
 struct ClearDialError<'a>(&'a DialError);
 
 impl ClearDialError<'_> {
-    fn most_inner_error(err: &(dyn std::error::Error)) -> &(dyn std::error::Error) {
+    fn most_inner_error(err: &dyn std::error::Error) -> &dyn std::error::Error {
         let mut current = err;
         while let Some(source) = current.source() {
             current = source;

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -652,9 +652,8 @@ fn test_tcp_blocks_by_range_chunked_rpc_terminates_correctly() {
                 }
 
                 // if we need to send messages send them here. This will happen after a delay
-                if message_info.is_some() {
+                if let Some((peer_id, inbound_request_id)) = &message_info {
                     messages_sent += 1;
-                    let (peer_id, inbound_request_id) = message_info.as_ref().unwrap();
                     receiver.send_response(*peer_id, *inbound_request_id, rpc_response.clone());
                     debug!("Sending message {}", messages_sent);
                     if messages_sent == messages_to_send + extra_messages_to_send {
@@ -1074,9 +1073,8 @@ fn test_tcp_blocks_by_root_chunked_rpc_terminates_correctly() {
                 }
 
                 // if we need to send messages send them here. This will happen after a delay
-                if message_info.is_some() {
+                if let Some((peer_id, inbound_request_id)) = &message_info {
                     messages_sent += 1;
-                    let (peer_id, inbound_request_id) = message_info.as_ref().unwrap();
                     receiver.send_response(*peer_id, *inbound_request_id, rpc_response.clone());
                     debug!("Sending message {}", messages_sent);
                     if messages_sent == messages_to_send + extra_messages_to_send {

--- a/beacon_node/store/src/database/redb_impl.rs
+++ b/beacon_node/store/src/database/redb_impl.rs
@@ -204,7 +204,11 @@ impl<E: EthSpec> Redb<E> {
         mut_db.compact().map_err(Into::into).map(|_| ())
     }
 
-    pub fn iter_column_keys_from<K: Key>(&self, column: DBColumn, from: &[u8]) -> ColumnKeyIter<K> {
+    pub fn iter_column_keys_from<K: Key>(
+        &self,
+        column: DBColumn,
+        from: &[u8],
+    ) -> ColumnKeyIter<'_, K> {
         let table_definition: TableDefinition<'_, &[u8], &[u8]> =
             TableDefinition::new(column.into());
 
@@ -232,11 +236,11 @@ impl<E: EthSpec> Redb<E> {
     }
 
     /// Iterate through all keys and values in a particular column.
-    pub fn iter_column_keys<K: Key>(&self, column: DBColumn) -> ColumnKeyIter<K> {
+    pub fn iter_column_keys<K: Key>(&self, column: DBColumn) -> ColumnKeyIter<'_, K> {
         self.iter_column_keys_from(column, &vec![0; column.key_size()])
     }
 
-    pub fn iter_column_from<K: Key>(&self, column: DBColumn, from: &[u8]) -> ColumnIter<K> {
+    pub fn iter_column_from<K: Key>(&self, column: DBColumn, from: &[u8]) -> ColumnIter<'_, K> {
         let table_definition: TableDefinition<'_, &[u8], &[u8]> =
             TableDefinition::new(column.into());
 
@@ -269,7 +273,7 @@ impl<E: EthSpec> Redb<E> {
         }
     }
 
-    pub fn iter_column<K: Key>(&self, column: DBColumn) -> ColumnIter<K> {
+    pub fn iter_column<K: Key>(&self, column: DBColumn) -> ColumnIter<'_, K> {
         self.iter_column_from(column, &vec![0; column.key_size()])
     }
 

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -906,7 +906,7 @@ async fn invalid_proposer_slashing_duplicate_slashing() {
     let mut ctxt = ConsensusContext::new(state.slot());
     let result_1 = process_operations::process_proposer_slashings(
         &mut state,
-        &[proposer_slashing.clone()],
+        std::slice::from_ref(&proposer_slashing),
         VerifySignatures::False,
         &mut ctxt,
         &spec,
@@ -915,7 +915,7 @@ async fn invalid_proposer_slashing_duplicate_slashing() {
 
     let result_2 = process_operations::process_proposer_slashings(
         &mut state,
-        &[proposer_slashing],
+        std::slice::from_ref(&proposer_slashing),
         VerifySignatures::False,
         &mut ctxt,
         &spec,

--- a/crypto/bls/tests/tests.rs
+++ b/crypto/bls/tests/tests.rs
@@ -370,7 +370,7 @@ macro_rules! test_suite {
         }
 
         impl OwnedSignatureSet {
-            pub fn multiple_pubkeys(&self) -> SignatureSet {
+            pub fn multiple_pubkeys(&self) -> SignatureSet<'_> {
                 let signing_keys = self.signing_keys.iter().map(Cow::Borrowed).collect();
                 SignatureSet::multiple_pubkeys(&self.signature, signing_keys, self.message)
             }

--- a/crypto/eth2_keystore/src/json_keystore/hex_bytes.rs
+++ b/crypto/eth2_keystore/src/json_keystore/hex_bytes.rs
@@ -37,7 +37,7 @@ impl TryFrom<String> for HexBytes {
     fn try_from(s: String) -> Result<Self, Self::Error> {
         // Left-pad with a zero if there is not an even number of hex digits to ensure
         // `hex::decode` doesn't return an error.
-        let s = if s.len() % 2 != 0 {
+        let s = if !s.len().is_multiple_of(2) {
             format!("0{}", s)
         } else {
             s

--- a/slasher/src/config.rs
+++ b/slasher/src/config.rs
@@ -104,7 +104,7 @@ impl Config {
             Err(Error::ConfigInvalidZeroParameter {
                 config: self.clone(),
             })
-        } else if self.history_length % self.chunk_size != 0 {
+        } else if !self.history_length.is_multiple_of(self.chunk_size) {
             Err(Error::ConfigInvalidChunkSize {
                 chunk_size: self.chunk_size,
                 history_length: self.history_length,

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -1002,7 +1002,7 @@ pub struct ManuallyVerifiedAttestation<'a, T: BeaconChainTypes> {
 }
 
 impl<T: BeaconChainTypes> VerifiedAttestation<T> for ManuallyVerifiedAttestation<'_, T> {
-    fn attestation(&self) -> AttestationRef<T::EthSpec> {
+    fn attestation(&self) -> AttestationRef<'_, T::EthSpec> {
         self.attestation.to_ref()
     }
 

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -171,7 +171,7 @@ impl<E: EthSpec> Operation<E> for Deposit {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        process_deposits(state, &[self.clone()], spec)
+        process_deposits(state, std::slice::from_ref(self), spec)
     }
 }
 
@@ -194,7 +194,7 @@ impl<E: EthSpec> Operation<E> for ProposerSlashing {
         initialize_progressive_balances_cache(state, spec)?;
         process_proposer_slashings(
             state,
-            &[self.clone()],
+            std::slice::from_ref(self),
             VerifySignatures::True,
             &mut ctxt,
             spec,
@@ -217,7 +217,12 @@ impl<E: EthSpec> Operation<E> for SignedVoluntaryExit {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        process_exits(state, &[self.clone()], VerifySignatures::True, spec)
+        process_exits(
+            state,
+            std::slice::from_ref(self),
+            VerifySignatures::True,
+            spec,
+        )
     }
 }
 
@@ -438,7 +443,12 @@ impl<E: EthSpec> Operation<E> for SignedBlsToExecutionChange {
         spec: &ChainSpec,
         _extra: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        process_bls_to_execution_changes(state, &[self.clone()], VerifySignatures::True, spec)
+        process_bls_to_execution_changes(
+            state,
+            std::slice::from_ref(self),
+            VerifySignatures::True,
+            spec,
+        )
     }
 }
 
@@ -462,7 +472,7 @@ impl<E: EthSpec> Operation<E> for WithdrawalRequest {
         _extra: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
         state.update_pubkey_cache()?;
-        process_withdrawal_requests(state, &[self.clone()], spec)
+        process_withdrawal_requests(state, std::slice::from_ref(self), spec)
     }
 }
 
@@ -485,7 +495,7 @@ impl<E: EthSpec> Operation<E> for DepositRequest {
         spec: &ChainSpec,
         _extra: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        process_deposit_requests(state, &[self.clone()], spec)
+        process_deposit_requests(state, std::slice::from_ref(self), spec)
     }
 }
 
@@ -509,7 +519,7 @@ impl<E: EthSpec> Operation<E> for ConsolidationRequest {
         _extra: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
         state.update_pubkey_cache()?;
-        process_consolidation_requests(state, &[self.clone()], spec)
+        process_consolidation_requests(state, std::slice::from_ref(self), spec)
     }
 }
 

--- a/validator_client/initialized_validators/src/key_cache.rs
+++ b/validator_client/initialized_validators/src/key_cache.rs
@@ -268,15 +268,7 @@ pub enum Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use eth2_keystore::json_keystore::{HexBytes, Kdf};
-
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct KeyCacheTest {
-        pub params: Kdf,
-        //pub checksum: ChecksumModule,
-        //pub cipher: CipherModule,
-        uuids: Vec<Uuid>,
-    }
+    use eth2_keystore::json_keystore::HexBytes;
 
     #[tokio::test]
     async fn test_serialization() {

--- a/validator_manager/src/list_validators.rs
+++ b/validator_manager/src/list_validators.rs
@@ -294,9 +294,7 @@ mod test {
 
             let result = run::<E>(self.list_config.clone().unwrap()).await;
 
-            if result.is_ok() {
-                let result_ref = result.as_ref().unwrap();
-
+            if let Ok(result_ref) = &result {
                 for local_validator in &self.validators {
                     let local_keystore = &local_validator.voting_keystore.0;
                     let local_pubkey = local_keystore.public_key().unwrap();


### PR DESCRIPTION
## Issue Addressed

Fix Clippy for recently released Rust 1.90 beta. There may be more changes required when Rust 1.89 stable is released in a few days, but possibly not :crossed_fingers: 
