### PR TITLE
bls: fix is_infinity when aggregating onto empty AggregateSignature

### DIFF
--- a/crypto/bls/src/generic_aggregate_signature.rs
+++ b/crypto/bls/src/generic_aggregate_signature.rs
@@ -124,13 +124,15 @@ where
     /// Aggregates a signature onto `self`.
     pub fn add_assign(&mut self, other: &GenericSignature<Pub, Sig>) {
         if let Some(other_point) = other.point() {
-            self.is_infinity = self.is_infinity && other.is_infinity;
             if let Some(self_point) = &mut self.point {
-                self_point.add_assign(other_point)
+                self_point.add_assign(other_point);
+                self.is_infinity = self.is_infinity && other.is_infinity;
             } else {
                 let mut self_point = AggSig::infinity();
                 self_point.add_assign(other_point);
-                self.point = Some(self_point)
+                self.point = Some(self_point);
+                // Treat empty as infinity before aggregation; the result is infinity iff `other` is.
+                self.is_infinity = other.is_infinity;
             }
         }
     }
@@ -138,13 +140,15 @@ where
     /// Aggregates an aggregate signature onto `self`.
     pub fn add_assign_aggregate(&mut self, other: &Self) {
         if let Some(other_point) = other.point() {
-            self.is_infinity = self.is_infinity && other.is_infinity;
             if let Some(self_point) = &mut self.point {
-                self_point.add_assign_aggregate(other_point)
+                self_point.add_assign_aggregate(other_point);
+                self.is_infinity = self.is_infinity && other.is_infinity;
             } else {
                 let mut self_point = AggSig::infinity();
                 self_point.add_assign_aggregate(other_point);
-                self.point = Some(self_point)
+                self.point = Some(self_point);
+                // Treat empty as infinity before aggregation; the result is infinity iff `other` is.
+                self.is_infinity = other.is_infinity;
             }
         }
     }


### PR DESCRIPTION
- Ensure is_infinity reflects the actual aggregate when aggregating onto an empty AggregateSignature.
- Previously, starting from empty() and aggregating an infinity signature produced an aggregate whose underlying point was infinity but is_infinity stayed false. This broke eth_fast_aggregate_verify for empty pubkeys and desynced the flag from the serialized value.
- Update add_assign and add_assign_aggregate: when self was empty, set is_infinity = other.is_infinity; otherwise keep the existing conjunction behavior. This aligns with the doc that empty acts as “set to infinity before aggregation” and keeps is_infinity consistent with the bytes.