### PR TITLE
fix: extra fields in logs

### DIFF
--- a/common/logging/src/tracing_logging_layer.rs
+++ b/common/logging/src/tracing_logging_layer.rs
@@ -2,6 +2,7 @@ use crate::utils::is_ascii_control;
 
 use chrono::prelude::*;
 use serde_json::{Map, Value};
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use tracing::Subscriber;
 use tracing::field::Field;
@@ -79,13 +80,26 @@ where
 
         event.record(&mut visitor);
 
-        let mut span_data = Vec::new();
+        let mut span_data = HashMap::new();
         if let Some(scope) = ctx.event_scope(event) {
             for span in scope.from_root() {
                 if let Some(data) = span.extensions().get::<SpanData>() {
-                    span_data.extend(data.fields.clone());
+                    for (k, v) in data.fields.clone() {
+                        span_data.insert(k, v);
+                    }
                 }
             }
+        }
+
+        // Remove span fields whose base names are already present on the event.
+        if !visitor.fields.is_empty() && !span_data.is_empty() {
+            let event_field_names: HashSet<&str> =
+                visitor.fields.iter().map(|(k, _)| k.as_str()).collect();
+
+            span_data.retain(|key, _| {
+                let base = key.rsplit('.').next().unwrap_or(key.as_str());
+                !event_field_names.contains(base)
+            });
         }
 
         // Remove ascii control codes from message.
