### PR TITLE
Remove Server header from HTTP API responses to reduce information disclosure

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -4910,8 +4910,7 @@ pub fn serve<T: BeaconChainTypes>(
         .recover(warp_utils::reject::handle_rejection)
         .with(tracing_logging())
         .with(prometheus_metrics())
-        // Add a `Server` header.
-        .map(|reply| warp::reply::with_header(reply, "Server", &version_with_platform()))
+        // Intentionally omit `Server` header to avoid version/platform disclosure.
         .with(cors_builder.build())
         .boxed();
 


### PR DESCRIPTION


**Description**
### Summary
Removes the `Server` header from `beacon_node` HTTP API responses to avoid exposing version/platform details.

### Rationale
- Minimizes fingerprinting and targeted attacks
- Follows least-information best practice for public APIs

### Changes
- `beacon_node/http_api/src/lib.rs`: drop `Server` header; add a brief comment

