### PR TITLE
Yeet env_logger into the sun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,17 +710,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "auto_impl"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,19 +2733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "environment"
 version = "0.1.2"
 dependencies = [
@@ -4056,15 +4032,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -5058,7 +5025,6 @@ dependencies = [
  "clap",
  "clap_utils",
  "deposit_contract",
- "env_logger 0.9.3",
  "environment",
  "eth2",
  "eth2_network_config",
@@ -7491,7 +7457,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger 0.8.4",
+ "env_logger",
  "log",
  "rand 0.8.5",
 ]
@@ -8961,7 +8927,6 @@ dependencies = [
  "beacon_chain",
  "bls",
  "derivative",
- "env_logger 0.9.3",
  "ethereum_hashing",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -9260,15 +9225,6 @@ dependencies = [
  "once_cell",
  "rustix 1.0.2",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,6 @@ dirs = "3"
 discv5 = { version = "0.9", features = ["libp2p"] }
 doppelganger_service = { path = "validator_client/doppelganger_service" }
 either = "1.9"
-env_logger = "0.9"
 environment = { path = "lighthouse/environment" }
 eth2 = { path = "common/eth2" }
 eth2_config = { path = "common/eth2_config" }

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -41,5 +41,4 @@ types = { workspace = true }
 
 [dev-dependencies]
 beacon_chain = { workspace = true }
-env_logger = { workspace = true }
 tokio = { workspace = true }

--- a/consensus/state_processing/src/per_epoch_processing/tests.rs
+++ b/consensus/state_processing/src/per_epoch_processing/tests.rs
@@ -3,13 +3,10 @@ use crate::per_epoch_processing::process_epoch;
 use beacon_chain::test_utils::BeaconChainHarness;
 use beacon_chain::types::{EthSpec, MinimalEthSpec};
 use bls::{FixedBytesExtended, Hash256};
-use env_logger::{Builder, Env};
 use types::Slot;
 
 #[tokio::test]
 async fn runs_without_error() {
-    Builder::from_env(Env::default().default_filter_or("error")).init();
-
     let harness = BeaconChainHarness::builder(MinimalEthSpec)
         .default_spec()
         .deterministic_keypairs(8)

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -20,7 +20,6 @@ bls = { workspace = true }
 clap = { workspace = true }
 clap_utils = { workspace = true }
 deposit_contract = { workspace = true }
-env_logger = { workspace = true }
 environment = { workspace = true }
 eth2 = { workspace = true }
 eth2_network_config = { workspace = true }


### PR DESCRIPTION
## Proposed Changes

- Remove explicit `env_logger` usage from `state_processing` tests and `lcli`.
- Set up tracing correctly for `lcli` (I've checked that we can see logs after this change).
- I didn't do anything to set up logging for the `state_processing` tests, as these are rarely run manually (they never fail). We could add `test_logger` in there on an as-needed basis.

## Additional Info

- This eliminates a dependency on `atty` which is abandonware with an [active RUSTSEC warning](https://rustsec.org/advisories/RUSTSEC-2024-0375.html).
- We still depend on a different version of `env_logger` via `quickcheck`. We could probably get rid of that by using `proptest` consistently.
