### PR TITLE
Try using sccache instead of disabling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,3 @@
 [env]
 # Set the number of arenas to 16 when using jemalloc.
 JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,narenas:16"
-
-# FIXME: sccache temporarily disabled due to Windows issues
-[build]
-rustc-wrapper = ""

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -13,7 +13,7 @@ jobs:
   build-and-upload-to-s3:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,7 +64,7 @@ jobs:
             VERSION: ${{ needs.extract-version.outputs.VERSION }}
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - name: Update Rust
               if: env.SELF_HOSTED_RUNNERS == 'false'
               run: rustup update stable

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run mdbook server
         run: |

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -16,7 +16,7 @@ jobs:
   dockerfile-ubuntu:
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build Docker image
         run: |
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: dockerfile-ubuntu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Kurtosis
         run: |
@@ -102,7 +102,7 @@ jobs:
     needs: dockerfile-ubuntu
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Kurtosis
         run: |
@@ -138,7 +138,7 @@ jobs:
     needs: dockerfile-ubuntu
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Kurtosis
         run: |
@@ -181,7 +181,7 @@ jobs:
       matrix:
         network: [sepolia, devnet]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Kurtosis
         run: |
@@ -224,7 +224,7 @@ jobs:
         fork: [electra, fulu]
         offline_secs: [120, 300]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Kurtosis
         run: |
@@ -268,7 +268,7 @@ jobs:
       'doppelganger-protection-failure-test',
     ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check that success job is dependent on all others
         run: |
           exclude_jobs='checkpoint-sync-test|genesis-sync-test'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         needs: extract-version
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
             - name: Get latest version of stable Rust
               if: env.SELF_HOSTED_RUNNERS == 'false'
               run: rustup update stable
@@ -160,7 +160,7 @@ jobs:
         steps:
             # This is necessary for generating the changelog. It has to come before "Download Artifacts" or else it deletes the artifacts.
             - name: Checkout sources
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -28,9 +28,6 @@ env:
   CARGO_INCREMENTAL: 0
   # Enable portable to prevent issues with caching `blst` for the wrong CPU type
   TEST_FEATURES: portable
-  # FIXME: sccache disabled
-  RUSTC_WRAPPER: ""
-  SCCACHE_CACHE_SIZE: 0
 jobs:
   check-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -104,7 +104,8 @@ jobs:
     - name: Run tests in release
       run: make nextest-release
     - name: Show cache stats
-      if: env.SELF_HOSTED_RUNNERS == 'true' && false
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      continue-on-error: true
       run: sccache --show-stats
   release-tests-windows:
     name: release-tests-windows
@@ -135,7 +136,8 @@ jobs:
     - name: Run tests in release
       run: make nextest-release
     - name: Show cache stats
-      if: env.SELF_HOSTED_RUNNERS == 'true' && false
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      continue-on-error: true
       run: sccache --show-stats
   beacon-chain-tests:
     name: beacon-chain-tests
@@ -157,7 +159,8 @@ jobs:
     - name: Run beacon_chain tests for all known forks
       run: make test-beacon-chain
     - name: Show cache stats
-      if: env.SELF_HOSTED_RUNNERS == 'true' && false
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      continue-on-error: true
       run: sccache --show-stats
   http-api-tests:
     name: http-api-tests
@@ -179,7 +182,8 @@ jobs:
     - name: Run http_api tests for all recent forks
       run: make test-http-api
     - name: Show cache stats
-      if: env.SELF_HOSTED_RUNNERS == 'true' && false
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      continue-on-error: true
       run: sccache --show-stats
   op-pool-tests:
     name: op-pool-tests
@@ -267,7 +271,8 @@ jobs:
     - name: Run tests in debug
       run: make nextest-debug
     - name: Show cache stats
-      if: env.SELF_HOSTED_RUNNERS == 'true' && false
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      continue-on-error: true
       run: sccache --show-stats
   state-transition-vectors-ubuntu:
     name: state-transition-vectors-ubuntu
@@ -303,7 +308,8 @@ jobs:
     - name: Run consensus-spec-tests with blst and fake_crypto
       run: make nextest-ef
     - name: Show cache stats
-      if: env.SELF_HOSTED_RUNNERS == 'true' && false
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      continue-on-error: true
       run: sccache --show-stats
   basic-simulator-ubuntu:
     name: basic-simulator-ubuntu

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -81,7 +81,7 @@ jobs:
     # Use self-hosted runners only on the sigp repo.
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     # Set Java version to 21. (required since Web3Signer 24.12.0).
     - uses: actions/setup-java@v4
       with:
@@ -113,7 +113,7 @@ jobs:
     if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "windows", "CI"]') || 'windows-2019'  }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1
@@ -148,7 +148,7 @@ jobs:
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1
@@ -171,7 +171,7 @@ jobs:
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1
@@ -193,7 +193,7 @@ jobs:
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -210,7 +210,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -238,7 +238,7 @@ jobs:
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -256,7 +256,7 @@ jobs:
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1
@@ -280,7 +280,7 @@ jobs:
     if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -297,7 +297,7 @@ jobs:
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1
@@ -317,7 +317,7 @@ jobs:
     if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -338,7 +338,7 @@ jobs:
     if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -359,7 +359,7 @@ jobs:
     if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "small"]') || 'ubuntu-latest'  }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1
@@ -380,7 +380,7 @@ jobs:
     env:
       CARGO_INCREMENTAL: 1
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -410,7 +410,7 @@ jobs:
     name: check-msrv
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install Rust at Minimum Supported Rust Version (MSRV)
       run: |
         metadata=$(cargo metadata --no-deps --format-version 1)
@@ -424,7 +424,7 @@ jobs:
     if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of nightly Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -452,7 +452,7 @@ jobs:
     if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install dependencies
       run: sudo apt update && sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
     - name: Use Rust beta
@@ -465,7 +465,7 @@ jobs:
     if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -479,7 +479,7 @@ jobs:
     if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -519,6 +519,6 @@ jobs:
       'cargo-sort',
     ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check that success job is dependent on all others
         run: ./scripts/ci/check-success-job.sh ./.github/workflows/test-suite.yml test-suite-success


### PR DESCRIPTION
## Issue Addressed

We temporarily can't build sccache on windows runners, but it's still available on linux. 
this smol change lets us use it when available, instead of disabling across the board. 

## Proposed Changes

The Windows runners now have a conditional check to disable (unset the `rustc-wrapper` env var) sccache in their entrypoint, just like the Linux ones have. 
Also the workflows no longer fail when `sccache --show-stats` fails.

## Additional Info

Additionally, bumped `checkout@v4` to `checkout@v5` to beat the bots proposing this oh-so-important life changing version bump. 