### PR TITLE
Fix data availability checker race condition causing partial data columns to be served over RPC

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3815,19 +3815,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .await??
         };
 
-        // Remove block components from da_checker AFTER completing block import. Then we can assert
-        // the following invariant:
-        // > A valid unfinalized block is either in fork-choice or da_checker.
-        //
-        // If we remove the block when it becomes available, there's some time window during
-        // `import_block` where the block is nowhere. Consumers of the da_checker can handle the
-        // extend time a block may exist in the da_checker.
-        //
-        // If `import_block` errors (only errors with internal errors), the pending components will
-        // be pruned on data_availability_checker maintenance as finality advances.
-        self.data_availability_checker
-            .remove_pending_components(block_root);
-
         Ok(AvailabilityProcessingStatus::Imported(block_root))
     }
 

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -346,11 +346,6 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
             .put_pending_executed_block(executed_block)
     }
 
-    pub fn remove_pending_components(&self, block_root: Hash256) {
-        self.availability_cache
-            .remove_pending_components(block_root)
-    }
-
     /// Verifies kzg commitments for an RpcBlock, returns a `MaybeAvailableBlock` that may
     /// include the fully available block.
     ///

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -38,19 +38,18 @@ use crate::observed_data_sidecars::ObservationStrategy;
 pub use error::{Error as AvailabilityCheckError, ErrorCategory as AvailabilityCheckErrorCategory};
 use types::non_zero_usize::new_non_zero_usize;
 
-/// The LRU Cache stores `PendingComponents`, which can store up to `MAX_BLOBS_PER_BLOCK` blobs each.
+/// The LRU Cache stores `PendingComponents`, which store block and its associated blob data:
 ///
 /// * Deneb blobs are 128 kb each and are stored in the form of `BlobSidecar`.
 /// * From Fulu (PeerDAS), blobs are erasure-coded and are 256 kb each, stored in the form of 128 `DataColumnSidecar`s.
 ///
 /// With `MAX_BLOBS_PER_BLOCK` = 48 (expected in the next year), the maximum size of data columns
-/// in `PendingComponents` is ~12.29 MB. Setting this to 64 means the maximum size of the cache is
-/// approximately 0.8 GB.
+/// in `PendingComponents` is ~12.29 MB. Setting this to 32 means the maximum size of the cache is
+/// approximately 0.4 GB.
 ///
-/// Under normal conditions, the cache should only store the current pending block, but could
-///  occasionally spike to 2-4 for various reasons e.g. components arriving late, but would very
-/// rarely go above this, unless there are many concurrent forks.
-pub const OVERFLOW_LRU_CAPACITY: NonZeroUsize = new_non_zero_usize(64);
+/// `PendingComponents` are now never removed from the cache manually are only removed via LRU
+/// eviction to prevent race conditions (#7961), so we expect this cache to be full all the time.
+pub const OVERFLOW_LRU_CAPACITY: NonZeroUsize = new_non_zero_usize(32);
 pub const STATE_LRU_CAPACITY_NON_ZERO: NonZeroUsize = new_non_zero_usize(32);
 pub const STATE_LRU_CAPACITY: usize = STATE_LRU_CAPACITY_NON_ZERO.get();
 
