### PR TITLE
Impl ForkVersionDecode for beacon state

### DIFF
--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -170,7 +170,7 @@ impl<'a, E: EthSpec, Payload: AbstractExecPayload<E>> BeaconBlockBodyRef<'a, E, 
         }
     }
 
-    pub(crate) fn body_merkle_leaves(&self) -> Vec<Hash256> {
+    pub fn body_merkle_leaves(&self) -> Vec<Hash256> {
         let mut leaves = vec![];
         match self {
             Self::Base(body) => {

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -2674,6 +2674,15 @@ impl<E: EthSpec> BeaconState<E> {
         ))
     }
 
+    /// Specialised deserialisation method that uses the ForkName as context
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn from_fork_ssz_bytes(
+        bytes: &[u8],
+        fork_name: ForkName,
+    ) -> Result<Self, ssz::DecodeError> {
+        Ok(map_fork_name!(fork_name, Self, <_>::from_ssz_bytes(bytes)?))
+    }
+
     #[allow(clippy::arithmetic_side_effects)]
     pub fn apply_pending_mutations(&mut self) -> Result<(), Error> {
         match self {

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -2632,6 +2632,12 @@ impl<E: EthSpec> BeaconState<E> {
     }
 }
 
+impl<E: EthSpec> ForkVersionDecode for BeaconState<E> {
+    fn from_ssz_bytes_by_fork(bytes: &[u8], fork_name: ForkName) -> Result<Self, ssz::DecodeError> {
+        Ok(map_fork_name!(fork_name, Self, <_>::from_ssz_bytes(bytes)?))
+    }
+}
+
 impl<E: EthSpec> BeaconState<E> {
     /// The number of fields of the `BeaconState` rounded up to the nearest power of two.
     ///
@@ -2672,15 +2678,6 @@ impl<E: EthSpec> BeaconState<E> {
             Self,
             <_>::from_ssz_bytes(bytes)?
         ))
-    }
-
-    /// Specialised deserialisation method that uses the ForkName as context
-    #[allow(clippy::arithmetic_side_effects)]
-    pub fn from_fork_ssz_bytes(
-        bytes: &[u8],
-        fork_name: ForkName,
-    ) -> Result<Self, ssz::DecodeError> {
-        Ok(map_fork_name!(fork_name, Self, <_>::from_ssz_bytes(bytes)?))
     }
 
     #[allow(clippy::arithmetic_side_effects)]

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -2760,7 +2760,7 @@ impl<E: EthSpec> BeaconState<E> {
         Ok(proof)
     }
 
-    fn generate_proof(
+    pub fn generate_proof(
         &self,
         field_index: usize,
         leaves: &[Hash256],
@@ -2775,7 +2775,7 @@ impl<E: EthSpec> BeaconState<E> {
         Ok(proof)
     }
 
-    fn get_beacon_state_leaves(&self) -> Vec<Hash256> {
+    pub fn get_beacon_state_leaves(&self) -> Vec<Hash256> {
         let mut leaves = vec![];
         #[allow(clippy::arithmetic_side_effects)]
         match self {


### PR DESCRIPTION
I just saw that the ForkVersionDecode trait is available, which I have implemented for the BeaconState type. I am maintaining [a crate](https://github.com/bankaixyz/beacon-state-proof) for generating inclusion proofs for the beacon state which relies on this, so it would be cool to get it merged, so I can drop my fork. Additionally, this PR makes some more functions public, which is also required by the library.

The changes are minimal, and I hope they can be considered to be merged, so I dont need to constantly sync a fork. Would be cool!
