### PR TITLE
Refine HTTP status logs

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -294,10 +294,7 @@ pub fn tracing_logging() -> warp::filters::log::Log<impl Fn(warp::filters::log::
         let path = info.path();
         let method = info.method().to_string();
 
-        if status == StatusCode::OK
-            || status == StatusCode::NOT_FOUND
-            || status == StatusCode::PARTIAL_CONTENT
-        {
+        if status.is_success() {
             debug!(
                 elapsed_ms = %elapsed,
                 status = %status,


### PR DESCRIPTION
## Proposed Changes

Ensure that we don't log a warning for HTTP 202s, which are expected on the blinded block endpoints after Fulu.
