### PR TITLE
Fix bug in fork calculation at fork boundaries

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_proposer_cache.rs
+++ b/beacon_node/beacon_chain/src/beacon_proposer_cache.rs
@@ -234,12 +234,19 @@ pub fn ensure_state_can_determine_proposers_for_epoch<E: EthSpec>(
     if state.current_epoch() > maximum_epoch {
         Err(BeaconStateError::SlotOutOfBounds.into())
     } else if state.current_epoch() >= minimum_epoch {
-        // Fulu allows us to access shufflings in multiple epochs (thanks to lookahead).
-        // Pre-Fulu we expect `minimum_epoch == maximum_epoch`, and this branch covers that case.
+        if target_epoch > state.current_epoch() {
+            let target_slot = target_epoch.start_slot(E::slots_per_epoch());
+
+            // Advance the state into the same epoch as the block. Use the "partial" method since state
+            // roots are not important for proposer/attester shuffling.
+            partial_state_advance(state, Some(state_root), target_slot, spec)
+                .map_err(BeaconChainError::from)?;
+        }
         Ok(())
     } else {
         // State's current epoch is less than the minimum epoch.
         // Advance the state up to the minimum epoch.
+        tracing::debug!(state_current_epoch=?state.current_epoch(), ?minimum_epoch,fork=?state.fork(),"No We are here");
         partial_state_advance(state, Some(state_root), minimum_slot, spec)
             .map_err(BeaconChainError::from)
     }

--- a/beacon_node/beacon_chain/src/beacon_proposer_cache.rs
+++ b/beacon_node/beacon_chain/src/beacon_proposer_cache.rs
@@ -246,7 +246,6 @@ pub fn ensure_state_can_determine_proposers_for_epoch<E: EthSpec>(
     } else {
         // State's current epoch is less than the minimum epoch.
         // Advance the state up to the minimum epoch.
-        tracing::debug!(state_current_epoch=?state.current_epoch(), ?minimum_epoch,fork=?state.fork(),"No We are here");
         partial_state_advance(state, Some(state_root), minimum_slot, spec)
             .map_err(BeaconChainError::from)
     }


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

In #8101 , when we modified the logic to get the proposer index post fulu, we seem to have missed advancing the state at the fork boundaries to get the right `Fork` for signature verification. 
This led to lighthouse failing all gossip verification right after transitioning to fulu that was observed on the holesky shadow fork
```
Sep 26 14:24:00.088 DEBUG Rejected gossip block                         error: "InvalidSignature(ProposerSignature)", graffiti: "grandine-geth-super-1", slot: 640 
Sep 26 14:24:00.099 WARN  Could not verify block for gossip. Rejecting the block  error: InvalidSignature(ProposerSignature)
```

I'm not completely sure this is the correct fix, but this fixes the issue with `InvalidProposerSignature` on the holesky shadow fork.

Thanks to @eserilev for helping debug this 