### PR TITLE
Remove deprecated CLI flags and references for v8.0.0

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -699,13 +699,6 @@ pub fn cli_app() -> Command {
                 .help_heading(FLAG_HEADER)
                 .display_order(0)
         )
-
-        /*
-         * Eth1 Integration
-         */
-
-
-
         .arg(
             Arg::new("slots-per-restore-point")
                 .long("slots-per-restore-point")

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -703,34 +703,9 @@ pub fn cli_app() -> Command {
         /*
          * Eth1 Integration
          */
-        .arg(
-            Arg::new("eth1-purge-cache")
-                .long("eth1-purge-cache")
-                .value_name("PURGE-CACHE")
-                .help("DEPRECATED")
-                .action(ArgAction::SetTrue)
-                .help_heading(FLAG_HEADER)
-                .display_order(0)
-                .hide(true)
-        )
-        .arg(
-            Arg::new("eth1-blocks-per-log-query")
-                .long("eth1-blocks-per-log-query")
-                .value_name("BLOCKS")
-                .help("DEPRECATED")
-                .action(ArgAction::Set)
-                .display_order(0)
-                .hide(true)
-        )
-        .arg(
-            Arg::new("eth1-cache-follow-distance")
-                .long("eth1-cache-follow-distance")
-                .value_name("BLOCKS")
-                .help("DEPRECATED")
-                .action(ArgAction::Set)
-                .display_order(0)
-                .hide(true)
-        )
+
+
+
         .arg(
             Arg::new("slots-per-restore-point")
                 .long("slots-per-restore-point")
@@ -1498,16 +1473,7 @@ pub fn cli_app() -> Command {
                 .help_heading(FLAG_HEADER)
                 .display_order(0)
         )
-        .arg(
-            Arg::new("disable-deposit-contract-sync")
-                .long("disable-deposit-contract-sync")
-                .help("DEPRECATED")
-                .action(ArgAction::SetTrue)
-                .help_heading(FLAG_HEADER)
-                .conflicts_with("staking")
-                .display_order(0)
-                .hide(true)
-        )
+
         .arg(
             Arg::new("disable-optimistic-finalized-sync")
                 .long("disable-optimistic-finalized-sync")
@@ -1518,15 +1484,7 @@ pub fn cli_app() -> Command {
                        Lighthouse and only passed to the EL if initial verification fails.")
                 .display_order(0)
         )
-        .arg(
-            Arg::new("light-client-server")
-                .long("light-client-server")
-                .help("DEPRECATED")
-                .action(ArgAction::SetTrue)
 
-                .help_heading(FLAG_HEADER)
-                .display_order(0)
-        )
         .arg(
             Arg::new("disable-light-client-server")
                 .long("disable-light-client-server")

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1466,7 +1466,6 @@ pub fn cli_app() -> Command {
                 .help_heading(FLAG_HEADER)
                 .display_order(0)
         )
-
         .arg(
             Arg::new("disable-optimistic-finalized-sync")
                 .long("disable-optimistic-finalized-sync")
@@ -1477,7 +1476,6 @@ pub fn cli_app() -> Command {
                        Lighthouse and only passed to the EL if initial verification fails.")
                 .display_order(0)
         )
-
         .arg(
             Arg::new("disable-light-client-server")
                 .long("disable-light-client-server")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -170,13 +170,6 @@ pub fn get_config<E: EthSpec>(
             parse_required(cli_args, "http-duplicate-block-status")?;
     }
 
-    if cli_args.get_flag("light-client-server") {
-        warn!(
-            "The --light-client-server flag is deprecated. The light client server is enabled \
-             by default"
-        );
-    }
-
     if cli_args.get_flag("disable-light-client-server") {
         client_config.chain.enable_light_client_server = false;
     }
@@ -260,24 +253,6 @@ pub fn get_config<E: EthSpec>(
     // Do not scrape for malloc metrics if we've disabled tuning malloc as it may cause panics.
     if cli_args.get_flag(DISABLE_MALLOC_TUNING_FLAG) {
         client_config.http_metrics.allocator_metrics_enabled = false;
-    }
-
-    /*
-     * Deprecated Eth1 flags (can be removed in the next minor release after v7.1.0)
-     */
-    if cli_args
-        .get_one::<String>("eth1-blocks-per-log-query")
-        .is_some()
-    {
-        warn!("The eth1-blocks-per-log-query flag is deprecated");
-    }
-
-    if cli_args.get_flag("eth1-purge-cache") {
-        warn!("The eth1-purge-cache flag is deprecated");
-    }
-
-    if clap_utils::parse_optional::<u64>(cli_args, "eth1-cache-follow-distance")?.is_some() {
-        warn!("The eth1-cache-follow-distance flag is deprecated");
     }
 
     // `--execution-endpoint` is required now.
@@ -771,10 +746,6 @@ pub fn get_config<E: EthSpec>(
                 DisallowedReOrgOffsets::new::<E>(disallowed_offsets)
                     .map_err(|e| format!("invalid disallowed-offsets: {e:?}"))?;
         }
-    }
-
-    if cli_args.get_flag("disable-deposit-contract-sync") {
-        warn!("The disable-deposit-contract-sync flag is deprecated");
     }
 
     client_config.chain.prepare_payload_lookahead =

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -513,8 +513,6 @@ Flags:
           subscriptions. This will only import attestations from
           already-subscribed subnets, use with --subscribe-all-subnets to ensure
           all attestations are received for import.
-      --light-client-server
-          DEPRECATED
       --log-color [<log-color>]
           Enables/Disables colors for logs in terminal. Set it to false to
           disable colors. [default: true] [possible values: true, false]

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -376,10 +376,6 @@ fn main() {
                 .global(true)
                 .display_order(0)
         )
-
-
-
-
         .arg(
             Arg::new("genesis-state-url")
                 .long("genesis-state-url")

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -126,7 +126,6 @@ fn main() {
                 .global(true)
                 .display_order(0),
         )
-
         .arg(
             Arg::new("logfile-dir")
                 .long("logfile-dir")

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -28,7 +28,7 @@ use std::path::PathBuf;
 use std::process::exit;
 use std::sync::LazyLock;
 use task_executor::ShutdownReason;
-use tracing::{Level, info, warn};
+use tracing::{Level, info};
 use tracing_subscriber::{Layer, filter::EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 use types::{EthSpec, EthSpecId};
 use validator_client::ProductionValidatorClient;
@@ -126,16 +126,7 @@ fn main() {
                 .global(true)
                 .display_order(0),
         )
-        .arg(
-            Arg::new("logfile")
-                .long("logfile")
-                .value_name("PATH")
-                .help("DEPRECATED")
-                .action(ArgAction::Set)
-                .global(true)
-                .hide(true)
-                .display_order(0)
-        )
+
         .arg(
             Arg::new("logfile-dir")
                 .long("logfile-dir")
@@ -385,48 +376,10 @@ fn main() {
                 .global(true)
                 .display_order(0)
         )
-        .arg(
-            Arg::new("terminal-total-difficulty-override")
-                .long("terminal-total-difficulty-override")
-                .value_name("INTEGER")
-                .help("DEPRECATED")
-                .action(ArgAction::Set)
-                .global(true)
-                .display_order(0)
-                .hide(true)
-        )
-        .arg(
-            Arg::new("terminal-block-hash-override")
-                .long("terminal-block-hash-override")
-                .value_name("TERMINAL_BLOCK_HASH")
-                .help("DEPRECATED")
-                .requires("terminal-block-hash-epoch-override")
-                .action(ArgAction::Set)
-                .global(true)
-                .display_order(0)
-                .hide(true)
-        )
-        .arg(
-            Arg::new("terminal-block-hash-epoch-override")
-                .long("terminal-block-hash-epoch-override")
-                .value_name("EPOCH")
-                .help("DEPRECATED")
-                .requires("terminal-block-hash-override")
-                .action(ArgAction::Set)
-                .global(true)
-                .display_order(0)
-                .hide(true)
-        )
-        .arg(
-            Arg::new("safe-slots-to-import-optimistically")
-                .long("safe-slots-to-import-optimistically")
-                .value_name("INTEGER")
-                .help("DEPRECATED")
-                .action(ArgAction::Set)
-                .global(true)
-                .display_order(0)
-                .hide(true)
-        )
+
+
+
+
         .arg(
             Arg::new("genesis-state-url")
                 .long("genesis-state-url")
@@ -780,31 +733,12 @@ fn run<E: EthSpec>(
     // Allow Prometheus access to the version and commit of the Lighthouse build.
     metrics::expose_lighthouse_version();
 
-    // DEPRECATED: can be removed in v7.2.0/v8.0.0.
-    if clap_utils::parse_optional::<PathBuf>(matches, "logfile")?.is_some() {
-        warn!("The --logfile flag is deprecated and replaced by --logfile-dir");
-    }
-
     #[cfg(all(feature = "modern", target_arch = "x86_64"))]
     if !std::is_x86_feature_detected!("adx") {
         tracing::warn!(
             advice = "If you get a SIGILL, please try Lighthouse portable build",
             "CPU seems incompatible with optimized Lighthouse build"
         );
-    }
-
-    // Warn for DEPRECATED global flags. This code should be removed when we finish deleting these
-    // flags.
-    let deprecated_flags = [
-        "terminal-total-difficulty-override",
-        "terminal-block-hash-override",
-        "terminal-block-hash-epoch-override",
-        "safe-slots-to-import-optimistically",
-    ];
-    for flag in deprecated_flags {
-        if matches.get_one::<String>(flag).is_some() {
-            warn!("The {} flag is deprecated and does nothing", flag);
-        }
     }
 
     // Note: the current code technically allows for starting a beacon node _and_ a validator

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -423,29 +423,6 @@ fn complete_blob_backfill_and_prune_blobs_true() {
         });
 }
 
-// Tests for Eth1 flags.
-// DEPRECATED but should not crash
-#[test]
-fn eth1_blocks_per_log_query_flag() {
-    CommandLineTest::new()
-        .flag("eth1-blocks-per-log-query", Some("500"))
-        .run_with_zero_port();
-}
-// DEPRECATED but should not crash
-#[test]
-fn eth1_purge_cache_flag() {
-    CommandLineTest::new()
-        .flag("eth1-purge-cache", None)
-        .run_with_zero_port();
-}
-// DEPRECATED but should not crash
-#[test]
-fn eth1_cache_follow_distance_manual() {
-    CommandLineTest::new()
-        .flag("eth1-cache-follow-distance", Some("128"))
-        .run_with_zero_port();
-}
-
 // Tests for Bellatrix flags.
 fn run_bellatrix_execution_endpoints_flag_test(flag: &str) {
     use sensitive_url::SensitiveUrl;
@@ -780,31 +757,6 @@ fn jwt_optional_flags() {
 #[test]
 fn jwt_optional_alias_flags() {
     run_jwt_optional_flags_test("jwt-secrets", "jwt-id", "jwt-version");
-}
-// DEPRECATED. This flag is deprecated but should not cause a crash.
-#[test]
-fn terminal_total_difficulty_override_flag() {
-    CommandLineTest::new()
-        .flag("terminal-total-difficulty-override", Some("1337424242"))
-        .run_with_zero_port();
-}
-// DEPRECATED. This flag is deprecated but should not cause a crash.
-#[test]
-fn terminal_block_hash_and_activation_epoch_override_flags() {
-    CommandLineTest::new()
-        .flag("terminal-block-hash-epoch-override", Some("1337"))
-        .flag(
-            "terminal-block-hash-override",
-            Some("0x4242424242424242424242424242424242424242424242424242424242424242"),
-        )
-        .run_with_zero_port();
-}
-// DEPRECATED. This flag is deprecated but should not cause a crash.
-#[test]
-fn safe_slots_to_import_optimistically_flag() {
-    CommandLineTest::new()
-        .flag("safe-slots-to-import-optimistically", Some("421337"))
-        .run_with_zero_port();
 }
 
 // Tests for Network flags.
@@ -2523,42 +2475,6 @@ fn logfile_format_flag() {
             )
         });
 }
-// DEPRECATED but should not crash.
-#[test]
-fn deprecated_logfile() {
-    CommandLineTest::new()
-        .flag("logfile", Some("test.txt"))
-        .run_with_zero_port();
-}
-
-// DEPRECATED but should not crash.
-#[test]
-fn sync_eth1_chain_disable_deposit_contract_sync_flag() {
-    let dir = TempDir::new().expect("Unable to create temporary directory");
-    CommandLineTest::new_with_no_execution_endpoint()
-        .flag("disable-deposit-contract-sync", None)
-        .flag("execution-endpoints", Some("http://localhost:8551/"))
-        .flag(
-            "execution-jwt",
-            dir.path().join("jwt-file").as_os_str().to_str(),
-        )
-        .run_with_zero_port();
-}
-
-#[test]
-#[should_panic]
-fn disable_deposit_contract_sync_conflicts_with_staking() {
-    let dir = TempDir::new().expect("Unable to create temporary directory");
-    CommandLineTest::new_with_no_execution_endpoint()
-        .flag("disable-deposit-contract-sync", None)
-        .flag("staking", None)
-        .flag("execution-endpoints", Some("http://localhost:8551/"))
-        .flag(
-            "execution-jwt",
-            dir.path().join("jwt-file").as_os_str().to_str(),
-        )
-        .run_with_zero_port();
-}
 
 #[test]
 fn light_client_server_default() {
@@ -2573,7 +2489,6 @@ fn light_client_server_default() {
 #[test]
 fn light_client_server_enabled() {
     CommandLineTest::new()
-        .flag("light-client-server", None)
         .run_with_zero_port()
         .with_config(|config| {
             assert!(config.network.enable_light_client_server);


### PR DESCRIPTION
## Issue Addressed

Closes #8131

- [x] Remove deprecated flags from beacon_node/src/cli.rs:
  - [x] eth1-purge-cache
  - [x] eth1-blocks-per-log-query  
  - [x] eth1-cache-follow-distance
  - [x] disable-deposit-contract-sync
  - [x] light-client-server
- [x] Remove deprecated flags from lighthouse/src/main.rs:
  - [x] logfile
  - [x] terminal-total-difficulty-override
  - [x] terminal-block-hash-override
  - [x] terminal-block-hash-epoch-override
  - [x] safe-slots-to-import-optimistically
- [x] Remove references to deprecated flags in config.rs files
- [x] Remove warning messages for deprecated flags in main.rs
- [x] Update/remove related tests in beacon_node.rs
