### PR TITLE
Remove dependency on target_info.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5687,7 +5687,6 @@ version = "0.1.0"
 dependencies = [
  "git-version",
  "regex",
- "target_info",
 ]
 
 [[package]]
@@ -9191,12 +9190,6 @@ version = "0.1.0"
 dependencies = [
  "static_assertions",
 ]
-
-[[package]]
-name = "target_info"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 
 [[package]]
 name = "task_executor"

--- a/common/lighthouse_version/Cargo.toml
+++ b/common/lighthouse_version/Cargo.toml
@@ -7,7 +7,6 @@ edition = { workspace = true }
 
 [dependencies]
 git-version = "0.3.4"
-target_info = "0.1.0"
 
 [dev-dependencies]
 regex = { workspace = true }

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -1,5 +1,5 @@
 use git_version::git_version;
-use target_info::Target;
+use std::env::consts;
 
 /// Returns the current version of this build of Lighthouse.
 ///
@@ -45,7 +45,7 @@ pub const COMMIT_PREFIX: &str = git_version!(
 ///
 /// `Lighthouse/v1.5.1-67da032+/x86_64-linux`
 pub fn version_with_platform() -> String {
-    format!("{}/{}-{}", VERSION, Target::arch(), Target::os())
+    format!("{}/{}-{}", VERSION, consts::ARCH, consts::OS)
 }
 
 /// Returns semantic versioning information only.


### PR DESCRIPTION
## Proposed Changes

Remove dependency on target_info, use standard library instead.

## Additional Info

The target_info crate hasn't been updated in nine years. While this isn't a problem in and of itself, its functionality is available in Rust's standard library. Because target_info's manifest is basically empty, it makes packaging lighthouse more difficult.