### PR TITLE
Run sync tests on CI by default.

### DIFF
--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -218,7 +218,6 @@ jobs:
     name: genesis-sync-test-${{ matrix.fork }}-${{ matrix.offline_secs }}s
     runs-on: ubuntu-latest
     needs: dockerfile-ubuntu
-    if: contains(github.event.pull_request.labels.*.name, 'syncing')
     strategy:
       matrix:
         fork: [electra, fulu]
@@ -266,10 +265,11 @@ jobs:
       'run-local-testnet',
       'doppelganger-protection-success-test',
       'doppelganger-protection-failure-test',
+      'genesis-sync-test'
     ]
     steps:
       - uses: actions/checkout@v5
       - name: Check that success job is dependent on all others
         run: |
-          exclude_jobs='checkpoint-sync-test|genesis-sync-test'
+          exclude_jobs='checkpoint-sync-test'
           ./scripts/ci/check-success-job.sh ./.github/workflows/local-testnet.yml local-testnet-success "$exclude_jobs" 


### PR DESCRIPTION
## Issue Addressed

This PR enables some sync tests by default on CI - this will help catch breakages on sync happy paths, e.g. this would have caught the bug #7926 if lighthouse is not able to sync OR serve sync requests.

The enabled tests are genesis-sync with 120s / 300s offline time, and should cover both serving / consuming by root and by range requests.

I'm leaving the checkpoint sync tests optional, as it has external dependencies on checkpoint server (which may cause CI instability) and may cause extra loads on them.