### PR TITLE
Rename `--subscribe-all-data-column-subnets` to `--supernode` and make it visible in help

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -54,8 +54,9 @@ pub fn cli_app() -> Command {
                 .help_heading(FLAG_HEADER)
                 .help("Run as a voluntary supernode. This node will subscribe to all data column \
                           subnets, custody all data columns, and perform reconstruction and cross-seeding. \
-                          Significantly increases bandwidth, storage, and computation requirements but \
-                          helps network resilience by ensuring data availability.")
+                          This requires significantly more bandwidth, storage, and computation requirements but \
+                          the node will have direct access to all blobs via the beacon API and it \
+                          helps network resilience by serving all data columns to syncing peers.")
                 .display_order(0)
         )
         .arg(

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -47,16 +47,16 @@ pub fn cli_app() -> Command {
          * Network parameters.
          */
         .arg(
-            Arg::new("subscribe-all-data-column-subnets")
-                .long("subscribe-all-data-column-subnets")
+            Arg::new("supernode")
+                .long("supernode")
+                .alias("subscribe-all-data-column-subnets")
                 .action(ArgAction::SetTrue)
                 .help_heading(FLAG_HEADER)
-                .help("Subscribe to all data column subnets and participate in data custody for \
-                        all columns. This will also advertise the beacon node as being long-lived \
-                        subscribed to all data column subnets. \
-                        NOTE: this is an experimental flag and may change any time without notice!")
+                .help("Run as a voluntary supernode. This node will subscribe to all data column \
+                          subnets, custody all data columns, and perform reconstruction and cross-seeding. \
+                          Significantly increases bandwidth, storage, and computation requirements but \
+                          helps network resilience by ensuring data availability.")
                 .display_order(0)
-                .hide(true)
         )
         .arg(
             // TODO(das): remove this before PeerDAS release

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1154,7 +1154,7 @@ pub fn set_network_config(
         config.network_dir = data_dir.join(DEFAULT_NETWORK_DIR);
     };
 
-    if parse_flag(cli_args, "subscribe-all-data-column-subnets") {
+    if parse_flag(cli_args, "supernode") {
         config.subscribe_all_data_column_subnets = true;
     }
 

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -574,9 +574,10 @@ Flags:
       --supernode
           Run as a voluntary supernode. This node will subscribe to all data
           column subnets, custody all data columns, and perform reconstruction
-          and cross-seeding. Significantly increases bandwidth, storage, and
-          computation requirements but helps network resilience by ensuring data
-          availability.
+          and cross-seeding. This requires significantly more bandwidth,
+          storage, and computation requirements but the node will have direct
+          access to all blobs via the beacon API and it helps network resilience
+          by custodying and serving data columns to peers.
       --validator-monitor-auto
           Enables the automatic detection and monitoring of validators connected
           to the HTTP API and using the subnet subscription endpoint. This

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -577,7 +577,7 @@ Flags:
           and cross-seeding. This requires significantly more bandwidth,
           storage, and computation requirements but the node will have direct
           access to all blobs via the beacon API and it helps network resilience
-          by custodying and serving data columns to peers.
+          by serving all data columns to syncing peers.
       --validator-monitor-auto
           Enables the automatic detection and monitoring of validators connected
           to the HTTP API and using the subnet subscription endpoint. This

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -571,6 +571,12 @@ Flags:
           Subscribe to all subnets regardless of validator count. This will also
           advertise the beacon node as being long-lived subscribed to all
           subnets.
+      --supernode
+          Run as a voluntary supernode. This node will subscribe to all data
+          column subnets, custody all data columns, and perform reconstruction
+          and cross-seeding. Significantly increases bandwidth, storage, and
+          computation requirements but helps network resilience by ensuring data
+          availability.
       --validator-monitor-auto
           Enables the automatic detection and monitoring of validators connected
           to the HTTP API and using the subnet subscription endpoint. This

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -797,6 +797,13 @@ fn network_target_peers_flag() {
 #[test]
 fn network_subscribe_all_data_column_subnets_flag() {
     CommandLineTest::new()
+        .flag("subscribe-all-data-column-subnets", None)
+        .run_with_zero_port()
+        .with_config(|config| assert!(config.network.subscribe_all_data_column_subnets));
+}
+#[test]
+fn network_supernode_flag() {
+    CommandLineTest::new()
         .flag("supernode", None)
         .run_with_zero_port()
         .with_config(|config| assert!(config.network.subscribe_all_data_column_subnets));

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -797,9 +797,15 @@ fn network_target_peers_flag() {
 #[test]
 fn network_subscribe_all_data_column_subnets_flag() {
     CommandLineTest::new()
-        .flag("subscribe-all-data-column-subnets", None)
+        .flag("supernode", None)
         .run_with_zero_port()
         .with_config(|config| assert!(config.network.subscribe_all_data_column_subnets));
+}
+#[test]
+fn network_subscribe_all_data_column_subnets_default() {
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| assert!(!config.network.subscribe_all_data_column_subnets));
 }
 #[test]
 fn blob_publication_batches() {


### PR DESCRIPTION
## Issue Addressed

Rename `--subscribe-all-data-column-subnets` to `--supernode` as it's now been officially accepted in the spec. Also make it visible in help in preparation for the fusaka release.

https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/p2p-interface.md#supernodes