### PR TITLE
Remove unnecessary warning logs and update logging levels

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -437,12 +437,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     }
                 }
                 Err(e) => {
-                    // TODO(das): lower log level when feature is stabilized
-                    error!(
+                    // The node is expected to be able to serve these columns, but it fails to retrieve them.
+                    warn!(
                         block_root = ?data_column_ids_by_root.block_root,
                         %peer_id,
                         error = ?e,
-                        "Error getting data column"
+                        "Error getting data column for by root request "
                     );
                     return Err((RpcErrorResponse::ServerError, "Error getting data column"));
                 }

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -333,14 +333,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "Blobs have already been imported"
                 );
             }
-            Err(e) => {
-                warn!(
-                    error = ?e,
-                    block_hash = %block_root,
-                    %slot,
-                    "Error when importing rpc blobs"
-                );
-            }
+            // Errors are handled and logged in `block_lookups`
+            Err(_) => {}
         }
 
         // Sync handles these results
@@ -414,13 +408,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "Custody columns have already been imported"
                 );
             }
-            Err(e) => {
-                warn!(
-                    error = ?e,
-                    block_hash = %block_root,
-                    "Error when importing rpc custody columns"
-                );
-            }
+            // Errors are handled and logged in `block_lookups`
+            Err(_) => {}
         }
 
         self.send_sync_message(SyncMessage::BlockComponentProcessed {


### PR DESCRIPTION
## Issue Addressed

@michaelsproul noticed this warning on a devnet-3 node

```
Oct 01 16:37:29.896 WARN  Error when importing rpc custody columns      error: ParentUnknown { parent_root: 0xe4cc85a2137b76eb083d7076255094a90f10caaec0afc8fd36807db742f6ff13 }, block_hash: 0x43ce63b2344990f5f4d8911b8f14e3d3b6b006edc35bbc833360e667df0edef7
```

We're also seeing similar `WARN` logs for blobs on our live nodes.

It's normal to get parent unknown in lookups and it's handled here
https://github.com/sigp/lighthouse/blob/a134d43446f776fe2a84f420854afbff76ca93d8/beacon_node/network/src/sync/block_lookups/mod.rs#L611-L619

These shouldn't be a `WARN`, and we also log the same error in block lookups at `DEBUG` level here:
https://github.com/sigp/lighthouse/blob/a134d43446f776fe2a84f420854afbff76ca93d8/beacon_node/network/src/sync/block_lookups/mod.rs#L643-L648 

So i've removed these extra WARN logs.

I've also lower the level of an `ERROR` log when unable to serve data column root requests - it's unexpected, but is unlikely to impact the nodes performance, so I think we can downgrade this.
