### PR TITLE
Grab newer version of leveldb-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5096,8 +5096,7 @@ dependencies = [
 [[package]]
 name = "leveldb-sys"
 version = "2.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd94a4d0242a437e5e41a27c782b69a624469ca1c4d1e5cb3c337f74a8031d4"
+source = "git+https://github.com/skade/leveldb-sys.git?rev=5b3102b7ea9b08e33acb3ffda400f78c52e8fa35#5b3102b7ea9b08e33acb3ffda400f78c52e8fa35"
 dependencies = [
  "cmake",
  "ffi-opaque",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,3 +303,4 @@ debug = true
 
 [patch.crates-io]
 quick-protobuf = { git = "https://github.com/sigp/quick-protobuf.git", rev = "681f413312404ab6e51f0b46f39b0075c6f4ebfd" }
+leveldb-sys = { git = "https://github.com/skade/leveldb-sys.git", rev = "5b3102b7ea9b08e33acb3ffda400f78c52e8fa35" }


### PR DESCRIPTION
## Proposed Changes

Patch leveldb-sys with the one from [this pull request](https://github.com/skade/leveldb-sys/pull/31).

## Additional Info

This commit grabs a version of leveldb-sys that:

 - Replaces snappy and leveldb with submodules (and updates to the latest releases).
 - Rewrites the CI workflow to be more modern.
 - Allows linking against the system version of leveldb and snappy by setting `LEVELDB_NO_VENDOR=1`.
 - Hopefully resolves a linking issue when using the vendored snappy.