### PR TITLE
Fix Makefile line continuation syntax in test-release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ build-release-tarballs:
 # test vectors.
 test-release:
 	cargo test --workspace --release --features "$(TEST_FEATURES)" \
- 		--exclude ef_tests --exclude beacon_chain --exclude slasher --exclude network
+ 		--exclude ef_tests --exclude beacon_chain --exclude slasher --exclude network \
 		--exclude http_api
 
 # Runs the full workspace tests in **release**, without downloading any additional


### PR DESCRIPTION
## Issue Addressed

#7833

## Proposed Changes

Fix a typo on the `Makefile` that was causing `make test` to run `http_api` tests when they should have been ignored.

## Additional Info

This led me to ask some questions: #7835 
