### PR TITLE
use DEFAULT_TARGET_PEERS for target peers everywhere

### DIFF
--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -1,4 +1,5 @@
 use crate::listen_addr::{ListenAddr, ListenAddress};
+use crate::peer_manager::config::DEFAULT_TARGET_PEERS;
 use crate::rpc::config::{InboundRateLimiterConfig, OutboundRateLimiterConfig};
 use crate::types::GossipKind;
 use crate::{Enr, PeerIdSerialized};
@@ -341,7 +342,7 @@ impl Default for Config {
             enr_udp6_port: None,
             enr_quic6_port: None,
             enr_tcp6_port: None,
-            target_peers: 200,
+            target_peers: DEFAULT_TARGET_PEERS,
             discv5_config,
             boot_nodes_enr: vec![],
             boot_nodes_multiaddr: vec![],

--- a/beacon_node/lighthouse_network/src/peer_manager/config.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/config.rs
@@ -8,7 +8,7 @@ pub const DEFAULT_PING_INTERVAL_OUTBOUND: u64 = 15;
 pub const DEFAULT_PING_INTERVAL_INBOUND: u64 = 20;
 
 /// Default number of peers to connect to.
-pub const DEFAULT_TARGET_PEERS: usize = 50;
+pub const DEFAULT_TARGET_PEERS: usize = 200;
 
 /// Configurations for the PeerManager.
 #[derive(Debug)]


### PR DESCRIPTION
## Issue Addressed
Was going to leave this as a comment on #7877 but when noticed it had already been merged.
we have `DEFAULT_TARGET_PEERS` which was set to 50 and only used on the `Default` impl for `peer_manager`'s `Config`, which then get's overridden by this `lighthouse_network::Config`s default 
This PR unifies everything on `DEFAULT_TARGET_PEERS`