### PR TITLE
Fix doppelganger protection script

### DIFF
--- a/scripts/tests/doppelganger_protection.sh
+++ b/scripts/tests/doppelganger_protection.sh
@@ -60,7 +60,7 @@ DELAY=$(( $SECONDS_PER_SLOT * 32 + $GENESIS_DELAY + $MIN_GENESIS_TIME - $CURRENT
 sleep $DELAY
 
 # Use BN2 for the next validator client
-bn_2_url=$(kurtosis service inspect $ENCLAVE_NAME cl-2-lighthouse-geth | grep 'enr-address' | cut -d'=' -f2)
+bn_2_url=$(kurtosis service inspect $ENCLAVE_NAME cl-2-lighthouse-geth | grep -oP '(?<=--enr-address=)[^ ]+')
 bn_2_port=4000
 
 if [[ "$BEHAVIOR" == "failure" ]]; then


### PR DESCRIPTION
## Issue Addressed

Previously `kurtosis service inspect` gives us output like this - flags in separate lines

```
CMD:
  lighthouse
  beacon_node
  --debug-level=debug
  --datadir=/data/lighthouse/beacon-data
  --listen-address=0.0.0.0
  --port=9000
  --http
  --http-address=0.0.0.0
  --http-port=4000
  --disable-packet-filter
  --execution-endpoints=http://172.16.0.8:8551
  --jwt-secrets=/jwt/jwtsecret
  --suggested-fee-recipient=0x8943545177806ED17B9F23F0a21ee5948eCaa776
  --disable-enr-auto-update
  --enr-address=172.16.0.11
```

In the latest version this has been updated to a single line

```
CMD:
  exec lighthouse beacon_node --debug-level=debug --datadir=/data/lighthouse/beacon-data --listen-address=0.0.0.0 --port=9000 --http --http-address=0.0.0.0 --http-port=4000 --disable-packet-filter --execution-endpoints=http://172.16.0.12:8551 --jwt-secrets=/jwt/jwtsecret --suggested-fee-recipient=0x8943545177806ED17B9F23F0a21ee5948eCaa776 --disable-enr-auto-update --enr-address=172.16.0.18 --enr-tcp-port=9000 --enr-udp-port=9000 --enr-quic-port=9001 --quic-port=9001 --metrics --metrics-address=0.0.0.0 --metrics-allow-origin=* --metrics-port=5054 --enable-private-discovery --testnet-dir=/network-configs --boot-nodes=enr:-N24QPYP7bj0aqoM2dXsP5hnosW27U6PTYJt1kYFhNkwIvlFQhGJ1om7f4zcHhVJwvUL7wCsVbDJbP_l-TF8X3q4pVEDh2F0dG5ldHOIAAAwAAAAAACGY2xpZW500YpMaWdodGhvdXNlhTcuMS4whGV0aDKQqFs_bWAAADj__________4JpZIJ2NIJpcISsEAAPhHF1aWOCIymJc2VjcDI1NmsxoQK_z4HQylgsOal74Jek9D_EhY0vcDX5AcLHnPD7iOeEdYhzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA --target-peers=3
```

and it broke our script. This PR update the extraction logic.