### PR TITLE
Spec Mapping for configs.yml in Lighthouse

### DIFF
--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,0 +1,76 @@
+version: v1.6.0-alpha.3
+style: hash
+
+specrefs:
+  search_root: ..
+  files:
+    - configs.yml
+    - constants.yml
+    - containers.yml
+    - dataclasses.yml
+    - functions.yml
+    - presets.yml
+
+exceptions:
+  configs:
+    # A mistake in the pyspec broke this
+    # Remove exception in the next release
+    - BLOB_SCHEDULE
+  constants: []
+  ssz_objects: []
+  dataclasses: []
+  functions:
+    # Functions implemented by KZG library for EIP-4844
+    - bit_reversal_permutation#deneb
+    - blob_to_kzg_commitment#deneb
+    - blob_to_polynomial#deneb
+    - bls_field_to_bytes#deneb
+    - bytes_to_bls_field#deneb
+    - bytes_to_kzg_commitment#deneb
+    - bytes_to_kzg_proof#deneb
+    - compute_blob_kzg_proof#deneb
+    - compute_challenge#deneb
+    - compute_kzg_proof#deneb
+    - compute_kzg_proof_impl#deneb
+    - compute_powers#deneb
+    - compute_quotient_eval_within_domain#deneb
+    - compute_roots_of_unity#deneb
+    - evaluate_polynomial_in_evaluation_form#deneb
+    - g1_lincomb#deneb
+    - hash_to_bls_field#deneb
+    - is_power_of_two#deneb
+    - multi_exp#deneb
+    - reverse_bits#deneb
+    - validate_kzg_g1#deneb
+    - verify_blob_kzg_proof#deneb
+    - verify_blob_kzg_proof_batch#deneb
+    - verify_kzg_proof#deneb
+    - verify_kzg_proof_batch#deneb
+    - verify_kzg_proof_impl#deneb
+
+    # Functions implemented by KZG library for EIP-7594
+    - _fft_field#fulu
+    - add_polynomialcoeff#fulu
+    - cell_to_coset_evals#fulu
+    - compute_cells#fulu
+    - compute_cells_and_kzg_proofs#fulu
+    - compute_cells_and_kzg_proofs_polynomialcoeff#fulu
+    - compute_kzg_proof_multi_impl#fulu
+    - compute_verify_cell_kzg_proof_batch_challenge#fulu
+    - construct_vanishing_polynomial#fulu
+    - coset_evals_to_cell#fulu
+    - coset_fft_field#fulu
+    - coset_for_cell#fulu
+    - coset_shift_for_cell#fulu
+    - divide_polynomialcoeff#fulu
+    - evaluate_polynomialcoeff#fulu
+    - fft_field#fulu
+    - interpolate_polynomialcoeff#fulu
+    - multiply_polynomialcoeff#fulu
+    - polynomial_eval_to_coeff#fulu
+    - recover_cells_and_kzg_proofs#fulu
+    - recover_polynomialcoeff#fulu
+    - vanishing_polynomialcoeff#fulu
+    - verify_cell_kzg_proof_batch#fulu
+    - verify_cell_kzg_proof_batch_impl#fulu
+

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -5,11 +5,11 @@ specrefs:
   search_root: ..
   files:
     - configs.yml
-    - constants.yml
-    - containers.yml
-    - dataclasses.yml
-    - functions.yml
-    - presets.yml
+    # - constants.yml
+    # - containers.yml
+    # - dataclasses.yml
+    # - functions.yml
+    # - presets.yml
 
 exceptions:
   configs:

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -99,7 +99,7 @@
 - name: CUSTODY_REQUIREMENT
   sources: 
     - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
-      search: CUSTODY_REQUIREMENT:
+      search: CUSTODY_REQUIREMENT: # To avoid ambiguous search we can use regex: ^\s*CUSTODY_REQUIREMENT:\s  make sure to turn on regex mode
   spec: |
     <spec config_var="CUSTODY_REQUIREMENT" fork="fulu" hash="b7340203" />
 
@@ -406,7 +406,7 @@
 
 - name: SECONDS_PER_SLOT
   sources:
-    - file: lighthouse/common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
       search: SECONDS_PER_SLOT:
   spec: |
     <spec config_var="SECONDS_PER_SLOT" fork="phase0" hash="a9118f10" />

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -1,324 +1,454 @@
 - name: ALTAIR_FORK_EPOCH
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: ALTAIR_FORK_EPOCH:
   spec: |
     <spec config_var="ALTAIR_FORK_EPOCH" fork="altair" hash="e62f5307" />
 
 - name: ALTAIR_FORK_VERSION
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: ALTAIR_FORK_VERSION:
   spec: |
     <spec config_var="ALTAIR_FORK_VERSION" fork="altair" hash="d9a64536" />
 
 - name: ATTESTATION_PROPAGATION_SLOT_RANGE
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: ATTESTATION_PROPAGATION_SLOT_RANGE:
   spec: |
     <spec config_var="ATTESTATION_PROPAGATION_SLOT_RANGE" fork="phase0" hash="40bcdb02" />
 
 - name: ATTESTATION_SUBNET_COUNT
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: ATTESTATION_SUBNET_COUNT:
   spec: |
     <spec config_var="ATTESTATION_SUBNET_COUNT" fork="phase0" hash="1c8c0a1b" />
 
 - name: ATTESTATION_SUBNET_EXTRA_BITS
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: ATTESTATION_SUBNET_EXTRA_BITS:
   spec: |
     <spec config_var="ATTESTATION_SUBNET_EXTRA_BITS" fork="phase0" hash="e233b5ba" />
 
 - name: ATTESTATION_SUBNET_PREFIX_BITS
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: ATTESTATION_SUBNET_PREFIX_BITS:
   spec: |
     <spec config_var="ATTESTATION_SUBNET_PREFIX_BITS" fork="phase0" hash="d6f5ea62" />
 
 - name: BALANCE_PER_ADDITIONAL_CUSTODY_GROUP
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: BALANCE_PER_ADDITIONAL_CUSTODY_GROUP:
   spec: |
     <spec config_var="BALANCE_PER_ADDITIONAL_CUSTODY_GROUP" fork="fulu" hash="5b556450" />
 
 - name: BELLATRIX_FORK_EPOCH
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: BELLATRIX_FORK_EPOCH:
   spec: |
     <spec config_var="BELLATRIX_FORK_EPOCH" fork="bellatrix" hash="f0afe6d8" />
 
 - name: BELLATRIX_FORK_VERSION
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: BELLATRIX_FORK_VERSION:
   spec: |
     <spec config_var="BELLATRIX_FORK_VERSION" fork="bellatrix" hash="e87eb2b4" />
 
 - name: BLOB_SIDECAR_SUBNET_COUNT
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: BLOB_SIDECAR_SUBNET_COUNT:
   spec: |
     <spec config_var="BLOB_SIDECAR_SUBNET_COUNT" fork="deneb" hash="03cc9976" />
 
 - name: BLOB_SIDECAR_SUBNET_COUNT_ELECTRA
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: BLOB_SIDECAR_SUBNET_COUNT_ELECTRA:
   spec: |
     <spec config_var="BLOB_SIDECAR_SUBNET_COUNT_ELECTRA" fork="electra" hash="37ca2860" />
 
 - name: CAPELLA_FORK_EPOCH
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: CAPELLA_FORK_EPOCH:
   spec: |
     <spec config_var="CAPELLA_FORK_EPOCH" fork="capella" hash="65767661" />
 
 - name: CAPELLA_FORK_VERSION
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: CAPELLA_FORK_VERSION:
   spec: |
     <spec config_var="CAPELLA_FORK_VERSION" fork="capella" hash="5f94766c" />
 
 - name: CHURN_LIMIT_QUOTIENT
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: CHURN_LIMIT_QUOTIENT:
   spec: |
     <spec config_var="CHURN_LIMIT_QUOTIENT" fork="phase0" hash="a43a1d33" />
 
 - name: CUSTODY_REQUIREMENT
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: CUSTODY_REQUIREMENT:
   spec: |
     <spec config_var="CUSTODY_REQUIREMENT" fork="fulu" hash="b7340203" />
 
 - name: DATA_COLUMN_SIDECAR_SUBNET_COUNT
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: DATA_COLUMN_SIDECAR_SUBNET_COUNT:
   spec: |
     <spec config_var="DATA_COLUMN_SIDECAR_SUBNET_COUNT" fork="fulu" hash="626172a6" />
 
 - name: DENEB_FORK_EPOCH
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: DENEB_FORK_EPOCH:
   spec: |
     <spec config_var="DENEB_FORK_EPOCH" fork="deneb" hash="46d3dfee" />
 
 - name: DENEB_FORK_VERSION
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: DENEB_FORK_VERSION:
   spec: |
     <spec config_var="DENEB_FORK_VERSION" fork="deneb" hash="da95e3b9" />
 
 - name: EJECTION_BALANCE
-  sources: []
+  sources:  
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: EJECTION_BALANCE:
   spec: |
     <spec config_var="EJECTION_BALANCE" fork="phase0" hash="3f86d864" />
 
 - name: ELECTRA_FORK_EPOCH
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: ELECTRA_FORK_EPOCH:
   spec: |
     <spec config_var="ELECTRA_FORK_EPOCH" fork="electra" hash="53fa3efa" />
 
 - name: ELECTRA_FORK_VERSION
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: ELECTRA_FORK_VERSION:
   spec: |
     <spec config_var="ELECTRA_FORK_VERSION" fork="electra" hash="918d6c63" />
 
 - name: EPOCHS_PER_SUBNET_SUBSCRIPTION
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: EPOCHS_PER_SUBNET_SUBSCRIPTION:
   spec: |
     <spec config_var="EPOCHS_PER_SUBNET_SUBSCRIPTION" fork="phase0" hash="1b832329" />
 
 - name: ETH1_FOLLOW_DISTANCE
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: ETH1_FOLLOW_DISTANCE:
   spec: |
     <spec config_var="ETH1_FOLLOW_DISTANCE" fork="phase0" hash="2f5ba1a0" />
 
 - name: FULU_FORK_EPOCH
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: FULU_FORK_EPOCH:
   spec: |
     <spec config_var="FULU_FORK_EPOCH" fork="fulu" hash="673334be" />
 
 - name: FULU_FORK_VERSION
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: FULU_FORK_VERSION:
   spec: |
     <spec config_var="FULU_FORK_VERSION" fork="fulu" hash="1e7fa12a" />
 
 - name: GENESIS_DELAY
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: GENESIS_DELAY:
   spec: |
     <spec config_var="GENESIS_DELAY" fork="phase0" hash="c50c75f1" />
 
 - name: GENESIS_FORK_VERSION
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: GENESIS_FORK_VERSION:
   spec: |
     <spec config_var="GENESIS_FORK_VERSION" fork="phase0" hash="32bbe06e" />
 
 - name: INACTIVITY_SCORE_BIAS
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: INACTIVITY_SCORE_BIAS:
   spec: |
     <spec config_var="INACTIVITY_SCORE_BIAS" fork="altair" hash="c84c24a9" />
 
 - name: INACTIVITY_SCORE_RECOVERY_RATE
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: INACTIVITY_SCORE_RECOVERY_RATE:
   spec: |
     <spec config_var="INACTIVITY_SCORE_RECOVERY_RATE" fork="altair" hash="d7876320" />
 
 - name: MAXIMUM_GOSSIP_CLOCK_DISPARITY
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MAXIMUM_GOSSIP_CLOCK_DISPARITY:
   spec: |
     <spec config_var="MAXIMUM_GOSSIP_CLOCK_DISPARITY" fork="phase0" hash="12990b53" />
 
 - name: MAX_BLOBS_PER_BLOCK
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MAX_BLOBS_PER_BLOCK:
   spec: |
     <spec config_var="MAX_BLOBS_PER_BLOCK" fork="deneb" hash="3e0b5383" />
 
 - name: MAX_BLOBS_PER_BLOCK_ELECTRA
-  sources: []
+  sources:  
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MAX_BLOBS_PER_BLOCK_ELECTRA:
   spec: |
     <spec config_var="MAX_BLOBS_PER_BLOCK_ELECTRA" fork="electra" hash="0d8ea1c9" />
 
 - name: MAX_PAYLOAD_SIZE
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MAX_PAYLOAD_SIZE:
   spec: |
     <spec config_var="MAX_PAYLOAD_SIZE" fork="phase0" hash="7f1566fb" />
 
 - name: MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT:
   spec: |
     <spec config_var="MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT" fork="deneb" hash="c4d9b0bb" />
 
 - name: MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT:
   spec: |
     <spec config_var="MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT" fork="electra" hash="87c05125" />
 
 - name: MAX_REQUEST_BLOB_SIDECARS
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MAX_REQUEST_BLOB_SIDECARS:
   spec: |
     <spec config_var="MAX_REQUEST_BLOB_SIDECARS" fork="deneb" hash="9b8ad30b" />
 
 - name: MAX_REQUEST_BLOB_SIDECARS_ELECTRA
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MAX_REQUEST_BLOB_SIDECARS_ELECTRA:
   spec: |
     <spec config_var="MAX_REQUEST_BLOB_SIDECARS_ELECTRA" fork="electra" hash="decc80ab" />
 
 - name: MAX_REQUEST_BLOCKS
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MAX_REQUEST_BLOCKS:
   spec: |
     <spec config_var="MAX_REQUEST_BLOCKS" fork="phase0" hash="a9ae6c77" />
 
 - name: MAX_REQUEST_BLOCKS_DENEB
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MAX_REQUEST_BLOCKS_DENEB:
   spec: |
     <spec config_var="MAX_REQUEST_BLOCKS_DENEB" fork="deneb" hash="8318964a" />
 
 - name: MAX_REQUEST_DATA_COLUMN_SIDECARS
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MAX_REQUEST_DATA_COLUMN_SIDECARS:
   spec: |
     <spec config_var="MAX_REQUEST_DATA_COLUMN_SIDECARS" fork="fulu" hash="bbe5c650" />
 
 - name: MESSAGE_DOMAIN_INVALID_SNAPPY
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MESSAGE_DOMAIN_INVALID_SNAPPY:
   spec: |
     <spec config_var="MESSAGE_DOMAIN_INVALID_SNAPPY" fork="phase0" hash="6b6fc19a" />
 
 - name: MESSAGE_DOMAIN_VALID_SNAPPY
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MESSAGE_DOMAIN_VALID_SNAPPY:
   spec: |
     <spec config_var="MESSAGE_DOMAIN_VALID_SNAPPY" fork="phase0" hash="a6de155f" />
 
 - name: MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS:
   spec: |
     <spec config_var="MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS" fork="deneb" hash="3df9114c" />
 
 - name: MIN_EPOCHS_FOR_BLOCK_REQUESTS
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MIN_EPOCHS_FOR_BLOCK_REQUESTS:
   spec: |
     <spec config_var="MIN_EPOCHS_FOR_BLOCK_REQUESTS" fork="phase0" hash="8ab131c4" />
 
 - name: MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS:
   spec: |
     <spec config_var="MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS" fork="fulu" hash="910e49bb" />
 
 - name: MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MIN_GENESIS_ACTIVE_VALIDATOR_COUNT:
   spec: |
     <spec config_var="MIN_GENESIS_ACTIVE_VALIDATOR_COUNT" fork="phase0" hash="7715513b" />
 
 - name: MIN_GENESIS_TIME
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MIN_GENESIS_TIME:
   spec: |
     <spec config_var="MIN_GENESIS_TIME" fork="phase0" hash="75c06876" />
 
 - name: MIN_PER_EPOCH_CHURN_LIMIT
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MIN_PER_EPOCH_CHURN_LIMIT:
   spec: |
     <spec config_var="MIN_PER_EPOCH_CHURN_LIMIT" fork="phase0" hash="ff24b223" />
 
 - name: MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA:
   spec: |
     <spec config_var="MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA" fork="electra" hash="201809f8" />
 
 - name: MIN_VALIDATOR_WITHDRAWABILITY_DELAY
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: MIN_VALIDATOR_WITHDRAWABILITY_DELAY:
   spec: |
     <spec config_var="MIN_VALIDATOR_WITHDRAWABILITY_DELAY" fork="phase0" hash="5c4eeded" />
 
 - name: NUMBER_OF_COLUMNS
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: NUMBER_OF_COLUMNS:
   spec: |
     <spec config_var="NUMBER_OF_COLUMNS" fork="fulu" hash="f6441e62" />
 
 - name: NUMBER_OF_CUSTODY_GROUPS
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: NUMBER_OF_CUSTODY_GROUPS:
   spec: |
     <spec config_var="NUMBER_OF_CUSTODY_GROUPS" fork="fulu" hash="05e3016e" />
 
 - name: PROPOSER_SCORE_BOOST
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: PROPOSER_SCORE_BOOST:
   spec: |
     <spec config_var="PROPOSER_SCORE_BOOST" fork="phase0" hash="fbc878c6" />
 
 - name: REORG_HEAD_WEIGHT_THRESHOLD
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: REORG_HEAD_WEIGHT_THRESHOLD:
   spec: |
     <spec config_var="REORG_HEAD_WEIGHT_THRESHOLD" fork="phase0" hash="d4ecaa84" />
 
 - name: REORG_MAX_EPOCHS_SINCE_FINALIZATION
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: REORG_MAX_EPOCHS_SINCE_FINALIZATION:
   spec: |
     <spec config_var="REORG_MAX_EPOCHS_SINCE_FINALIZATION" fork="phase0" hash="8567706e" />
 
 - name: REORG_PARENT_WEIGHT_THRESHOLD
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: REORG_PARENT_WEIGHT_THRESHOLD:
   spec: |
     <spec config_var="REORG_PARENT_WEIGHT_THRESHOLD" fork="phase0" hash="cb81e3da" />
 
 - name: SAMPLES_PER_SLOT
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: SAMPLES_PER_SLOT:
   spec: |
     <spec config_var="SAMPLES_PER_SLOT" fork="fulu" hash="158798b8" />
 
 - name: SECONDS_PER_ETH1_BLOCK
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: SECONDS_PER_ETH1_BLOCK:
   spec: |
     <spec config_var="SECONDS_PER_ETH1_BLOCK" fork="phase0" hash="90c9f3d1" />
 
 - name: SECONDS_PER_SLOT
