### PR TITLE
Increase HTTP timeouts on CI

### DIFF
--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -145,12 +145,11 @@ impl<E: EthSpec> InteractiveTester<E> {
             tokio::spawn(mock_builder_server);
         }
 
-        // Override the default timeout to 2s to timeouts on CI, as CI seems to require longer
-        // to process. The 1s timeouts for other tasks have been working for a long time, so we'll
-        // keep it as it is, as it may help identify a performance regression.
+        // Use 5s timeouts on CI, as there are several sources of artifical slowness, including
+        // mock-builder.
         let timeouts = Timeouts {
-            default: Duration::from_secs(2),
-            ..Timeouts::set_all(Duration::from_secs(1))
+            default: Duration::from_secs(5),
+            ..Timeouts::set_all(Duration::from_secs(5))
         };
         let client = BeaconNodeHttpClient::new(beacon_url.clone(), timeouts);
 

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -1383,7 +1383,8 @@ pub async fn blinded_equivocation_gossip() {
         // XXX: this should be a 400 but is a 500 due to the mock-builder being janky
         assert_eq!(
             error_response.status(),
-            Some(StatusCode::INTERNAL_SERVER_ERROR)
+            Some(StatusCode::INTERNAL_SERVER_ERROR),
+            "{error_response:?}"
         );
     } else {
         assert_eq!(error_response.status(), Some(StatusCode::BAD_REQUEST));


### PR DESCRIPTION
## Issue Addressed

Since we re-enabled HTTP API tests on CI (https://github.com/sigp/lighthouse/pull/7943) there have been a few spurious failures:

- https://github.com/sigp/lighthouse/actions/runs/17608432465/job/50024519938?pr=7783

That error is awkward, but running locally with a short timeout confirms it to be a timeout.

## Proposed Changes

Change the request timeout to 5s everywhere. We had kept it shorter to try to detect performance regressions, but I think this is better suited to being done with metrics & traces. On CI we really just want things to pass reliably without flakiness, so I think a longer timeout to handle slower test code (like mock-builder) and overworked CI boxes makes sense.
