### PR TITLE
Do not filter validators by status if filter is an empty list

### DIFF
--- a/beacon_node/http_api/src/validators.rs
+++ b/beacon_node/http_api/src/validators.rs
@@ -43,7 +43,8 @@ pub fn get_beacon_state_validators<T: BeaconChainTypes>(
                             );
 
                             let status_matches = query_statuses.as_ref().is_none_or(|statuses| {
-                                statuses.contains(&status)
+                                statuses.is_empty()
+                                    || statuses.contains(&status)
                                     || statuses.contains(&status.superstatus())
                             });
 

--- a/beacon_node/http_api/src/validators.rs
+++ b/beacon_node/http_api/src/validators.rs
@@ -18,8 +18,18 @@ pub fn get_beacon_state_validators<T: BeaconChainTypes>(
             |state, execution_optimistic, finalized| {
                 let epoch = state.current_epoch();
                 let far_future_epoch = chain.spec.far_future_epoch;
-                let ids_filter_set: Option<HashSet<&ValidatorId>> =
-                    query_ids.as_ref().map(HashSet::from_iter);
+
+                // Map [] to None, indicating that no filtering should be applied (return all
+                // validators).
+                let ids_filter_set: Option<HashSet<&ValidatorId>> = query_ids
+                    .as_ref()
+                    .filter(|list| !list.is_empty())
+                    .map(HashSet::from_iter);
+
+                let statuses_filter_set: Option<HashSet<&ValidatorStatus>> = query_statuses
+                    .as_ref()
+                    .filter(|list| !list.is_empty())
+                    .map(HashSet::from_iter);
 
                 Ok((
                     state
@@ -42,11 +52,11 @@ pub fn get_beacon_state_validators<T: BeaconChainTypes>(
                                 far_future_epoch,
                             );
 
-                            let status_matches = query_statuses.as_ref().is_none_or(|statuses| {
-                                statuses.is_empty()
-                                    || statuses.contains(&status)
-                                    || statuses.contains(&status.superstatus())
-                            });
+                            let status_matches =
+                                statuses_filter_set.as_ref().is_none_or(|statuses| {
+                                    statuses.contains(&status)
+                                        || statuses.contains(&status.superstatus())
+                                });
 
                             if status_matches {
                                 Some(ValidatorData {

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1,30 +1,30 @@
 use beacon_chain::test_utils::RelativeSyncCommittee;
 use beacon_chain::{
-    test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType},
     BeaconChain, ChainConfig, StateSkipConfig, WhenSlotSkipped,
+    test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType},
 };
 use eth2::{
+    BeaconNodeHttpClient, Error,
+    Error::ServerMessage,
+    StatusCode, Timeouts,
     mixin::{RequestAccept, ResponseForkName, ResponseOptional},
     reqwest::RequestBuilder,
     types::{
         BlockId as CoreBlockId, ForkChoiceNode, ProduceBlockV3Response, StateId as CoreStateId, *,
     },
-    BeaconNodeHttpClient, Error,
-    Error::ServerMessage,
-    StatusCode, Timeouts,
 };
 use execution_layer::expected_gas_limit;
 use execution_layer::test_utils::{
-    mock_builder_extra_data, mock_el_extra_data, MockBuilder, Operation,
     DEFAULT_BUILDER_PAYLOAD_VALUE_WEI, DEFAULT_GAS_LIMIT, DEFAULT_MOCK_EL_PAYLOAD_VALUE_WEI,
+    MockBuilder, Operation, mock_builder_extra_data, mock_el_extra_data,
 };
-use futures::stream::{Stream, StreamExt};
 use futures::FutureExt;
+use futures::stream::{Stream, StreamExt};
 use http_api::{
-    test_utils::{create_api_server, ApiServer},
     BlockId, StateId,
+    test_utils::{ApiServer, create_api_server},
 };
-use lighthouse_network::{types::SyncState, Enr, EnrExt, PeerId};
+use lighthouse_network::{Enr, EnrExt, PeerId, types::SyncState};
 use network::NetworkReceivers;
 use operation_pool::attestation_storage::CheckpointKey;
 use proto_array::ExecutionStatus;
@@ -39,9 +39,9 @@ use tokio::time::Duration;
 use tree_hash::TreeHash;
 use types::application_domain::ApplicationDomain;
 use types::{
-    attestation::AttestationBase, AggregateSignature, BitList, Domain, EthSpec, ExecutionBlockHash,
-    Hash256, Keypair, MainnetEthSpec, RelativeEpoch, SelectionProof, SignedRoot, SingleAttestation,
-    Slot,
+    AggregateSignature, BitList, Domain, EthSpec, ExecutionBlockHash, Hash256, Keypair,
+    MainnetEthSpec, RelativeEpoch, SelectionProof, SignedRoot, SingleAttestation, Slot,
+    attestation::AttestationBase,
 };
 
 type E = MainnetEthSpec;
@@ -1578,11 +1578,12 @@ impl ApiTester {
             .await
             .0;
 
-        assert!(self
-            .client
-            .post_beacon_blocks(&PublishBlockRequest::from(block))
-            .await
-            .is_err());
+        assert!(
+            self.client
+                .post_beacon_blocks(&PublishBlockRequest::from(block))
+                .await
+                .is_err()
+        );
 
         assert!(
             self.network_rx.network_recv.recv().await.is_some(),
@@ -1605,11 +1606,12 @@ impl ApiTester {
             .await
             .0;
 
-        assert!(self
-            .client
-            .post_beacon_blocks_ssz(&PublishBlockRequest::from(block))
-            .await
-            .is_err());
+        assert!(
+            self.client
+                .post_beacon_blocks_ssz(&PublishBlockRequest::from(block))
+                .await
+                .is_err()
+        );
 
         assert!(
             self.network_rx.network_recv.recv().await.is_some(),
@@ -1630,11 +1632,12 @@ impl ApiTester {
             .0
             .into();
 
-        assert!(self
-            .client
-            .post_beacon_blocks(&block_contents)
-            .await
-            .is_ok());
+        assert!(
+            self.client
+                .post_beacon_blocks(&block_contents)
+                .await
+                .is_ok()
+        );
 
         // Blinded deneb block contents is just the blinded block
         let blinded_block_contents = block_contents.signed_block().clone_as_blinded();
@@ -4604,13 +4607,14 @@ impl ApiTester {
 
         // If this cache is empty, it indicates fallback was not used, so the payload came from the
         // mock builder.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_none());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_none()
+        );
 
         self
     }
@@ -4649,13 +4653,14 @@ impl ApiTester {
         assert_eq!(payload.gas_limit(), builder_limit);
 
         // This cache should not be populated because fallback should not have been used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_none());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_none()
+        );
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -4689,13 +4694,14 @@ impl ApiTester {
             .into();
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -4765,13 +4771,14 @@ impl ApiTester {
         assert_eq!(payload.fee_recipient(), test_fee_recipient);
 
         // This cache should not be populated because fallback should not have been used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_none());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_none()
+        );
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -4851,13 +4858,14 @@ impl ApiTester {
         assert_eq!(payload.parent_hash(), expected_parent_hash);
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -4943,13 +4951,14 @@ impl ApiTester {
         assert_eq!(payload.prev_randao(), expected_prev_randao);
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5033,13 +5042,14 @@ impl ApiTester {
         assert_eq!(payload.block_number(), expected_block_number);
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5122,13 +5132,14 @@ impl ApiTester {
         assert!(payload.timestamp() > min_expected_timestamp);
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5195,13 +5206,14 @@ impl ApiTester {
             .into();
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5258,13 +5270,14 @@ impl ApiTester {
             .into();
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5334,13 +5347,14 @@ impl ApiTester {
             .into();
 
         // This cache should not be populated because fallback should not have been used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_none());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_none()
+        );
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -5365,13 +5379,14 @@ impl ApiTester {
             .into();
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5473,13 +5488,14 @@ impl ApiTester {
             .into();
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5514,13 +5530,14 @@ impl ApiTester {
             .into();
 
         // This cache should not be populated because fallback should not have been used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_none());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_none()
+        );
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -5633,13 +5650,14 @@ impl ApiTester {
         assert_eq!(payload.fee_recipient(), expected_fee_recipient);
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5711,13 +5729,14 @@ impl ApiTester {
             .into();
 
         // The builder's payload should've been chosen, so this cache should not be populated
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_none());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_none()
+        );
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -5779,13 +5798,14 @@ impl ApiTester {
             .into();
 
         // The local payload should've been chosen, so this cache should be populated
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5847,13 +5867,14 @@ impl ApiTester {
             .into();
 
         // The local payload should've been chosen, so this cache should be populated
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5914,13 +5935,14 @@ impl ApiTester {
             .into();
 
         // The builder's payload should've been chosen, so this cache should not be populated
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_none());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_none()
+        );
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -5985,13 +6007,14 @@ impl ApiTester {
             .into();
 
         // The local payload should've been chosen because the builder's was invalid
-        assert!(self
-            .chain
-            .execution_layer
-            .as_ref()
-            .unwrap()
-            .get_payload_by_root(&payload.tree_hash_root())
-            .is_some());
+        assert!(
+            self.chain
+                .execution_layer
+                .as_ref()
+                .unwrap()
+                .get_payload_by_root(&payload.tree_hash_root())
+                .is_some()
+        );
         self
     }
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1,30 +1,30 @@
 use beacon_chain::test_utils::RelativeSyncCommittee;
 use beacon_chain::{
-    BeaconChain, ChainConfig, StateSkipConfig, WhenSlotSkipped,
     test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType},
+    BeaconChain, ChainConfig, StateSkipConfig, WhenSlotSkipped,
 };
 use eth2::{
-    BeaconNodeHttpClient, Error,
-    Error::ServerMessage,
-    StatusCode, Timeouts,
     mixin::{RequestAccept, ResponseForkName, ResponseOptional},
     reqwest::RequestBuilder,
     types::{
         BlockId as CoreBlockId, ForkChoiceNode, ProduceBlockV3Response, StateId as CoreStateId, *,
     },
+    BeaconNodeHttpClient, Error,
+    Error::ServerMessage,
+    StatusCode, Timeouts,
 };
 use execution_layer::expected_gas_limit;
 use execution_layer::test_utils::{
+    mock_builder_extra_data, mock_el_extra_data, MockBuilder, Operation,
     DEFAULT_BUILDER_PAYLOAD_VALUE_WEI, DEFAULT_GAS_LIMIT, DEFAULT_MOCK_EL_PAYLOAD_VALUE_WEI,
-    MockBuilder, Operation, mock_builder_extra_data, mock_el_extra_data,
 };
-use futures::FutureExt;
 use futures::stream::{Stream, StreamExt};
+use futures::FutureExt;
 use http_api::{
+    test_utils::{create_api_server, ApiServer},
     BlockId, StateId,
-    test_utils::{ApiServer, create_api_server},
 };
-use lighthouse_network::{Enr, EnrExt, PeerId, types::SyncState};
+use lighthouse_network::{types::SyncState, Enr, EnrExt, PeerId};
 use network::NetworkReceivers;
 use operation_pool::attestation_storage::CheckpointKey;
 use proto_array::ExecutionStatus;
@@ -39,9 +39,9 @@ use tokio::time::Duration;
 use tree_hash::TreeHash;
 use types::application_domain::ApplicationDomain;
 use types::{
-    AggregateSignature, BitList, Domain, EthSpec, ExecutionBlockHash, Hash256, Keypair,
-    MainnetEthSpec, RelativeEpoch, SelectionProof, SignedRoot, SingleAttestation, Slot,
-    attestation::AttestationBase,
+    attestation::AttestationBase, AggregateSignature, BitList, Domain, EthSpec, ExecutionBlockHash,
+    Hash256, Keypair, MainnetEthSpec, RelativeEpoch, SelectionProof, SignedRoot, SingleAttestation,
+    Slot,
 };
 
 type E = MainnetEthSpec;
@@ -1079,7 +1079,7 @@ impl ApiTester {
                         .get_beacon_states_validators(
                             state_id.0,
                             Some(validator_index_ids.as_slice()),
-                            None,
+                            Some(statuses.as_slice()),
                         )
                         .await
                         .unwrap()
@@ -1089,20 +1089,28 @@ impl ApiTester {
                         .get_beacon_states_validators(
                             state_id.0,
                             Some(validator_pubkey_ids.as_slice()),
-                            None,
+                            Some(statuses.as_slice()),
                         )
                         .await
                         .unwrap()
                         .map(|res| res.data);
                     let post_result_index_ids = self
                         .client
-                        .post_beacon_states_validators(state_id.0, Some(validator_index_ids), None)
+                        .post_beacon_states_validators(
+                            state_id.0,
+                            Some(validator_index_ids),
+                            Some(statuses.clone()),
+                        )
                         .await
                         .unwrap()
                         .map(|res| res.data);
                     let post_result_pubkey_ids = self
                         .client
-                        .post_beacon_states_validators(state_id.0, Some(validator_pubkey_ids), None)
+                        .post_beacon_states_validators(
+                            state_id.0,
+                            Some(validator_pubkey_ids),
+                            Some(statuses.clone()),
+                        )
                         .await
                         .unwrap()
                         .map(|res| res.data);
@@ -1113,7 +1121,13 @@ impl ApiTester {
 
                         let mut validators = Vec::with_capacity(validator_indices.len());
 
-                        for i in validator_indices {
+                        let expected_indices = if validator_indices.is_empty() {
+                            (0..state.validators().len() as u64).collect()
+                        } else {
+                            validator_indices.clone()
+                        };
+
+                        for i in expected_indices {
                             if i >= state.validators().len() as u64 {
                                 continue;
                             }
@@ -1123,8 +1137,8 @@ impl ApiTester {
                                 epoch,
                                 far_future_epoch,
                             );
-                            if statuses.contains(&status)
-                                || statuses.is_empty()
+                            if statuses.is_empty()
+                                || statuses.contains(&status)
                                 || statuses.contains(&status.superstatus())
                             {
                                 validators.push(ValidatorData {
@@ -1139,7 +1153,7 @@ impl ApiTester {
                         validators
                     });
 
-                    assert_eq!(result_index_ids, expected, "{:?}", state_id);
+                    assert_eq!(result_index_ids, expected, "{:?}", state_id,);
                     assert_eq!(result_pubkey_ids, expected, "{:?}", state_id);
                     assert_eq!(post_result_index_ids, expected, "{:?}", state_id);
                     assert_eq!(post_result_pubkey_ids, expected, "{:?}", state_id);
@@ -1564,12 +1578,11 @@ impl ApiTester {
             .await
             .0;
 
-        assert!(
-            self.client
-                .post_beacon_blocks(&PublishBlockRequest::from(block))
-                .await
-                .is_err()
-        );
+        assert!(self
+            .client
+            .post_beacon_blocks(&PublishBlockRequest::from(block))
+            .await
+            .is_err());
 
         assert!(
             self.network_rx.network_recv.recv().await.is_some(),
@@ -1592,12 +1605,11 @@ impl ApiTester {
             .await
             .0;
 
-        assert!(
-            self.client
-                .post_beacon_blocks_ssz(&PublishBlockRequest::from(block))
-                .await
-                .is_err()
-        );
+        assert!(self
+            .client
+            .post_beacon_blocks_ssz(&PublishBlockRequest::from(block))
+            .await
+            .is_err());
 
         assert!(
             self.network_rx.network_recv.recv().await.is_some(),
@@ -1618,12 +1630,11 @@ impl ApiTester {
             .0
             .into();
 
-        assert!(
-            self.client
-                .post_beacon_blocks(&block_contents)
-                .await
-                .is_ok()
-        );
+        assert!(self
+            .client
+            .post_beacon_blocks(&block_contents)
+            .await
+            .is_ok());
 
         // Blinded deneb block contents is just the blinded block
         let blinded_block_contents = block_contents.signed_block().clone_as_blinded();
@@ -4593,14 +4604,13 @@ impl ApiTester {
 
         // If this cache is empty, it indicates fallback was not used, so the payload came from the
         // mock builder.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_none()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_none());
 
         self
     }
@@ -4639,14 +4649,13 @@ impl ApiTester {
         assert_eq!(payload.gas_limit(), builder_limit);
 
         // This cache should not be populated because fallback should not have been used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_none()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_none());
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -4680,14 +4689,13 @@ impl ApiTester {
             .into();
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -4757,14 +4765,13 @@ impl ApiTester {
         assert_eq!(payload.fee_recipient(), test_fee_recipient);
 
         // This cache should not be populated because fallback should not have been used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_none()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_none());
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -4844,14 +4851,13 @@ impl ApiTester {
         assert_eq!(payload.parent_hash(), expected_parent_hash);
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -4937,14 +4943,13 @@ impl ApiTester {
         assert_eq!(payload.prev_randao(), expected_prev_randao);
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5028,14 +5033,13 @@ impl ApiTester {
         assert_eq!(payload.block_number(), expected_block_number);
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5118,14 +5122,13 @@ impl ApiTester {
         assert!(payload.timestamp() > min_expected_timestamp);
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5192,14 +5195,13 @@ impl ApiTester {
             .into();
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5256,14 +5258,13 @@ impl ApiTester {
             .into();
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5333,14 +5334,13 @@ impl ApiTester {
             .into();
 
         // This cache should not be populated because fallback should not have been used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_none()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_none());
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -5365,14 +5365,13 @@ impl ApiTester {
             .into();
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5474,14 +5473,13 @@ impl ApiTester {
             .into();
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5516,14 +5514,13 @@ impl ApiTester {
             .into();
 
         // This cache should not be populated because fallback should not have been used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_none()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_none());
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -5636,14 +5633,13 @@ impl ApiTester {
         assert_eq!(payload.fee_recipient(), expected_fee_recipient);
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5715,14 +5711,13 @@ impl ApiTester {
             .into();
 
         // The builder's payload should've been chosen, so this cache should not be populated
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_none()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_none());
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -5784,14 +5779,13 @@ impl ApiTester {
             .into();
 
         // The local payload should've been chosen, so this cache should be populated
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5853,14 +5847,13 @@ impl ApiTester {
             .into();
 
         // The local payload should've been chosen, so this cache should be populated
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         // another way is to check for the extra data of the local EE
         assert_eq!(payload.extra_data(), mock_el_extra_data::<E>());
 
@@ -5921,14 +5914,13 @@ impl ApiTester {
             .into();
 
         // The builder's payload should've been chosen, so this cache should not be populated
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_none()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_none());
         // Another way is to check for the extra data of the mock builder
         assert_eq!(payload.extra_data(), mock_builder_extra_data::<E>());
 
@@ -5993,14 +5985,13 @@ impl ApiTester {
             .into();
 
         // The local payload should've been chosen because the builder's was invalid
-        assert!(
-            self.chain
-                .execution_layer
-                .as_ref()
-                .unwrap()
-                .get_payload_by_root(&payload.tree_hash_root())
-                .is_some()
-        );
+        assert!(self
+            .chain
+            .execution_layer
+            .as_ref()
+            .unwrap()
+            .get_payload_by_root(&payload.tree_hash_root())
+            .is_some());
         self
     }
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1153,7 +1153,7 @@ impl ApiTester {
                         validators
                     });
 
-                    assert_eq!(result_index_ids, expected, "{:?}", state_id,);
+                    assert_eq!(result_index_ids, expected, "{:?}", state_id);
                     assert_eq!(result_pubkey_ids, expected, "{:?}", state_id);
                     assert_eq!(post_result_index_ids, expected, "{:?}", state_id);
                     assert_eq!(post_result_pubkey_ids, expected, "{:?}", state_id);

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -366,7 +366,7 @@ pub struct ValidatorIdentityData {
 // this proposal:
 //
 // https://hackmd.io/bQxMDRt1RbS1TLno8K4NPg?view
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ValidatorStatus {
     PendingInitialized,


### PR DESCRIPTION
## Issue Addressed

https://github.com/ethereum/beacon-APIs/blob/69d2feb12a6047c4f21e628dea8b0135b7e9013a/apis/beacon/states/validators.yaml#L128-L130 says we need to not filter if the filter is an empty list.

## Proposed Changes

Add a check for `statuses.is_empty()`.