-  sources: []
+  sources:
+    - file: lighthouse/common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: SECONDS_PER_SLOT:
   spec: |
     <spec config_var="SECONDS_PER_SLOT" fork="phase0" hash="a9118f10" />
 
 - name: SHARD_COMMITTEE_PERIOD
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: SHARD_COMMITTEE_PERIOD:
   spec: |
     <spec config_var="SHARD_COMMITTEE_PERIOD" fork="phase0" hash="5d0e85a4" />
 
 - name: SUBNETS_PER_NODE
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: SUBNETS_PER_NODE:
   spec: |
     <spec config_var="SUBNETS_PER_NODE" fork="phase0" hash="4799f8f3" />
 
 - name: TERMINAL_BLOCK_HASH
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: TERMINAL_BLOCK_HASH:
   spec: |
     <spec config_var="TERMINAL_BLOCK_HASH" fork="bellatrix" hash="964c3bfe" />
 
 - name: TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH:
   spec: |
     <spec config_var="TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH" fork="bellatrix" hash="81928369" />
 
 - name: TERMINAL_TOTAL_DIFFICULTY
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: TERMINAL_TOTAL_DIFFICULTY:
   spec: |
     <spec config_var="TERMINAL_TOTAL_DIFFICULTY" fork="bellatrix" hash="e0f3a816" />
 
 - name: VALIDATOR_CUSTODY_REQUIREMENT
-  sources: []
+  sources: 
+    - file: common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+      search: VALIDATOR_CUSTODY_REQUIREMENT:
   spec: |
     <spec config_var="VALIDATOR_CUSTODY_REQUIREMENT" fork="fulu" hash="4dfc4457" />

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -1,0 +1,344 @@
+- name: ALTAIR_FORK_EPOCH
+  sources: []
+  spec: |
+    <spec config_var="ALTAIR_FORK_EPOCH" fork="altair" hash="e62f5307" />
+
+- name: ALTAIR_FORK_VERSION
+  sources: []
+  spec: |
+    <spec config_var="ALTAIR_FORK_VERSION" fork="altair" hash="d9a64536" />
+
+- name: ATTESTATION_PROPAGATION_SLOT_RANGE
+  sources: []
+  spec: |
+    <spec config_var="ATTESTATION_PROPAGATION_SLOT_RANGE" fork="phase0" hash="40bcdb02" />
+
+- name: ATTESTATION_SUBNET_COUNT
+  sources: []
+  spec: |
+    <spec config_var="ATTESTATION_SUBNET_COUNT" fork="phase0" hash="1c8c0a1b" />
+
+- name: ATTESTATION_SUBNET_EXTRA_BITS
+  sources: []
+  spec: |
+    <spec config_var="ATTESTATION_SUBNET_EXTRA_BITS" fork="phase0" hash="e233b5ba" />
+
+- name: ATTESTATION_SUBNET_PREFIX_BITS
+  sources: []
+  spec: |
+    <spec config_var="ATTESTATION_SUBNET_PREFIX_BITS" fork="phase0" hash="d6f5ea62" />
+
+- name: BALANCE_PER_ADDITIONAL_CUSTODY_GROUP
+  sources: []
+  spec: |
+    <spec config_var="BALANCE_PER_ADDITIONAL_CUSTODY_GROUP" fork="fulu" hash="5b556450" />
+
+- name: BELLATRIX_FORK_EPOCH
+  sources: []
+  spec: |
+    <spec config_var="BELLATRIX_FORK_EPOCH" fork="bellatrix" hash="f0afe6d8" />
+
+- name: BELLATRIX_FORK_VERSION
+  sources: []
+  spec: |
+    <spec config_var="BELLATRIX_FORK_VERSION" fork="bellatrix" hash="e87eb2b4" />
+
+- name: BLOB_SIDECAR_SUBNET_COUNT
+  sources: []
+  spec: |
+    <spec config_var="BLOB_SIDECAR_SUBNET_COUNT" fork="deneb" hash="03cc9976" />
+
+- name: BLOB_SIDECAR_SUBNET_COUNT_ELECTRA
+  sources: []
+  spec: |
+    <spec config_var="BLOB_SIDECAR_SUBNET_COUNT_ELECTRA" fork="electra" hash="37ca2860" />
+
+- name: CAPELLA_FORK_EPOCH
+  sources: []
+  spec: |
+    <spec config_var="CAPELLA_FORK_EPOCH" fork="capella" hash="65767661" />
+
+- name: CAPELLA_FORK_VERSION
+  sources: []
+  spec: |
+    <spec config_var="CAPELLA_FORK_VERSION" fork="capella" hash="5f94766c" />
+
+- name: CHURN_LIMIT_QUOTIENT#phase0
+  sources: []
+  spec: |
+    <spec config_var="CHURN_LIMIT_QUOTIENT" fork="phase0" hash="a43a1d33" />
+
+- name: CHURN_LIMIT_QUOTIENT#electra
+  sources: []
+  spec: |
+    <spec config_var="CHURN_LIMIT_QUOTIENT" fork="electra" hash="a43a1d33" />
+
+- name: CUSTODY_REQUIREMENT
+  sources: []
+  spec: |
+    <spec config_var="CUSTODY_REQUIREMENT" fork="fulu" hash="b7340203" />
+
+- name: DATA_COLUMN_SIDECAR_SUBNET_COUNT
+  sources: []
+  spec: |
+    <spec config_var="DATA_COLUMN_SIDECAR_SUBNET_COUNT" fork="fulu" hash="626172a6" />
+
+- name: DENEB_FORK_EPOCH
+  sources: []
+  spec: |
+    <spec config_var="DENEB_FORK_EPOCH" fork="deneb" hash="46d3dfee" />
+
+- name: DENEB_FORK_VERSION
+  sources: []
+  spec: |
+    <spec config_var="DENEB_FORK_VERSION" fork="deneb" hash="da95e3b9" />
+
+- name: EJECTION_BALANCE#phase0
+  sources: []
+  spec: |
+    <spec config_var="EJECTION_BALANCE" fork="phase0" hash="3f86d864" />
+
+- name: EJECTION_BALANCE#electra
+  sources: []
+  spec: |
+    <spec config_var="EJECTION_BALANCE" fork="electra" hash="3f86d864" />
+
+- name: ELECTRA_FORK_EPOCH
+  sources: []
+  spec: |
+    <spec config_var="ELECTRA_FORK_EPOCH" fork="electra" hash="53fa3efa" />
+
+- name: ELECTRA_FORK_VERSION
+  sources: []
+  spec: |
+    <spec config_var="ELECTRA_FORK_VERSION" fork="electra" hash="918d6c63" />
+
+- name: EPOCHS_PER_SUBNET_SUBSCRIPTION
+  sources: []
+  spec: |
+    <spec config_var="EPOCHS_PER_SUBNET_SUBSCRIPTION" fork="phase0" hash="1b832329" />
+
+- name: ETH1_FOLLOW_DISTANCE#phase0
+  sources: []
+  spec: |
+    <spec config_var="ETH1_FOLLOW_DISTANCE" fork="phase0" hash="2f5ba1a0" />
+
+- name: ETH1_FOLLOW_DISTANCE#electra
+  sources: []
+  spec: |
+    <spec config_var="ETH1_FOLLOW_DISTANCE" fork="electra" hash="2f5ba1a0" />
+
+- name: FULU_FORK_EPOCH
+  sources: []
+  spec: |
+    <spec config_var="FULU_FORK_EPOCH" fork="fulu" hash="673334be" />
+
+- name: FULU_FORK_VERSION
+  sources: []
+  spec: |
+    <spec config_var="FULU_FORK_VERSION" fork="fulu" hash="1e7fa12a" />
+
+- name: GENESIS_DELAY
+  sources: []
+  spec: |
+    <spec config_var="GENESIS_DELAY" fork="phase0" hash="c50c75f1" />
+
+- name: GENESIS_FORK_VERSION
+  sources: []
+  spec: |
+    <spec config_var="GENESIS_FORK_VERSION" fork="phase0" hash="32bbe06e" />
+
+- name: INACTIVITY_SCORE_BIAS
+  sources: []
+  spec: |
+    <spec config_var="INACTIVITY_SCORE_BIAS" fork="altair" hash="c84c24a9" />
+
+- name: INACTIVITY_SCORE_RECOVERY_RATE
+  sources: []
+  spec: |
+    <spec config_var="INACTIVITY_SCORE_RECOVERY_RATE" fork="altair" hash="d7876320" />
+
+- name: MAXIMUM_GOSSIP_CLOCK_DISPARITY
+  sources: []
+  spec: |
+    <spec config_var="MAXIMUM_GOSSIP_CLOCK_DISPARITY" fork="phase0" hash="12990b53" />
+
+- name: MAX_BLOBS_PER_BLOCK
+  sources: []
+  spec: |
+    <spec config_var="MAX_BLOBS_PER_BLOCK" fork="deneb" hash="3e0b5383" />
+
+- name: MAX_BLOBS_PER_BLOCK_ELECTRA
+  sources: []
+  spec: |
+    <spec config_var="MAX_BLOBS_PER_BLOCK_ELECTRA" fork="electra" hash="0d8ea1c9" />
+
+- name: MAX_PAYLOAD_SIZE
+  sources: []
+  spec: |
+    <spec config_var="MAX_PAYLOAD_SIZE" fork="phase0" hash="7f1566fb" />
+
+- name: MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT
+  sources: []
+  spec: |
+    <spec config_var="MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT" fork="deneb" hash="c4d9b0bb" />
+
+- name: MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT
+  sources: []
+  spec: |
+    <spec config_var="MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT" fork="electra" hash="87c05125" />
+
+- name: MAX_REQUEST_BLOB_SIDECARS
+  sources: []
+  spec: |
+    <spec config_var="MAX_REQUEST_BLOB_SIDECARS" fork="deneb" hash="9b8ad30b" />
+
+- name: MAX_REQUEST_BLOB_SIDECARS_ELECTRA
+  sources: []
+  spec: |
+    <spec config_var="MAX_REQUEST_BLOB_SIDECARS_ELECTRA" fork="electra" hash="decc80ab" />
+
+- name: MAX_REQUEST_BLOCKS
+  sources: []
+  spec: |
+    <spec config_var="MAX_REQUEST_BLOCKS" fork="phase0" hash="a9ae6c77" />
+
+- name: MAX_REQUEST_BLOCKS_DENEB
+  sources: []
+  spec: |
+    <spec config_var="MAX_REQUEST_BLOCKS_DENEB" fork="deneb" hash="8318964a" />
+
+- name: MAX_REQUEST_DATA_COLUMN_SIDECARS
+  sources: []
+  spec: |
+    <spec config_var="MAX_REQUEST_DATA_COLUMN_SIDECARS" fork="fulu" hash="bbe5c650" />
+
+- name: MESSAGE_DOMAIN_INVALID_SNAPPY
+  sources: []
+  spec: |
+    <spec config_var="MESSAGE_DOMAIN_INVALID_SNAPPY" fork="phase0" hash="6b6fc19a" />
+
+- name: MESSAGE_DOMAIN_VALID_SNAPPY
+  sources: []
+  spec: |
+    <spec config_var="MESSAGE_DOMAIN_VALID_SNAPPY" fork="phase0" hash="a6de155f" />
+
+- name: MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
+  sources: []
+  spec: |
+    <spec config_var="MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS" fork="deneb" hash="3df9114c" />
+
+- name: MIN_EPOCHS_FOR_BLOCK_REQUESTS
+  sources: []
+  spec: |
+    <spec config_var="MIN_EPOCHS_FOR_BLOCK_REQUESTS" fork="phase0" hash="8ab131c4" />
+
+- name: MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS
+  sources: []
+  spec: |
+    <spec config_var="MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS" fork="fulu" hash="910e49bb" />
+
+- name: MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+  sources: []
+  spec: |
+    <spec config_var="MIN_GENESIS_ACTIVE_VALIDATOR_COUNT" fork="phase0" hash="7715513b" />
+
+- name: MIN_GENESIS_TIME
+  sources: []
+  spec: |
+    <spec config_var="MIN_GENESIS_TIME" fork="phase0" hash="75c06876" />
+
+- name: MIN_PER_EPOCH_CHURN_LIMIT#phase0
+  sources: []
+  spec: |
+    <spec config_var="MIN_PER_EPOCH_CHURN_LIMIT" fork="phase0" hash="ff24b223" />
+
+- name: MIN_PER_EPOCH_CHURN_LIMIT#electra
+  sources: []
+  spec: |
+    <spec config_var="MIN_PER_EPOCH_CHURN_LIMIT" fork="electra" hash="ff24b223" />
+
+- name: MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA
+  sources: []
+  spec: |
+    <spec config_var="MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA" fork="electra" hash="201809f8" />
+
+- name: MIN_VALIDATOR_WITHDRAWABILITY_DELAY
+  sources: []
+  spec: |
+    <spec config_var="MIN_VALIDATOR_WITHDRAWABILITY_DELAY" fork="phase0" hash="5c4eeded" />
+
+- name: NUMBER_OF_COLUMNS
+  sources: []
+  spec: |
+    <spec config_var="NUMBER_OF_COLUMNS" fork="fulu" hash="f6441e62" />
+
+- name: NUMBER_OF_CUSTODY_GROUPS
+  sources: []
+  spec: |
+    <spec config_var="NUMBER_OF_CUSTODY_GROUPS" fork="fulu" hash="05e3016e" />
+
+- name: PROPOSER_SCORE_BOOST
+  sources: []
+  spec: |
+    <spec config_var="PROPOSER_SCORE_BOOST" fork="phase0" hash="fbc878c6" />
+
+- name: REORG_HEAD_WEIGHT_THRESHOLD
+  sources: []
+  spec: |
+    <spec config_var="REORG_HEAD_WEIGHT_THRESHOLD" fork="phase0" hash="d4ecaa84" />
+
+- name: REORG_MAX_EPOCHS_SINCE_FINALIZATION
+  sources: []
+  spec: |
+    <spec config_var="REORG_MAX_EPOCHS_SINCE_FINALIZATION" fork="phase0" hash="8567706e" />
+
+- name: REORG_PARENT_WEIGHT_THRESHOLD
+  sources: []
+  spec: |
+    <spec config_var="REORG_PARENT_WEIGHT_THRESHOLD" fork="phase0" hash="cb81e3da" />
+
+- name: SAMPLES_PER_SLOT
+  sources: []
+  spec: |
+    <spec config_var="SAMPLES_PER_SLOT" fork="fulu" hash="158798b8" />
+
+- name: SECONDS_PER_ETH1_BLOCK
+  sources: []
+  spec: |
+    <spec config_var="SECONDS_PER_ETH1_BLOCK" fork="phase0" hash="90c9f3d1" />
+
+- name: SECONDS_PER_SLOT
+  sources: []
+  spec: |
+    <spec config_var="SECONDS_PER_SLOT" fork="phase0" hash="a9118f10" />
+
+- name: SHARD_COMMITTEE_PERIOD
+  sources: []
+  spec: |
+    <spec config_var="SHARD_COMMITTEE_PERIOD" fork="phase0" hash="5d0e85a4" />
+
+- name: SUBNETS_PER_NODE
+  sources: []
+  spec: |
+    <spec config_var="SUBNETS_PER_NODE" fork="phase0" hash="4799f8f3" />
+
+- name: TERMINAL_BLOCK_HASH
+  sources: []
+  spec: |
+    <spec config_var="TERMINAL_BLOCK_HASH" fork="bellatrix" hash="964c3bfe" />
+
+- name: TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
+  sources: []
+  spec: |
+    <spec config_var="TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH" fork="bellatrix" hash="81928369" />
+
+- name: TERMINAL_TOTAL_DIFFICULTY
+  sources: []
+  spec: |
+    <spec config_var="TERMINAL_TOTAL_DIFFICULTY" fork="bellatrix" hash="e0f3a816" />
+
+- name: VALIDATOR_CUSTODY_REQUIREMENT
+  sources: []
+  spec: |
+    <spec config_var="VALIDATOR_CUSTODY_REQUIREMENT" fork="fulu" hash="4dfc4457" />

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -63,15 +63,10 @@
   spec: |
     <spec config_var="CAPELLA_FORK_VERSION" fork="capella" hash="5f94766c" />
 
-- name: CHURN_LIMIT_QUOTIENT#phase0
+- name: CHURN_LIMIT_QUOTIENT
   sources: []
   spec: |
     <spec config_var="CHURN_LIMIT_QUOTIENT" fork="phase0" hash="a43a1d33" />
-
-- name: CHURN_LIMIT_QUOTIENT#electra
-  sources: []
-  spec: |
-    <spec config_var="CHURN_LIMIT_QUOTIENT" fork="electra" hash="a43a1d33" />
 
 - name: CUSTODY_REQUIREMENT
   sources: []
@@ -93,15 +88,10 @@
   spec: |
     <spec config_var="DENEB_FORK_VERSION" fork="deneb" hash="da95e3b9" />
 
-- name: EJECTION_BALANCE#phase0
+- name: EJECTION_BALANCE
   sources: []
   spec: |
     <spec config_var="EJECTION_BALANCE" fork="phase0" hash="3f86d864" />
