### PR TITLE
Add tempo to local testnet config and update fulu kurtosis config files

### DIFF
--- a/scripts/local_testnet/network_params.yaml
+++ b/scripts/local_testnet/network_params.yaml
@@ -16,3 +16,4 @@ additional_services:
   - dora
   - spamoor
   - prometheus_grafana
+  - tempo

--- a/scripts/local_testnet/network_params_das.yaml
+++ b/scripts/local_testnet/network_params_das.yaml
@@ -2,7 +2,7 @@ participants:
   - cl_type: lighthouse
     cl_image: lighthouse:local
     el_type: geth
-    el_image: ethpandaops/geth:fusaka-devnet-3
+    el_image: ethpandaops/geth:master
     supernode: true
     cl_extra_params:
       # Note: useful for testing range sync (only produce block if the node is in sync to prevent forking)
@@ -12,7 +12,7 @@ participants:
   - cl_type: lighthouse
     cl_image: lighthouse:local
     el_type: geth
-    el_image: ethpandaops/geth:fusaka-devnet-3
+    el_image: ethpandaops/geth:master
     supernode: false
     cl_extra_params:
       # Note: useful for testing range sync (only produce block if the node is in sync to prevent forking)
@@ -29,7 +29,9 @@ additional_services:
   - dora
   - spamoor
   - prometheus_grafana
+  - tempo
 spamoor_params:
+  image: ethpandaops/spamoor:master
   spammers:
     - scenario: eoatx
       config:

--- a/scripts/tests/checkpoint-sync-config-devnet.yaml
+++ b/scripts/tests/checkpoint-sync-config-devnet.yaml
@@ -3,20 +3,18 @@ participants:
   - cl_type: lighthouse
     cl_image: lighthouse:local
     el_type: geth
-    # There isn't a devnet-4 image
-    el_image: ethpandaops/geth:fusaka-devnet-3
+    el_image: ethpandaops/geth:master
     supernode: true
   - cl_type: lighthouse
     cl_image: lighthouse:local
     el_type: geth
-    # There isn't a devnet-4 image
-    el_image: ethpandaops/geth:fusaka-devnet-3
+    el_image: ethpandaops/geth:master
     supernode: false
 
 checkpoint_sync_enabled: true
-checkpoint_sync_url: "https://checkpoint-sync.fusaka-devnet-4.ethpandaops.io"
+checkpoint_sync_url: "https://checkpoint-sync.fusaka-devnet-3.ethpandaops.io"
 
 global_log_level: debug
 
 network_params:
-  network: fusaka-devnet-4
+  network: fusaka-devnet-3

--- a/scripts/tests/genesis-sync-config-fulu.yaml
+++ b/scripts/tests/genesis-sync-config-fulu.yaml
@@ -3,20 +3,20 @@ participants:
   - cl_type: lighthouse
     cl_image: lighthouse:local
     el_type: geth
-    el_image: ethpandaops/geth:fusaka-devnet-2
+    el_image: ethpandaops/geth:master
     supernode: true
     count: 2
   # nodes without validators, used for testing sync.
   - cl_type: lighthouse
     cl_image: lighthouse:local
     el_type: geth
-    el_image: ethpandaops/geth:fusaka-devnet-2
+    el_image: ethpandaops/geth:master
     supernode: true
     validator_count: 0
   - cl_type: lighthouse
     cl_image: lighthouse:local
     el_type: geth
-    el_image: ethpandaops/geth:fusaka-devnet-2
+    el_image: ethpandaops/geth:master
     supernode: false
     validator_count: 0
 network_params:


### PR DESCRIPTION
## Issue Addressed

This PR adds tempo to kurtosis config and will collect lighthouse traces on kurtosis local testnet. The traces can be viewed / queried from Grafana.

Also updated fulu kurtosis configs to use latest geth image.
