### PR TITLE
Fix proposer shuffling decision slot at boundary

### DIFF
--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -172,7 +172,13 @@ impl Block {
     ) -> Hash256 {
         let block_epoch = self.current_epoch_shuffling_id.shuffling_epoch;
 
-        if !spec.fork_name_at_epoch(child_block_epoch).fulu_enabled() {
+        // For child blocks in the Fulu fork epoch itself, we want to use the old logic. There is no
+        // lookahead in the first Fulu epoch. So we check whether Fulu is enabled at
+        // `child_block_epoch - 1`, i.e. whether `child_block_epoch > fulu_fork_epoch`.
+        if !spec
+            .fork_name_at_epoch(child_block_epoch.saturating_sub(1_u64))
+            .fulu_enabled()
+        {
             // Prior to Fulu the proposer shuffling decision root for the current epoch is the same
             // as the attestation shuffling for the *next* epoch, i.e. it is determined at the start
             // of the current epoch.


### PR DESCRIPTION
## Issue Addressed

Follow-up to the bug fixed in:

- https://github.com/sigp/lighthouse/pull/8121

This fixes the root cause of that bug, which was introduced by me in:

- https://github.com/sigp/lighthouse/pull/8101

Jimmy and Lion both identified the issue here:

- https://github.com/sigp/lighthouse/pull/8101#discussion_r2382258842
- https://github.com/sigp/lighthouse/pull/8101#discussion_r2382710356

## Proposed Changes

In the methods that compute the proposer shuffling decision root, ensure we don't use lookahead for the Fulu fork epoch itself. This is accomplished by checking if Fulu is enabled at `epoch - 1`, i.e. if `epoch > fulu_fork_epoch`.

I haven't updated the methods that _compute_ shufflings to use these new corrected bounds (e.g. `BeaconState::compute_proposer_indices`), although we could make this change in future. The `get_beacon_proposer_indices` method already gracefully handles the Fulu boundary case by using the `proposer_lookahead` field (if initialised).

## Additional Info

- [x] Unit test added for `proposer_shuffling_decision_slot` at the boundary
- [x] Updated the consistency tests to check cases around the fork boundary