-
-- name: EJECTION_BALANCE#electra
-  sources: []
-  spec: |
-    <spec config_var="EJECTION_BALANCE" fork="electra" hash="3f86d864" />
 
 - name: ELECTRA_FORK_EPOCH
   sources: []
@@ -118,15 +108,10 @@
   spec: |
     <spec config_var="EPOCHS_PER_SUBNET_SUBSCRIPTION" fork="phase0" hash="1b832329" />
 
-- name: ETH1_FOLLOW_DISTANCE#phase0
+- name: ETH1_FOLLOW_DISTANCE
   sources: []
   spec: |
     <spec config_var="ETH1_FOLLOW_DISTANCE" fork="phase0" hash="2f5ba1a0" />
-
-- name: ETH1_FOLLOW_DISTANCE#electra
-  sources: []
-  spec: |
-    <spec config_var="ETH1_FOLLOW_DISTANCE" fork="electra" hash="2f5ba1a0" />
 
 - name: FULU_FORK_EPOCH
   sources: []
@@ -248,15 +233,10 @@
   spec: |
     <spec config_var="MIN_GENESIS_TIME" fork="phase0" hash="75c06876" />
 
-- name: MIN_PER_EPOCH_CHURN_LIMIT#phase0
+- name: MIN_PER_EPOCH_CHURN_LIMIT
   sources: []
   spec: |
     <spec config_var="MIN_PER_EPOCH_CHURN_LIMIT" fork="phase0" hash="ff24b223" />
-
-- name: MIN_PER_EPOCH_CHURN_LIMIT#electra
-  sources: []
-  spec: |
-    <spec config_var="MIN_PER_EPOCH_CHURN_LIMIT" fork="electra" hash="ff24b223" />
 
 - name: MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA
   sources: []

--- a/specrefs/constants.yml
+++ b/specrefs/constants.yml
@@ -1,0 +1,320 @@
+
+- name: BASE_REWARDS_PER_EPOCH
+  sources: []
+  spec: |
+    <spec constant_var="BASE_REWARDS_PER_EPOCH" fork="phase0" hash="395f7528" />
+
+- name: BLS_MODULUS
+  sources: []
+  spec: |
+    <spec constant_var="BLS_MODULUS" fork="deneb" hash="dfa6ff32" />
+
+- name: BLS_WITHDRAWAL_PREFIX
+  sources: []
+  spec: |
+    <spec constant_var="BLS_WITHDRAWAL_PREFIX" fork="phase0" hash="4153ae92" />
+
+- name: BYTES_PER_COMMITMENT
+  sources: []
+  spec: |
+    <spec constant_var="BYTES_PER_COMMITMENT" fork="deneb" hash="c46710b5" />
+
+- name: BYTES_PER_FIELD_ELEMENT
+  sources: []
+  spec: |
+    <spec constant_var="BYTES_PER_FIELD_ELEMENT" fork="deneb" hash="4563f0ce" />
+
+- name: BYTES_PER_PROOF
+  sources: []
+  spec: |
+    <spec constant_var="BYTES_PER_PROOF" fork="deneb" hash="7fec794e" />
+
+- name: COMPOUNDING_WITHDRAWAL_PREFIX
+  sources: []
+  spec: |
+    <spec constant_var="COMPOUNDING_WITHDRAWAL_PREFIX" fork="electra" hash="e52fdfea" />
+
+- name: CONSOLIDATION_REQUEST_TYPE
+  sources: []
+  spec: |
+    <spec constant_var="CONSOLIDATION_REQUEST_TYPE" fork="electra" hash="4d01eb44" />
+
+- name: DEPOSIT_CONTRACT_TREE_DEPTH
+  sources: []
+  spec: |
+    <spec constant_var="DEPOSIT_CONTRACT_TREE_DEPTH" fork="phase0" hash="5763e551" />
+
+- name: DEPOSIT_REQUEST_TYPE
+  sources: []
+  spec: |
+    <spec constant_var="DEPOSIT_REQUEST_TYPE" fork="electra" hash="54ca462e" />
+
+- name: DOMAIN_AGGREGATE_AND_PROOF
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_AGGREGATE_AND_PROOF" fork="phase0" hash="9f7a43fb" />
+
+- name: DOMAIN_APPLICATION_MASK
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_APPLICATION_MASK" fork="phase0" hash="82d95c51" />
+
+- name: DOMAIN_BEACON_ATTESTER
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_BEACON_ATTESTER" fork="phase0" hash="511529c3" />
+
+- name: DOMAIN_BEACON_PROPOSER
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_BEACON_PROPOSER" fork="phase0" hash="c6ec551e" />
+
+- name: DOMAIN_BLS_TO_EXECUTION_CHANGE
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_BLS_TO_EXECUTION_CHANGE" fork="capella" hash="08a623ec" />
+
+- name: DOMAIN_CONTRIBUTION_AND_PROOF
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_CONTRIBUTION_AND_PROOF" fork="altair" hash="67dcb5cb" />
+
+- name: DOMAIN_DEPOSIT
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_DEPOSIT" fork="phase0" hash="eab99f9f" />
+
+- name: DOMAIN_RANDAO
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_RANDAO" fork="phase0" hash="1bf33286" />
+
+- name: DOMAIN_SELECTION_PROOF
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_SELECTION_PROOF" fork="phase0" hash="5443c8b0" />
+
+- name: DOMAIN_SYNC_COMMITTEE
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_SYNC_COMMITTEE" fork="altair" hash="26073f5d" />
+
+- name: DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF" fork="altair" hash="f7e4d78c" />
+
+- name: DOMAIN_VOLUNTARY_EXIT
+  sources: []
+  spec: |
+    <spec constant_var="DOMAIN_VOLUNTARY_EXIT" fork="phase0" hash="6abf51b5" />
+
+- name: ENDIANNESS
+  sources: []
+  spec: |
+    <spec constant_var="ENDIANNESS" fork="phase0" hash="76922bbc" />
+
+- name: ETH1_ADDRESS_WITHDRAWAL_PREFIX
+  sources: []
+  spec: |
+    <spec constant_var="ETH1_ADDRESS_WITHDRAWAL_PREFIX" fork="phase0" hash="faffaf83" />
+
+- name: ETH_TO_GWEI
+  sources: []
+  spec: |
+    <spec constant_var="ETH_TO_GWEI" fork="phase0" hash="37392e73" />
+
+- name: FAR_FUTURE_EPOCH
+  sources: []
+  spec: |
+    <spec constant_var="FAR_FUTURE_EPOCH" fork="phase0" hash="b11f052e" />
+
+- name: FIAT_SHAMIR_PROTOCOL_DOMAIN
+  sources: []
+  spec: |
+    <spec constant_var="FIAT_SHAMIR_PROTOCOL_DOMAIN" fork="deneb" hash="b1198e8c" />
+
+- name: FULL_EXIT_REQUEST_AMOUNT
+  sources: []
+  spec: |
+    <spec constant_var="FULL_EXIT_REQUEST_AMOUNT" fork="electra" hash="4f49380e" />
+
+- name: G1_POINT_AT_INFINITY
+  sources: []
+  spec: |
+    <spec constant_var="G1_POINT_AT_INFINITY" fork="deneb" hash="974ad898" />
+
+- name: G2_POINT_AT_INFINITY
+  sources: []
+  spec: |
+    <spec constant_var="G2_POINT_AT_INFINITY" fork="altair" hash="55ddc9fd" />
+
+- name: GENESIS_EPOCH
+  sources: []
+  spec: |
+    <spec constant_var="GENESIS_EPOCH" fork="phase0" hash="56876077" />
+
+- name: GENESIS_SLOT
+  sources: []
+  spec: |
+    <spec constant_var="GENESIS_SLOT" fork="phase0" hash="2d6f8884" />
+
+- name: INTERVALS_PER_SLOT
+  sources: []
+  spec: |
+    <spec constant_var="INTERVALS_PER_SLOT" fork="phase0" hash="3352e419" />
+
+- name: JUSTIFICATION_BITS_LENGTH
+  sources: []
+  spec: |
+    <spec constant_var="JUSTIFICATION_BITS_LENGTH" fork="phase0" hash="e7ec73ea" />
+
+- name: KZG_ENDIANNESS
+  sources: []
+  spec: |
+    <spec constant_var="KZG_ENDIANNESS" fork="deneb" hash="b67e714d" />
+
+- name: KZG_SETUP_G2_LENGTH
+  sources: []
+  spec: |
+    <spec constant_var="KZG_SETUP_G2_LENGTH" fork="deneb" hash="6cb8d5fd" />
+
+- name: KZG_SETUP_G2_MONOMIAL
+  sources: []
+  spec: |
+    <spec constant_var="KZG_SETUP_G2_MONOMIAL" fork="deneb" hash="4e0f802f" />
+
+- name: MAX_CONCURRENT_REQUESTS
+  sources: []
+  spec: |
+    <spec constant_var="MAX_CONCURRENT_REQUESTS" fork="phase0" hash="f5ff241b" />
+
+- name: MAX_REQUEST_LIGHT_CLIENT_UPDATES
+  sources: []
+  spec: |
+    <spec constant_var="MAX_REQUEST_LIGHT_CLIENT_UPDATES" fork="altair" hash="aa7e3917" />
+
+- name: NODE_ID_BITS
+  sources: []
+  spec: |
+    <spec constant_var="NODE_ID_BITS" fork="phase0" hash="57dab5f1" />
+
+- name: PARTICIPATION_FLAG_WEIGHTS
+  sources: []
+  spec: |
+    <spec constant_var="PARTICIPATION_FLAG_WEIGHTS" fork="altair" hash="0068cac2" />
+
+- name: PRIMITIVE_ROOT_OF_UNITY
+  sources: []
+  spec: |
+    <spec constant_var="PRIMITIVE_ROOT_OF_UNITY" fork="deneb" hash="004e6753" />
+
+- name: PROPOSER_WEIGHT
+  sources: []
+  spec: |
+    <spec constant_var="PROPOSER_WEIGHT" fork="altair" hash="4dcb6f6c" />
+
+- name: RANDOM_CHALLENGE_KZG_BATCH_DOMAIN
+  sources: []
+  spec: |
+    <spec constant_var="RANDOM_CHALLENGE_KZG_BATCH_DOMAIN" fork="deneb" hash="a994f6c6" />
+
+- name: RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN
+  sources: []
+  spec: |
+    <spec constant_var="RANDOM_CHALLENGE_KZG_CELL_BATCH_DOMAIN" fork="fulu" hash="907a9534" />
+
+- name: SAFETY_DECAY
+  sources: []
+  spec: |
+    <spec constant_var="SAFETY_DECAY" fork="phase0" hash="298e03fe" />
+
+- name: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY
+  sources: []
+  spec: |
+    <spec constant_var="SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY" fork="bellatrix" hash="87b7dd5b" />
+
+- name: SYNC_COMMITTEE_SUBNET_COUNT
+  sources: []
+  spec: |
+    <spec constant_var="SYNC_COMMITTEE_SUBNET_COUNT" fork="altair" hash="58794943" />
+
+- name: SYNC_REWARD_WEIGHT
+  sources: []
+  spec: |
+    <spec constant_var="SYNC_REWARD_WEIGHT" fork="altair" hash="ea70c5e0" />
+
+- name: TARGET_AGGREGATORS_PER_COMMITTEE
+  sources: []
+  spec: |
+    <spec constant_var="TARGET_AGGREGATORS_PER_COMMITTEE" fork="phase0" hash="3a65ef1c" />
+
+- name: TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE
+  sources: []
+  spec: |
+    <spec constant_var="TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE" fork="altair" hash="af3f6c9e" />
+
+- name: TIMELY_HEAD_FLAG_INDEX
+  sources: []
+  spec: |
+    <spec constant_var="TIMELY_HEAD_FLAG_INDEX" fork="altair" hash="a01306fb" />
+
+- name: TIMELY_HEAD_WEIGHT
+  sources: []
+  spec: |
+    <spec constant_var="TIMELY_HEAD_WEIGHT" fork="altair" hash="d6f53c91" />
+
+- name: TIMELY_SOURCE_FLAG_INDEX
+  sources: []
+  spec: |
+    <spec constant_var="TIMELY_SOURCE_FLAG_INDEX" fork="altair" hash="57f25239" />
+
+- name: TIMELY_SOURCE_WEIGHT
+  sources: []
+  spec: |
+    <spec constant_var="TIMELY_SOURCE_WEIGHT" fork="altair" hash="9cf6e565" />
+
+- name: TIMELY_TARGET_FLAG_INDEX
+  sources: []
+  spec: |
+    <spec constant_var="TIMELY_TARGET_FLAG_INDEX" fork="altair" hash="32530e5a" />
+
+- name: TIMELY_TARGET_WEIGHT
+  sources: []
+  spec: |
+    <spec constant_var="TIMELY_TARGET_WEIGHT" fork="altair" hash="5413dfe8" />
+
+- name: UINT256_MAX
+  sources: []
+  spec: |
+    <spec constant_var="UINT256_MAX" fork="fulu" hash="57a47f45" />
+
+- name: UINT64_MAX
+  sources: []
+  spec: |
+    <spec constant_var="UINT64_MAX" fork="phase0" hash="0efe6bd6" />
+
+- name: UINT64_MAX_SQRT
+  sources: []
+  spec: |
+    <spec constant_var="UINT64_MAX_SQRT" fork="phase0" hash="28d7e92a" />
+
+- name: UNSET_DEPOSIT_REQUESTS_START_INDEX
+  sources: []
+  spec: |
+    <spec constant_var="UNSET_DEPOSIT_REQUESTS_START_INDEX" fork="electra" hash="5eb703dc" />
+
+- name: VERSIONED_HASH_VERSION_KZG
+  sources: []
+  spec: |
+    <spec constant_var="VERSIONED_HASH_VERSION_KZG" fork="deneb" hash="fc402ca2" />
+
+- name: WEIGHT_DENOMINATOR
+  sources: []
+  spec: |
+    <spec constant_var="WEIGHT_DENOMINATOR" fork="altair" hash="0d498a82" />
+
+- name: WITHDRAWAL_REQUEST_TYPE
+  sources: []
+  spec: |
+    <spec constant_var="WITHDRAWAL_REQUEST_TYPE" fork="electra" hash="e8e70397" />

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -1,0 +1,399 @@
+- name: AggregateAndProof#phase0
+  sources: []
+  spec: |
+    <spec ssz_object="AggregateAndProof" fork="phase0" hash="a218764f" />
+
+- name: AggregateAndProof#electra
+  sources: []
+  spec: |
+    <spec ssz_object="AggregateAndProof" fork="electra" hash="a7f482d7" />
+
+- name: Attestation#phase0
+  sources: []
+  spec: |
+    <spec ssz_object="Attestation" fork="phase0" hash="5fc71dce" />
+
+- name: Attestation#electra
+  sources: []
+  spec: |
+    <spec ssz_object="Attestation" fork="electra" hash="a27cddfb" />
+
+- name: AttestationData
+  sources: []
+  spec: |
+    <spec ssz_object="AttestationData" fork="phase0" hash="854be491" />
+
+- name: AttesterSlashing#phase0
+  sources: []
+  spec: |
+    <spec ssz_object="AttesterSlashing" fork="phase0" hash="caf8a91a" />
+
+- name: AttesterSlashing#electra
+  sources: []
+  spec: |
+    <spec ssz_object="AttesterSlashing" fork="electra" hash="2b9f773d" />
+
+- name: BLSToExecutionChange
+  sources: []
+  spec: |
+    <spec ssz_object="BLSToExecutionChange" fork="capella" hash="9271c356" />
+
+- name: BeaconBlock
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconBlock" fork="phase0" hash="79909f0a" />
+
+- name: BeaconBlockBody#phase0
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconBlockBody" fork="phase0" hash="e982fea2" />
+
+- name: BeaconBlockBody#altair
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconBlockBody" fork="altair" hash="4afb2e64" />
+
+- name: BeaconBlockBody#bellatrix
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconBlockBody" fork="bellatrix" hash="2ba73fc8" />
+
+- name: BeaconBlockBody#capella
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconBlockBody" fork="capella" hash="3136f99b" />
+
+- name: BeaconBlockBody#deneb
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconBlockBody" fork="deneb" hash="cf0c1053" />
+
+- name: BeaconBlockBody#electra
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconBlockBody" fork="electra" hash="cd172b8c" />
+
+- name: BeaconBlockHeader
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconBlockHeader" fork="phase0" hash="0be4f2e7" />
+
+- name: BeaconState#phase0
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconState" fork="phase0" hash="05beaa1c" />
+
+- name: BeaconState#altair
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconState" fork="altair" hash="8de7d5fb" />
+
+- name: BeaconState#bellatrix
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconState" fork="bellatrix" hash="e5633a51" />
+
+- name: BeaconState#capella
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconState" fork="capella" hash="245ba83b" />
+
+- name: BeaconState#deneb
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconState" fork="deneb" hash="32fd9dc4" />
+
+- name: BeaconState#electra
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconState" fork="electra" hash="55e40daf" />
+
+- name: BeaconState#fulu
+  sources: []
+  spec: |
+    <spec ssz_object="BeaconState" fork="fulu" hash="0923b253" />
+
+- name: BlobIdentifier
+  sources: []
+  spec: |
+    <spec ssz_object="BlobIdentifier" fork="deneb" hash="14d845de" />
+
+- name: BlobSidecar
+  sources: []
+  spec: |
+    <spec ssz_object="BlobSidecar" fork="deneb" hash="b4f28e34" />
+
+- name: Checkpoint
+  sources: []
+  spec: |
+    <spec ssz_object="Checkpoint" fork="phase0" hash="24947006" />
+
+- name: ConsolidationRequest
+  sources: []
+  spec: |
+    <spec ssz_object="ConsolidationRequest" fork="electra" hash="269fdb77" />
+
+- name: ContributionAndProof
+  sources: []
+  spec: |
+    <spec ssz_object="ContributionAndProof" fork="altair" hash="f7a5150c" />
+
+- name: DataColumnSidecar
+  sources: []
+  spec: |
+    <spec ssz_object="DataColumnSidecar" fork="fulu" hash="03586114" />
+
+- name: DataColumnsByRootIdentifier
+  sources: []
+  spec: |
+    <spec ssz_object="DataColumnsByRootIdentifier" fork="fulu" hash="f0478456" />
+
+- name: Deposit
+  sources: []
+  spec: |
+    <spec ssz_object="Deposit" fork="phase0" hash="cc281399" />
+
+- name: DepositData
+  sources: []
+  spec: |
+    <spec ssz_object="DepositData" fork="phase0" hash="44ba3a61" />
+
+- name: DepositMessage
+  sources: []
+  spec: |
+    <spec ssz_object="DepositMessage" fork="phase0" hash="d6f4c2ef" />
+
+- name: DepositRequest
+  sources: []
+  spec: |
+    <spec ssz_object="DepositRequest" fork="electra" hash="3af9895d" />
+
+- name: Eth1Block
+  sources: []
+  spec: |
+    <spec ssz_object="Eth1Block" fork="phase0" hash="0a5c6b45" />
+
+- name: Eth1Data
+  sources: []
+  spec: |
+    <spec ssz_object="Eth1Data" fork="phase0" hash="1d7be228" />
+
+- name: ExecutionPayload#bellatrix
+  sources: []
+  spec: |
+    <spec ssz_object="ExecutionPayload" fork="bellatrix" hash="da4d8580" />
+
+- name: ExecutionPayload#capella
+  sources: []
+  spec: |
+    <spec ssz_object="ExecutionPayload" fork="capella" hash="5533cb47" />
+
+- name: ExecutionPayload#deneb
+  sources: []
+  spec: |
+    <spec ssz_object="ExecutionPayload" fork="deneb" hash="974f7cc9" />
+
+- name: ExecutionPayloadHeader#bellatrix
+  sources: []
+  spec: |
+    <spec ssz_object="ExecutionPayloadHeader" fork="bellatrix" hash="08fc7165" />
+
+- name: ExecutionPayloadHeader#capella
+  sources: []
+  spec: |
+    <spec ssz_object="ExecutionPayloadHeader" fork="capella" hash="5f481de3" />
+
+- name: ExecutionPayloadHeader#deneb
+  sources: []
+  spec: |
+    <spec ssz_object="ExecutionPayloadHeader" fork="deneb" hash="957fa918" />
+
+- name: ExecutionRequests
+  sources: []
+  spec: |
+    <spec ssz_object="ExecutionRequests" fork="electra" hash="048c4a44" />
+
+- name: Fork
+  sources: []
+  spec: |
+    <spec ssz_object="Fork" fork="phase0" hash="d210b04e" />
+
+- name: ForkData
+  sources: []
+  spec: |
+    <spec ssz_object="ForkData" fork="phase0" hash="8ed39352" />
+
+- name: HistoricalBatch
+  sources: []
+  spec: |
+    <spec ssz_object="HistoricalBatch" fork="phase0" hash="3b677eb3" />
+
+- name: HistoricalSummary
+  sources: []
+  spec: |
+    <spec ssz_object="HistoricalSummary" fork="capella" hash="bfff1483" />
+
+- name: IndexedAttestation#phase0
+  sources: []
+  spec: |
+    <spec ssz_object="IndexedAttestation" fork="phase0" hash="b321d4c3" />
+
+- name: IndexedAttestation#electra
+  sources: []
+  spec: |
+    <spec ssz_object="IndexedAttestation" fork="electra" hash="2f924640" />
+
+- name: LightClientBootstrap
+  sources: []
+  spec: |
+    <spec ssz_object="LightClientBootstrap" fork="altair" hash="e0d2fa88" />
+
+- name: LightClientFinalityUpdate
+  sources: []
+  spec: |
+    <spec ssz_object="LightClientFinalityUpdate" fork="altair" hash="d392e9f3" />
+
+- name: LightClientHeader#altair
+  sources: []
+  spec: |
+    <spec ssz_object="LightClientHeader" fork="altair" hash="53de7cd2" />
+
+- name: LightClientHeader#capella
+  sources: []
+  spec: |
+    <spec ssz_object="LightClientHeader" fork="capella" hash="366cbdcd" />
+
+- name: LightClientOptimisticUpdate
+  sources: []
+  spec: |
+    <spec ssz_object="LightClientOptimisticUpdate" fork="altair" hash="0818d65f" />
+
+- name: LightClientUpdate
+  sources: []
+  spec: |
+    <spec ssz_object="LightClientUpdate" fork="altair" hash="abbfc36b" />
+
+- name: MatrixEntry
+  sources: []
+  spec: |
+    <spec ssz_object="MatrixEntry" fork="fulu" hash="0da9cc8e" />
+
+- name: PendingAttestation
+  sources: []
+  spec: |
+    <spec ssz_object="PendingAttestation" fork="phase0" hash="e0a37cea" />
+
+- name: PendingConsolidation
+  sources: []
+  spec: |
+    <spec ssz_object="PendingConsolidation" fork="electra" hash="6ded98cf" />
+
+- name: PendingDeposit
+  sources: []
+  spec: |
+    <spec ssz_object="PendingDeposit" fork="electra" hash="62923226" />
+
+- name: PendingPartialWithdrawal
+  sources: []
+  spec: |
+    <spec ssz_object="PendingPartialWithdrawal" fork="electra" hash="44f687d1" />
+
+- name: PowBlock
+  sources: []
+  spec: |
+    <spec ssz_object="PowBlock" fork="bellatrix" hash="c6c8739a" />
+
+- name: ProposerSlashing
+  sources: []
+  spec: |
+    <spec ssz_object="ProposerSlashing" fork="phase0" hash="2cd89ad8" />
+
+- name: SignedAggregateAndProof#phase0
+  sources: []
+  spec: |
+    <spec ssz_object="SignedAggregateAndProof" fork="phase0" hash="52046edd" />
+
+- name: SignedAggregateAndProof#electra
+  sources: []
+  spec: |
+    <spec ssz_object="SignedAggregateAndProof" fork="electra" hash="7e784e12" />
+
+- name: SignedBLSToExecutionChange
+  sources: []
+  spec: |
+    <spec ssz_object="SignedBLSToExecutionChange" fork="capella" hash="09a5e4b9" />
+
+- name: SignedBeaconBlock
+  sources: []
+  spec: |
+    <spec ssz_object="SignedBeaconBlock" fork="phase0" hash="627b8629" />
+
+- name: SignedBeaconBlockHeader
+  sources: []
+  spec: |
+    <spec ssz_object="SignedBeaconBlockHeader" fork="phase0" hash="5784d47c" />
+
+- name: SignedContributionAndProof
+  sources: []
+  spec: |
+    <spec ssz_object="SignedContributionAndProof" fork="altair" hash="56c7a91a" />
+
+- name: SignedVoluntaryExit
+  sources: []
+  spec: |
+    <spec ssz_object="SignedVoluntaryExit" fork="phase0" hash="89ba48b3" />
+
+- name: SigningData
+  sources: []
+  spec: |
+    <spec ssz_object="SigningData" fork="phase0" hash="c9a66f76" />
+
+- name: SingleAttestation
+  sources: []
+  spec: |
+    <spec ssz_object="SingleAttestation" fork="electra" hash="f67f746a" />
+
+- name: SyncAggregate
+  sources: []
+  spec: |
+    <spec ssz_object="SyncAggregate" fork="altair" hash="51e247e5" />
+
+- name: SyncAggregatorSelectionData
+  sources: []
+  spec: |
+    <spec ssz_object="SyncAggregatorSelectionData" fork="altair" hash="990a8a7f" />
+
+- name: SyncCommittee
+  sources: []
+  spec: |
+    <spec ssz_object="SyncCommittee" fork="altair" hash="b1d52376" />
+
+- name: SyncCommitteeContribution
+  sources: []
+  spec: |
+    <spec ssz_object="SyncCommitteeContribution" fork="altair" hash="9f9b0125" />
+
+- name: SyncCommitteeMessage
+  sources: []
+  spec: |
+    <spec ssz_object="SyncCommitteeMessage" fork="altair" hash="0764ce67" />
+
+- name: Validator
+  sources: []
+  spec: |
+    <spec ssz_object="Validator" fork="phase0" hash="54f88c17" />
+
+- name: VoluntaryExit
+  sources: []
+  spec: |
+    <spec ssz_object="VoluntaryExit" fork="phase0" hash="aa780f75" />
+
+- name: Withdrawal
+  sources: []
+  spec: |
+    <spec ssz_object="Withdrawal" fork="capella" hash="ba17e57d" />
+
+- name: WithdrawalRequest
+  sources: []
+  spec: |
+    <spec ssz_object="WithdrawalRequest" fork="electra" hash="05b4d2de" />

