### PR TITLE
Simplify some fork-variant boilerplate

### DIFF
--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -1,4 +1,5 @@
 use crate::test_utils::TestRandom;
+use crate::variant_mappings::BaseAndElectra;
 use crate::*;
 use derivative::Derivative;
 use merkle_proof::{MerkleTree, MerkleTreeError};
@@ -64,7 +65,9 @@ pub const BLOB_KZG_COMMITMENTS_INDEX: usize = 11;
         Gloas(metastruct(mappings(beacon_block_body_gloas_fields(groups(fields))))),
     ),
     cast_error(ty = "Error", expr = "Error::IncorrectStateVariant"),
-    partial_getter_error(ty = "Error", expr = "Error::IncorrectStateVariant")
+    partial_getter_error(ty = "Error", expr = "Error::IncorrectStateVariant"),
+    map_ref_into(AttestationRef, AttesterSlashingRef),
+    map_ref_mut_into(AttestationRefMut)
 )]
 #[cfg_attr(
     feature = "arbitrary",
@@ -318,87 +321,29 @@ impl<'a, E: EthSpec, Payload: AbstractExecPayload<E>> BeaconBlockBodyRef<'a, E, 
     }
 
     pub fn attestations_len(&self) -> usize {
-        match self {
-            Self::Base(body) => body.attestations.len(),
-            Self::Altair(body) => body.attestations.len(),
-            Self::Bellatrix(body) => body.attestations.len(),
-            Self::Capella(body) => body.attestations.len(),
-            Self::Deneb(body) => body.attestations.len(),
-            Self::Electra(body) => body.attestations.len(),
-            Self::Fulu(body) => body.attestations.len(),
-            Self::Gloas(body) => body.attestations.len(),
-        }
+        map_beacon_block_body_ref!(&'a _, self, |inner, cons| {
+            cons(inner);
+            inner.attestations.len()
+        })
     }
 
     pub fn attester_slashings_len(&self) -> usize {
-        match self {
-            Self::Base(body) => body.attester_slashings.len(),
-            Self::Altair(body) => body.attester_slashings.len(),
-            Self::Bellatrix(body) => body.attester_slashings.len(),
-            Self::Capella(body) => body.attester_slashings.len(),
-            Self::Deneb(body) => body.attester_slashings.len(),
-            Self::Electra(body) => body.attester_slashings.len(),
-            Self::Fulu(body) => body.attester_slashings.len(),
-            Self::Gloas(body) => body.attester_slashings.len(),
-        }
+        map_beacon_block_body_ref!(&'a _, self, |inner, cons| {
+            cons(inner);
+            inner.attester_slashings.len()
+        })
     }
 
     pub fn attestations(&self) -> Box<dyn Iterator<Item = AttestationRef<'a, E>> + 'a> {
-        match self {
-            Self::Base(body) => Box::new(body.attestations.iter().map(AttestationRef::Base)),
-            Self::Altair(body) => Box::new(body.attestations.iter().map(AttestationRef::Base)),
-            Self::Bellatrix(body) => Box::new(body.attestations.iter().map(AttestationRef::Base)),
-            Self::Capella(body) => Box::new(body.attestations.iter().map(AttestationRef::Base)),
-            Self::Deneb(body) => Box::new(body.attestations.iter().map(AttestationRef::Base)),
-            Self::Electra(body) => Box::new(body.attestations.iter().map(AttestationRef::Electra)),
-            Self::Fulu(body) => Box::new(body.attestations.iter().map(AttestationRef::Electra)),
-            Self::Gloas(body) => Box::new(body.attestations.iter().map(AttestationRef::Electra)),
-        }
+        map_beacon_block_body_ref_into_attestation_ref!(&'a _, self, |body, cons| {
+            Box::new(body.attestations.iter().map(cons))
+        })
     }
 
     pub fn attester_slashings(&self) -> Box<dyn Iterator<Item = AttesterSlashingRef<'a, E>> + 'a> {
-        match self {
-            Self::Base(body) => Box::new(
-                body.attester_slashings
-                    .iter()
-                    .map(AttesterSlashingRef::Base),
-            ),
-            Self::Altair(body) => Box::new(
-                body.attester_slashings
-                    .iter()
-                    .map(AttesterSlashingRef::Base),
-            ),
-            Self::Bellatrix(body) => Box::new(
-                body.attester_slashings
-                    .iter()
-                    .map(AttesterSlashingRef::Base),
-            ),
-            Self::Capella(body) => Box::new(
-                body.attester_slashings
-                    .iter()
-                    .map(AttesterSlashingRef::Base),
-            ),
-            Self::Deneb(body) => Box::new(
-                body.attester_slashings
-                    .iter()
-                    .map(AttesterSlashingRef::Base),
-            ),
-            Self::Electra(body) => Box::new(
-                body.attester_slashings
-                    .iter()
-                    .map(AttesterSlashingRef::Electra),
-            ),
-            Self::Fulu(body) => Box::new(
-                body.attester_slashings
-                    .iter()
-                    .map(AttesterSlashingRef::Electra),
-            ),
-            Self::Gloas(body) => Box::new(
-                body.attester_slashings
-                    .iter()
-                    .map(AttesterSlashingRef::Electra),
-            ),
-        }
+        map_beacon_block_body_ref_into_attester_slashing_ref!(&'a _, self, |body, cons| {
+            Box::new(body.attester_slashings.iter().map(cons))
+        })
     }
 }
 
