### PR TITLE
No default features for store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,7 +239,7 @@ smallvec = { version = "1.11.2", features = ["arbitrary"] }
 snap = "1"
 ssz_types = "0.11.0"
 state_processing = { path = "consensus/state_processing" }
-store = { path = "beacon_node/store" }
+store = { path = "beacon_node/store", default-features = false }
 strum = { version = "0.24", features = ["derive"] }
 superstruct = "0.8"
 swap_or_not_shuffle = { path = "consensus/swap_or_not_shuffle" }


### PR DESCRIPTION
## Proposed Changes

Unless store's default features are disabled, it is impossible to unselect leveldb as a backend.