### PR TITLE
Add co-author to mergify commits

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -105,6 +105,10 @@ queue_rules:
 
 
         {{ body | get_section("## Proposed Changes", "") }}
+      
+      {% for commit in commits | unique(attribute='email_author') %}
+      Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
+      {% endfor %}
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - "check-success=license/cla"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,6 +14,11 @@ pull_request_rules:
       comment:
         message: This pull request has merge conflicts. Could you please resolve them
           @{{author}}? 🙏
+      label:
+        add:
+          - waiting-on-author
+        remove:
+          - ready-for-review
 
   - name: Ask to resolve CI failures
     conditions:
@@ -27,6 +32,32 @@ pull_request_rules:
     actions:
       comment:
         message: Some required checks have failed. Could you please take a look @{{author}}? 🙏
+      label:
+        add:
+          - waiting-on-author
+        remove:
+          - ready-for-review
+
+  - name: Update labels when PR is unblocked
+    conditions:
+      - -closed
+      - -draft
+      - label=waiting-on-author
+      - -conflict
+      # Unfortunately, it doesn't look like there's an easy way to check for PRs pending
+      # CI workflows approvals.
+      - check-success=test-suite-success
+      - check-success=local-testnet-success
+      # Update the label only if there are no more change requests from any reviewers and no unresolved threads.
+      # This rule ensures that a PR with passing CI can be marked as `waiting-on-author`.
+      - "#changes-requested-reviews-by = 0"
+      - "#review-threads-unresolved = 0"
+    actions:
+      label:
+        remove:
+          - waiting-on-author
+        add:
+          - ready-for-review
 
   - name: Close stale pull request after 30 days of inactivity
     conditions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,11 +14,6 @@ pull_request_rules:
       comment:
         message: This pull request has merge conflicts. Could you please resolve them
           @{{author}}? 🙏
-      label:
-        add:
-          - waiting-on-author
-        remove:
-          - ready-for-review
 
   - name: Ask to resolve CI failures
     conditions:
@@ -32,32 +27,6 @@ pull_request_rules:
     actions:
       comment:
         message: Some required checks have failed. Could you please take a look @{{author}}? 🙏
-      label:
-        add:
-          - waiting-on-author
-        remove:
-          - ready-for-review
-
-  - name: Update labels when PR is unblocked
-    conditions:
-      - -closed
-      - -draft
-      - label=waiting-on-author
-      - -conflict
-      # Unfortunately, it doesn't look like there's an easy way to check for PRs pending
-      # CI workflows approvals.
-      - check-success=test-suite-success
-      - check-success=local-testnet-success
-      # Update the label only if there are no more change requests from any reviewers and no unresolved threads.
-      # This rule ensures that a PR with passing CI can be marked as `waiting-on-author`.
-      - "#changes-requested-reviews-by = 0"
-      - "#review-threads-unresolved = 0"
-    actions:
-      label:
-        remove:
-          - waiting-on-author
-        add:
-          - ready-for-review
 
   - name: Close stale pull request after 30 days of inactivity
     conditions:


### PR DESCRIPTION
## Issue Addressed

We lost this feature after we moved to mergify. It would be good to keep the pull request co-authors in the the merge commits too.

I've tested this on my fork and it works:
https://github.com/jimmygchen/lighthouse/commit/774c38de5ff32acfc9393fa429f0bafc987292f4