@@ -406,30 +351,9 @@ impl<'a, E: EthSpec, Payload: AbstractExecPayload<E>> BeaconBlockBodyRefMut<'a, 
     pub fn attestations_mut(
         &'a mut self,
     ) -> Box<dyn Iterator<Item = AttestationRefMut<'a, E>> + 'a> {
-        match self {
-            Self::Base(body) => Box::new(body.attestations.iter_mut().map(AttestationRefMut::Base)),
-            Self::Altair(body) => {
-                Box::new(body.attestations.iter_mut().map(AttestationRefMut::Base))
-            }
-            Self::Bellatrix(body) => {
-                Box::new(body.attestations.iter_mut().map(AttestationRefMut::Base))
-            }
-            Self::Capella(body) => {
-                Box::new(body.attestations.iter_mut().map(AttestationRefMut::Base))
-            }
-            Self::Deneb(body) => {
-                Box::new(body.attestations.iter_mut().map(AttestationRefMut::Base))
-            }
-            Self::Electra(body) => {
-                Box::new(body.attestations.iter_mut().map(AttestationRefMut::Electra))
-            }
-            Self::Fulu(body) => {
-                Box::new(body.attestations.iter_mut().map(AttestationRefMut::Electra))
-            }
-            Self::Gloas(body) => {
-                Box::new(body.attestations.iter_mut().map(AttestationRefMut::Electra))
-            }
-        }
+        map_beacon_block_body_ref_mut_into_attestation_ref_mut!(&'a _, self, |body, cons| {
+            Box::new(body.attestations.iter_mut().map(cons))
+        })
     }
 }
 

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -96,6 +96,7 @@ pub mod sync_committee_message;
 pub mod sync_selection_proof;
 pub mod sync_subnet_id;
 pub mod validator_registration_data;
+pub mod variant_mappings;
 pub mod withdrawal;
 
 pub mod epoch_cache;

--- a/consensus/types/src/variant_mappings.rs
+++ b/consensus/types/src/variant_mappings.rs
@@ -1,0 +1,49 @@
+use crate::{
+    AttestationBase, AttestationElectra, AttestationRef, AttestationRefMut, AttesterSlashingBase,
+    AttesterSlashingElectra, AttesterSlashingRef, EthSpec,
+};
+
+/// Just completely normal Rust things happening here, nothing to worry about.
+///
+/// This trait provides "dummy constructors" for fork variants on types that *actually* just
+/// have Base and Electra variants.
+pub trait BaseAndElectra: Sized {
+    #![allow(non_upper_case_globals)]
+    type Base;
+    type Electra;
+
+    const BASE: fn(Self::Base) -> Self;
+    const ELECTRA: fn(Self::Electra) -> Self;
+
+    const Altair: fn(Self::Base) -> Self = Self::BASE;
+    const Bellatrix: fn(Self::Base) -> Self = Self::BASE;
+    const Capella: fn(Self::Base) -> Self = Self::BASE;
+    const Deneb: fn(Self::Base) -> Self = Self::BASE;
+
+    const Fulu: fn(Self::Electra) -> Self = Self::ELECTRA;
+    const Gloas: fn(Self::Electra) -> Self = Self::ELECTRA;
+}
+
+impl<'a, E: EthSpec> BaseAndElectra for AttestationRef<'a, E> {
+    type Base = &'a AttestationBase<E>;
+    type Electra = &'a AttestationElectra<E>;
+
+    const BASE: fn(<Self as BaseAndElectra>::Base) -> Self = Self::Base;
+    const ELECTRA: fn(<Self as BaseAndElectra>::Electra) -> Self = Self::Electra;
+}
+
+impl<'a, E: EthSpec> BaseAndElectra for AttestationRefMut<'a, E> {
+    type Base = &'a mut AttestationBase<E>;
+    type Electra = &'a mut AttestationElectra<E>;
+
+    const BASE: fn(<Self as BaseAndElectra>::Base) -> Self = Self::Base;
+    const ELECTRA: fn(<Self as BaseAndElectra>::Electra) -> Self = Self::Electra;
+}
+
+impl<'a, E: EthSpec> BaseAndElectra for AttesterSlashingRef<'a, E> {
+    type Base = &'a AttesterSlashingBase<E>;
+    type Electra = &'a AttesterSlashingElectra<E>;
+
+    const BASE: fn(<Self as BaseAndElectra>::Base) -> Self = Self::Base;
+    const ELECTRA: fn(<Self as BaseAndElectra>::Electra) -> Self = Self::Electra;
+}


### PR DESCRIPTION
## Proposed Changes

Simplify some fork boilerplate by using `superstruct` mapping macros some more.

Due to a limitation of the current `superstruct` macros, we can't map between superstructs with different variants. The `BaseAndElectra` trait solves this by shimming the missing variants to their respective variants on the RHS.

This is probably not the best way to solve this, extending `superstruct`'s macros would likely be cleaner long term:

- https://github.com/sigp/superstruct/issues/54

## Additional Info

I've opened another PR with _just_ the non-spicy changes from this PR:

- https://github.com/sigp/lighthouse/pull/7989
