### PR TITLE
Remove unused logging metrics

### DIFF
--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -1,5 +1,3 @@
-use metrics::{IntCounter, Result as MetricsResult, try_create_int_counter};
-use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 use tracing_subscriber::EnvFilter;
 

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -23,15 +23,6 @@ pub use utils::build_workspace_filter;
 /// The minimum interval between log messages indicating that a queue is full.
 const LOG_DEBOUNCE_INTERVAL: Duration = Duration::from_secs(30);
 
-pub static INFOS_TOTAL: LazyLock<MetricsResult<IntCounter>> =
-    LazyLock::new(|| try_create_int_counter("info_total", "Count of infos logged"));
-pub static WARNS_TOTAL: LazyLock<MetricsResult<IntCounter>> =
-    LazyLock::new(|| try_create_int_counter("warn_total", "Count of warns logged"));
-pub static ERRORS_TOTAL: LazyLock<MetricsResult<IntCounter>> =
-    LazyLock::new(|| try_create_int_counter("error_total", "Count of errors logged"));
-pub static CRITS_TOTAL: LazyLock<MetricsResult<IntCounter>> =
-    LazyLock::new(|| try_create_int_counter("crit_total", "Count of crits logged"));
-
 /// Provides de-bounce functionality for logging.
 #[derive(Default)]
 pub struct TimeLatch(Option<Instant>);


### PR DESCRIPTION
## Issue Addressed

@chong-he noticed that the INFO/WARN/ERRO log counts on our dashboards had stopped working. Since switching to `tracing` we are now tracking total events _per crate_, and the global counters are unused.

Per-crate metrics are here:

https://github.com/sigp/lighthouse/blob/cfb1f7331064b758c6786e4e1dc15507af5ff5d1/common/logging/src/tracing_metrics_layer.rs#L61-L63

## Proposed Changes

Delete the unused global counters from the source.

We can sum across the per-crate metric in our dashboards to restore the previous functionality.