--- a/specrefs/dataclasses.yml
+++ b/specrefs/dataclasses.yml
@@ -1,0 +1,90 @@
+
+- name: BlobParameters
+  sources: []
+  spec: |
+    <spec dataclass="BlobParameters" fork="fulu" hash="a4575aa8" />
+
+- name: BlobsBundle#deneb
+  sources: []
+  spec: |
+    <spec dataclass="BlobsBundle" fork="deneb" hash="8d6e7be6" />
+
+- name: BlobsBundle#fulu
+  sources: []
+  spec: |
+    <spec dataclass="BlobsBundle" fork="fulu" hash="e265362d" />
+
+- name: GetPayloadResponse#bellatrix
+  sources: []
+  spec: |
+    <spec dataclass="GetPayloadResponse" fork="bellatrix" hash="bc71e6e6" />
+
+- name: GetPayloadResponse#capella
+  sources: []
+  spec: |
+    <spec dataclass="GetPayloadResponse" fork="capella" hash="5f10deae" />
+
+- name: GetPayloadResponse#deneb
+  sources: []
+  spec: |
+    <spec dataclass="GetPayloadResponse" fork="deneb" hash="243ad324" />
+
+- name: GetPayloadResponse#electra
+  sources: []
+  spec: |
+    <spec dataclass="GetPayloadResponse" fork="electra" hash="43f23b8d" />
+
+- name: GetPayloadResponse#fulu
+  sources: []
+  spec: |
+    <spec dataclass="GetPayloadResponse" fork="fulu" hash="38a6e364" />
+
+- name: LatestMessage
+  sources: []
+  spec: |
+    <spec dataclass="LatestMessage" fork="phase0" hash="44e832d0" />
+
+- name: LightClientStore
+  sources: []
+  spec: |
+    <spec dataclass="LightClientStore" fork="altair" hash="24725cec" />
+
+- name: NewPayloadRequest#bellatrix
+  sources: []
+  spec: |
+    <spec dataclass="NewPayloadRequest" fork="bellatrix" hash="4d32e8c7" />
+
+- name: NewPayloadRequest#deneb
+  sources: []
+  spec: |
+    <spec dataclass="NewPayloadRequest" fork="deneb" hash="26cf2e26" />
+
+- name: NewPayloadRequest#electra
+  sources: []
+  spec: |
+    <spec dataclass="NewPayloadRequest" fork="electra" hash="b1f69cc9" />
+
+- name: OptimisticStore
+  sources: []
+  spec: |
+    <spec dataclass="OptimisticStore" fork="bellatrix" hash="a2b2182c" />
+
+- name: PayloadAttributes#bellatrix
+  sources: []
+  spec: |
+    <spec dataclass="PayloadAttributes" fork="bellatrix" hash="8f6fc523" />
+
+- name: PayloadAttributes#capella
+  sources: []
+  spec: |
+    <spec dataclass="PayloadAttributes" fork="capella" hash="730ada60" />
+
+- name: PayloadAttributes#deneb
+  sources: []
+  spec: |
+    <spec dataclass="PayloadAttributes" fork="deneb" hash="9598d52c" />
+
+- name: Store
+  sources: []
+  spec: |
+    <spec dataclass="Store" fork="phase0" hash="abe525d6" />

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -9,7 +9,9 @@
     <spec fn="add_validator_to_registry" fork="phase0" hash="53699dc0" />
 
 - name: add_validator_to_registry#altair
