### PR TITLE
Prioritise `StatusV2` over `StatusV1` RPC protocol

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -825,8 +825,8 @@ impl<E: EthSpec> RequestType<E> {
         match self {
             // add more protocols when versions/encodings are supported
             RequestType::Status(_) => vec![
-                ProtocolId::new(SupportedProtocol::StatusV1, Encoding::SSZSnappy),
                 ProtocolId::new(SupportedProtocol::StatusV2, Encoding::SSZSnappy),
+                ProtocolId::new(SupportedProtocol::StatusV1, Encoding::SSZSnappy),
             ],
             RequestType::Goodbye(_) => vec![ProtocolId::new(
                 SupportedProtocol::GoodbyeV1,

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -76,21 +76,23 @@ fn test_tcp_status_rpc() {
         .await;
 
         // Dummy STATUS RPC message
-        let rpc_request = RequestType::Status(StatusMessage::V1(StatusMessageV1 {
+        let rpc_request = RequestType::Status(StatusMessage::V2(StatusMessageV2 {
             fork_digest: [0; 4],
             finalized_root: Hash256::zero(),
             finalized_epoch: Epoch::new(1),
             head_root: Hash256::zero(),
             head_slot: Slot::new(1),
+            earliest_available_slot: Slot::new(0),
         }));
 
         // Dummy STATUS RPC message
-        let rpc_response = Response::Status(StatusMessage::V1(StatusMessageV1 {
+        let rpc_response = Response::Status(StatusMessage::V2(StatusMessageV2 {
             fork_digest: [0; 4],
             finalized_root: Hash256::zero(),
             finalized_epoch: Epoch::new(1),
             head_root: Hash256::zero(),
             head_slot: Slot::new(1),
+            earliest_available_slot: Slot::new(0),
         }));
 
         // build the sender future
@@ -1205,21 +1207,23 @@ fn test_delayed_rpc_response() {
         .await;
 
         // Dummy STATUS RPC message
-        let rpc_request = RequestType::Status(StatusMessage::V1(StatusMessageV1 {
+        let rpc_request = RequestType::Status(StatusMessage::V2(StatusMessageV2 {
             fork_digest: [0; 4],
             finalized_root: Hash256::from_low_u64_be(0),
             finalized_epoch: Epoch::new(1),
             head_root: Hash256::from_low_u64_be(0),
             head_slot: Slot::new(1),
+            earliest_available_slot: Slot::new(0),
         }));
 
         // Dummy STATUS RPC message
-        let rpc_response = Response::Status(StatusMessage::V1(StatusMessageV1 {
+        let rpc_response = Response::Status(StatusMessage::V2(StatusMessageV2 {
             fork_digest: [0; 4],
             finalized_root: Hash256::from_low_u64_be(0),
             finalized_epoch: Epoch::new(1),
             head_root: Hash256::from_low_u64_be(0),
             head_slot: Slot::new(1),
+            earliest_available_slot: Slot::new(0),
         }));
 
         // build the sender future
@@ -1335,21 +1339,23 @@ fn test_active_requests() {
         .await;
 
         // Dummy STATUS RPC request.
-        let rpc_request = RequestType::Status(StatusMessage::V1(StatusMessageV1 {
+        let rpc_request = RequestType::Status(StatusMessage::V2(StatusMessageV2 {
             fork_digest: [0; 4],
             finalized_root: Hash256::from_low_u64_be(0),
             finalized_epoch: Epoch::new(1),
             head_root: Hash256::from_low_u64_be(0),
             head_slot: Slot::new(1),
+            earliest_available_slot: Slot::new(0),
         }));
 
         // Dummy STATUS RPC response.
-        let rpc_response = Response::Status(StatusMessage::V1(StatusMessageV1 {
+        let rpc_response = Response::Status(StatusMessage::V2(StatusMessageV2 {
             fork_digest: [0; 4],
             finalized_root: Hash256::zero(),
             finalized_epoch: Epoch::new(1),
             head_root: Hash256::zero(),
             head_slot: Slot::new(1),
+            earliest_available_slot: Slot::new(0),
         }));
 
         // Number of requests.


### PR DESCRIPTION
## Issue Addressed

Prioritise `StatusV2` over `StatusV1` RPC protocol.

A bug discovered during devnet-4 testing and extracted from the sync fixes PR #7876.