### PR TITLE
Release v8.0.0 rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "7.1.0"
+version = "8.0.0-rc.0"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "7.1.0"
+version = "8.0.0-rc.0"
 dependencies = [
  "beacon_node",
  "bytes",
@@ -5051,7 +5051,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "7.1.0"
+version = "8.0.0-rc.0"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "7.1.0"
+version = "8.0.0-rc.0"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "7.1.0"
+version = "8.0.0-rc.0"
 authors = [
     "Paul Hauner <paul@paulhauner.com>",
     "Age Manning <Age@AgeManning.com",

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "7.1.0"
+version = "8.0.0-rc.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v7.1.0-",
-    fallback = "Lighthouse/v7.1.0"
+    prefix = "Lighthouse/v8.0.0-rc.0-",
+    fallback = "Lighthouse/v8.0.0-rc.0"
 );
 
 /// Returns the first eight characters of the latest commit hash for this build.
@@ -54,7 +54,7 @@ pub fn version_with_platform() -> String {
 ///
 /// `1.5.1`
 pub fn version() -> &'static str {
-    "7.1.0"
+    "8.0.0-rc.0"
 }
 
 /// Returns the name of the current client running.

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "7.1.0"
+version = "8.0.0-rc.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = { workspace = true }
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "7.1.0"
+version = "8.0.0-rc.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 autotests = false


### PR DESCRIPTION
## Issue Addressed

Testnet release for the upcoming Fusaka fork.

##  Release tasks

- [ ] Update schema versions (v27) in Lighthouse book

## Changes

```
 #   Commit SHA    PR Number    Has backwards-incompat Label    PR Title
---  ------------  -----------  ------------------------------  --------------------------------------------
1    01ec2ec7ad87  7706         False                           Update LH book for v7.1.0 (#7706)
2    3e6b0bd0a36d  7708         False                           Make `notifier_service::notify` pub (#7708)
3    b9c1a2b0c099  7716         False                           Fix description of DB read bytes metric (#7716)
4    734ad90dd879  7271         False                           Upgrade to c-kzg 2.1.0 and alloy-primitives 1.0 (#7271)
5    538067f1ff98  -            -                               [NO PR MATCH]: Merge remote-tracking branch 'origin/stable' into unstable
6    3826fe91f4e0  7717         False                           Improve data column KZG verification metric buckets (#7717)
7    b43e0b446cd1  7655         False                           Final changes for `fusaka-devnet-2` (#7655)
8    90ff64381e89  7733         False                           Sync peer attribution (#7733)
9    6409a32274ea  7679         False                           Add a guide to partially reconstruct historic states to Lighthouse book (#7679)
10   309c30136374  7729         False                           Allow /validator apis to work pre-genesis (#7729)
11   d6de8a748477  7325         False                           Add additional broadcast validation tests for Fulu/PeerDAS  (#7325)
12   3f06e5dfbac1  7754         False                           Fix enr loading from disk with cgc (#7754)
13   1046dfbfe79f  7753         False                           Serialize bpo schedule in asending order (#7753)
14   4a3e248b7e63  7764         False                           Add heaptrack support (#7764)
15   b48879a56620  7713         False                           Remove KZG verification from local block production and blobs fetched from the EL (#7713)
16   db8b6be9df17  7648         True                            Data column custody info (#7648)
17   e6089fe7db78  7239         False                           Control span data through tracing Extensions (#7239)
18   ce99e0c383f2  7705         False                           Refine delayed head block logging (#7705)
19   c4b973f5bafc  7727         False                           Use SSZ by default when calling /eth/v3/validator/blocks (#7727)
20   4daa01597155  7768         False                           Remove peer sampling code (#7768)
21   9911f348bc17  7743         True                            Feature gate arbitrary crate in the consensus types crate (#7743)
22   b9049560748a  7779         False                           Skip serializing blob_schedule before Fulu (#7779)
23   1a6eeb228cf5  7787         True                            Bump Rust version to 1.88 (#7787)
24   6a52454647eb  7786         False                           Update spec tests to 1.6.0-alpha.3 (#7786)
25   2aae08a8aa98  7771         False                           Remove KZG verification on blobs fetched from the EL (#7771)
26   09065a851fb3  7778         False                           Add builder blinded_blocks v2 (#7778)
27   134039d0146b  7777         True                            Simplify ConfigAndPreset (#7777)
28   2f59d5208a1f  7819         False                           Filter dependencies from SSE logging (#7819)
29   adf6ad70f0d5  7823         False                           Update fetch blobs metrics buckets (#7823)
30   0dcce40ccb1a  7826         False                           Fix Clippy for Rust 1.90 beta (#7826)
31   c06ac81c671a  7725         False                           Shuffling for 32 bit platforms (#7725)
32   9c972201bcce  7734         False                           Fix: RPC test failures (#7734)
33   8bc6693dacfd  7792         False                           Fix wrong columns getting processed on a CGC change (#7792)
34   3a02bdd94a29  7825         False                           Adjust DA checker cache size (#7825)
35   cafb3644e2c6  7834         False                           Fix Makefile line continuation syntax in test-release target (#7834)
36   6dfab2226783  7844         False                           Fix Rust 1.89 compiler warnings in slasher tests. (#7844)
37   40c2fd5ff421  7816         False                           Instrument tracing spans for block processing and import (#7816)
38   4262ad3e0148  7853         False                           Add a flag to disable getBlobs (#7853)
39   122f16776fab  7808         False                           Add metrics to track beacon processor queue times (#7808)
40   80ba0b169bb0  7762         False                           Backfill peer attribution (#7762)
41   918121e31341  7849         False                           Fix bugs in rebasing of states prior to finalization (#7849)
42   152f2bb2e46c  7852         False                           Re-export `context_deserialize_derive` inside `context_deserialize` (#7852)
43   4ef4bdc38b90  7848         False                           Initial Claude.md draft (#7848)
44   6604fd10b4f8  7862         True                            Deprecate macOS-x86 binaries (#7862)
45   bd6b8b6a652e  7867         False                           Disable sccache to fix Windows builds (#7867)
46   522bd9e9c6ac  7766         True                            Update Rust Edition to 2024 (#7766)
47   ee1b0ae2ffad  7391         False                           Allow for sync state where batch is unknown (#7391)
48   5ebb44e22275  7873         False                           Try using sccache instead of disabling (#7873)
49   42f6d7b02d90  7872         False                           Yeet env_logger into the sun (#7872)
50   90fa7c216e11  7806         False                           Fix ssz formatting for `/light_client/updates` beacon API endpoint (#7806)
51   317dc0f56cab  7770         True                            Fix malloc_utils features (sysmalloc) (#7770)
52   92000429108e  7665         True                            Transition network key to hex format (#7665)
53   aa8cba3741fa  7870         False                           Upgrade rust-eth-kzg to `0.8.0` (#7870)
54   08234b2823e8  7888         False                           Add rustfmt config with edition 2024 (#7888)
55   836c39efaaee  7805         True                            Shrink persisted fork choice data (#7805)
56   1fd7ead0109d  7884         False                           Do not filter validators by status if filter is an empty list (#7884)
57   34dd1b27aeb4  7887         False                           Revise data column rpc limits and queue sizes (#7887)
58   95882bfa6637  7903         False                           Add `--telemetry-service-name` CLI flag for OpenTelemetry service name override (#7903)
59   b4704eab4ac8  7890         False                           Fulu update to spec v1.6.0-alpha.4 (#7890)
60   f6859b1137de  7898         False                           Add tempo to local testnet config and update fulu kurtosis config files (#7898)
61   2d223575d614  7897         False                           Avoid unnecessary database lookups in data column RPC requests (#7897)
62   f19d4f6af124  7831         False                           Implement tracing spans for data columm RPC requests and responses (#7831)
63   c9ffdf7f712f  7877         False                           Re-assess Lighthouse's peer count for Fusaka (#7877)
64   cee30d8ca50d  7828         False                           Update lighthouse to the latest upstream libp2p and gossipsub (#7828)
65   d24a6d2a45f2  7912         False                           Prioritise `StatusV2` over `StatusV1` RPC protocol (#7912)
66   884f30094a16  7916         False                           use DEFAULT_TARGET_PEERS for target peers everywhere (#7916)
67   c41d1181d2c3  7909         False                           Use Fork variants instead of version for JsonPayload types (#7909)
68   747d9118ff4c  7928         False                           Fix `DataColumnsByRoot` request limit validation bug (#7928)
69   daf1c7c3af8e  7927         False                           Fix RPC blocks not getting fully KZG verified (#7927)
70   e438691683e6  7728         False                           Add Gloas boilerplate (#7728)
71   78b4cca46bac  7929         False                           Run sync tests on CI by default. (#7929)
72   3e78034de6cc  7935         True                            Add `BEACON_PROCESSOR_WORKERS_ACTIVE_GAUGE_BY_TYPE` metric (#7935)
73   8901c7417d4c  7940         False                           Notify lookup after gossip data column processing resulted in an import (#7940)
74   2b33fe662039  7910         False                           Update to spec v1.6.0-alpha.5 (#7910)
75   ccf03e1c8809  7942         False                           Fix data columns by range returning all columns (#7942)
76   d235f2c69708  7930         False                           Delete `RuntimeVariableList::from_vec` (#7930)
77   746da7ffd5c2  7959         False                           Fix doppelganger protection script (#7959)
78   c13fb2fb46e5  7945         False                           Instrument `publish_block` code path  (#7945)
79   b6792d85d208  7958         False                           Reduce backfill batch buffer size (#7958)
80   a134d43446f7  7921         False                           Use `rayon` to speed up batch KZG verification (#7921)
81   438fb65d4500  7962         False                           Avoid serving validator endpoints while the node is far behind syncing head (#7962)
82   66edda2690f4  7954         False                           Impl ForkVersionDecode for beacon state (#7954)
83   477c534cd7e1  7964         False                           Remove dependency on target_info. (#7964)
84   c7492f1c27d2  7967         False                           Update to `1.6.0 alpha.6` spec (#7967)
85   9cc3c0553bb0  7902         False                           chore: small refactor of `epoch` method (#7902)
86   979ed2557cd8  7957         False                           Remove `expect` usage in `kzg_utils`  (#7957)
87   eef02afc9326  7961         False                           Fix data availability checker race condition causing partial data columns to be served over RPC (#7961)
88   a9db8523a2d6  7981         False                           Update tracing (#7981)
89   7b5be8b1e74c  7925         False                           Remove ttfb_timeout and resp_timeout (#7925)
90   a93cafee08a1  7016         False                           Implement `selections` Beacon API endpoints to support DVT middleware (#7016)
91   10e72df3318c  7987         False                           Add `tls-roots` feature to `opentelemetry_otlp` to support exporting traces over https (#7987)
92   76adedff2788  7989         False                           Simplify length methods on BeaconBlockBody (#7989)
93   c2a92f1a8ced  7915         False                           Maintain peers across all data column subnets (#7915)
94   84ec209eba63  7984         False                           Allow AwaitingDownload to be a valid in-between state (#7984)
95   677de70025b7  7999         False                           Fix incorrect prune test logic (#7999)
96   9d2f55a39984  7998         False                           Fix data column reconstruction error (#7998)
97   fd10b632740e  7993         False                           Add co-author to mergify commits (#7993)
98   8ec2640e04db  7996         False                           Don't penalize peers if locally constructed light client data is stale (#7996)
99   ee734d145665  8005         False                           Fix stuck data column lookups by improving peer selection and retry logic (#8005)
100  2b22903fbaa1  8009         False                           fix: extra fields in logs (#8009)
101  8a4f6cf0d5b6  8017         False                           Instrument tracing on block production code path (#8017)
102  811eccdf3434  8007         False                           Reduce noise in `Debug` impl of `RuntimeVariableList` (#8007)
103  38205192caaf  7943         False                           Fix http api tests ci (#7943)
104  caa1df6fc381  7973         False                           Skip column gossip verification logic during block production (#7973)
105  ee1b6bc81bb4  7761         False                           Create `network_utils` crate (#7761)
106  f71d69755d39  7979         False                           chore: add comment to PendingComponents (#7979)
107  2ecbb7f90bcf  7874         False                           Remove cargo test targets, use nextest exclusively (#7874)
108  02d519e95706  8026         False                           Fixed orphaned `verify_cell_proof_chunk` span. (#8026)
109  a080bb5ceede  8031         False                           Increase HTTP timeouts on CI (#8031)
110  58156815f12d  7783         False                           Expose functions to do preliminary slashing checks (#7783)
111  87ae301d0942  7997         False                           Remove unused logging metrics (#7997)
112  fb77ce9e192e  8033         False                           Add missing event in `PendingComponent` span and clean up sync logs (#8033)
113  aef8291f94fb  7976         False                           Add max delay to reconstruction (#7976)
114  b8178515cd1b  8038         False                           Update engine methods in notifier (#8038)
115  f04d5ecddd97  8050         False                           Another check to prevent duplicate block imports (#8050)
116  4409500f6300  8051         False                           Remove column reconstruction when processing rpc requests (#8051)
117  aba362709990  8053         False                           Reduce reconstruction queue capacity (#8053)
118  242bdfcf1229  8049         False                           Add instrumentation to `recompute_head_at_slot` (#8049)
119  3de646c8b32b  8052         False                           Enable reconstruction for nodes custodying more than 50% of columns and instrument tracing (#8052)
120  191570e4a162  8056         False                           chore: Bump discv5 and remove generic DefaultProtocolId in metrics (#8056)
121  b7d78a91e03d  8042         False                           Don't penalize peers for extending ignored chains (#8042)
122  5928407ce45b  8058         False                           fix(rate_limiter): add missing prune calls for light client protocols (#8058)
123  3cb7e59be2eb  7938         False                           Update issue template (#7938)
124  521be2b7576e  8023         False                           Prevent silently dropping cell proof chunks (#8023)
125  684632df731a  8065         False                           Fix reprocess queue memory leak (#8065)
126  3543a20192bb  7751         False                           Add experimental complete-blob-backfill flag (#7751)
127  92f60b8fd2a9  7737         False                           Add release helper script to list PRs and breaking changes (#7737)
128  51321daabb5f  8066         True                            Make the block cache optional (#8066)
129  4111bcb39bb8  7924         False                           Use scoped rayon pool for backfill chain segment processing (#7924)
130  78d330e4b7e2  8045         False                           Consolidate `reqresp_pre_import_cache`  into `data_availability_checker` (#8045)
131  4efe47b3c3cc  8083         False                           Rename `--subscribe-all-data-column-subnets` to `--supernode` and make it visible in help (#8083)
132  366fb0ee0dc3  8082         False                           Always upload sim test logs (#8082)
133  c1fb060ae123  -            -                               [NO PR MATCH]: Merge remote-tracking branch 'origin/stable' into unstable
134  1dbc4f861b3f  8098         False                           Refine HTTP status logs (#8098)
135  7a7fe9663cb6  8102         False                           Reduce `TARGET_BACKFILL_SLOTS` in checkpoint sync test (#8102)
136  d80c0ff5b57c  8094         False                           Use HTTPS for xdelta3 in Cargo.toml (#8094)
137  af274029e8c6  8075         False                           Run reconstruction inside a scoped rayon pool (#8075)
138  79b33214ea8e  8109         False                           Only send data coumn subnet discovery requests after peerdas is scheduled (#8109)
139  ffa7b2b2b9e3  8112         False                           Only mark block lookups as pending if block is importing from gossip (#8112)
140  20c6ce455300  8117         False                           Fulu testnet configs (#8117)
141  c754234b2c94  8101         False                           Fix bugs in proposer calculation post-Fulu (#8101)
142  edcfee636cd7  8121         False                           Fix bug in fork calculation at fork boundaries (#8121)
143  38fdaf791ce7  8128         False                           Fix proposer shuffling decision slot at boundary (#8128)
```