@@ -242,7 +256,7 @@ fn build_log_json(
     visitor: &FieldVisitor,
     plain_level_str: &str,
     meta: &tracing::Metadata<'_>,
-    span_fields: &[(String, String)],
+    span_fields: &HashMap<String, String>,
     writer: &mut impl Write,
 ) {
     let utc_timestamp = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
@@ -291,7 +305,7 @@ fn build_log_text(
     visitor: &FieldVisitor,
     plain_level_str: &str,
     timestamp: &str,
-    span_fields: &[(String, String)],
+    span_fields: &HashMap<String, String>,
     location: &str,
     color_level_str: &str,
     use_color: bool,
@@ -301,7 +315,9 @@ fn build_log_text(
     let bold_end = "\x1b[0m";
 
     let mut formatted_spans = String::new();
-    for (i, (field_name, field_value)) in span_fields.iter().rev().enumerate() {
+    let mut span_items: Vec<_> = span_fields.iter().collect();
+    span_items.reverse();
+    for (i, (field_name, field_value)) in span_items.iter().enumerate() {
         if use_color {
             formatted_spans.push_str(&format!(
                 "{}{}{}: {}",
@@ -312,7 +328,7 @@ fn build_log_text(
         }
 
         // Check if this is not the last span.
-        if i != span_fields.len() - 1 {
+        if i != span_items.len() - 1 {
             formatted_spans.push_str(", ");
         }
     }
@@ -406,7 +422,7 @@ fn parse_field(val: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use crate::tracing_logging_layer::{FieldVisitor, build_log_text};
-    use std::io::Write;
+    use std::{collections::HashMap, io::Write};
 
     struct Buffer {
         data: Vec<u8>,
@@ -436,7 +452,7 @@ mod tests {
     #[test]
     fn test_build_log_text_single_log_field() {
         let log_fields = vec![("field_name".to_string(), "field_value".to_string())];
-        let span_fields = vec![];
+        let span_fields: HashMap<String, String> = HashMap::new();
         let expected = "Jan 1 08:00:00.000 INFO  test message                                  field_name: field_value \n";
         test_build_log_text(log_fields, span_fields, expected);
     }
@@ -447,7 +463,7 @@ mod tests {
             ("field_name1".to_string(), "field_value1".to_string()),
             ("field_name2".to_string(), "field_value2".to_string()),
         ];
-        let span_fields = vec![];
+        let span_fields: HashMap<String, String> = HashMap::new();
         let expected = "Jan 1 08:00:00.000 INFO  test message                                  field_name1: field_value1, field_name2: field_value2 \n";
         test_build_log_text(log_fields, span_fields, expected);
     }
@@ -455,10 +471,10 @@ mod tests {
     #[test]
     fn test_build_log_text_log_field_and_span() {
         let log_fields = vec![("field_name".to_string(), "field_value".to_string())];
-        let span_fields = vec![(
+        let span_fields = HashMap::<String, String>::from([(
             "span_field_name".to_string(),
             "span_field_value".to_string(),
-        )];
+        )]);
         let expected = "Jan 1 08:00:00.000 INFO  test message                                  field_name: field_value, span_field_name: span_field_value\n";
         test_build_log_text(log_fields, span_fields, expected);
     }
@@ -466,10 +482,10 @@ mod tests {
     #[test]
     fn test_build_log_text_single_span() {
         let log_fields = vec![];
-        let span_fields = vec![(
+        let span_fields = HashMap::<String, String>::from([(
             "span_field_name".to_string(),
             "span_field_value".to_string(),
-        )];
+        )]);
         let expected = "Jan 1 08:00:00.000 INFO  test message                                 span_field_name: span_field_value\n";
         test_build_log_text(log_fields, span_fields, expected);
     }
@@ -477,7 +493,7 @@ mod tests {
     #[test]
     fn test_build_log_text_multiple_spans() {
         let log_fields = vec![];
-        let span_fields = vec![
+        let span_fields: HashMap<String, String> = vec![
             (
                 "span_field_name1".to_string(),
                 "span_field_value1".to_string(),
@@ -486,7 +502,9 @@ mod tests {
                 "span_field_name2".to_string(),
                 "span_field_value2".to_string(),
             ),
-        ];
+        ]
+        .into_iter()
+        .collect();
         let expected = "Jan 1 08:00:00.000 INFO  test message                                 span_field_name2: span_field_value2, span_field_name1: span_field_value1\n";
         test_build_log_text(log_fields, span_fields, expected);
     }
@@ -494,7 +512,7 @@ mod tests {
     #[test]
     fn test_build_log_text_multiple_span_fields() {
         let log_fields = vec![];
-        let span_fields = vec![
+        let span_fields: HashMap<String, String> = vec![
             (
                 "span_field_name1-1".to_string(),
                 "span_field_value1-1".to_string(),
@@ -503,14 +521,16 @@ mod tests {
                 "span_field_name1-2".to_string(),
                 "span_field_value1-2".to_string(),
             ),
-        ];
+        ]
+        .into_iter()
+        .collect();
         let expected = "Jan 1 08:00:00.000 INFO  test message                                 span_field_name1-2: span_field_value1-2, span_field_name1-1: span_field_value1-1\n";
         test_build_log_text(log_fields, span_fields, expected);
     }
 
     fn test_build_log_text(
         log_fields: Vec<(String, String)>,
-        span_fields: Vec<(String, String)>,
+        span_fields: HashMap<String, String>,
         expected: &str,
     ) {
         let visitor = FieldVisitor {

--- a/common/logging/src/tracing_logging_layer.rs
+++ b/common/logging/src/tracing_logging_layer.rs
@@ -80,12 +80,11 @@ where
         event.record(&mut visitor);
 
         let mut span_data = Vec::new();
-        if let Some(mut scope) = ctx.event_scope(event) {
-            if let Some(span) = scope.next() {
-                if let Some(data) = span.extensions().get::<SpanData>() {
-                    span_data.extend(data.fields.clone());
-                }
-            }
+        if let Some(mut scope) = ctx.event_scope(event)
+            && let Some(span) = scope.next()
+            && let Some(data) = span.extensions().get::<SpanData>()
+        {
+            span_data.extend(data.fields.clone());
         }
 
         // Remove ascii control codes from message.

--- a/common/logging/src/tracing_logging_layer.rs
+++ b/common/logging/src/tracing_logging_layer.rs
@@ -2,7 +2,7 @@ use crate::utils::is_ascii_control;
 
 use chrono::prelude::*;
 use serde_json::{Map, Value};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::io::Write;
 use tracing::Subscriber;
 use tracing::field::Field;
@@ -81,25 +81,14 @@ where
         event.record(&mut visitor);
 
         let mut span_data = HashMap::new();
-        if let Some(scope) = ctx.event_scope(event) {
-            for span in scope.from_root() {
+        if let Some(mut scope) = ctx.event_scope(event) {
+            if let Some(span) = scope.next() {
                 if let Some(data) = span.extensions().get::<SpanData>() {
                     for (k, v) in data.fields.clone() {
                         span_data.insert(k, v);
                     }
                 }
             }
-        }
-
-        // Remove span fields whose base names are already present on the event.
-        if !visitor.fields.is_empty() && !span_data.is_empty() {
-            let event_field_names: HashSet<&str> =
-                visitor.fields.iter().map(|(k, _)| k.as_str()).collect();
-
-            span_data.retain(|key, _| {
-                let base = key.rsplit('.').next().unwrap_or(key.as_str());
-                !event_field_names.contains(base)
-            });
         }
 
         // Remove ascii control codes from message.

--- a/common/logging/src/tracing_logging_layer.rs
+++ b/common/logging/src/tracing_logging_layer.rs
@@ -2,7 +2,6 @@ use crate::utils::is_ascii_control;
 
 use chrono::prelude::*;
 use serde_json::{Map, Value};
-use std::collections::HashMap;
 use std::io::Write;
 use tracing::Subscriber;
 use tracing::field::Field;
@@ -80,13 +79,11 @@ where
 
         event.record(&mut visitor);
 
-        let mut span_data = HashMap::new();
+        let mut span_data = Vec::new();
         if let Some(mut scope) = ctx.event_scope(event) {
             if let Some(span) = scope.next() {
                 if let Some(data) = span.extensions().get::<SpanData>() {
-                    for (k, v) in data.fields.clone() {
-                        span_data.insert(k, v);
-                    }
+                    span_data.extend(data.fields.clone());
                 }
             }
         }
@@ -245,7 +242,7 @@ fn build_log_json(
     visitor: &FieldVisitor,
     plain_level_str: &str,
     meta: &tracing::Metadata<'_>,
-    span_fields: &HashMap<String, String>,
+    span_fields: &[(String, String)],
     writer: &mut impl Write,
 ) {
     let utc_timestamp = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
@@ -294,7 +291,7 @@ fn build_log_text(
     visitor: &FieldVisitor,
     plain_level_str: &str,
     timestamp: &str,
-    span_fields: &HashMap<String, String>,
+    span_fields: &[(String, String)],
     location: &str,
     color_level_str: &str,
     use_color: bool,
@@ -304,9 +301,7 @@ fn build_log_text(
     let bold_end = "\x1b[0m";
 
     let mut formatted_spans = String::new();
-    let mut span_items: Vec<_> = span_fields.iter().collect();
-    span_items.reverse();
-    for (i, (field_name, field_value)) in span_items.iter().enumerate() {
+    for (i, (field_name, field_value)) in span_fields.iter().rev().enumerate() {
         if use_color {
             formatted_spans.push_str(&format!(
                 "{}{}{}: {}",
@@ -317,7 +312,7 @@ fn build_log_text(
         }
 
         // Check if this is not the last span.
-        if i != span_items.len() - 1 {
+        if i != span_fields.len() - 1 {
             formatted_spans.push_str(", ");
         }
     }
@@ -411,7 +406,7 @@ fn parse_field(val: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use crate::tracing_logging_layer::{FieldVisitor, build_log_text};
-    use std::{collections::HashMap, io::Write};
+    use std::io::Write;
 
     struct Buffer {
         data: Vec<u8>,
@@ -441,7 +436,7 @@ mod tests {
     #[test]
     fn test_build_log_text_single_log_field() {
         let log_fields = vec![("field_name".to_string(), "field_value".to_string())];
-        let span_fields: HashMap<String, String> = HashMap::new();
+        let span_fields = vec![];
         let expected = "Jan 1 08:00:00.000 INFO  test message                                  field_name: field_value \n";
         test_build_log_text(log_fields, span_fields, expected);
     }
@@ -452,7 +447,7 @@ mod tests {
             ("field_name1".to_string(), "field_value1".to_string()),
             ("field_name2".to_string(), "field_value2".to_string()),
         ];
-        let span_fields: HashMap<String, String> = HashMap::new();
+        let span_fields = vec![];
         let expected = "Jan 1 08:00:00.000 INFO  test message                                  field_name1: field_value1, field_name2: field_value2 \n";
         test_build_log_text(log_fields, span_fields, expected);
     }
@@ -460,10 +455,10 @@ mod tests {
     #[test]
     fn test_build_log_text_log_field_and_span() {
         let log_fields = vec![("field_name".to_string(), "field_value".to_string())];
-        let span_fields = HashMap::<String, String>::from([(
+        let span_fields = vec![(
             "span_field_name".to_string(),
             "span_field_value".to_string(),
-        )]);
+        )];
         let expected = "Jan 1 08:00:00.000 INFO  test message                                  field_name: field_value, span_field_name: span_field_value\n";
         test_build_log_text(log_fields, span_fields, expected);
     }
@@ -471,10 +466,10 @@ mod tests {
     #[test]
     fn test_build_log_text_single_span() {
         let log_fields = vec![];
-        let span_fields = HashMap::<String, String>::from([(
+        let span_fields = vec![(
             "span_field_name".to_string(),
             "span_field_value".to_string(),
-        )]);
+        )];
         let expected = "Jan 1 08:00:00.000 INFO  test message                                 span_field_name: span_field_value\n";
         test_build_log_text(log_fields, span_fields, expected);
     }
@@ -482,7 +477,7 @@ mod tests {
     #[test]
     fn test_build_log_text_multiple_spans() {
         let log_fields = vec![];
-        let span_fields: HashMap<String, String> = vec![
+        let span_fields = vec![
             (
                 "span_field_name1".to_string(),
                 "span_field_value1".to_string(),
@@ -491,9 +486,7 @@ mod tests {
                 "span_field_name2".to_string(),
                 "span_field_value2".to_string(),
             ),
-        ]
-        .into_iter()
-        .collect();
+        ];
         let expected = "Jan 1 08:00:00.000 INFO  test message                                 span_field_name2: span_field_value2, span_field_name1: span_field_value1\n";
         test_build_log_text(log_fields, span_fields, expected);
     }
@@ -501,7 +494,7 @@ mod tests {
     #[test]
     fn test_build_log_text_multiple_span_fields() {
         let log_fields = vec![];
-        let span_fields: HashMap<String, String> = vec![
+        let span_fields = vec![
             (
                 "span_field_name1-1".to_string(),
                 "span_field_value1-1".to_string(),
@@ -510,16 +503,14 @@ mod tests {
                 "span_field_name1-2".to_string(),
                 "span_field_value1-2".to_string(),
             ),
-        ]
-        .into_iter()
-        .collect();
+        ];
         let expected = "Jan 1 08:00:00.000 INFO  test message                                 span_field_name1-2: span_field_value1-2, span_field_name1-1: span_field_value1-1\n";
         test_build_log_text(log_fields, span_fields, expected);
     }
 
     fn test_build_log_text(
         log_fields: Vec<(String, String)>,
-        span_fields: HashMap<String, String>,
+        span_fields: Vec<(String, String)>,
         expected: &str,
     ) {
         let visitor = FieldVisitor {


### PR DESCRIPTION
## Issue Addressed

Potentially fixes #7995

## Proposed Changes

changed `span_data` to a `HashMap` and added a new check to remove span fields whose base names are already present on the event.