### PR TITLE
Remove column reconstruction when processing rpc requests

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1067,7 +1067,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                                 slot: *slot,
                                 process_fn: Box::pin(async move {
                                     cloned_self
-                                        .attempt_data_column_reconstruction(block_root, true)
+                                        .attempt_data_column_reconstruction(block_root)
                                         .await;
                                 }),
                             },

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -837,7 +837,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     async fn attempt_data_column_reconstruction(
         self: &Arc<Self>,
         block_root: Hash256,
-        publish_columns: bool,
     ) -> Option<AvailabilityProcessingStatus> {
         // Only supernodes attempt reconstruction
         if !self
@@ -852,9 +851,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let result = self.chain.reconstruct_data_columns(block_root).await;
         match result {
             Ok(Some((availability_processing_status, data_columns_to_publish))) => {
-                if publish_columns {
-                    self.publish_data_columns_gradually(data_columns_to_publish, block_root);
-                }
+                self.publish_data_columns_gradually(data_columns_to_publish, block_root);
                 match &availability_processing_status {
                     AvailabilityProcessingStatus::Imported(hash) => {
                         debug!(

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -383,7 +383,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             "RPC custody data columns received"
         );
 
-        let mut result = self
+        let result = self
             .chain
             .process_rpc_custody_columns(custody_columns)
             .await;

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -404,17 +404,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         block_hash = %block_root,
                         "Missing components over rpc"
                     );
-                    // Attempt reconstruction here before notifying sync, to avoid sending out more requests
-                    // that we may no longer need.
-                    // We don't publish columns reconstructed from rpc columns to the gossip network,
-                    // as these are likely historic columns.
-                    let publish_columns = false;
-                    if let Some(availability) = self
-                        .attempt_data_column_reconstruction(block_root, publish_columns)
-                        .await
-                    {
-                        result = Ok(availability)
-                    }
                 }
             },
             Err(BlockError::DuplicateFullyImported(_)) => {


### PR DESCRIPTION
Prevent the node from attempting to reconstruct data columns during RPC request processing. Instead allow sync to send out requests to fetch missing columns. Reconstruction is a computationally expensive task, especially at higher blob counts and should be avoided when possible.