### PR TITLE
fix: paths so markdownlint-cli finds and fixes files properly

### DIFF
--- a/scripts/mdlint.sh
+++ b/scripts/mdlint.sh
@@ -5,7 +5,7 @@
 # Run `make mdlint` from the root of the repository instead.
 
 # use markdownlint-cli to check for markdown files
-docker run --rm -v ./book:/workdir ghcr.io/igorshubovych/markdownlint-cli:latest '**/*.md' --ignore node_modules
+docker run --rm -v "$PWD/book":/workdir -w /workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --ignore node_modules
 
 # exit code
 exit_code=$(echo $?)
@@ -15,7 +15,7 @@ if [[ $exit_code == 0 ]]; then
     exit 0
 elif [[ $exit_code == 1 ]]; then
     echo "Exiting with errors. Run 'make mdlint' locally and commit the changes. Note that not all errors can be fixed automatically, if there are still errors after running 'make mdlint', look for the errors and fix manually."
-    docker run --rm -v ./book:/workdir ghcr.io/igorshubovych/markdownlint-cli:latest '**/*.md' --ignore node_modules --fix
+    docker run --rm -v "$PWD/book":/workdir -w /workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md" --ignore node_modules --fix
     exit 1
 else
     echo "Exiting with exit code >1. Check for the error logs and fix them accordingly."


### PR DESCRIPTION
## Proposed Changes

the script had a bug where markdownlint-cli couldn’t find files or apply fixes because of wrong paths.
now it uses `-w /workdir` and absolute paths, so everything works smoothly.

