### PR TITLE
Reduce `TARGET_BACKFILL_SLOTS` in checkpoint sync test

### DIFF
--- a/scripts/tests/checkpoint-sync-config-devnet.yaml
+++ b/scripts/tests/checkpoint-sync-config-devnet.yaml
@@ -4,11 +4,15 @@ participants:
     cl_image: lighthouse:local
     el_type: geth
     el_image: ethpandaops/geth:master
+    cl_extra_params:
+      - --disable-backfill-rate-limiting
     supernode: true
   - cl_type: lighthouse
     cl_image: lighthouse:local
     el_type: geth
     el_image: ethpandaops/geth:master
+    cl_extra_params:
+      - --disable-backfill-rate-limiting
     supernode: false
 
 checkpoint_sync_enabled: true

--- a/scripts/tests/checkpoint-sync.sh
+++ b/scripts/tests/checkpoint-sync.sh
@@ -15,7 +15,7 @@ CONFIG=${2:-$SCRIPT_DIR/checkpoint-sync-config-sepolia.yaml}
 # Interval for polling the /lighthouse/syncing endpoint for sync status
 POLL_INTERVAL_SECS=5
 # Target number of slots to backfill to complete this test.
-TARGET_BACKFILL_SLOTS=1024
+TARGET_BACKFILL_SLOTS=256
 # Timeout for this test, if the node(s) fail to backfill `TARGET_BACKFILL_SLOTS` slots, fail the test.
 TIMEOUT_MINS=10
 TIMEOUT_SECS=$((TIMEOUT_MINS * 60))


### PR DESCRIPTION
Our devnet checkpoint sync test is having a hard time finishing in under 10 minutes, I believe because of the higher blob counts on devnet3 (20-ish blobs). I tried disabling backfill rate limiting, but the test was still timing out. This PR reduces `TARGET_BACKFILL_SLOTS` from 1024 to 256 and disables backfill rate limiting so that the test doesn't time out.