### PR TITLE
Add `--telemetry-service-name` CLI flag for OpenTelemetry service name override

### DIFF
--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -395,6 +395,10 @@ Options:
       --telemetry-collector-url <URL>
           URL of the OpenTelemetry collector to export tracing spans (e.g.,
           http://localhost:4317). If not set, tracing export is disabled.
+      --telemetry-service-name <NAME>
+          Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
+          for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
+          for other subcommands.
       --trusted-peers <TRUSTED_PEERS>
           One or more comma-delimited trusted peer ids which always have the
           highest score according to the peer scoring system.

--- a/book/src/help_general.md
+++ b/book/src/help_general.md
@@ -79,6 +79,10 @@ Options:
       --telemetry-collector-url <URL>
           URL of the OpenTelemetry collector to export tracing spans (e.g.,
           http://localhost:4317). If not set, tracing export is disabled.
+      --telemetry-service-name <NAME>
+          Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
+          for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
+          for other subcommands.
   -V, --version
           Print version
 

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -137,6 +137,10 @@ Options:
       --telemetry-collector-url <URL>
           URL of the OpenTelemetry collector to export tracing spans (e.g.,
           http://localhost:4317). If not set, tracing export is disabled.
+      --telemetry-service-name <NAME>
+          Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
+          for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
+          for other subcommands.
       --validator-registration-batch-size <INTEGER>
           Defines the number of validators per validator/register_validator
           request sent to the BN. This value can be reduced to avoid timeouts

--- a/book/src/help_vm.md
+++ b/book/src/help_vm.md
@@ -80,6 +80,10 @@ Options:
       --telemetry-collector-url <URL>
           URL of the OpenTelemetry collector to export tracing spans (e.g.,
           http://localhost:4317). If not set, tracing export is disabled.
+      --telemetry-service-name <NAME>
+          Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
+          for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
+          for other subcommands.
 
 Flags:
       --disable-log-timestamp

--- a/book/src/help_vm_create.md
+++ b/book/src/help_vm_create.md
@@ -96,6 +96,10 @@ Options:
       --telemetry-collector-url <URL>
           URL of the OpenTelemetry collector to export tracing spans (e.g.,
           http://localhost:4317). If not set, tracing export is disabled.
+      --telemetry-service-name <NAME>
+          Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
+          for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
+          for other subcommands.
 
 Flags:
       --disable-deposits

--- a/book/src/help_vm_import.md
+++ b/book/src/help_vm_import.md
@@ -76,6 +76,10 @@ Options:
       --telemetry-collector-url <URL>
           URL of the OpenTelemetry collector to export tracing spans (e.g.,
           http://localhost:4317). If not set, tracing export is disabled.
+      --telemetry-service-name <NAME>
+          Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
+          for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
+          for other subcommands.
       --validators-file <PATH_TO_JSON_FILE>
           The path to a JSON file containing a list of validators to be imported
           to the validator client. This file is usually named "validators.json".

--- a/book/src/help_vm_move.md
+++ b/book/src/help_vm_move.md
@@ -85,6 +85,10 @@ Options:
       --telemetry-collector-url <URL>
           URL of the OpenTelemetry collector to export tracing spans (e.g.,
           http://localhost:4317). If not set, tracing export is disabled.
+      --telemetry-service-name <NAME>
+          Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
+          for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
+          for other subcommands.
       --validators <STRING>
           The validators to be moved. Either a list of 0x-prefixed validator
           pubkeys or the keyword "all".

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -298,6 +298,7 @@ fn main() {
                     Defaults to 'lighthouse-bn' for beacon node, 'lighthouse-vc' for validator \
                     client, or 'lighthouse' for other subcommands."
                 )
+                .requires("telemetry-collector-url")
                 .action(ArgAction::Set)
                 .global(true)
                 .display_order(0)

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -290,6 +290,19 @@ fn main() {
                 .display_order(0)
         )
         .arg(
+            Arg::new("telemetry-service-name")
+                .long("telemetry-service-name")
+                .value_name("NAME")
+                .help(
+                    "Override the OpenTelemetry service name. \
+                    Defaults to 'lighthouse-bn' for beacon node, 'lighthouse-vc' for validator \
+                    client, or 'lighthouse' for other subcommands."
+                )
+                .action(ArgAction::Set)
+                .global(true)
+                .display_order(0)
+        )
+        .arg(
             Arg::new("datadir")
                 .long("datadir")
                 .short('d')
@@ -702,11 +715,20 @@ fn run<E: EthSpec>(
                 .build()
                 .map_err(|e| format!("Failed to create OTLP exporter: {:?}", e))?;
 
+            let service_name = matches
+                .get_one::<String>("telemetry-service-name")
+                .cloned()
+                .unwrap_or_else(|| match matches.subcommand() {
+                    Some(("beacon_node", _)) => "lighthouse-bn".to_string(),
+                    Some(("validator_client", _)) => "lighthouse-vc".to_string(),
+                    _ => "lighthouse".to_string(),
+                });
+
             let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
                 .with_batch_exporter(exporter)
                 .with_resource(
                     opentelemetry_sdk::Resource::builder()
-                        .with_service_name("lighthouse")
+                        .with_service_name(service_name)
                         .build(),
                 )
                 .build();


### PR DESCRIPTION
## Issue Addressed

Allows users to customize the OpenTelemetry service name instead of using the hardcoded default `lighthouse`. Defaults to 'lighthouse-bn' for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse' for other subcommands.

This is useful when analysing traces from multiple nodes, see Grafana screenshot below with service name overrides in Kurtosis (`ethereum-package` PR: https://github.com/ethpandaops/ethereum-package/pull/1160):

<img width="1148" height="627" alt="image" src="https://github.com/user-attachments/assets/7e875639-10f7-4756-837f-2006fa4b12e0" />
