### PR TITLE
Don't penalize peers if locally constructed light client data is stale

### DIFF
--- a/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
@@ -116,12 +116,12 @@ impl<T: BeaconChainTypes> VerifiedLightClientFinalityUpdate<T> {
         // Verify that the gossiped finality update is the same as the locally constructed one.
         if latest_finality_update != rcv_finality_update {
             let signature_slot = latest_finality_update.signature_slot();
-           
+
             if signature_slot != rcv_finality_update.signature_slot() {
                 // The locally constructed finality update is not up to date, probably
                 // because the node has fallen behind and needs to sync.
-                if rcv_finality_update.signature_slot() >  signature_slot {
-                    return Err(Error::Ignore)
+                if rcv_finality_update.signature_slot() > signature_slot {
+                    return Err(Error::Ignore);
                 }
                 return Err(Error::MismatchedSignatureSlot {
                     local: signature_slot,

--- a/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
@@ -116,7 +116,13 @@ impl<T: BeaconChainTypes> VerifiedLightClientFinalityUpdate<T> {
         // Verify that the gossiped finality update is the same as the locally constructed one.
         if latest_finality_update != rcv_finality_update {
             let signature_slot = latest_finality_update.signature_slot();
+           
             if signature_slot != rcv_finality_update.signature_slot() {
+                // The locally constructed finality update is not up to date, probably
+                // because the node has fallen behind and needs to sync.
+                if rcv_finality_update.signature_slot() >  signature_slot {
+                    return Err(Error::Ignore)
+                }
                 return Err(Error::MismatchedSignatureSlot {
                     local: signature_slot,
                     observed: rcv_finality_update.signature_slot(),

--- a/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
@@ -120,8 +120,8 @@ impl<T: BeaconChainTypes> VerifiedLightClientOptimisticUpdate<T> {
             if signature_slot != rcv_optimistic_update.signature_slot() {
                 // The locally constructed optimistic update is not up to date, probably
                 // because the node has fallen behind and needs to sync.
-                if rcv_optimistic_update.signature_slot() >  signature_slot {
-                    return Err(Error::Ignore)
+                if rcv_optimistic_update.signature_slot() > signature_slot {
+                    return Err(Error::Ignore);
                 }
                 return Err(Error::MismatchedSignatureSlot {
                     local: signature_slot,

--- a/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
@@ -118,6 +118,11 @@ impl<T: BeaconChainTypes> VerifiedLightClientOptimisticUpdate<T> {
         if latest_optimistic_update != rcv_optimistic_update {
             let signature_slot = latest_optimistic_update.signature_slot();
             if signature_slot != rcv_optimistic_update.signature_slot() {
+                // The locally constructed optimistic update is not up to date, probably
+                // because the node has fallen behind and needs to sync.
+                if rcv_optimistic_update.signature_slot() >  signature_slot {
+                    return Err(Error::Ignore)
+                }
                 return Err(Error::MismatchedSignatureSlot {
                     local: signature_slot,
                     observed: rcv_optimistic_update.signature_slot(),


### PR DESCRIPTION
## Issue Addressed

#7994

## Proposed Changes

We seem to be penalizing peers in situations where locally constructed light client data is stale. This PR ignores incoming light client data if our locally constructed light client data isn't up to date.
