### PR TITLE
Remove deprecated flag --disable-deposit-contract-sync from doc

### DIFF
--- a/book/src/run_a_node.md
+++ b/book/src/run_a_node.md
@@ -78,11 +78,8 @@ lighthouse bn \
   --network mainnet \
   --execution-endpoint http://localhost:8551 \
   --execution-jwt /secrets/jwt.hex \
-  --checkpoint-sync-url https://mainnet.checkpoint.sigp.io \
-  --disable-deposit-contract-sync
+  --checkpoint-sync-url https://mainnet.checkpoint.sigp.io
 ```
-
-Since we are not staking, we can use the `--disable-deposit-contract-sync` flag to disable syncing of deposit logs from the execution node.
 
 Once Lighthouse runs, we can monitor the logs to see if it is syncing correctly.
 


### PR DESCRIPTION
Flag --disable-deposit-contract-sync can be removed from documentation since in the release 7.1.0 it was deprecated.