@@ -584,8 +583,8 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
 
         // Check indices from cache again to make sure we don't publish components we've already received.
         let Some(existing_column_indices) = self.cached_data_column_indexes(block_root) else {
-            return Ok(DataColumnReconstructionResult::RecoveredColumnsNotImported(
-                "block already imported",
+            return Err(AvailabilityCheckError::Unexpected(
+                "block no longer exists in the data availability checker".to_string(),
             ));
         };
 

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -7,11 +7,13 @@ use crate::blob_verification::KzgVerifiedBlob;
 use crate::block_verification_types::{
     AvailabilityPendingExecutedBlock, AvailableBlock, AvailableExecutedBlock,
 };
+use crate::data_availability_checker::error::Error;
 use crate::data_availability_checker::{Availability, AvailabilityCheckError};
 use crate::data_column_verification::KzgVerifiedCustodyDataColumn;
 use lighthouse_tracing::SPAN_PENDING_COMPONENTS;
 use lru::LruCache;
-use parking_lot::RwLock;
+use parking_lot::lock_api::RwLockWriteGuard;
+use parking_lot::{RawRwLock, RwLock};
 use std::cmp::Ordering;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -21,6 +23,31 @@ use types::{
     BlobSidecar, ChainSpec, ColumnIndex, DataColumnSidecar, DataColumnSidecarList, Epoch, EthSpec,
     Hash256, RuntimeFixedVector, RuntimeVariableList, SignedBeaconBlock,
 };
+
+pub enum CachedComponents<E: EthSpec> {
+    Pending(PendingComponents<E>),
+    Available(PendingComponents<E>),
+}
+
+impl<E: EthSpec> CachedComponents<E> {
+    fn inner(&self) -> Option<&PendingComponents<E>> {
+        match self {
+            CachedComponents::Pending(p) | CachedComponents::Available(p) => Some(p),
+        }
+    }
+
+    fn inner_mut(&mut self) -> Option<&mut PendingComponents<E>> {
+        match self {
+            CachedComponents::Pending(p) | CachedComponents::Available(p) => Some(p),
+        }
+    }
+
+    fn into_inner(self) -> Option<PendingComponents<E>> {
+        match self {
+            CachedComponents::Pending(p) | CachedComponents::Available(p) => Some(p),
+        }
+    }
+}
 
 /// This represents the components of a partially available block
 ///
@@ -89,8 +116,6 @@ impl<E: EthSpec> PendingComponents<E> {
 
     /// Inserts a block into the cache.
     pub fn insert_block(&mut self, block: DietAvailabilityPendingExecutedBlock<E>) {
-        let _guard = self.span.clone().entered();
-        debug!("Block added to pending components");
         *self.get_cached_block_mut() = Some(block)
     }
 
@@ -98,9 +123,7 @@ impl<E: EthSpec> PendingComponents<E> {
     ///
     /// Existing blob at the index will be replaced.
     pub fn insert_blob_at_index(&mut self, blob_index: usize, blob: KzgVerifiedBlob<E>) {
-        let _guard = self.span.clone().entered();
         if let Some(b) = self.get_cached_blobs_mut().get_mut(blob_index) {
-            debug!(blob_index, "Blob added to pending components");
             *b = Some(blob);
         }
     }
@@ -140,13 +163,8 @@ impl<E: EthSpec> PendingComponents<E> {
         &mut self,
         kzg_verified_data_columns: I,
     ) -> Result<(), AvailabilityCheckError> {
-        let _guard = self.span.clone().entered();
         for data_column in kzg_verified_data_columns {
             if self.get_cached_data_column(data_column.index()).is_none() {
-                debug!(
-                    column_index = data_column.index(),
-                    "Data column added to pending components"
-                );
                 self.verified_data_columns.push(data_column);
             }
         }
@@ -171,7 +189,7 @@ impl<E: EthSpec> PendingComponents<E> {
     pub fn make_available<R>(
         &mut self,
         spec: &Arc<ChainSpec>,
-        num_expected_columns: usize,
+        num_expected_columns_opt: Option<usize>,
         recover: R,
     ) -> Result<Option<AvailableExecutedBlock<E>>, AvailabilityCheckError>
     where
@@ -188,7 +206,7 @@ impl<E: EthSpec> PendingComponents<E> {
         let num_expected_blobs = block.num_blobs_expected();
         let blob_data = if num_expected_blobs == 0 {
             Some(AvailableBlockData::NoData)
-        } else if spec.is_peer_das_enabled_for_epoch(block.epoch()) {
+        } else if let Some(num_expected_columns) = num_expected_columns_opt {
             let num_received_columns = self.verified_data_columns.len();
             match num_received_columns.cmp(&num_expected_columns) {
                 Ordering::Greater => {
@@ -327,21 +345,14 @@ impl<E: EthSpec> PendingComponents<E> {
             })
     }
 
-    pub fn status_str(
-        &self,
-        block_epoch: Epoch,
-        num_expected_columns: Option<usize>,
-        spec: &ChainSpec,
-    ) -> String {
+    pub fn status_str(&self, num_expected_columns_opt: Option<usize>) -> String {
         let block_count = if self.executed_block.is_some() { 1 } else { 0 };
-        if spec.is_peer_das_enabled_for_epoch(block_epoch) {
+        if let Some(num_expected_columns) = num_expected_columns_opt {
             format!(
                 "block {} data_columns {}/{}",
                 block_count,
                 self.verified_data_columns.len(),
                 num_expected_columns
-                    .map(|c| c.to_string())
-                    .unwrap_or("?".into())
             )
         } else {
             let num_expected_blobs = if let Some(block) = self.get_cached_block() {
@@ -363,7 +374,7 @@ impl<E: EthSpec> PendingComponents<E> {
 /// interact with the cache through this.
 pub struct DataAvailabilityCheckerInner<T: BeaconChainTypes> {
     /// Contains all the data we keep in memory, protected by an RwLock
-    critical: RwLock<LruCache<Hash256, PendingComponents<T::EthSpec>>>,
+    critical: RwLock<LruCache<Hash256, CachedComponents<T::EthSpec>>>,
     /// This cache holds a limited number of states in memory and reconstructs them
     /// from disk when necessary. This is necessary until we merge tree-states
     state_cache: StateLRUCache<T>,
@@ -403,11 +414,13 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         self.critical
             .read()
             .peek(block_root)
-            .and_then(|pending_components| {
-                pending_components
-                    .executed_block
-                    .as_ref()
-                    .map(|block| block.block_cloned())
+            .and_then(|cached_components| {
+                cached_components.inner().and_then(|pending_components| {
+                    pending_components
+                        .executed_block
+                        .as_ref()
+                        .map(|block| block.block_cloned())
+                })
             })
     }
 
@@ -416,7 +429,12 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         &self,
         blob_id: &BlobIdentifier,
     ) -> Result<Option<Arc<BlobSidecar<T::EthSpec>>>, AvailabilityCheckError> {
-        if let Some(pending_components) = self.critical.read().peek(&blob_id.block_root) {
+        if let Some(pending_components) = self
+            .critical
+            .read()
+            .peek(&blob_id.block_root)
+            .and_then(|c| c.inner())
+        {
             Ok(pending_components
                 .verified_blobs
                 .get(blob_id.index as usize)
@@ -436,12 +454,14 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         self.critical
             .read()
             .peek(&block_root)
-            .map(|pending_components| {
-                pending_components
-                    .verified_data_columns
-                    .iter()
-                    .map(|col| col.clone_arc())
-                    .collect()
+            .and_then(|cached_components| {
+                cached_components.inner().map(|pending_components| {
+                    pending_components
+                        .verified_data_columns
+                        .iter()
+                        .map(|col| col.clone_arc())
+                        .collect()
+                })
             })
     }
 
@@ -450,7 +470,11 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         block_root: &Hash256,
         f: F,
     ) -> R {
-        f(self.critical.read().peek(block_root))
+        f(self
+            .critical
+            .read()
+            .peek(block_root)
+            .and_then(|cached_components| cached_components.inner()))
     }
 
     /// Puts the KZG verified blobs into the availability cache as pending components.
@@ -479,39 +503,25 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         }
 
         let mut write_lock = self.critical.write();
+        let mut pending_components =
+            self.get_or_create_pending_components(block_root, epoch, &mut write_lock);
 
-        // Grab existing entry or create a new entry.
-        let mut pending_components = write_lock
-            .pop_entry(&block_root)
-            .map(|(_, v)| v)
-            .unwrap_or_else(|| {
-                PendingComponents::empty(block_root, self.spec.max_blobs_per_block(epoch) as usize)
-            });
-
-        // Merge in the blobs.
         pending_components.merge_blobs(fixed_blobs);
 
-        debug!(
-            component = "blobs",
-            ?block_root,
-            status = pending_components.status_str(epoch, None, &self.spec),
-            "Component added to data availability checker"
-        );
+        pending_components.span.in_scope(|| {
+            debug!(
+                component = "blobs",
+                status = pending_components.status_str(None),
+                "Component added to data availability checker"
+            );
+        });
 
-        if let Some(available_block) = pending_components.make_available(
-            &self.spec,
-            self.custody_context
-                .num_of_data_columns_to_sample(epoch, &self.spec),
-            |block, span| self.state_cache.recover_pending_executed_block(block, span),
-        )? {
-            // We keep the pending components in the availability cache during block import (#5845).
-            write_lock.put(block_root, pending_components);
-            drop(write_lock);
-            Ok(Availability::Available(Box::new(available_block)))
-        } else {
-            write_lock.put(block_root, pending_components);
-            Ok(Availability::MissingComponents(block_root))
-        }
+        self.check_availability_and_cache_components(
+            block_root,
+            write_lock,
+            pending_components,
+            None,
+        )
     }
 
     #[allow(clippy::type_complexity)]
@@ -535,41 +545,71 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         };
 
         let mut write_lock = self.critical.write();
+        let mut pending_components =
+            self.get_or_create_pending_components(block_root, epoch, &mut write_lock);
 
-        // Grab existing entry or create a new entry.
-        let mut pending_components = write_lock
-            .pop_entry(&block_root)
-            .map(|(_, v)| v)
-            .unwrap_or_else(|| {
-                PendingComponents::empty(block_root, self.spec.max_blobs_per_block(epoch) as usize)
-            });
-
-        // Merge in the data columns.
         pending_components.merge_data_columns(kzg_verified_data_columns)?;
 
         let num_expected_columns = self
             .custody_context
             .num_of_data_columns_to_sample(epoch, &self.spec);
-        debug!(
-            component = "data_columns",
-            ?block_root,
-            status = pending_components.status_str(epoch, Some(num_expected_columns), &self.spec),
-            "Component added to data availability checker"
-        );
 
-        if let Some(available_block) =
-            pending_components.make_available(&self.spec, num_expected_columns, |block, span| {
-                self.state_cache.recover_pending_executed_block(block, span)
-            })?
-        {
-            // We keep the pending components in the availability cache during block import (#5845).
-            write_lock.put(block_root, pending_components);
+        pending_components.span.in_scope(|| {
+            debug!(
+                component = "data_columns",
+                status = pending_components.status_str(Some(num_expected_columns)),
+                "Component added to data availability checker"
+            );
+        });
+
+        self.check_availability_and_cache_components(
+            block_root,
+            write_lock,
+            pending_components,
+            Some(num_expected_columns),
+        )
+    }
+
+    fn check_availability_and_cache_components(
+        &self,
+        block_root: Hash256,
+        mut write_lock: RwLockWriteGuard<
+            RawRwLock,
+            LruCache<Hash256, CachedComponents<T::EthSpec>>,
+        >,
+        mut pending_components: PendingComponents<T::EthSpec>,
+        num_expected_columns_opt: Option<usize>,
+    ) -> Result<Availability<<T as BeaconChainTypes>::EthSpec>, Error> {
+        if let Some(available_block) = pending_components.make_available(
+            &self.spec,
+            num_expected_columns_opt,
+            |block, span| self.state_cache.recover_pending_executed_block(block, span),
+        )? {
+            // We never remove the pending components manually to avoid race conditions.
+            write_lock.put(block_root, CachedComponents::Available(pending_components));
             drop(write_lock);
             Ok(Availability::Available(Box::new(available_block)))
         } else {
-            write_lock.put(block_root, pending_components);
+            write_lock.put(block_root, CachedComponents::Pending(pending_components));
             Ok(Availability::MissingComponents(block_root))
         }
+    }
+
+    fn get_or_create_pending_components(
+        &self,
+        block_root: Hash256,
+        epoch: Epoch,
+        write_lock: &mut RwLockWriteGuard<
+            RawRwLock,
+            LruCache<Hash256, CachedComponents<T::EthSpec>>,
+        >,
+    ) -> PendingComponents<T::EthSpec> {
+        write_lock
+            .pop_entry(&block_root)
+            .and_then(|(_, v)| v.into_inner())
+            .unwrap_or_else(|| {
+                PendingComponents::empty(block_root, self.spec.max_blobs_per_block(epoch) as usize)
+            })
     }
 
     /// Check whether data column reconstruction should be attempted.
@@ -586,7 +626,10 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         block_root: &Hash256,
     ) -> ReconstructColumnsDecision<T::EthSpec> {
         let mut write_lock = self.critical.write();
-        let Some(pending_components) = write_lock.get_mut(block_root) else {
+        let Some(pending_components) = write_lock
+            .get_mut(block_root)
+            .and_then(|cached| cached.inner_mut())
+        else {
             // Block may have been imported as it does not exist in availability cache.
             return ReconstructColumnsDecision::No("block already imported");
         };
@@ -613,7 +656,12 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
     /// In this case, we remove all data columns in `PendingComponents`, reset reconstruction
     /// status so that we can attempt to retrieve columns from peers again.
     pub fn handle_reconstruction_failure(&self, block_root: &Hash256) {
-        if let Some(pending_components_mut) = self.critical.write().get_mut(block_root) {
+        if let Some(pending_components_mut) = self
+            .critical
+            .write()
+            .get_mut(block_root)
+            .and_then(|cached| cached.inner_mut())
+        {
             pending_components_mut.verified_data_columns = vec![];
             pending_components_mut.reconstruction_started = false;
         }
@@ -634,45 +682,32 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
             .state_cache
             .register_pending_executed_block(executed_block);
 
-        // Grab existing entry or create a new entry.
-        let mut pending_components = write_lock
-            .pop_entry(&block_root)
-            .map(|(_, v)| v)
-            .unwrap_or_else(|| {
-                PendingComponents::empty(block_root, self.spec.max_blobs_per_block(epoch) as usize)
-            });
+        let mut pending_components =
+            self.get_or_create_pending_components(block_root, epoch, &mut write_lock);
 
-        // Merge in the block.
         pending_components.merge_block(diet_executed_block);
 
-        let num_expected_columns = self
-            .custody_context
-            .num_of_data_columns_to_sample(epoch, &self.spec);
+        let num_expected_columns_opt = if self.spec.is_peer_das_enabled_for_epoch(epoch) {
+            let num_of_column_samples = self
+                .custody_context
+                .num_of_data_columns_to_sample(epoch, &self.spec);
+            Some(num_of_column_samples)
+        } else {
+            None
+        };
+
         debug!(
             component = "block",
-            ?block_root,
-            status = pending_components.status_str(epoch, Some(num_expected_columns), &self.spec),
+            status = pending_components.status_str(num_expected_columns_opt),
             "Component added to data availability checker"
         );
 
-        // Check if we have all components and entire set is consistent.
-        if let Some(available_block) =
-            pending_components.make_available(&self.spec, num_expected_columns, |block, span| {
-                self.state_cache.recover_pending_executed_block(block, span)
-            })?
-        {
-            // We keep the pending components in the availability cache during block import (#5845).
-            write_lock.put(block_root, pending_components);
-            drop(write_lock);
-            Ok(Availability::Available(Box::new(available_block)))
-        } else {
-            write_lock.put(block_root, pending_components);
-            Ok(Availability::MissingComponents(block_root))
-        }
-    }
-
-    pub fn remove_pending_components(&self, block_root: Hash256) {
-        self.critical.write().pop_entry(&block_root);
+        self.check_availability_and_cache_components(
+            block_root,
+            write_lock,
+            pending_components,
+            num_expected_columns_opt,
+        )
     }
 
     /// maintain the cache
@@ -684,7 +719,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         let mut write_lock = self.critical.write();
         let mut keys_to_remove = vec![];
         for (key, value) in write_lock.iter() {
-            if let Some(epoch) = value.epoch()
+            if let Some(epoch) = value.inner().and_then(|p| p.epoch())
                 && epoch < cutoff_epoch
             {
                 keys_to_remove.push(*key);
@@ -960,13 +995,6 @@ mod test {
                 1,
                 "cache should still have block as it hasn't been imported yet"
             );
-            // remove the blob to simulate successful import
-            cache.remove_pending_components(root);
-            assert_eq!(
-                cache.critical.read().len(),
-                0,
-                "cache should be empty now that block has been imported"
-            );
         } else {
             assert!(
                 matches!(availability, Availability::MissingComponents(_)),
@@ -996,12 +1024,6 @@ mod test {
                 assert_eq!(cache.critical.read().len(), 1);
             }
         }
-        // remove the blob to simulate successful import
-        cache.remove_pending_components(root);
-        assert!(
-            cache.critical.read().is_empty(),
-            "cache should be empty now that all components available"
-        );
 
         let (pending_block, blobs) = availability_pending_block(&harness).await;
         let blobs_expected = pending_block.num_blobs_expected();
@@ -1034,12 +1056,6 @@ mod test {
         assert!(
             cache.critical.read().len() == 1,
             "cache should still have available block until import"
-        );
-        // remove the blob to simulate successful import
-        cache.remove_pending_components(root);
-        assert!(
-            cache.critical.read().is_empty(),
-            "cache should be empty now that all components available"
         );
     }
 
@@ -1100,6 +1116,7 @@ mod test {
                 .critical
                 .read()
                 .peek(&block_root)
+                .and_then(|c| c.inner())
                 .map(|pending_components| {
                     pending_components
                         .executed_block

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -7,13 +7,11 @@ use crate::blob_verification::KzgVerifiedBlob;
 use crate::block_verification_types::{
     AvailabilityPendingExecutedBlock, AvailableBlock, AvailableExecutedBlock,
 };
-use crate::data_availability_checker::error::Error;
 use crate::data_availability_checker::{Availability, AvailabilityCheckError};
 use crate::data_column_verification::KzgVerifiedCustodyDataColumn;
 use lighthouse_tracing::SPAN_PENDING_COMPONENTS;
 use lru::LruCache;
-use parking_lot::lock_api::RwLockWriteGuard;
-use parking_lot::{RawRwLock, RwLock};
+use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::cmp::Ordering;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -161,10 +159,8 @@ impl<E: EthSpec> PendingComponents<E> {
     ///
     /// WARNING: This function can potentially take a lot of time if the state needs to be
     /// reconstructed from disk. Ensure you are not holding any write locks while calling this.
-    /// TODO: add doc for `num_expected_columns_opt`
-    /// We probably dont need to hold the write lock for this
     pub fn make_available<R>(
-        &mut self,
+        &self,
         spec: &Arc<ChainSpec>,
         num_expected_columns_opt: Option<usize>,
         recover: R,
@@ -465,12 +461,11 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
                 *blob_opt = Some(blob);
             }
         }
-
-        let mut write_lock = self.critical.write();
-        let mut pending_components =
-            self.get_or_create_pending_components(block_root, epoch, &mut write_lock);
-
-        pending_components.merge_blobs(fixed_blobs);
+        let pending_components =
+            self.update_or_insert_pending_components(block_root, epoch, |pending_components| {
+                pending_components.merge_blobs(fixed_blobs);
+                Ok(())
+            })?;
 
         pending_components.span.in_scope(|| {
             debug!(
@@ -480,12 +475,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
             );
         });
 
-        self.check_availability_and_cache_components(
-            block_root,
-            write_lock,
-            pending_components,
-            None,
-        )
+        self.check_availability_and_cache_components(block_root, &pending_components, None)
     }
 
     #[allow(clippy::type_complexity)]
@@ -508,11 +498,10 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
             return Ok(Availability::MissingComponents(block_root));
         };
 
-        let mut write_lock = self.critical.write();
-        let mut pending_components =
-            self.get_or_create_pending_components(block_root, epoch, &mut write_lock);
-
-        pending_components.merge_data_columns(kzg_verified_data_columns)?;
+        let pending_components =
+            self.update_or_insert_pending_components(block_root, epoch, |pending_components| {
+                pending_components.merge_data_columns(kzg_verified_data_columns)
+            })?;
 
         let num_expected_columns = self
             .custody_context
@@ -528,8 +517,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
 
         self.check_availability_and_cache_components(
             block_root,
-            write_lock,
-            pending_components,
+            &pending_components,
             Some(num_expected_columns),
         )
     }
@@ -537,13 +525,9 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
     fn check_availability_and_cache_components(
         &self,
         block_root: Hash256,
-        mut write_lock: RwLockWriteGuard<
-            RawRwLock,
-            LruCache<Hash256, PendingComponents<T::EthSpec>>,
-        >,
-        mut pending_components: PendingComponents<T::EthSpec>,
+        pending_components: &PendingComponents<T::EthSpec>,
         num_expected_columns_opt: Option<usize>,
-    ) -> Result<Availability<<T as BeaconChainTypes>::EthSpec>, Error> {
+    ) -> Result<Availability<<T as BeaconChainTypes>::EthSpec>, AvailabilityCheckError> {
         if let Some(available_block) = pending_components.make_available(
             &self.spec,
             num_expected_columns_opt,
@@ -555,26 +539,40 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
             // imported, but re-inserted immediately, causing partial pending components to be
             // stored and served to peers.
             // Components are only removed via LRU eviction as finality advances.
-            write_lock.put(block_root, pending_components);
-            drop(write_lock);
             Ok(Availability::Available(Box::new(available_block)))
         } else {
-            write_lock.put(block_root, pending_components);
             Ok(Availability::MissingComponents(block_root))
         }
     }
 
-    fn get_or_create_pending_components(
+    /// Updates or inserts a new `PendingComponents` if it doesn't exist, and then apply the
+    /// `update_fn` while holding the write lock.
+    ///
+    /// Once the update is complete, the write lock is downgraded and a read guard with a
+    /// reference of the updated `PendingComponents` is returned.
+    fn update_or_insert_pending_components<F>(
         &self,
         block_root: Hash256,
         epoch: Epoch,
-        write_lock: &mut RwLockWriteGuard<
-            RawRwLock,
-            LruCache<Hash256, PendingComponents<T::EthSpec>>,
-        >,
-    ) -> PendingComponents<T::EthSpec> {
-        write_lock.pop(&block_root).unwrap_or_else(|| {
-            PendingComponents::empty(block_root, self.spec.max_blobs_per_block(epoch) as usize)
+        update_fn: F,
+    ) -> Result<MappedRwLockReadGuard<'_, PendingComponents<T::EthSpec>>, AvailabilityCheckError>
+    where
+        F: FnOnce(&mut PendingComponents<T::EthSpec>) -> Result<(), AvailabilityCheckError>,
+    {
+        let mut write_lock = self.critical.write();
+
+        {
+            let pending_components = write_lock.get_or_insert_mut(block_root, || {
+                PendingComponents::empty(block_root, self.spec.max_blobs_per_block(epoch) as usize)
+            });
+            update_fn(pending_components)?
+        }
+
+        RwLockReadGuard::try_map(RwLockWriteGuard::downgrade(write_lock), |cache| {
+            cache.peek(&block_root)
+        })
+        .map_err(|_| {
+            AvailabilityCheckError::Unexpected("pending components should exist".to_string())
         })
     }
 
@@ -631,7 +629,6 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         &self,
         executed_block: AvailabilityPendingExecutedBlock<T::EthSpec>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
-        let mut write_lock = self.critical.write();
         let epoch = executed_block.as_block().epoch();
         let block_root = executed_block.import_data.block_root;
 
@@ -640,10 +637,11 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
             .state_cache
             .register_pending_executed_block(executed_block);
 
-        let mut pending_components =
-            self.get_or_create_pending_components(block_root, epoch, &mut write_lock);
-
-        pending_components.merge_block(diet_executed_block);
+        let pending_components =
+            self.update_or_insert_pending_components(block_root, epoch, |pending_components| {
+                pending_components.merge_block(diet_executed_block);
+                Ok(())
+            })?;
 
         let num_expected_columns_opt = if self.spec.is_peer_das_enabled_for_epoch(epoch) {
             let num_of_column_samples = self
@@ -662,8 +660,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
 
         self.check_availability_and_cache_components(
             block_root,
-            write_lock,
-            pending_components,
+            &pending_components,
             num_expected_columns_opt,
         )
     }

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -24,31 +24,6 @@ use types::{
     Hash256, RuntimeFixedVector, RuntimeVariableList, SignedBeaconBlock,
 };
 
-pub enum CachedComponents<E: EthSpec> {
-    Pending(PendingComponents<E>),
-    Available(PendingComponents<E>),
-}
-
-impl<E: EthSpec> CachedComponents<E> {
-    fn inner(&self) -> Option<&PendingComponents<E>> {
-        match self {
-            CachedComponents::Pending(p) | CachedComponents::Available(p) => Some(p),
-        }
-    }
-
-    fn inner_mut(&mut self) -> Option<&mut PendingComponents<E>> {
-        match self {
-            CachedComponents::Pending(p) | CachedComponents::Available(p) => Some(p),
-        }
-    }
-
-    fn into_inner(self) -> Option<PendingComponents<E>> {
-        match self {
-            CachedComponents::Pending(p) | CachedComponents::Available(p) => Some(p),
-        }
-    }
-}
-
 /// This represents the components of a partially available block
 ///
 /// The blobs are all gossip and kzg verified.
@@ -186,6 +161,8 @@ impl<E: EthSpec> PendingComponents<E> {
     ///
     /// WARNING: This function can potentially take a lot of time if the state needs to be
     /// reconstructed from disk. Ensure you are not holding any write locks while calling this.
+    /// TODO: add doc for `num_expected_columns_opt`
+    /// We probably dont need to hold the write lock for this
     pub fn make_available<R>(
         &mut self,
         spec: &Arc<ChainSpec>,
@@ -374,7 +351,7 @@ impl<E: EthSpec> PendingComponents<E> {
 /// interact with the cache through this.
 pub struct DataAvailabilityCheckerInner<T: BeaconChainTypes> {
     /// Contains all the data we keep in memory, protected by an RwLock
-    critical: RwLock<LruCache<Hash256, CachedComponents<T::EthSpec>>>,
+    critical: RwLock<LruCache<Hash256, PendingComponents<T::EthSpec>>>,
     /// This cache holds a limited number of states in memory and reconstructs them
     /// from disk when necessary. This is necessary until we merge tree-states
     state_cache: StateLRUCache<T>,
@@ -414,13 +391,11 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         self.critical
             .read()
             .peek(block_root)
-            .and_then(|cached_components| {
-                cached_components.inner().and_then(|pending_components| {
-                    pending_components
-                        .executed_block
-                        .as_ref()
-                        .map(|block| block.block_cloned())
-                })
+            .and_then(|pending_components| {
+                pending_components
+                    .executed_block
+                    .as_ref()
+                    .map(|block| block.block_cloned())
             })
     }
 
@@ -429,12 +404,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         &self,
         blob_id: &BlobIdentifier,
     ) -> Result<Option<Arc<BlobSidecar<T::EthSpec>>>, AvailabilityCheckError> {
-        if let Some(pending_components) = self
-            .critical
-            .read()
-            .peek(&blob_id.block_root)
-            .and_then(|c| c.inner())
-        {
+        if let Some(pending_components) = self.critical.read().peek(&blob_id.block_root) {
             Ok(pending_components
                 .verified_blobs
                 .get(blob_id.index as usize)
@@ -454,14 +424,12 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         self.critical
             .read()
             .peek(&block_root)
-            .and_then(|cached_components| {
-                cached_components.inner().map(|pending_components| {
-                    pending_components
-                        .verified_data_columns
-                        .iter()
-                        .map(|col| col.clone_arc())
-                        .collect()
-                })
+            .map(|pending_components| {
+                pending_components
+                    .verified_data_columns
+                    .iter()
+                    .map(|col| col.clone_arc())
+                    .collect()
             })
     }
 
@@ -470,11 +438,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         block_root: &Hash256,
         f: F,
     ) -> R {
-        f(self
-            .critical
-            .read()
-            .peek(block_root)
-            .and_then(|cached_components| cached_components.inner()))
+        f(self.critical.read().peek(block_root))
     }
 
     /// Puts the KZG verified blobs into the availability cache as pending components.
@@ -575,7 +539,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         block_root: Hash256,
         mut write_lock: RwLockWriteGuard<
             RawRwLock,
-            LruCache<Hash256, CachedComponents<T::EthSpec>>,
+            LruCache<Hash256, PendingComponents<T::EthSpec>>,
         >,
         mut pending_components: PendingComponents<T::EthSpec>,
         num_expected_columns_opt: Option<usize>,
@@ -591,11 +555,11 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
             // imported, but re-inserted immediately, causing partial pending components to be
             // stored and served to peers.
             // Components are only removed via LRU eviction as finality advances.
-            write_lock.put(block_root, CachedComponents::Available(pending_components));
+            write_lock.put(block_root, pending_components);
             drop(write_lock);
             Ok(Availability::Available(Box::new(available_block)))
         } else {
-            write_lock.put(block_root, CachedComponents::Pending(pending_components));
+            write_lock.put(block_root, pending_components);
             Ok(Availability::MissingComponents(block_root))
         }
     }
@@ -606,15 +570,12 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         epoch: Epoch,
         write_lock: &mut RwLockWriteGuard<
             RawRwLock,
-            LruCache<Hash256, CachedComponents<T::EthSpec>>,
+            LruCache<Hash256, PendingComponents<T::EthSpec>>,
         >,
     ) -> PendingComponents<T::EthSpec> {
-        write_lock
-            .pop_entry(&block_root)
-            .and_then(|(_, v)| v.into_inner())
-            .unwrap_or_else(|| {
-                PendingComponents::empty(block_root, self.spec.max_blobs_per_block(epoch) as usize)
-            })
+        write_lock.pop(&block_root).unwrap_or_else(|| {
+            PendingComponents::empty(block_root, self.spec.max_blobs_per_block(epoch) as usize)
+        })
     }
 
     /// Check whether data column reconstruction should be attempted.
@@ -631,10 +592,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         block_root: &Hash256,
     ) -> ReconstructColumnsDecision<T::EthSpec> {
         let mut write_lock = self.critical.write();
-        let Some(pending_components) = write_lock
-            .get_mut(block_root)
-            .and_then(|cached| cached.inner_mut())
-        else {
+        let Some(pending_components) = write_lock.get_mut(block_root) else {
             // Block may have been imported as it does not exist in availability cache.
             return ReconstructColumnsDecision::No("block already imported");
         };
@@ -661,12 +619,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
     /// In this case, we remove all data columns in `PendingComponents`, reset reconstruction
     /// status so that we can attempt to retrieve columns from peers again.
     pub fn handle_reconstruction_failure(&self, block_root: &Hash256) {
-        if let Some(pending_components_mut) = self
-            .critical
-            .write()
-            .get_mut(block_root)
-            .and_then(|cached| cached.inner_mut())
-        {
+        if let Some(pending_components_mut) = self.critical.write().get_mut(block_root) {
             pending_components_mut.verified_data_columns = vec![];
             pending_components_mut.reconstruction_started = false;
         }
@@ -724,7 +677,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         let mut write_lock = self.critical.write();
         let mut keys_to_remove = vec![];
         for (key, value) in write_lock.iter() {
-            if let Some(epoch) = value.inner().and_then(|p| p.epoch())
+            if let Some(epoch) = value.epoch()
                 && epoch < cutoff_epoch
             {
                 keys_to_remove.push(*key);
@@ -1125,7 +1078,6 @@ mod test {
                 .critical
                 .read()
                 .peek(&block_root)
-                .and_then(|c| c.inner())
                 .map(|pending_components| {
                     pending_components
                         .executed_block

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -475,7 +475,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
             );
         });
 
-        self.check_availability_and_cache_components(block_root, &pending_components, None)
+        self.check_availability_and_cache_components(block_root, pending_components, None)
     }
 
     #[allow(clippy::type_complexity)]
@@ -517,7 +517,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
 
         self.check_availability_and_cache_components(
             block_root,
-            &pending_components,
+            pending_components,
             Some(num_expected_columns),
         )
     }
@@ -525,14 +525,21 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
     fn check_availability_and_cache_components(
         &self,
         block_root: Hash256,
-        pending_components: &PendingComponents<T::EthSpec>,
+        pending_components: MappedRwLockReadGuard<'_, PendingComponents<T::EthSpec>>,
         num_expected_columns_opt: Option<usize>,
-    ) -> Result<Availability<<T as BeaconChainTypes>::EthSpec>, AvailabilityCheckError> {
+    ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
         if let Some(available_block) = pending_components.make_available(
             &self.spec,
             num_expected_columns_opt,
             |block, span| self.state_cache.recover_pending_executed_block(block, span),
         )? {
+            // Explicitly drop read lock before acquiring write lock
+            drop(pending_components);
+            if let Some(components) = self.critical.write().get_mut(&block_root) {
+                // Clean up span now that block is available
+                components.span = Span::none();
+            }
+
             // We never remove the pending components manually to avoid race conditions.
             // This ensures components remain available during and right after block import,
             // preventing a race condition where a component was removed after the block was
@@ -660,7 +667,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
 
         self.check_availability_and_cache_components(
             block_root,
-            &pending_components,
+            pending_components,
             num_expected_columns_opt,
         )
     }

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -586,6 +586,11 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
             |block, span| self.state_cache.recover_pending_executed_block(block, span),
         )? {
             // We never remove the pending components manually to avoid race conditions.
+            // This ensures components remain available during and right after block import,
+            // preventing a race condition where a component was removed after the block was
+            // imported, but re-inserted immediately, causing partial pending components to be
+            // stored and served to peers.
+            // Components are only removed via LRU eviction as finality advances.
             write_lock.put(block_root, CachedComponents::Available(pending_components));
             drop(write_lock);
             Ok(Availability::Available(Box::new(available_block)))
@@ -1043,7 +1048,11 @@ mod test {
                 matches!(availability, Availability::MissingComponents(_)),
                 "should be pending block"
             );
-            assert_eq!(cache.critical.read().len(), 1);
+            assert_eq!(
+                cache.critical.read().len(),
+                2,
+                "cache should have two blocks now"
+            );
         }
         let availability = cache
             .put_pending_executed_block(pending_block)
@@ -1054,8 +1063,8 @@ mod test {
             availability
         );
         assert!(
-            cache.critical.read().len() == 1,
-            "cache should still have available block until import"
+            cache.critical.read().len() == 2,
+            "cache should still have available block"
         );
     }
 
@@ -1177,14 +1186,6 @@ mod test {
             Some(&recovered_pending_block.import_data.state),
             states.last(),
             "recovered state should be the same as the original"
-        );
-        // the state should no longer be in the cache
-        assert!(
-            state_cache
-                .read()
-                .peek(&last_block.as_block().state_root())
-                .is_none(),
-            "last block state should no longer be in cache"
         );
     }
 }

--- a/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
@@ -113,8 +113,9 @@ impl<T: BeaconChainTypes> StateLRUCache<T> {
         diet_executed_block: DietAvailabilityPendingExecutedBlock<T::EthSpec>,
         _span: &Span,
     ) -> Result<AvailabilityPendingExecutedBlock<T::EthSpec>, AvailabilityCheckError> {
-        let state = if let Some(state) = self.states.write().pop(&diet_executed_block.state_root) {
-            state
+        // Keep the state in the cache to prevent reconstruction in race conditions
+        let state = if let Some(state) = self.states.write().get(&diet_executed_block.state_root) {
+            state.clone()
         } else {
             self.reconstruct_state(&diet_executed_block)?
         };


### PR DESCRIPTION
## Issue Addressed

Partially resolves #6439, an simpler alternative to #7931.

Race condition occurs when RPC data columns arrives after a block has been imported and removed from the DA checker:
 1. Block becomes available via gossip
 2. RPC columns arrive and pass fork choice check (block hasn't been imported)
 3. Block import completes (removing block from DA checker)
 4. RPC data columns finish verification and get imported into DA checker

This causes two issues:
1. **Partial data serving**: Already imported components get re-inserted, potentially causing LH to serve incomplete data
2. **State cache misses**: Leads to state reconstruction, holding the availability cache write lock longer and increasing race likelihood

### Proposed Changes

1. Never manually remove pending components from DA checker. Components are only removed via LRU eviction as finality advances. This makes sure we don't run into the issue described above.
2. Use `get` instead of `pop` when recovering the executed block, this prevents cache misses in race condition. This should reduce the likelihood of the race condition
3. Refactor DA checker to drop write lock as soon as components are added. This should also reduce the likelihood of the race condition

**Trade-offs:**

This solution eliminates a few nasty race conditions while allowing simplicity, with the cost of allowing block re-import (already existing). 

The increase in memory in DA checker can be partially offset by a reduction in block cache size if this really comes an issue (as we now serve recent blocks from DA checker).
