### PR TITLE
Block proposal optimisations

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5233,16 +5233,20 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             None
         };
 
+        let slashings_and_exits_span = debug_span!("get_slashings_and_exits").entered();
         let (mut proposer_slashings, mut attester_slashings, mut voluntary_exits) =
             self.op_pool.get_slashings_and_exits(&state, &self.spec);
+        drop(slashings_and_exits_span);
 
         let eth1_data = state.eth1_data().clone();
 
         let deposits = vec![];
 
+        let bls_changes_span = debug_span!("get_bls_to_execution_changes").entered();
         let bls_to_execution_changes = self
             .op_pool
             .get_bls_to_execution_changes(&state, &self.spec);
+        drop(bls_changes_span);
 
         // Iterate through the naive aggregation pool and ensure all the attestations from there
         // are included in the operation pool.

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -937,13 +937,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .execution_status
             .is_optimistic_or_invalid();
 
-        self.op_pool.prune_all(
-            &new_snapshot.beacon_block,
-            &new_snapshot.beacon_state,
-            self.epoch()?,
-            &self.spec,
-        );
-
         self.observed_block_producers.write().prune(
             new_view
                 .finalized_checkpoint
@@ -982,9 +975,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }));
         }
 
-        // The store migration task requires the *state at the slot of the finalized epoch*,
-        // rather than the state of the latest finalized block. These two values will only
-        // differ when the first slot of the finalized epoch is a skip slot.
+        // The store migration task and op pool pruning require the *state at the slot of the
+        // finalized epoch*, rather than the state of the latest finalized block. These two values
+        // will only differ when the first slot of the finalized epoch is a skip slot.
         //
         // Use the `StateRootsIterator` directly rather than `BeaconChain::state_root_at_slot`
         // to ensure we use the same state that we just set as the head.
@@ -1006,6 +999,23 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         )?
         .ok_or(Error::MissingFinalizedStateRoot(new_finalized_slot))?;
 
+        let update_cache = true;
+        let new_finalized_state = self
+            .store
+            .get_hot_state(&new_finalized_state_root, update_cache)?
+            .ok_or(Error::MissingBeaconState(new_finalized_state_root))?;
+
+        self.op_pool.prune_all(
+            &new_snapshot.beacon_block,
+            &new_snapshot.beacon_state,
+            &new_finalized_state,
+            self.epoch()?,
+            &self.spec,
+        );
+
+        // We just pass the state root to the finalization thread. It should be able to reload the
+        // state from the state_cache near instantly anyway. We could experiment with sending the
+        // state over a channel in future, but it's probably no quicker.
         self.store_migrator.process_finalization(
             new_finalized_state_root.into(),
             new_view.finalized_checkpoint,

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -975,7 +975,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }));
         }
 
-        // The store migration task and op pool pruning require the *state at the slot of the
+        // The store migration task and op pool pruning require the *state at the first slot of the
         // finalized epoch*, rather than the state of the latest finalized block. These two values
         // will only differ when the first slot of the finalized epoch is a skip slot.
         //

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -49,17 +49,7 @@ enum Error {
     HeadMissingFromSnapshotCache(#[allow(dead_code)] Hash256),
     BeaconState(#[allow(dead_code)] BeaconStateError),
     Store(#[allow(dead_code)] store::Error),
-    MaxDistanceExceeded {
-        current_slot: Slot,
-        head_slot: Slot,
-    },
-    StateAlreadyAdvanced {
-        block_root: Hash256,
-    },
-    BadStateSlot {
-        _state_slot: Slot,
-        _block_slot: Slot,
-    },
+    MaxDistanceExceeded { current_slot: Slot, head_slot: Slot },
 }
 
 impl From<BeaconChainError> for Error {
@@ -180,9 +170,6 @@ async fn state_advance_timer<T: BeaconChainTypes>(
                             error = ?e,
                             "Failed to advance head state"
                         ),
-                        Err(Error::StateAlreadyAdvanced { block_root }) => {
-                            debug!(?block_root, "State already advanced on slot")
-                        }
                         Err(Error::MaxDistanceExceeded {
                             current_slot,
                             head_slot,

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -33,7 +33,7 @@ use types::{AttestationShufflingId, BeaconStateError, EthSpec, Hash256, Relative
 ///
 /// This avoids doing unnecessary work whilst the node is syncing or has perhaps been put to sleep
 /// for some period of time.
-const MAX_ADVANCE_DISTANCE: u64 = 4;
+const MAX_ADVANCE_DISTANCE: u64 = 256;
 
 /// Similarly for fork choice: avoid the fork choice lookahead during sync.
 ///
@@ -294,25 +294,6 @@ fn advance_head<T: BeaconChainTypes>(beacon_chain: &Arc<BeaconChain<T>>) -> Resu
         .store
         .get_advanced_hot_state(head_block_root, current_slot, head_block_state_root)?
         .ok_or(Error::HeadMissingFromSnapshotCache(head_block_root))?;
-
-    // Protect against advancing a state more than a single slot.
-    //
-    // Advancing more than one slot without storing the intermediate state would corrupt the
-    // database. Future works might store intermediate states inside this function.
-    match state.slot().cmp(&state.latest_block_header().slot) {
-        std::cmp::Ordering::Equal => (),
-        std::cmp::Ordering::Greater => {
-            return Err(Error::StateAlreadyAdvanced {
-                block_root: head_block_root,
-            });
-        }
-        std::cmp::Ordering::Less => {
-            return Err(Error::BadStateSlot {
-                _block_slot: state.latest_block_header().slot,
-                _state_slot: state.slot(),
-            });
-        }
-    }
 
     let initial_slot = state.slot();
     let initial_epoch = state.current_epoch();


### PR DESCRIPTION
## Issue Addressed

Closes:

- https://github.com/sigp/lighthouse/issues/4412

This should reduce Lighthouse's block proposal times on Holesky and prevent us getting reorged.

## Proposed Changes

- [x] Allow the head state to be advanced further than 1 slot. This lets us avoid epoch processing on hot paths including block production, by having new epoch boundaries pre-computed and available in the state cache. 
- [x] Use the finalized state to prune the op pool. We were previously using the head state and trying to infer slashing/exit relevance based on `exit_epoch`. However some exit epochs are far in the future, despite occurring recently.
