### PR TITLE
chore: Bump discv5 and remove generic DefaultProtocolId in metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b4e7798d2ff74e29cee344dc490af947ae657d6ab5273dde35d58ce06a4d71"
+checksum = "8ce2e2da4a384e7309c363a0628aab52f64975c64800ce3d1556979559dd8f24"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,7 +2163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 2.0.100",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2395,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2e2da4a384e7309c363a0628aab52f64975c64800ce3d1556979559dd8f24"
+checksum = "a20b702c8491b3325866a4935d0b5101e49144d74540384243b6293794aad6fa"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -5122,7 +5122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ deposit_contract = { path = "common/deposit_contract" }
 derivative = "2"
 directory = { path = "common/directory" }
 dirs = "3"
-discv5 = { version = "0.9", features = ["libp2p"] }
+discv5 = { version = "0.10", features = ["libp2p"] }
 doppelganger_service = { path = "validator_client/doppelganger_service" }
 either = "1.9"
 environment = { path = "lighthouse/environment" }

--- a/common/network_utils/src/discovery_metrics.rs
+++ b/common/network_utils/src/discovery_metrics.rs
@@ -36,7 +36,7 @@ pub static DISCOVERY_SESSIONS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
 
 pub fn scrape_discovery_metrics() {
     let metrics =
-        discv5::metrics::Metrics::from(discv5::Discv5::<discv5::DefaultProtocolId>::raw_metrics());
+        discv5::metrics::Metrics::from(discv5::Discv5::raw_metrics());
     set_float_gauge(&DISCOVERY_REQS, metrics.unsolicited_requests_per_second);
     set_gauge(&DISCOVERY_SESSIONS, metrics.active_sessions as i64);
     set_gauge_vec(&DISCOVERY_BYTES, &["inbound"], metrics.bytes_recv as i64);

--- a/common/network_utils/src/discovery_metrics.rs
+++ b/common/network_utils/src/discovery_metrics.rs
@@ -35,8 +35,7 @@ pub static DISCOVERY_SESSIONS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
 });
 
 pub fn scrape_discovery_metrics() {
-    let metrics =
-        discv5::metrics::Metrics::from(discv5::Discv5::raw_metrics());
+    let metrics = discv5::metrics::Metrics::from(discv5::Discv5::raw_metrics());
     set_float_gauge(&DISCOVERY_REQS, metrics.unsolicited_requests_per_second);
     set_gauge(&DISCOVERY_SESSIONS, metrics.active_sessions as i64);
     set_gauge_vec(&DISCOVERY_BYTES, &["inbound"], metrics.bytes_recv as i64);


### PR DESCRIPTION
## Proposed Changes

Bump discv5 version 

## Additional Info

[discv5 release v0.10.0](https://github.com/sigp/discv5/releases/tag/v0.10.0)
[discv5 release v0.10.1](https://github.com/sigp/discv5/releases/tag/v0.10.1)