-  sources: []
+  sources: 
+    - file: consensus/types/src/beacon_state.rs
+      search: pub fn add_validator_to_registry(
   spec: |
     <spec fn="add_validator_to_registry" fork="altair" hash="18054f42" />
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1,0 +1,1854 @@
+- name: add_flag
+  sources: []
+  spec: |
+    <spec fn="add_flag" fork="altair" hash="0e22f6e5" />
+
+- name: add_validator_to_registry#phase0
+  sources: []
+  spec: |
+    <spec fn="add_validator_to_registry" fork="phase0" hash="53699dc0" />
+
+- name: add_validator_to_registry#altair
+  sources: []
+  spec: |
+    <spec fn="add_validator_to_registry" fork="altair" hash="18054f42" />
+
+- name: add_validator_to_registry#electra
+  sources: []
+  spec: |
+    <spec fn="add_validator_to_registry" fork="electra" hash="7970ce24" />
+
+- name: apply_deposit#phase0
+  sources: []
+  spec: |
+    <spec fn="apply_deposit" fork="phase0" hash="a53ef920" />
+
+- name: apply_deposit#electra
+  sources: []
+  spec: |
+    <spec fn="apply_deposit" fork="electra" hash="6259bfc5" />
+
+- name: apply_light_client_update
+  sources: []
+  spec: |
+    <spec fn="apply_light_client_update" fork="altair" hash="211a52c9" />
+
+- name: apply_pending_deposit
+  sources: []
+  spec: |
+    <spec fn="apply_pending_deposit" fork="electra" hash="e60b5fed" />
+
+- name: block_to_light_client_header#altair
+  sources: []
+  spec: |
+    <spec fn="block_to_light_client_header" fork="altair" hash="94342f64" />
+
+- name: block_to_light_client_header#capella
+  sources: []
+  spec: |
+    <spec fn="block_to_light_client_header" fork="capella" hash="597ddeac" />
+
+- name: block_to_light_client_header#deneb
+  sources: []
+  spec: |
+    <spec fn="block_to_light_client_header" fork="deneb" hash="b5ed5bf8" />
+
+- name: bytes_to_uint64
+  sources: []
+  spec: |
+    <spec fn="bytes_to_uint64" fork="phase0" hash="3099d397" />
+
+- name: calculate_committee_fraction
+  sources: []
+  spec: |
+    <spec fn="calculate_committee_fraction" fork="phase0" hash="782b50e9" />
+
+- name: check_if_validator_active
+  sources: []
+  spec: |
+    <spec fn="check_if_validator_active" fork="phase0" hash="66fe85e7" />
+
+- name: compute_activation_exit_epoch
+  sources: []
+  spec: |
+    <spec fn="compute_activation_exit_epoch" fork="phase0" hash="7a265fe3" />
+
+- name: compute_columns_for_custody_group
+  sources: []
+  spec: |
+    <spec fn="compute_columns_for_custody_group" fork="fulu" hash="af24b659" />
+
+- name: compute_committee
+  sources: []
+  spec: |
+    <spec fn="compute_committee" fork="phase0" hash="eb55fdd0" />
+
+- name: compute_consolidation_epoch_and_update_churn
+  sources: []
+  spec: |
+    <spec fn="compute_consolidation_epoch_and_update_churn" fork="electra" hash="21eba846" />
+
+- name: compute_domain
+  sources: []
+  spec: |
+    <spec fn="compute_domain" fork="phase0" hash="948e1334" />
+
+- name: compute_epoch_at_slot
+  sources: []
+  spec: |
+    <spec fn="compute_epoch_at_slot" fork="phase0" hash="d8b1cda2" />
+
+- name: compute_exit_epoch_and_update_churn
+  sources: []
+  spec: |
+    <spec fn="compute_exit_epoch_and_update_churn" fork="electra" hash="b3983004" />
+
+- name: compute_fork_data_root
+  sources: []
+  spec: |
+    <spec fn="compute_fork_data_root" fork="phase0" hash="155b0991" />
+
+- name: compute_fork_digest#phase0
+  sources: []
+  spec: |
+    <spec fn="compute_fork_digest" fork="phase0" hash="8b33f64d" />
+
+- name: compute_fork_digest#fulu
+  sources: []
+  spec: |
+    <spec fn="compute_fork_digest" fork="fulu" hash="860655fd" />
+
+- name: compute_fork_version#altair
+  sources: []
+  spec: |
+    <spec fn="compute_fork_version" fork="altair" hash="ac13fc52" />
+
+- name: compute_fork_version#bellatrix
+  sources: []
+  spec: |
+    <spec fn="compute_fork_version" fork="bellatrix" hash="2e5e09be" />
+
+- name: compute_fork_version#capella
+  sources: []
+  spec: |
+    <spec fn="compute_fork_version" fork="capella" hash="cf11ff98" />
+
+- name: compute_fork_version#deneb
+  sources: []
+  spec: |
+    <spec fn="compute_fork_version" fork="deneb" hash="287e691a" />
+
+- name: compute_fork_version#electra
+  sources: []
+  spec: |
+    <spec fn="compute_fork_version" fork="electra" hash="c142a405" />
+
+- name: compute_fork_version#fulu
+  sources: []
+  spec: |
+    <spec fn="compute_fork_version" fork="fulu" hash="6d472038" />
+
+- name: compute_matrix
+  sources: []
+  spec: |
+    <spec fn="compute_matrix" fork="fulu" hash="b39370ca" />
+
+- name: compute_new_state_root
+  sources: []
+  spec: |
+    <spec fn="compute_new_state_root" fork="phase0" hash="ad3c03b7" />
+
+- name: compute_on_chain_aggregate
+  sources: []
+  spec: |
+    <spec fn="compute_on_chain_aggregate" fork="electra" hash="128055d6" />
+
+- name: compute_proposer_index#phase0
+  sources: []
+  spec: |
+    <spec fn="compute_proposer_index" fork="phase0" hash="865ac464" />
+
+- name: compute_proposer_index#electra
+  sources: []
+  spec: |
+    <spec fn="compute_proposer_index" fork="electra" hash="c3b14daf" />
+
+- name: compute_proposer_indices
+  sources: []
+  spec: |
+    <spec fn="compute_proposer_indices" fork="fulu" hash="9e13dbfe" />
+
+- name: compute_pulled_up_tip
+  sources: []
+  spec: |
+    <spec fn="compute_pulled_up_tip" fork="phase0" hash="ef9c1f02" />
+
+- name: compute_shuffled_index
+  sources: []
+  spec: |
+    <spec fn="compute_shuffled_index" fork="phase0" hash="e1e6a19d" />
+
+- name: compute_signed_block_header
+  sources: []
+  spec: |
+    <spec fn="compute_signed_block_header" fork="deneb" hash="552442e1" />
+
+- name: compute_signing_root
+  sources: []
+  spec: |
+    <spec fn="compute_signing_root" fork="phase0" hash="07ab9f76" />
+
+- name: compute_slots_since_epoch_start
+  sources: []
+  spec: |
+    <spec fn="compute_slots_since_epoch_start" fork="phase0" hash="8cd580dc" />
+
+- name: compute_start_slot_at_epoch
+  sources: []
+  spec: |
+    <spec fn="compute_start_slot_at_epoch" fork="phase0" hash="d3c7b518" />
+
+- name: compute_subnet_for_attestation
+  sources: []
+  spec: |
+    <spec fn="compute_subnet_for_attestation" fork="phase0" hash="2e9cf65d" />
+
+- name: compute_subnet_for_blob_sidecar#deneb
+  sources: []
+  spec: |
+    <spec fn="compute_subnet_for_blob_sidecar" fork="deneb" hash="09ae77b3" />
+
+- name: compute_subnet_for_blob_sidecar#electra
+  sources: []
+  spec: |
+    <spec fn="compute_subnet_for_blob_sidecar" fork="electra" hash="d07c6ad7" />
+
+- name: compute_subnet_for_data_column_sidecar
+  sources: []
+  spec: |
+    <spec fn="compute_subnet_for_data_column_sidecar" fork="fulu" hash="cc47a6bd" />
+
+- name: compute_subnets_for_sync_committee
+  sources: []
+  spec: |
+    <spec fn="compute_subnets_for_sync_committee" fork="altair" hash="637ad33a" />
+
+- name: compute_subscribed_subnet
+  sources: []
+  spec: |
+    <spec fn="compute_subscribed_subnet" fork="phase0" hash="54ac02e6" />
+
+- name: compute_subscribed_subnets
+  sources: []
+  spec: |
+    <spec fn="compute_subscribed_subnets" fork="phase0" hash="e8ca2772" />
+
+- name: compute_sync_committee_period
+  sources: []
+  spec: |
+    <spec fn="compute_sync_committee_period" fork="altair" hash="c5bb031f" />
+
+- name: compute_sync_committee_period_at_slot
+  sources: []
+  spec: |
+    <spec fn="compute_sync_committee_period_at_slot" fork="altair" hash="6ad449b8" />
+
+- name: compute_time_at_slot
+  sources: []
+  spec: |
+    <spec fn="compute_time_at_slot" fork="phase0" hash="7d4e9e46" />
+
+- name: compute_weak_subjectivity_period#phase0
+  sources: []
+  spec: |
+    <spec fn="compute_weak_subjectivity_period" fork="phase0" hash="3f528e06" />
+
+- name: compute_weak_subjectivity_period#electra
+  sources: []
+  spec: |
+    <spec fn="compute_weak_subjectivity_period" fork="electra" hash="8d95104c" />
+
+- name: create_light_client_bootstrap
+  sources: []
+  spec: |
+    <spec fn="create_light_client_bootstrap" fork="altair" hash="54e41304" />
+
+- name: create_light_client_finality_update
+  sources: []
+  spec: |
+    <spec fn="create_light_client_finality_update" fork="altair" hash="21956507" />
+
+- name: create_light_client_optimistic_update
+  sources: []
+  spec: |
+    <spec fn="create_light_client_optimistic_update" fork="altair" hash="5a993ad2" />
+
+- name: create_light_client_update
+  sources: []
+  spec: |
+    <spec fn="create_light_client_update" fork="altair" hash="cde7d86c" />
+
+- name: current_sync_committee_gindex_at_slot#altair
+  sources: []
+  spec: |
+    <spec fn="current_sync_committee_gindex_at_slot" fork="altair" hash="caf087c0" />
+
+- name: current_sync_committee_gindex_at_slot#electra
+  sources: []
+  spec: |
+    <spec fn="current_sync_committee_gindex_at_slot" fork="electra" hash="6f71f075" />
+
+- name: decrease_balance
+  sources: []
+  spec: |
+    <spec fn="decrease_balance" fork="phase0" hash="3dd9c03a" />
+
+- name: eth_aggregate_pubkeys
+  sources: []
+  spec: |
+    <spec fn="eth_aggregate_pubkeys" fork="altair" hash="977edbdb" />
+
+- name: eth_fast_aggregate_verify
+  sources: []
+  spec: |
+    <spec fn="eth_fast_aggregate_verify" fork="altair" hash="452a1740" />
+
+- name: filter_block_tree
+  sources: []
+  spec: |
+    <spec fn="filter_block_tree" fork="phase0" hash="a1924421" />
+
+- name: finalized_root_gindex_at_slot#altair
+  sources: []
+  spec: |
+    <spec fn="finalized_root_gindex_at_slot" fork="altair" hash="9028cbc5" />
+
+- name: finalized_root_gindex_at_slot#electra
+  sources: []
+  spec: |
+    <spec fn="finalized_root_gindex_at_slot" fork="electra" hash="bc7a7fe9" />
+
+- name: get_activation_exit_churn_limit
+  sources: []
+  spec: |
+    <spec fn="get_activation_exit_churn_limit" fork="electra" hash="e3598970" />
+
+- name: get_active_validator_indices
+  sources: []
+  spec: |
+    <spec fn="get_active_validator_indices" fork="phase0" hash="b515ea11" />
+
+- name: get_aggregate_and_proof
+  sources: []
+  spec: |
+    <spec fn="get_aggregate_and_proof" fork="phase0" hash="bb7f6018" />
+
+- name: get_aggregate_and_proof_signature
+  sources: []
+  spec: |
+    <spec fn="get_aggregate_and_proof_signature" fork="phase0" hash="6c77571c" />
+
+- name: get_aggregate_signature
+  sources: []
+  spec: |
+    <spec fn="get_aggregate_signature" fork="phase0" hash="1797b223" />
+
+- name: get_ancestor
+  sources: []
+  spec: |
+    <spec fn="get_ancestor" fork="phase0" hash="0e8c06f9" />
+
+- name: get_attestation_component_deltas
+  sources: []
+  spec: |
+    <spec fn="get_attestation_component_deltas" fork="phase0" hash="c6d7c444" />
+
+- name: get_attestation_deltas
+  sources: []
+  spec: |
+    <spec fn="get_attestation_deltas" fork="phase0" hash="17fcc0d9" />
+
+- name: get_attestation_participation_flag_indices#altair
+  sources: []
+  spec: |
+    <spec fn="get_attestation_participation_flag_indices" fork="altair" hash="c13f596c" />
+
+- name: get_attestation_participation_flag_indices#deneb
+  sources: []
+  spec: |
+    <spec fn="get_attestation_participation_flag_indices" fork="deneb" hash="7e267a44" />
+
+- name: get_attestation_signature
+  sources: []
+  spec: |
+    <spec fn="get_attestation_signature" fork="phase0" hash="0b339b31" />
+
+- name: get_attesting_balance
+  sources: []
+  spec: |
+    <spec fn="get_attesting_balance" fork="phase0" hash="bc7890c1" />
+
+- name: get_attesting_indices#phase0
+  sources: []
+  spec: |
+    <spec fn="get_attesting_indices" fork="phase0" hash="abbf9f2d" />
+
+- name: get_attesting_indices#electra
+  sources: []
+  spec: |
+    <spec fn="get_attesting_indices" fork="electra" hash="fd4b0475" />
+
+- name: get_balance_churn_limit
+  sources: []
+  spec: |
+    <spec fn="get_balance_churn_limit" fork="electra" hash="f4498c02" />
+
+- name: get_base_reward#phase0
+  sources: []
+  spec: |
+    <spec fn="get_base_reward" fork="phase0" hash="46418226" />
+
+- name: get_base_reward#altair
+  sources: []
+  spec: |
+    <spec fn="get_base_reward" fork="altair" hash="edb30df0" />
+
+- name: get_base_reward_per_increment
+  sources: []
+  spec: |
+    <spec fn="get_base_reward_per_increment" fork="altair" hash="8b1aba66" />
+
+- name: get_beacon_committee
+  sources: []
+  spec: |
+    <spec fn="get_beacon_committee" fork="phase0" hash="09ee43b7" />
+
+- name: get_beacon_proposer_index#phase0
+  sources: []
+  spec: |
+    <spec fn="get_beacon_proposer_index" fork="phase0" hash="a4562612" />
+
+- name: get_beacon_proposer_index#fulu
+  sources: []
+  spec: |
+    <spec fn="get_beacon_proposer_index" fork="fulu" hash="8e1ef77d" />
+
+- name: get_beacon_proposer_indices
+  sources: []
+  spec: |
+    <spec fn="get_beacon_proposer_indices" fork="fulu" hash="f5866a8f" />
+
+- name: get_blob_parameters
+  sources: []
+  spec: |
+    <spec fn="get_blob_parameters" fork="fulu" hash="e390b1c8" />
+
+- name: get_blob_sidecars
+  sources: []
+  spec: |
+    <spec fn="get_blob_sidecars" fork="deneb" hash="0206e9a5" />
+
+- name: get_block_root
+  sources: []
+  spec: |
+    <spec fn="get_block_root" fork="phase0" hash="92504d2d" />
+
+- name: get_block_root_at_slot
+  sources: []
+  spec: |
+    <spec fn="get_block_root_at_slot" fork="phase0" hash="0c5003ec" />
+
+- name: get_block_signature
+  sources: []
+  spec: |
+    <spec fn="get_block_signature" fork="phase0" hash="1f2edb6b" />
+
+- name: get_checkpoint_block
+  sources: []
+  spec: |
+    <spec fn="get_checkpoint_block" fork="phase0" hash="9d8daa22" />
+
+- name: get_committee_assignment
+  sources: []
+  spec: |
+    <spec fn="get_committee_assignment" fork="phase0" hash="8b41515e" />
+
+- name: get_committee_count_per_slot
+  sources: []
+  spec: |
+    <spec fn="get_committee_count_per_slot" fork="phase0" hash="3238e1ea" />
+
+- name: get_committee_indices
+  sources: []
+  spec: |
+    <spec fn="get_committee_indices" fork="electra" hash="fa701795" />
+
+- name: get_consolidation_churn_limit
+  sources: []
+  spec: |
+    <spec fn="get_consolidation_churn_limit" fork="electra" hash="3d296032" />
+
+- name: get_contribution_and_proof
+  sources: []
+  spec: |
+    <spec fn="get_contribution_and_proof" fork="altair" hash="ea4e6980" />
+
+- name: get_contribution_and_proof_signature
+  sources: []
+  spec: |
+    <spec fn="get_contribution_and_proof_signature" fork="altair" hash="2d842fca" />
+
+- name: get_current_epoch
+  sources: []
+  spec: |
+    <spec fn="get_current_epoch" fork="phase0" hash="73a94be9" />
+
+- name: get_current_slot
+  sources: []
+  spec: |
+    <spec fn="get_current_slot" fork="phase0" hash="49408b6a" />
+
+- name: get_current_store_epoch
+  sources: []
+  spec: |
+    <spec fn="get_current_store_epoch" fork="phase0" hash="4d86e690" />
+
+- name: get_custody_groups
+  sources: []
+  spec: |
+    <spec fn="get_custody_groups" fork="fulu" hash="cc02e9a4" />
+
+- name: get_data_column_sidecars
+  sources: []
+  spec: |
+    <spec fn="get_data_column_sidecars" fork="fulu" hash="317fc596" />
+
+- name: get_data_column_sidecars_from_block
+  sources: []
+  spec: |
+    <spec fn="get_data_column_sidecars_from_block" fork="fulu" hash="02ffae23" />
+
+- name: get_data_column_sidecars_from_column_sidecar
+  sources: []
+  spec: |
+    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="fulu" hash="4304cdec" />
+
+- name: get_domain
+  sources: []
+  spec: |
+    <spec fn="get_domain" fork="phase0" hash="99ea23f6" />
+
+- name: get_eligible_validator_indices
+  sources: []
+  spec: |
+    <spec fn="get_eligible_validator_indices" fork="phase0" hash="22a24ce4" />
+
+- name: get_epoch_signature
+  sources: []
+  spec: |
+    <spec fn="get_epoch_signature" fork="phase0" hash="31a86d34" />
+
+- name: get_eth1_pending_deposit_count
+  sources: []
+  spec: |
+    <spec fn="get_eth1_pending_deposit_count" fork="electra" hash="5dc54930" />
+
+- name: get_eth1_vote#phase0
+  sources: []
+  spec: |
+    <spec fn="get_eth1_vote" fork="phase0" hash="850a63eb" />
+
+- name: get_eth1_vote#electra
+  sources: []
+  spec: |
+    <spec fn="get_eth1_vote" fork="electra" hash="978c2389" />
+
+- name: get_execution_payload
+  sources: []
+  spec: |
+    <spec fn="get_execution_payload" fork="bellatrix" hash="abcc202e" />
+
+- name: get_execution_requests
+  sources: []
+  spec: |
+    <spec fn="get_execution_requests" fork="electra" hash="2c0fb728" />
+
+- name: get_execution_requests_list
+  sources: []
+  spec: |
+    <spec fn="get_execution_requests_list" fork="electra" hash="0a0be93f" />
+
+- name: get_expected_withdrawals#capella
+  sources: []
+  spec: |
+    <spec fn="get_expected_withdrawals" fork="capella" hash="09191977" />
+
+- name: get_expected_withdrawals#electra
+  sources: []
+  spec: |
+    <spec fn="get_expected_withdrawals" fork="electra" hash="2ed962a3" />
+
+- name: get_filtered_block_tree
+  sources: []
+  spec: |
+    <spec fn="get_filtered_block_tree" fork="phase0" hash="31b703b4" />
+
+- name: get_finality_delay
+  sources: []
+  spec: |
+    <spec fn="get_finality_delay" fork="phase0" hash="df3ca52e" />
+
+- name: get_flag_index_deltas
+  sources: []
+  spec: |
+    <spec fn="get_flag_index_deltas" fork="altair" hash="efadf009" />
+
+- name: get_forkchoice_store
+  sources: []
+  spec: |
+    <spec fn="get_forkchoice_store" fork="phase0" hash="aaa3553b" />
+
+- name: get_head
+  sources: []
+  spec: |
+    <spec fn="get_head" fork="phase0" hash="9fa2b1bd" />
+
+- name: get_head_deltas
+  sources: []
+  spec: |
+    <spec fn="get_head_deltas" fork="phase0" hash="3e9b5111" />
+
+- name: get_inactivity_penalty_deltas#phase0
+  sources: []
+  spec: |
+    <spec fn="get_inactivity_penalty_deltas" fork="phase0" hash="11718f1b" />
+
+- name: get_inactivity_penalty_deltas#altair
+  sources: []
+  spec: |
+    <spec fn="get_inactivity_penalty_deltas" fork="altair" hash="1d27298b" />
+
+- name: get_inactivity_penalty_deltas#bellatrix
+  sources: []
+  spec: |
+    <spec fn="get_inactivity_penalty_deltas" fork="bellatrix" hash="b289e0cd" />
+
+- name: get_inclusion_delay_deltas
+  sources: []
+  spec: |
+    <spec fn="get_inclusion_delay_deltas" fork="phase0" hash="aa690a2f" />
+
+- name: get_index_for_new_validator
+  sources: []
+  spec: |
+    <spec fn="get_index_for_new_validator" fork="altair" hash="e78e8714" />
+
+- name: get_indexed_attestation
+  sources: []
+  spec: |
+    <spec fn="get_indexed_attestation" fork="phase0" hash="424c7a96" />
+
+- name: get_lc_execution_root#capella
+  sources: []
+  spec: |
+    <spec fn="get_lc_execution_root" fork="capella" hash="1fe004a9" />
+
+- name: get_lc_execution_root#deneb
+  sources: []
+  spec: |
+    <spec fn="get_lc_execution_root" fork="deneb" hash="311e3c71" />
+
+- name: get_lc_execution_root#electra
+  sources: []
+  spec: |
+    <spec fn="get_lc_execution_root" fork="electra" hash="939f89bd" />
+
+- name: get_matching_head_attestations
+  sources: []
+  spec: |
+    <spec fn="get_matching_head_attestations" fork="phase0" hash="9e3ca171" />
+
+- name: get_matching_source_attestations
+  sources: []
+  spec: |
+    <spec fn="get_matching_source_attestations" fork="phase0" hash="4771b4df" />
+
+- name: get_matching_target_attestations
+  sources: []
+  spec: |
+    <spec fn="get_matching_target_attestations" fork="phase0" hash="811f3459" />
+
+- name: get_max_effective_balance
+  sources: []
+  spec: |
+    <spec fn="get_max_effective_balance" fork="electra" hash="77f96872" />
+
+- name: get_next_sync_committee
+  sources: []
+  spec: |
+    <spec fn="get_next_sync_committee" fork="altair" hash="ba4f5d3e" />
+
+- name: get_next_sync_committee_indices#altair
+  sources: []
+  spec: |
+    <spec fn="get_next_sync_committee_indices" fork="altair" hash="29891ee8" />
+
+- name: get_next_sync_committee_indices#electra
+  sources: []
+  spec: |
+    <spec fn="get_next_sync_committee_indices" fork="electra" hash="ff7c2d75" />
+
+- name: get_pending_balance_to_withdraw
+  sources: []
+  spec: |
+    <spec fn="get_pending_balance_to_withdraw" fork="electra" hash="3960d28f" />
+
+- name: get_pow_block_at_terminal_total_difficulty
+  sources: []
+  spec: |
+    <spec fn="get_pow_block_at_terminal_total_difficulty" fork="bellatrix" hash="7b6668d2" />
+
+- name: get_previous_epoch
+  sources: []
+  spec: |
+    <spec fn="get_previous_epoch" fork="phase0" hash="935f3711" />
+
+- name: get_proposer_head
+  sources: []
+  spec: |
+    <spec fn="get_proposer_head" fork="phase0" hash="15d44290" />
+
+- name: get_proposer_reward
+  sources: []
+  spec: |
+    <spec fn="get_proposer_reward" fork="phase0" hash="2ccc4963" />
+
+- name: get_proposer_score
+  sources: []
+  spec: |
+    <spec fn="get_proposer_score" fork="phase0" hash="164b8de0" />
+
+- name: get_randao_mix
+  sources: []
+  spec: |
+    <spec fn="get_randao_mix" fork="phase0" hash="c79ea866" />
+
+- name: get_safety_threshold
+  sources: []
+  spec: |
+    <spec fn="get_safety_threshold" fork="altair" hash="72f3d7ff" />
+
+- name: get_seed
+  sources: []
+  spec: |
+    <spec fn="get_seed" fork="phase0" hash="b0921a0a" />
+
+- name: get_slot_signature
+  sources: []
+  spec: |
+    <spec fn="get_slot_signature" fork="phase0" hash="b28edd87" />
+
+- name: get_slots_since_genesis
+  sources: []
+  spec: |
+    <spec fn="get_slots_since_genesis" fork="phase0" hash="3c697269" />
+
+- name: get_source_deltas
+  sources: []
+  spec: |
+    <spec fn="get_source_deltas" fork="phase0" hash="af1e0223" />
+
+- name: get_subtree_index
+  sources: []
+  spec: |
+    <spec fn="get_subtree_index" fork="altair" hash="74962089" />
+
+- name: get_sync_committee_message
+  sources: []
+  spec: |
+    <spec fn="get_sync_committee_message" fork="altair" hash="f5ff7ff2" />
+
+- name: get_sync_committee_selection_proof
+  sources: []
+  spec: |
+    <spec fn="get_sync_committee_selection_proof" fork="altair" hash="fa4e7704" />
+
+- name: get_sync_subcommittee_pubkeys
+  sources: []
+  spec: |
+    <spec fn="get_sync_subcommittee_pubkeys" fork="altair" hash="772addda" />
+
+- name: get_target_deltas
+  sources: []
+  spec: |
+    <spec fn="get_target_deltas" fork="phase0" hash="2e16c38d" />
+
+- name: get_terminal_pow_block
+  sources: []
+  spec: |
+    <spec fn="get_terminal_pow_block" fork="bellatrix" hash="90e145ca" />
+
+- name: get_total_active_balance
+  sources: []
+  spec: |
+    <spec fn="get_total_active_balance" fork="phase0" hash="500e8576" />
+
+- name: get_total_balance
+  sources: []
+  spec: |
+    <spec fn="get_total_balance" fork="phase0" hash="32fd5ad7" />
+
+- name: get_unslashed_attesting_indices
+  sources: []
+  spec: |
+    <spec fn="get_unslashed_attesting_indices" fork="phase0" hash="21c7dd12" />
+
+- name: get_unslashed_participating_indices
+  sources: []
+  spec: |
+    <spec fn="get_unslashed_participating_indices" fork="altair" hash="8a8aae5f" />
+
+- name: get_validator_activation_churn_limit
+  sources: []
+  spec: |
+    <spec fn="get_validator_activation_churn_limit" fork="deneb" hash="cfc9e54a" />
+
+- name: get_validator_churn_limit
+  sources: []
+  spec: |
+    <spec fn="get_validator_churn_limit" fork="phase0" hash="76f815b3" />
+
+- name: get_validator_from_deposit#phase0
+  sources: []
+  spec: |
+    <spec fn="get_validator_from_deposit" fork="phase0" hash="d267aa31" />
+
+- name: get_validator_from_deposit#electra
+  sources: []
+  spec: |
+    <spec fn="get_validator_from_deposit" fork="electra" hash="b1164a28" />
+
+- name: get_validators_custody_requirement
+  sources: []
+  spec: |
+    <spec fn="get_validators_custody_requirement" fork="fulu" hash="b2f47d03" />
+
+- name: get_voting_source
+  sources: []
+  spec: |
+    <spec fn="get_voting_source" fork="phase0" hash="0af91bae" />
+
+- name: get_weight
+  sources: []
+  spec: |
+    <spec fn="get_weight" fork="phase0" hash="f2e4e8ef" />
+
+- name: has_compounding_withdrawal_credential
+  sources: []
+  spec: |
+    <spec fn="has_compounding_withdrawal_credential" fork="electra" hash="a83f0327" />
+
+- name: has_eth1_withdrawal_credential
+  sources: []
+  spec: |
+    <spec fn="has_eth1_withdrawal_credential" fork="capella" hash="184688ed" />
+
+- name: has_execution_withdrawal_credential
+  sources: []
+  spec: |
+    <spec fn="has_execution_withdrawal_credential" fork="electra" hash="afc14c81" />
+
+- name: has_flag
+  sources: []
+  spec: |
+    <spec fn="has_flag" fork="altair" hash="313bedd9" />
+
+- name: increase_balance
+  sources: []
+  spec: |
+    <spec fn="increase_balance" fork="phase0" hash="33ddd025" />
+
+- name: initialize_beacon_state_from_eth1
+  sources: []
+  spec: |
+    <spec fn="initialize_beacon_state_from_eth1" fork="phase0" hash="c69537d6" />
+
+- name: initialize_light_client_store
+  sources: []
+  spec: |
+    <spec fn="initialize_light_client_store" fork="altair" hash="f3de55b9" />
+
+- name: initialize_proposer_lookahead
+  sources: []
+  spec: |
+    <spec fn="initialize_proposer_lookahead" fork="fulu" hash="58f9a307" />
+
+- name: initiate_validator_exit#phase0
+  sources: []
+  spec: |
+    <spec fn="initiate_validator_exit" fork="phase0" hash="0483a058" />
+
+- name: initiate_validator_exit#electra
+  sources: []
+  spec: |
+    <spec fn="initiate_validator_exit" fork="electra" hash="0adfd988" />
+
+- name: integer_squareroot
+  sources: []
+  spec: |
+    <spec fn="integer_squareroot" fork="phase0" hash="f99da6e7" />
+
+- name: is_active_validator
+  sources: []
+  spec: |
+    <spec fn="is_active_validator" fork="phase0" hash="f8673b09" />
+
+- name: is_aggregator
+  sources: []
+  spec: |
+    <spec fn="is_aggregator" fork="phase0" hash="20aea893" />
+
+- name: is_assigned_to_sync_committee
+  sources: []
+  spec: |
+    <spec fn="is_assigned_to_sync_committee" fork="altair" hash="b83187d8" />
+
+- name: is_better_update
+  sources: []
+  spec: |
+    <spec fn="is_better_update" fork="altair" hash="b99582ff" />
+
+- name: is_candidate_block
+  sources: []
+  spec: |
+    <spec fn="is_candidate_block" fork="phase0" hash="c588dc0a" />
+
+- name: is_compounding_withdrawal_credential
+  sources: []
+  spec: |
+    <spec fn="is_compounding_withdrawal_credential" fork="electra" hash="5f97fbb0" />
+
+- name: is_data_available#deneb
+  sources: []
+  spec: |
+    <spec fn="is_data_available" fork="deneb" hash="98ad45cf" />
+
+- name: is_data_available#fulu
+  sources: []
+  spec: |
+    <spec fn="is_data_available" fork="fulu" hash="2062e9c6" />
+
+- name: is_eligible_for_activation
+  sources: []
+  spec: |
+    <spec fn="is_eligible_for_activation" fork="phase0" hash="46b8f01a" />
+
+- name: is_eligible_for_activation_queue#phase0
+  sources: []
+  spec: |
+    <spec fn="is_eligible_for_activation_queue" fork="phase0" hash="513e6ed5" />
+
+- name: is_eligible_for_activation_queue#electra
+  sources: []
+  spec: |
+    <spec fn="is_eligible_for_activation_queue" fork="electra" hash="df3ee6a5" />
+
+- name: is_execution_block
+  sources: []
+  spec: |
+    <spec fn="is_execution_block" fork="bellatrix" hash="26be0b84" />
+
+- name: is_execution_enabled
+  sources: []
+  spec: |
+    <spec fn="is_execution_enabled" fork="bellatrix" hash="3f36d4f4" />
+
+- name: is_ffg_competitive
+  sources: []
+  spec: |
+    <spec fn="is_ffg_competitive" fork="phase0" hash="f6a3c0c5" />
+
+- name: is_finality_update
+  sources: []
+  spec: |
+    <spec fn="is_finality_update" fork="altair" hash="4d0080ac" />
+
+- name: is_finalization_ok
+  sources: []
+  spec: |
+    <spec fn="is_finalization_ok" fork="phase0" hash="760ff77e" />
+
+- name: is_fully_withdrawable_validator#capella
+  sources: []
+  spec: |
+    <spec fn="is_fully_withdrawable_validator" fork="capella" hash="e936da25" />
+
+- name: is_fully_withdrawable_validator#electra
+  sources: []
+  spec: |
+    <spec fn="is_fully_withdrawable_validator" fork="electra" hash="0db6f143" />
+
+- name: is_head_late
+  sources: []
+  spec: |
+    <spec fn="is_head_late" fork="phase0" hash="e393dce6" />
+
+- name: is_head_weak
+  sources: []
+  spec: |
+    <spec fn="is_head_weak" fork="phase0" hash="3a6650d7" />
+
+- name: is_in_inactivity_leak
+  sources: []
+  spec: |
+    <spec fn="is_in_inactivity_leak" fork="phase0" hash="e95b1146" />
+
+- name: is_merge_transition_block
+  sources: []
+  spec: |
+    <spec fn="is_merge_transition_block" fork="bellatrix" hash="f0b5e2a0" />
+
+- name: is_merge_transition_complete
+  sources: []
+  spec: |
+    <spec fn="is_merge_transition_complete" fork="bellatrix" hash="b13c98c6" />
+
+- name: is_next_sync_committee_known
+  sources: []
+  spec: |
+    <spec fn="is_next_sync_committee_known" fork="altair" hash="f5d3196e" />
+
+- name: is_optimistic
+  sources: []
+  spec: |
+    <spec fn="is_optimistic" fork="bellatrix" hash="d5afd615" />
+
+- name: is_optimistic_candidate_block
+  sources: []
+  spec: |
+    <spec fn="is_optimistic_candidate_block" fork="bellatrix" hash="fdb54007" />
+
+- name: is_parent_strong
+  sources: []
+  spec: |
+    <spec fn="is_parent_strong" fork="phase0" hash="e06641a8" />
+
+- name: is_partially_withdrawable_validator#capella
+  sources: []
+  spec: |
+    <spec fn="is_partially_withdrawable_validator" fork="capella" hash="75d433d4" />
+
+- name: is_partially_withdrawable_validator#electra
+  sources: []
+  spec: |
+    <spec fn="is_partially_withdrawable_validator" fork="electra" hash="82f25b17" />
+
+- name: is_proposer
+  sources: []
+  spec: |
+    <spec fn="is_proposer" fork="phase0" hash="d9e66d76" />
+
+- name: is_proposing_on_time
+  sources: []
+  spec: |
+    <spec fn="is_proposing_on_time" fork="phase0" hash="81d1985f" />
+
+- name: is_shuffling_stable
+  sources: []
+  spec: |
+    <spec fn="is_shuffling_stable" fork="phase0" hash="680f0aa0" />
+
+- name: is_slashable_attestation_data
+  sources: []
+  spec: |
+    <spec fn="is_slashable_attestation_data" fork="phase0" hash="47bacf1f" />
+
+- name: is_slashable_validator
+  sources: []
+  spec: |
+    <spec fn="is_slashable_validator" fork="phase0" hash="84f09f6b" />
+
+- name: is_sync_committee_aggregator
+  sources: []
+  spec: |
+    <spec fn="is_sync_committee_aggregator" fork="altair" hash="13d9d470" />
+
+- name: is_sync_committee_update
+  sources: []
+  spec: |
+    <spec fn="is_sync_committee_update" fork="altair" hash="af6f8cb0" />
+
+- name: is_valid_deposit_signature
+  sources: []
+  spec: |
+    <spec fn="is_valid_deposit_signature" fork="electra" hash="7347b754" />
+
+- name: is_valid_genesis_state
+  sources: []
+  spec: |
+    <spec fn="is_valid_genesis_state" fork="phase0" hash="af8478cd" />
+
+- name: is_valid_indexed_attestation
+  sources: []
+  spec: |
+    <spec fn="is_valid_indexed_attestation" fork="phase0" hash="31223a33" />
+
+- name: is_valid_light_client_header#altair
+  sources: []
+  spec: |
+    <spec fn="is_valid_light_client_header" fork="altair" hash="a4c4f0f3" />
+
+- name: is_valid_light_client_header#capella
+  sources: []
+  spec: |
+    <spec fn="is_valid_light_client_header" fork="capella" hash="232ae1d9" />
+
+- name: is_valid_light_client_header#deneb
+  sources: []
+  spec: |
+    <spec fn="is_valid_light_client_header" fork="deneb" hash="f458ba78" />
+
+- name: is_valid_merkle_branch
+  sources: []
+  spec: |
+    <spec fn="is_valid_merkle_branch" fork="phase0" hash="f754117e" />
+
+- name: is_valid_normalized_merkle_branch
+  sources: []
+  spec: |
+    <spec fn="is_valid_normalized_merkle_branch" fork="altair" hash="ef32cdea" />
+
+- name: is_valid_switch_to_compounding_request
+  sources: []
+  spec: |
+    <spec fn="is_valid_switch_to_compounding_request" fork="electra" hash="91aa69bb" />
+
+- name: is_valid_terminal_pow_block
+  sources: []
+  spec: |
+    <spec fn="is_valid_terminal_pow_block" fork="bellatrix" hash="96a7d581" />
+
+- name: is_within_weak_subjectivity_period#phase0
+  sources: []
+  spec: |
+    <spec fn="is_within_weak_subjectivity_period" fork="phase0" hash="f8a94089" />
+
+- name: is_within_weak_subjectivity_period#electra
+  sources: []
+  spec: |
+    <spec fn="is_within_weak_subjectivity_period" fork="electra" hash="c7d4d484" />
+
+- name: kzg_commitment_to_versioned_hash
+  sources: []
+  spec: |
+    <spec fn="kzg_commitment_to_versioned_hash" fork="deneb" hash="fad217c1" />
+
+- name: latest_verified_ancestor
+  sources: []
+  spec: |
+    <spec fn="latest_verified_ancestor" fork="bellatrix" hash="c2ee2c55" />
+
+- name: max_compressed_len
+  sources: []
+  spec: |
+    <spec fn="max_compressed_len" fork="phase0" hash="2e531709" />
+
+- name: max_message_size
+  sources: []
+  spec: |
+    <spec fn="max_message_size" fork="phase0" hash="8abedfdb" />
+
+- name: next_sync_committee_gindex_at_slot#altair
+  sources: []
+  spec: |
+    <spec fn="next_sync_committee_gindex_at_slot" fork="altair" hash="129a53c6" />
+
+- name: next_sync_committee_gindex_at_slot#electra
+  sources: []
+  spec: |
+    <spec fn="next_sync_committee_gindex_at_slot" fork="electra" hash="87d7c53a" />
+
+- name: normalize_merkle_branch
+  sources: []
+  spec: |
+    <spec fn="normalize_merkle_branch" fork="electra" hash="149d7b0c" />
+
+- name: on_attestation
+  sources: []
+  spec: |
+    <spec fn="on_attestation" fork="phase0" hash="b7b4d7de" />
+
+- name: on_attester_slashing
+  sources: []
+  spec: |
+    <spec fn="on_attester_slashing" fork="phase0" hash="73957b9b" />
+
+- name: on_block#phase0
+  sources: []
+  spec: |
+    <spec fn="on_block" fork="phase0" hash="f44d049a" />
+
+- name: on_block#bellatrix
+  sources: []
+  spec: |
+    <spec fn="on_block" fork="bellatrix" hash="1b2d9640" />
+
+- name: on_block#capella
+  sources: []
+  spec: |
+    <spec fn="on_block" fork="capella" hash="14995ab0" />
+
+- name: on_block#deneb
+  sources: []
+  spec: |
+    <spec fn="on_block" fork="deneb" hash="34d79a7b" />
+
+- name: on_block#fulu
+  sources: []
+  spec: |
+    <spec fn="on_block" fork="fulu" hash="b01ca61f" />
+
+- name: on_tick
+  sources: []
+  spec: |
+    <spec fn="on_tick" fork="phase0" hash="9cc6e040" />
+
+- name: on_tick_per_slot
+  sources: []
+  spec: |
+    <spec fn="on_tick_per_slot" fork="phase0" hash="ae9ef172" />
+
+- name: prepare_execution_payload#bellatrix
+  sources: []
+  spec: |
+    <spec fn="prepare_execution_payload" fork="bellatrix" hash="6af4de76" />
+
+- name: prepare_execution_payload#capella
+  sources: []
+  spec: |
+    <spec fn="prepare_execution_payload" fork="capella" hash="bb6a6056" />
+
+- name: prepare_execution_payload#deneb
+  sources: []
+  spec: |
+    <spec fn="prepare_execution_payload" fork="deneb" hash="e7dab7ae" />
+
+- name: prepare_execution_payload#electra
+  sources: []
+  spec: |
+    <spec fn="prepare_execution_payload" fork="electra" hash="a8c031a3" />
+
+- name: process_attestation#phase0
+  sources: []
+  spec: |
+    <spec fn="process_attestation" fork="phase0" hash="6ac78cd0" />
+
+- name: process_attestation#altair
+  sources: []
+  spec: |
+    <spec fn="process_attestation" fork="altair" hash="5bec7f7a" />
+
+- name: process_attestation#deneb
+  sources: []
+  spec: |
+    <spec fn="process_attestation" fork="deneb" hash="5a10209c" />
+
+- name: process_attestation#electra
+  sources: []
+  spec: |
+    <spec fn="process_attestation" fork="electra" hash="52d8bb9a" />
+
+- name: process_attester_slashing
+  sources: []
+  spec: |
+    <spec fn="process_attester_slashing" fork="phase0" hash="e47f6e1e" />
+
+- name: process_block#phase0
+  sources: []
+  spec: |
+    <spec fn="process_block" fork="phase0" hash="188d4c44" />
+
+- name: process_block#altair
+  sources: []
+  spec: |
+    <spec fn="process_block" fork="altair" hash="f80f79de" />
+
+- name: process_block#bellatrix
+  sources: []
+  spec: |
+    <spec fn="process_block" fork="bellatrix" hash="4d7485a2" />
+
+- name: process_block#capella
+  sources: []
+  spec: |
+    <spec fn="process_block" fork="capella" hash="48f1bad4" />
+
+- name: process_block#electra
+  sources: []
+  spec: |
+    <spec fn="process_block" fork="electra" hash="26d93faf" />
+
+- name: process_block_header
+  sources: []
+  spec: |
+    <spec fn="process_block_header" fork="phase0" hash="e782040b" />
+
+- name: process_bls_to_execution_change
+  sources: []
+  spec: |
+    <spec fn="process_bls_to_execution_change" fork="capella" hash="1fade4f1" />
+
+- name: process_consolidation_request
+  sources: []
+  spec: |
+    <spec fn="process_consolidation_request" fork="electra" hash="4da4b0fb" />
+
+- name: process_deposit#phase0
+  sources: []
+  spec: |
+    <spec fn="process_deposit" fork="phase0" hash="ee6b3afe" />
+
+- name: process_deposit#electra
+  sources: []
+  spec: |
+    <spec fn="process_deposit" fork="electra" hash="b75831d0" />
+
+- name: process_deposit_request
+  sources: []
+  spec: |
+    <spec fn="process_deposit_request" fork="electra" hash="547c4a35" />
+
+- name: process_effective_balance_updates#phase0
+  sources: []
+  spec: |
+    <spec fn="process_effective_balance_updates" fork="phase0" hash="678d0327" />
+
+- name: process_effective_balance_updates#electra
+  sources: []
+  spec: |
+    <spec fn="process_effective_balance_updates" fork="electra" hash="6b447363" />
+
+- name: process_epoch#phase0
+  sources: []
+  spec: |
+    <spec fn="process_epoch" fork="phase0" hash="9b0ba41d" />
+
+- name: process_epoch#altair
+  sources: []
+  spec: |
+    <spec fn="process_epoch" fork="altair" hash="6f9c70d8" />
+
+- name: process_epoch#capella
+  sources: []
+  spec: |
+    <spec fn="process_epoch" fork="capella" hash="5fb03e76" />
+
+- name: process_epoch#electra
+  sources: []
+  spec: |
+    <spec fn="process_epoch" fork="electra" hash="505b801d" />
+
+- name: process_epoch#fulu
+  sources: []
+  spec: |
+    <spec fn="process_epoch" fork="fulu" hash="86037019" />
+
+- name: process_eth1_data
+  sources: []
+  spec: |
+    <spec fn="process_eth1_data" fork="phase0" hash="a320a108" />
+
+- name: process_eth1_data_reset
+  sources: []
+  spec: |
+    <spec fn="process_eth1_data_reset" fork="phase0" hash="c777739e" />
+
+- name: process_execution_payload#bellatrix
+  sources: []
+  spec: |
+    <spec fn="process_execution_payload" fork="bellatrix" hash="d1d1e466" />
+
+- name: process_execution_payload#capella
+  sources: []
+  spec: |
+    <spec fn="process_execution_payload" fork="capella" hash="3a3d1751" />
+
+- name: process_execution_payload#deneb
+  sources: []
+  spec: |
+    <spec fn="process_execution_payload" fork="deneb" hash="4c3960f2" />
+
+- name: process_execution_payload#electra
+  sources: []
+  spec: |
+    <spec fn="process_execution_payload" fork="electra" hash="67d2ee10" />
+
+- name: process_execution_payload#fulu
+  sources: []
+  spec: |
+    <spec fn="process_execution_payload" fork="fulu" hash="cc18d6ef" />
+
+- name: process_historical_roots_update
+  sources: []
+  spec: |
+    <spec fn="process_historical_roots_update" fork="phase0" hash="4cda7ad5" />
+
+- name: process_historical_summaries_update
+  sources: []
+  spec: |
+    <spec fn="process_historical_summaries_update" fork="capella" hash="8eb6dcbb" />
+
+- name: process_inactivity_updates
+  sources: []
+  spec: |
+    <spec fn="process_inactivity_updates" fork="altair" hash="4fe14f5a" />
+
+- name: process_justification_and_finalization#phase0
+  sources: []
+  spec: |
+    <spec fn="process_justification_and_finalization" fork="phase0" hash="4a2b2108" />
+
+- name: process_justification_and_finalization#altair
+  sources: []
+  spec: |
+    <spec fn="process_justification_and_finalization" fork="altair" hash="863cfca6" />
+
+- name: process_light_client_finality_update
+  sources: []
+  spec: |
+    <spec fn="process_light_client_finality_update" fork="altair" hash="befaba5b" />
+
+- name: process_light_client_optimistic_update
+  sources: []
+  spec: |
+    <spec fn="process_light_client_optimistic_update" fork="altair" hash="06c0365a" />
+
+- name: process_light_client_store_force_update
+  sources: []
+  spec: |
+    <spec fn="process_light_client_store_force_update" fork="altair" hash="fbb77069" />
+
+- name: process_light_client_update
+  sources: []
+  spec: |
+    <spec fn="process_light_client_update" fork="altair" hash="b64a67ff" />
+
+- name: process_operations#phase0
+  sources: []
+  spec: |
+    <spec fn="process_operations" fork="phase0" hash="eb7114df" />
+
+- name: process_operations#capella
+  sources: []
+  spec: |
+    <spec fn="process_operations" fork="capella" hash="1314042b" />
+
+- name: process_operations#electra
+  sources: []
+  spec: |
+    <spec fn="process_operations" fork="electra" hash="643f18b4" />
+
+- name: process_participation_flag_updates
+  sources: []
+  spec: |
+    <spec fn="process_participation_flag_updates" fork="altair" hash="92852f31" />
+
+- name: process_participation_record_updates
+  sources: []
+  spec: |
+    <spec fn="process_participation_record_updates" fork="phase0" hash="6a203574" />
+
+- name: process_pending_consolidations
+  sources: []
+  spec: |
+    <spec fn="process_pending_consolidations" fork="electra" hash="75e32e4b" />
+
+- name: process_pending_deposits
+  sources: []
+  spec: |
+    <spec fn="process_pending_deposits" fork="electra" hash="f0e7c738" />
+
+- name: process_proposer_lookahead
+  sources: []
+  spec: |
+    <spec fn="process_proposer_lookahead" fork="fulu" hash="3ff130cc" />
+
+- name: process_proposer_slashing
+  sources: []
+  spec: |
+    <spec fn="process_proposer_slashing" fork="phase0" hash="279ec199" />
+
+- name: process_randao
+  sources: []
+  spec: |
+    <spec fn="process_randao" fork="phase0" hash="607c511e" />
+
+- name: process_randao_mixes_reset
+  sources: []
+  spec: |
+    <spec fn="process_randao_mixes_reset" fork="phase0" hash="0faaabf3" />
+
+- name: process_registry_updates#phase0
+  sources: []
+  spec: |
+    <spec fn="process_registry_updates" fork="phase0" hash="3adacc1e" />
+
+- name: process_registry_updates#deneb
+  sources: []
+  spec: |
+    <spec fn="process_registry_updates" fork="deneb" hash="71a6a2d9" />
+
+- name: process_registry_updates#electra
+  sources: []
+  spec: |
+    <spec fn="process_registry_updates" fork="electra" hash="7d405632" />
+
+- name: process_rewards_and_penalties#phase0
+  sources: []
+  spec: |
+    <spec fn="process_rewards_and_penalties" fork="phase0" hash="93779fdb" />
+
+- name: process_rewards_and_penalties#altair
+  sources: []
+  spec: |
+    <spec fn="process_rewards_and_penalties" fork="altair" hash="373af4c1" />
+
+- name: process_slashings#phase0
+  sources: []
+  spec: |
+    <spec fn="process_slashings" fork="phase0" hash="a18a9045" />
+
+- name: process_slashings#altair
+  sources: []
+  spec: |
+    <spec fn="process_slashings" fork="altair" hash="96cce87d" />
+
+- name: process_slashings#bellatrix
+  sources: []
+  spec: |
+    <spec fn="process_slashings" fork="bellatrix" hash="73fe6802" />
+
+- name: process_slashings#electra
+  sources: []
+  spec: |
+    <spec fn="process_slashings" fork="electra" hash="a948faff" />
+
+- name: process_slashings_reset
+  sources: []
+  spec: |
+    <spec fn="process_slashings_reset" fork="phase0" hash="a82fb03c" />
+
+- name: process_slot
+  sources: []
+  spec: |
+    <spec fn="process_slot" fork="phase0" hash="1ba7e009" />
+
+- name: process_slots
+  sources: []
+  spec: |
+    <spec fn="process_slots" fork="phase0" hash="f50107a2" />
+
+- name: process_sync_aggregate
+  sources: []
+  spec: |
+    <spec fn="process_sync_aggregate" fork="altair" hash="d9a71877" />
+
+- name: process_sync_committee_contributions
+  sources: []
+  spec: |
+    <spec fn="process_sync_committee_contributions" fork="altair" hash="34e95c46" />
+
+- name: process_sync_committee_updates
+  sources: []
+  spec: |
+    <spec fn="process_sync_committee_updates" fork="altair" hash="9e59de37" />
+
+- name: process_voluntary_exit#phase0
+  sources: []
+  spec: |
+    <spec fn="process_voluntary_exit" fork="phase0" hash="d867310e" />
+
+- name: process_voluntary_exit#deneb
+  sources: []
+  spec: |
+    <spec fn="process_voluntary_exit" fork="deneb" hash="f97fd167" />
+
+- name: process_voluntary_exit#electra
+  sources: []
+  spec: |
+    <spec fn="process_voluntary_exit" fork="electra" hash="6dcb5530" />
+
+- name: process_withdrawal_request
+  sources: []
+  spec: |
+    <spec fn="process_withdrawal_request" fork="electra" hash="c21a0a53" />
+
+- name: process_withdrawals#capella
+  sources: []
+  spec: |
+    <spec fn="process_withdrawals" fork="capella" hash="ed6a9c5a" />
+
+- name: process_withdrawals#electra
+  sources: []
+  spec: |
+    <spec fn="process_withdrawals" fork="electra" hash="bb094f95" />
+
+- name: queue_excess_active_balance
+  sources: []
+  spec: |
+    <spec fn="queue_excess_active_balance" fork="electra" hash="2c952be0" />
+
+- name: recover_matrix
+  sources: []
+  spec: |
+    <spec fn="recover_matrix" fork="fulu" hash="9b01f005" />
+
+- name: saturating_sub
+  sources: []
+  spec: |
+    <spec fn="saturating_sub" fork="phase0" hash="ab62a392" />
+
+- name: set_or_append_list
+  sources: []
+  spec: |
+    <spec fn="set_or_append_list" fork="altair" hash="a48f6f4c" />
+
+- name: should_override_forkchoice_update
+  sources: []
+  spec: |
+    <spec fn="should_override_forkchoice_update" fork="bellatrix" hash="9a8043af" />
+
+- name: slash_validator#phase0
+  sources: []
+  spec: |
+    <spec fn="slash_validator" fork="phase0" hash="85d8d7c9" />
+
+- name: slash_validator#altair
+  sources: []
+  spec: |
+    <spec fn="slash_validator" fork="altair" hash="88f6c284" />
+
+- name: slash_validator#bellatrix
+  sources: []
+  spec: |
+    <spec fn="slash_validator" fork="bellatrix" hash="124f6889" />
+
+- name: slash_validator#electra
+  sources: []
+  spec: |
+    <spec fn="slash_validator" fork="electra" hash="54b64d21" />
+
+- name: state_transition
+  sources: []
+  spec: |
+    <spec fn="state_transition" fork="phase0" hash="0b7e562f" />
+
+- name: store_target_checkpoint_state
+  sources: []
+  spec: |
+    <spec fn="store_target_checkpoint_state" fork="phase0" hash="2e4ff2b7" />
+
+- name: switch_to_compounding_validator
+  sources: []
+  spec: |
+    <spec fn="switch_to_compounding_validator" fork="electra" hash="a6fd864b" />
+
+- name: translate_participation
+  sources: []
+  spec: |
+    <spec fn="translate_participation" fork="altair" hash="3d7c74a1" />
+
+- name: update_checkpoints
+  sources: []
+  spec: |
+    <spec fn="update_checkpoints" fork="phase0" hash="89e18dc4" />
+
+- name: update_latest_messages
+  sources: []
+  spec: |
+    <spec fn="update_latest_messages" fork="phase0" hash="3da3b413" />
+
+- name: update_unrealized_checkpoints
+  sources: []
+  spec: |
+    <spec fn="update_unrealized_checkpoints" fork="phase0" hash="8cee5d3b" />
+
+- name: upgrade_lc_bootstrap_to_capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_bootstrap_to_capella" fork="capella" hash="2c8939e7" />
+
+- name: upgrade_lc_bootstrap_to_deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_bootstrap_to_deneb" fork="deneb" hash="f91baf71" />
+
+- name: upgrade_lc_bootstrap_to_electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_bootstrap_to_electra" fork="electra" hash="93818ed1" />
+
+- name: upgrade_lc_finality_update_to_capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_finality_update_to_capella" fork="capella" hash="5315d1df" />
+
+- name: upgrade_lc_finality_update_to_deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_finality_update_to_deneb" fork="deneb" hash="bfa53da6" />
+
+- name: upgrade_lc_finality_update_to_electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_finality_update_to_electra" fork="electra" hash="1bcc6b97" />
+
+- name: upgrade_lc_header_to_capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_header_to_capella" fork="capella" hash="9eaa5026" />
+
+- name: upgrade_lc_header_to_deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_header_to_deneb" fork="deneb" hash="dbc82244" />
+
+- name: upgrade_lc_header_to_electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_header_to_electra" fork="electra" hash="90aa82aa" />
+
+- name: upgrade_lc_optimistic_update_to_capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_optimistic_update_to_capella" fork="capella" hash="488c41c5" />
+
+- name: upgrade_lc_optimistic_update_to_deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_optimistic_update_to_deneb" fork="deneb" hash="66aa73ab" />
+
+- name: upgrade_lc_optimistic_update_to_electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_optimistic_update_to_electra" fork="electra" hash="a6059e7d" />
+
+- name: upgrade_lc_store_to_capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_store_to_capella" fork="capella" hash="a25064df" />
+
+- name: upgrade_lc_store_to_deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_store_to_deneb" fork="deneb" hash="29b26f52" />
+
+- name: upgrade_lc_store_to_electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_store_to_electra" fork="electra" hash="e9096017" />
+
+- name: upgrade_lc_update_to_capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_update_to_capella" fork="capella" hash="e7dbaf33" />
+
+- name: upgrade_lc_update_to_deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_update_to_deneb" fork="deneb" hash="64adb1e0" />
+
+- name: upgrade_lc_update_to_electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_lc_update_to_electra" fork="electra" hash="4d42b63e" />
+
+- name: upgrade_to_altair
+  sources: []
+  spec: |
+    <spec fn="upgrade_to_altair" fork="altair" hash="4f858ca3" />
+
+- name: upgrade_to_bellatrix
+  sources: []
+  spec: |
+    <spec fn="upgrade_to_bellatrix" fork="bellatrix" hash="73a0a7ba" />
+
+- name: upgrade_to_capella
+  sources: []
+  spec: |
+    <spec fn="upgrade_to_capella" fork="capella" hash="673c74f0" />
+
+- name: upgrade_to_deneb
+  sources: []
+  spec: |
+    <spec fn="upgrade_to_deneb" fork="deneb" hash="0c371849" />
+
+- name: upgrade_to_electra
+  sources: []
+  spec: |
+    <spec fn="upgrade_to_electra" fork="electra" hash="c82f0e68" />
+
+- name: upgrade_to_fulu
+  sources: []
+  spec: |
+    <spec fn="upgrade_to_fulu" fork="fulu" hash="7c4bae8d" />
+
+- name: validate_light_client_update
+  sources: []
+  spec: |
+    <spec fn="validate_light_client_update" fork="altair" hash="eb5d169b" />
+
+- name: validate_merge_block
+  sources: []
+  spec: |
+    <spec fn="validate_merge_block" fork="bellatrix" hash="d51209cc" />
+
+- name: validate_on_attestation
+  sources: []
+  spec: |
+    <spec fn="validate_on_attestation" fork="phase0" hash="4571ccf8" />
+
+- name: validate_target_epoch_against_current_time
+  sources: []
+  spec: |
+    <spec fn="validate_target_epoch_against_current_time" fork="phase0" hash="f7352056" />
+
+- name: verify_blob_sidecar_inclusion_proof
+  sources: []
+  spec: |
+    <spec fn="verify_blob_sidecar_inclusion_proof" fork="deneb" hash="0ccdc846" />
+
+- name: verify_block_signature
+  sources: []
+  spec: |
+    <spec fn="verify_block_signature" fork="phase0" hash="3a777e68" />
+
+- name: verify_data_column_sidecar
+  sources: []
+  spec: |
+    <spec fn="verify_data_column_sidecar" fork="fulu" hash="509c0986" />
+
+- name: verify_data_column_sidecar_inclusion_proof
+  sources: []
+  spec: |
+    <spec fn="verify_data_column_sidecar_inclusion_proof" fork="fulu" hash="a6757e5e" />
+
+- name: verify_data_column_sidecar_kzg_proofs
+  sources: []
+  spec: |
+    <spec fn="verify_data_column_sidecar_kzg_proofs" fork="fulu" hash="1cd21395" />
+
+- name: voting_period_start_time
+  sources: []
+  spec: |
+    <spec fn="voting_period_start_time" fork="phase0" hash="4eb8d0ca" />
+
+- name: weigh_justification_and_finalization
+  sources: []
+  spec: |
+    <spec fn="weigh_justification_and_finalization" fork="phase0" hash="1087de6f" />
+
+- name: xor
+  sources: []
+  spec: |
+    <spec fn="xor" fork="phase0" hash="3b45f2e1" />

--- a/specrefs/presets.yml
+++ b/specrefs/presets.yml
@@ -1,0 +1,354 @@
+- name: BASE_REWARD_FACTOR
+  sources: []
+  spec: |
+    <spec preset_var="BASE_REWARD_FACTOR" fork="phase0" hash="ba06d7ce" />
+
+- name: BYTES_PER_LOGS_BLOOM
+  sources: []
+  spec: |
+    <spec preset_var="BYTES_PER_LOGS_BLOOM" fork="bellatrix" hash="97101cb2" />
+
+- name: EFFECTIVE_BALANCE_INCREMENT
+  sources: []
+  spec: |
+    <spec preset_var="EFFECTIVE_BALANCE_INCREMENT" fork="phase0" hash="23dfe52c" />
+
+- name: EPOCHS_PER_ETH1_VOTING_PERIOD
+  sources: []
+  spec: |
+    <spec preset_var="EPOCHS_PER_ETH1_VOTING_PERIOD" fork="phase0" hash="6b6a0053" />
+
+- name: EPOCHS_PER_HISTORICAL_VECTOR
+  sources: []
+  spec: |
+    <spec preset_var="EPOCHS_PER_HISTORICAL_VECTOR" fork="phase0" hash="6156dc33" />
+
+- name: EPOCHS_PER_SLASHINGS_VECTOR
+  sources: []
+  spec: |
+    <spec preset_var="EPOCHS_PER_SLASHINGS_VECTOR" fork="phase0" hash="c237469a" />
+
+- name: EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+  sources: []
+  spec: |
+    <spec preset_var="EPOCHS_PER_SYNC_COMMITTEE_PERIOD" fork="altair" hash="f02bdf72" />
+
+- name: FIELD_ELEMENTS_PER_BLOB
+  sources: []
+  spec: |
+    <spec preset_var="FIELD_ELEMENTS_PER_BLOB" fork="deneb" hash="a86948eb" />
+
+- name: FIELD_ELEMENTS_PER_CELL
+  sources: []
+  spec: |
+    <spec preset_var="FIELD_ELEMENTS_PER_CELL" fork="fulu" hash="6af85ab8" />
+
+- name: FIELD_ELEMENTS_PER_EXT_BLOB
+  sources: []
+  spec: |
+    <spec preset_var="FIELD_ELEMENTS_PER_EXT_BLOB" fork="fulu" hash="6994b51d" />
+
+- name: HISTORICAL_ROOTS_LIMIT
+  sources: []
+  spec: |
+    <spec preset_var="HISTORICAL_ROOTS_LIMIT" fork="phase0" hash="498b6597" />
+
+- name: HYSTERESIS_DOWNWARD_MULTIPLIER
+  sources: []
+  spec: |
+    <spec preset_var="HYSTERESIS_DOWNWARD_MULTIPLIER" fork="phase0" hash="95d603c9" />
+
+- name: HYSTERESIS_QUOTIENT
+  sources: []
+  spec: |
+    <spec preset_var="HYSTERESIS_QUOTIENT" fork="phase0" hash="c3849917" />
+
+- name: HYSTERESIS_UPWARD_MULTIPLIER
+  sources: []
+  spec: |
+    <spec preset_var="HYSTERESIS_UPWARD_MULTIPLIER" fork="phase0" hash="34607474" />
+
+- name: INACTIVITY_PENALTY_QUOTIENT
+  sources: []
+  spec: |
+    <spec preset_var="INACTIVITY_PENALTY_QUOTIENT" fork="phase0" hash="5d82db62" />
+
+- name: INACTIVITY_PENALTY_QUOTIENT_ALTAIR
+  sources: []
+  spec: |
+    <spec preset_var="INACTIVITY_PENALTY_QUOTIENT_ALTAIR" fork="altair" hash="d0d3c505" />
+
+- name: INACTIVITY_PENALTY_QUOTIENT_BELLATRIX
+  sources: []
+  spec: |
+    <spec preset_var="INACTIVITY_PENALTY_QUOTIENT_BELLATRIX" fork="bellatrix" hash="33fd626d" />
+
+- name: KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH
+  sources: []
+  spec: |
+    <spec preset_var="KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH" fork="fulu" hash="22280638" />
+
+- name: KZG_COMMITMENT_INCLUSION_PROOF_DEPTH
+  sources: []
+  spec: |
+    <spec preset_var="KZG_COMMITMENT_INCLUSION_PROOF_DEPTH" fork="deneb" hash="79db011d" />
+
+- name: MAX_ATTESTATIONS
+  sources: []
+  spec: |
+    <spec preset_var="MAX_ATTESTATIONS" fork="phase0" hash="afe55d3f" />
+
+- name: MAX_ATTESTATIONS_ELECTRA
+  sources: []
+  spec: |
+    <spec preset_var="MAX_ATTESTATIONS_ELECTRA" fork="electra" hash="4dbaf2dd" />
+
+- name: MAX_ATTESTER_SLASHINGS
+  sources: []
+  spec: |
+    <spec preset_var="MAX_ATTESTER_SLASHINGS" fork="phase0" hash="c1416d33" />
+
+- name: MAX_ATTESTER_SLASHINGS_ELECTRA
+  sources: []
+  spec: |
+    <spec preset_var="MAX_ATTESTER_SLASHINGS_ELECTRA" fork="electra" hash="fc70c923" />
+
+- name: MAX_BLOB_COMMITMENTS_PER_BLOCK
+  sources: []
+  spec: |
+    <spec preset_var="MAX_BLOB_COMMITMENTS_PER_BLOCK" fork="deneb" hash="0ad15e8f" />
+
+- name: MAX_BLS_TO_EXECUTION_CHANGES
+  sources: []
+  spec: |
+    <spec preset_var="MAX_BLS_TO_EXECUTION_CHANGES" fork="capella" hash="1eee2f2f" />
+
+- name: MAX_BYTES_PER_TRANSACTION
+  sources: []
+  spec: |
+    <spec preset_var="MAX_BYTES_PER_TRANSACTION" fork="bellatrix" hash="3684e68f" />
+
+- name: MAX_COMMITTEES_PER_SLOT#phase0
+  sources: []
+  spec: |
+    <spec preset_var="MAX_COMMITTEES_PER_SLOT" fork="phase0" hash="0442c4b7" />
+
+- name: MAX_COMMITTEES_PER_SLOT#electra
+  sources: []
+  spec: |
+    <spec preset_var="MAX_COMMITTEES_PER_SLOT" fork="electra" hash="0442c4b7" />
+
+- name: MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
+  sources: []
+  spec: |
+    <spec preset_var="MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD" fork="electra" hash="59ec80e5" />
+
+- name: MAX_DEPOSITS
+  sources: []
+  spec: |
+    <spec preset_var="MAX_DEPOSITS" fork="phase0" hash="542a0f96" />
+
+- name: MAX_DEPOSIT_REQUESTS_PER_PAYLOAD
+  sources: []
+  spec: |
+    <spec preset_var="MAX_DEPOSIT_REQUESTS_PER_PAYLOAD" fork="electra" hash="6c60ff83" />
+
+- name: MAX_EFFECTIVE_BALANCE
+  sources: []
+  spec: |
+    <spec preset_var="MAX_EFFECTIVE_BALANCE" fork="phase0" hash="13dd1310" />
+
+- name: MAX_EFFECTIVE_BALANCE_ELECTRA
+  sources: []
+  spec: |
+    <spec preset_var="MAX_EFFECTIVE_BALANCE_ELECTRA" fork="electra" hash="2ec17dc4" />
+
+- name: MAX_EXTRA_DATA_BYTES
+  sources: []
+  spec: |
+    <spec preset_var="MAX_EXTRA_DATA_BYTES" fork="bellatrix" hash="9d278744" />
+
+- name: MAX_PENDING_DEPOSITS_PER_EPOCH
+  sources: []
+  spec: |
+    <spec preset_var="MAX_PENDING_DEPOSITS_PER_EPOCH" fork="electra" hash="f532a46f" />
+
+- name: MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
+  sources: []
+  spec: |
+    <spec preset_var="MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP" fork="electra" hash="e7b2f394" />
+
+- name: MAX_PROPOSER_SLASHINGS
+  sources: []
+  spec: |
+    <spec preset_var="MAX_PROPOSER_SLASHINGS" fork="phase0" hash="87bfd9ed" />
+
+- name: MAX_SEED_LOOKAHEAD
+  sources: []
+  spec: |
+    <spec preset_var="MAX_SEED_LOOKAHEAD" fork="phase0" hash="b7ae8929" />
+
+- name: MAX_TRANSACTIONS_PER_PAYLOAD
+  sources: []
+  spec: |
+    <spec preset_var="MAX_TRANSACTIONS_PER_PAYLOAD" fork="bellatrix" hash="1088e3b2" />
+
+- name: MAX_VALIDATORS_PER_COMMITTEE#phase0
+  sources: []
+  spec: |
+    <spec preset_var="MAX_VALIDATORS_PER_COMMITTEE" fork="phase0" hash="900abcb2" />
+
+- name: MAX_VALIDATORS_PER_COMMITTEE#electra
+  sources: []
+  spec: |
+    <spec preset_var="MAX_VALIDATORS_PER_COMMITTEE" fork="electra" hash="900abcb2" />
+
+- name: MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
+  sources: []
+  spec: |
+    <spec preset_var="MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP" fork="capella" hash="ac61940c" />
+
+- name: MAX_VOLUNTARY_EXITS
+  sources: []
+  spec: |
+    <spec preset_var="MAX_VOLUNTARY_EXITS" fork="phase0" hash="a0a7ac5e" />
+
+- name: MAX_WITHDRAWALS_PER_PAYLOAD
+  sources: []
+  spec: |
+    <spec preset_var="MAX_WITHDRAWALS_PER_PAYLOAD" fork="capella" hash="c406effb" />
+
+- name: MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD
+  sources: []
+  spec: |
+    <spec preset_var="MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD" fork="electra" hash="9f04de0d" />
+
+- name: MIN_ACTIVATION_BALANCE
+  sources: []
+  spec: |
+    <spec preset_var="MIN_ACTIVATION_BALANCE" fork="electra" hash="fcbcbab5" />
+
+- name: MIN_ATTESTATION_INCLUSION_DELAY
+  sources: []
+  spec: |
+    <spec preset_var="MIN_ATTESTATION_INCLUSION_DELAY" fork="phase0" hash="2e9435aa" />
+
+- name: MIN_DEPOSIT_AMOUNT
+  sources: []
+  spec: |
+    <spec preset_var="MIN_DEPOSIT_AMOUNT" fork="phase0" hash="388f2923" />
+
+- name: MIN_EPOCHS_TO_INACTIVITY_PENALTY
+  sources: []
+  spec: |
+    <spec preset_var="MIN_EPOCHS_TO_INACTIVITY_PENALTY" fork="phase0" hash="339d14c4" />
+
+- name: MIN_SEED_LOOKAHEAD
+  sources: []
+  spec: |
+    <spec preset_var="MIN_SEED_LOOKAHEAD" fork="phase0" hash="48a0462b" />
+
+- name: MIN_SLASHING_PENALTY_QUOTIENT
+  sources: []
+  spec: |
+    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT" fork="phase0" hash="0204123d" />
+
+- name: MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR
+  sources: []
+  spec: |
+    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR" fork="altair" hash="4845bc05" />
+
+- name: MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX
+  sources: []
+  spec: |
+    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX" fork="bellatrix" hash="2a5af13c" />
+
+- name: MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA
+  sources: []
+  spec: |
+    <spec preset_var="MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA" fork="electra" hash="03888289" />
+
+- name: MIN_SYNC_COMMITTEE_PARTICIPANTS
+  sources: []
+  spec: |
+    <spec preset_var="MIN_SYNC_COMMITTEE_PARTICIPANTS" fork="altair" hash="7ca6fd1f" />
+
+- name: PENDING_CONSOLIDATIONS_LIMIT
+  sources: []
+  spec: |
+    <spec preset_var="PENDING_CONSOLIDATIONS_LIMIT" fork="electra" hash="f28398d0" />
+
+- name: PENDING_DEPOSITS_LIMIT
+  sources: []
+  spec: |
+    <spec preset_var="PENDING_DEPOSITS_LIMIT" fork="electra" hash="8f7ed296" />
+
+- name: PENDING_PARTIAL_WITHDRAWALS_LIMIT
+  sources: []
+  spec: |
+    <spec preset_var="PENDING_PARTIAL_WITHDRAWALS_LIMIT" fork="electra" hash="9ae3fe56" />
+
+- name: PROPORTIONAL_SLASHING_MULTIPLIER
+  sources: []
+  spec: |
+    <spec preset_var="PROPORTIONAL_SLASHING_MULTIPLIER" fork="phase0" hash="7675c5ad" />
+
+- name: PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR
+  sources: []
+  spec: |
+    <spec preset_var="PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR" fork="altair" hash="5e6aedb9" />
+
+- name: PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX
+  sources: []
+  spec: |
+    <spec preset_var="PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX" fork="bellatrix" hash="e36837df" />
+
+- name: PROPOSER_REWARD_QUOTIENT
+  sources: []
+  spec: |
+    <spec preset_var="PROPOSER_REWARD_QUOTIENT" fork="phase0" hash="a60dab3e" />
+
+- name: SHUFFLE_ROUND_COUNT
+  sources: []
+  spec: |
+    <spec preset_var="SHUFFLE_ROUND_COUNT" fork="phase0" hash="ed107076" />
+
+- name: SLOTS_PER_EPOCH
+  sources: []
+  spec: |
+    <spec preset_var="SLOTS_PER_EPOCH" fork="phase0" hash="cb41af43" />
+
+- name: SLOTS_PER_HISTORICAL_ROOT
+  sources: []
+  spec: |
+    <spec preset_var="SLOTS_PER_HISTORICAL_ROOT" fork="phase0" hash="1d0bdd1d" />
+
+- name: SYNC_COMMITTEE_SIZE
+  sources: []
+  spec: |
+    <spec preset_var="SYNC_COMMITTEE_SIZE" fork="altair" hash="d31740c9" />
+
+- name: TARGET_COMMITTEE_SIZE
+  sources: []
+  spec: |
+    <spec preset_var="TARGET_COMMITTEE_SIZE" fork="phase0" hash="d56fdb68" />
+
+- name: UPDATE_TIMEOUT
+  sources: []
+  spec: |
+    <spec preset_var="UPDATE_TIMEOUT" fork="altair" hash="e633d57e" />
+
+- name: VALIDATOR_REGISTRY_LIMIT
+  sources: []
+  spec: |
+    <spec preset_var="VALIDATOR_REGISTRY_LIMIT" fork="phase0" hash="8fa5412c" />
+
+- name: WHISTLEBLOWER_REWARD_QUOTIENT
+  sources: []
+  spec: |
+    <spec preset_var="WHISTLEBLOWER_REWARD_QUOTIENT" fork="phase0" hash="62962c52" />
+
+- name: WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA
+  sources: []
+  spec: |
+    <spec preset_var="WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA" fork="electra" hash="8021dedf" />


### PR DESCRIPTION
Lighthouse Spec Mapping

## Proposed Changes

Added all of the file paths and search terms for each of the spec implementations in configs.yml.

## Additional Info

Ethspecify checks pass for all implementations except 1:

AMBIGUOUS SEARCH: configs.CUSTODY_REQUIREMENT#fulu | 'CUSTODY_REQUIREMENT:' found 2 times in common/eth2_network_config/built_in_network_configs/mainnet/config.yaml


