### PR TITLE
Add a flag to disable getBlobs

### DIFF
--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -114,6 +114,8 @@ pub struct ChainConfig {
     /// On Holesky there is a block which is added to this set by default but which can be removed
     /// by using `--invalid-block-roots ""`.
     pub invalid_block_roots: HashSet<Hash256>,
+    /// Disable the getBlobs optimisation to fetch blobs from the EL mempool.
+    pub disable_get_blobs: bool,
 }
 
 impl Default for ChainConfig {
@@ -152,6 +154,7 @@ impl Default for ChainConfig {
             block_publishing_delay: None,
             data_column_publishing_delay: None,
             invalid_block_roots: HashSet::new(),
+            disable_get_blobs: false,
         }
     }
 }

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -751,6 +751,9 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         block_root: Hash256,
         publish_blobs: bool,
     ) {
+        if self.chain.config.disable_get_blobs {
+            return;
+        }
         let epoch = block.slot().epoch(T::EthSpec::slots_per_epoch());
         let custody_columns = self.chain.sampling_columns_for_epoch(epoch);
         let self_cloned = self.clone();

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -910,6 +910,14 @@ pub fn cli_app() -> Command {
                 .display_order(0)
         )
         .arg(
+            Arg::new("disable-get-blobs")
+                .long("disable-get-blobs")
+                .help("Disables the getBlobs optimisation to fetch blobs from the EL mempool")
+                .action(ArgAction::SetTrue)
+                .help_heading(FLAG_HEADER)
+                .display_order(0)
+        )
+        .arg(
             Arg::new("builder-header-timeout")
                 .long("builder-header-timeout")
                 .value_name("MILLISECONDS")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -182,6 +182,10 @@ pub fn get_config<E: EthSpec>(
         client_config.chain.enable_light_client_server = false;
     }
 
+    if cli_args.get_flag("disable-get-blobs") {
+        client_config.chain.disable_get_blobs = true;
+    }
+
     if let Some(sync_tolerance_epochs) =
         clap_utils::parse_optional(cli_args, "sync-tolerance-epochs")?
     {

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -453,6 +453,8 @@ Flags:
           IP address and port as seen by other peers on the network. This
           disables this feature, fixing the ENR's IP/PORT to those specified on
           boot.
+      --disable-get-blobs
+          Disables the getBlobs optimisation to fetch blobs from the EL mempool
       --disable-inbound-rate-limiter
           Disables the inbound rate limiter (requests received by this node).
       --disable-light-client-server

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2545,7 +2545,6 @@ fn get_blobs_disabled() {
 #[test]
 fn get_blobs_enabled() {
     CommandLineTest::new()
-        .flag("disable-get-blobs", None)
         .run_with_zero_port()
         .with_config(|config| {
             assert!(!config.chain.disable_get_blobs);

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2533,6 +2533,26 @@ fn light_client_server_disabled() {
 }
 
 #[test]
+fn get_blobs_disabled() {
+    CommandLineTest::new()
+        .flag("disable-get-blobs", None)
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(config.chain.disable_get_blobs);
+        });
+}
+
+#[test]
+fn get_blobs_enabled() {
+    CommandLineTest::new()
+        .flag("disable-get-blobs", None)
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(!config.chain.disable_get_blobs);
+        });
+}
+
+#[test]
 fn light_client_http_server_disabled() {
     CommandLineTest::new()
         .flag("http", None)


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Add a flag to disable get blobs. I configured the flag to disable it regardless of version because its most likely something we use for testing anyway.

