### PR TITLE
Use OnceCell in HotHDiffBufferCache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9005,6 +9005,7 @@ dependencies = [
  "logging",
  "lru",
  "metrics",
+ "once_cell",
  "parking_lot 0.12.3",
  "rand 0.9.0",
  "redb",

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -802,6 +802,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // Update the state cache so it doesn't mistakenly prune the new head.
         self.store
             .state_cache
+            .inner
             .lock()
             .update_head_block_root(new_cached_head.head_block_root());
 

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -20,6 +20,7 @@ leveldb = { version = "0.8.6", optional = true, default-features = false }
 logging = { workspace = true }
 lru = { workspace = true }
 metrics = { workspace = true }
+once_cell = { workspace = true }
 parking_lot = { workspace = true }
 redb = { version = "2.1.3", optional = true }
 safe_arith = { workspace = true }

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -477,7 +477,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         let pre_finalized_slots_to_retain = self
             .hierarchy
             .closest_layer_points(state.slot(), start_slot);
-        self.state_cache.inner.lock().update_finalized_state(
+        self.state_cache.update_finalized_state(
             state_root,
             block_root,
             state,

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -74,7 +74,7 @@ pub struct HotColdDB<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
     /// Cache of beacon states.
     ///
     /// LOCK ORDERING: this lock must always be locked *after* the `split` if both are required.
-    pub state_cache: Mutex<StateCache<E>>,
+    pub state_cache: StateCache<E>,
     /// Cache of historic states and hierarchical diff buffers.
     ///
     /// This cache is never pruned. It is only populated in response to historical queries from the
@@ -232,11 +232,11 @@ impl<E: EthSpec> HotColdDB<E, MemoryStore<E>, MemoryStore<E>> {
             block_cache: NonZeroUsize::new(config.block_cache_size)
                 .map(BlockCache::new)
                 .map(Mutex::new),
-            state_cache: Mutex::new(StateCache::new(
+            state_cache: StateCache::new(
                 config.state_cache_size,
                 config.state_cache_headroom,
                 config.hot_hdiff_buffer_cache_size,
-            )),
+            ),
             historic_state_cache: Mutex::new(HistoricStateCache::new(
                 config.cold_hdiff_buffer_cache_size,
                 config.historic_state_cache_size,
@@ -286,11 +286,11 @@ impl<E: EthSpec> HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>> {
             block_cache: NonZeroUsize::new(config.block_cache_size)
                 .map(BlockCache::new)
                 .map(Mutex::new),
-            state_cache: Mutex::new(StateCache::new(
+            state_cache: StateCache::new(
                 config.state_cache_size,
                 config.state_cache_headroom,
                 config.hot_hdiff_buffer_cache_size,
-            )),
+            ),
             historic_state_cache: Mutex::new(HistoricStateCache::new(
                 config.cold_hdiff_buffer_cache_size,
                 config.historic_state_cache_size,
@@ -477,7 +477,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         let pre_finalized_slots_to_retain = self
             .hierarchy
             .closest_layer_points(state.slot(), start_slot);
-        self.state_cache.lock().update_finalized_state(
+        self.state_cache.inner.lock().update_finalized_state(
             state_root,
             block_root,
             state,
@@ -486,7 +486,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     }
 
     pub fn state_cache_len(&self) -> usize {
-        self.state_cache.lock().len()
+        self.state_cache.inner.lock().len()
     }
 
     pub fn register_metrics(&self) {
@@ -503,7 +503,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 cache.blob_cache.len() as i64,
             );
         }
-        let state_cache = self.state_cache.lock();
+        let state_cache = self.state_cache.inner.lock();
         metrics::set_gauge(
             &metrics::STORE_BEACON_STATE_CACHE_SIZE,
             state_cache.len() as i64,
@@ -1109,6 +1109,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             state.build_all_caches(&self.spec)?;
             if let PutStateOutcome::New(deleted_states) =
                 self.state_cache
+                    .inner
                     .lock()
                     .put_state(*state_root, block_root, state)?
             {
@@ -1137,6 +1138,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         max_slot: Slot,
     ) -> Option<(Hash256, BeaconState<E>)> {
         self.state_cache
+            .inner
             .lock()
             .get_by_block_root(block_root, max_slot)
     }
@@ -1467,10 +1469,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         for op in &hot_db_cache_ops {
             match op {
                 StoreOp::DeleteBlock(block_root) => {
-                    self.state_cache.lock().delete_block_states(block_root);
+                    self.state_cache
+                        .inner
+                        .lock()
+                        .delete_block_states(block_root);
                 }
                 StoreOp::DeleteState(state_root, _) => {
-                    self.state_cache.lock().delete_state(state_root)
+                    self.state_cache.inner.lock().delete_state(state_root)
                 }
                 _ => (),
             }
@@ -1538,7 +1543,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         state: &BeaconState<E>,
         ops: &mut Vec<KeyValueStoreOp>,
     ) -> Result<(), Error> {
-        match self.state_cache.lock().put_state(
+        match self.state_cache.inner.lock().put_state(
             *state_root,
             state.get_latest_block_root(*state_root),
             state,
@@ -1688,7 +1693,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         state_root: &Hash256,
         update_cache: bool,
     ) -> Result<Option<BeaconState<E>>, Error> {
-        if let Some(state) = self.state_cache.lock().get_by_state_root(*state_root) {
+        if let Some(state) = self.state_cache.inner.lock().get_by_state_root(*state_root) {
             return Ok(Some(state));
         }
 
@@ -1705,10 +1710,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             state.update_tree_hash_cache()?;
             state.build_all_caches(&self.spec)?;
             if update_cache {
-                if let PutStateOutcome::New(deleted_states) =
-                    self.state_cache
-                        .lock()
-                        .put_state(*state_root, block_root, &state)?
+                if let PutStateOutcome::New(deleted_states) = self
+                    .state_cache
+                    .inner
+                    .lock()
+                    .put_state(*state_root, block_root, &state)?
                 {
                     debug!(
                         ?state_root,
@@ -1733,11 +1739,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     }
 
     fn load_hot_hdiff_buffer(&self, state_root: Hash256) -> Result<HDiffBuffer, Error> {
-        if let Some(buffer) = self
-            .state_cache
-            .lock()
-            .get_hdiff_buffer_by_state_root(state_root)
-        {
+        if let Some(buffer) = self.state_cache.get_hdiff_buffer_by_state_root(state_root) {
             return Ok(buffer);
         }
 
@@ -1794,6 +1796,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         // Add buffer to cache for future calls.
         self.state_cache
+            .inner
             .lock()
             .put_hdiff_buffer(state_root, slot, &buffer);
 
@@ -1853,6 +1856,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     // Immediately rebase the state from diffs on the finalized state so that we
                     // can utilise structural sharing and don't consume excess memory.
                     self.state_cache
+                        .inner
                         .lock()
                         .rebase_on_finalized(&mut state, &self.spec)?;
 
@@ -1878,6 +1882,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     // Immediately rebase the state from disk on the finalized state so that we can
                     // reuse parts of the tree for state root calculation in `replay_blocks`.
                     self.state_cache
+                        .inner
                         .lock()
                         .rebase_on_finalized(&mut base_state, &self.spec)?;
 
@@ -1925,6 +1930,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             let latest_block_root = state.get_latest_block_root(state_root);
             if let PutStateOutcome::New(_) =
                 self.state_cache
+                    .inner
                     .lock()
                     .put_state(state_root, latest_block_root, state)?
             {

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -114,14 +114,10 @@ impl<E: EthSpec> StateCache<E> {
             drop(inner);
 
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
-            let timer =
+            let _timer =
                 metrics::start_timer_vec(&metrics::BEACON_HDIFF_BUFFER_CLONE_TIME, HOT_METRIC);
-            let result = Some(buffer.clone());
-            drop(timer);
-            return result;
-        }
-
-        if let Some(state) = inner.get_by_state_root(state_root) {
+            Some(buffer.clone())
+        } else if let Some(state) = inner.get_by_state_root(state_root) {
             // Drop the lock before performing the conversion from state to buffer, as this
             // conversion is somewhat expensive.
             drop(inner);
@@ -132,10 +128,11 @@ impl<E: EthSpec> StateCache<E> {
 
             // Put the buffer back into the cache without re-locking, by using the OnceCell.
             buffer_cell.get_or_init(|| (slot, buffer.clone()));
-            return Some(buffer);
+            Some(buffer)
+        } else {
+            metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, HOT_METRIC);
+            None
         }
-        metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, HOT_METRIC);
-        None
     }
 }
 

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -104,11 +104,7 @@ impl<E: EthSpec> StateCache<E> {
     pub fn get_hdiff_buffer_by_state_root(&self, state_root: Hash256) -> Option<HDiffBuffer> {
         let mut inner = self.inner.lock();
 
-        let buffer_cell = inner
-            .hdiff_buffers
-            .hdiff_buffers
-            .get_or_insert(state_root, || Arc::new(OnceCell::new()))
-            .clone();
+        let buffer_cell = inner.hdiff_buffers.hdiff_buffers.get(&state_root).clone();
 
         if let Some((_, buffer)) = buffer_cell.get() {
             drop(inner);
@@ -118,16 +114,25 @@ impl<E: EthSpec> StateCache<E> {
                 metrics::start_timer_vec(&metrics::BEACON_HDIFF_BUFFER_CLONE_TIME, HOT_METRIC);
             Some(buffer.clone())
         } else if let Some(state) = inner.get_by_state_root(state_root) {
+            // Insert an empty cell to the cache. Use get_or_insert to get a reference of the
+            // inserted value.
+            let buffer_cell = inner
+                .hdiff_buffers
+                .hdiff_buffers
+                .get_or_insert(&state_root, || Arc::new(OnceCell::new()))
+                .clone();
             // Drop the lock before performing the conversion from state to buffer, as this
             // conversion is somewhat expensive.
             drop(inner);
 
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
-            let slot = state.slot();
-            let buffer = HDiffBuffer::from_state(state);
 
             // Put the buffer back into the cache without re-locking, by using the OnceCell.
-            buffer_cell.get_or_init(|| (slot, buffer.clone()));
+            let (_, buffer) = buffer_cell.get_or_init(|| {
+                let slot = state.slot();
+                let buffer = HDiffBuffer::from_state(state);
+                (slot, buffer.clone())
+            });
             Some(buffer)
         } else {
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, HOT_METRIC);

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -58,14 +58,11 @@ pub struct StateCacheInner<E: EthSpec> {
 
 /// Cache of hdiff buffers for hot states.
 ///
-/// This cache only keeps buffers prior to the finalized state, which are required by the
-/// hierarchical state diff scheme to construct newer unfinalized states.
-///
 /// The cache always retains the hdiff buffer for the most recent snapshot so that even if the
 /// cache capacity is 1, this snapshot never needs to be loaded from disk.
 #[derive(Debug)]
 pub struct HotHDiffBufferCache {
-    /// Cache of HDiffBuffers for states *prior* to the `finalized_state`.
+    /// Cache of HDiffBuffers.
     ///
     /// Maps state_root -> (slot, buffer).
     hdiff_buffers: LruCache<Hash256, (Slot, Arc<OnceCell<HDiffBuffer>>)>,

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -4,8 +4,11 @@ use crate::{
     metrics::{self, HOT_METRIC},
 };
 use lru::LruCache;
+use once_cell::sync::OnceCell;
+use parking_lot::Mutex;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 use tracing::instrument;
 use types::{BeaconState, ChainSpec, Epoch, EthSpec, Hash256, Slot};
 
@@ -37,6 +40,11 @@ pub struct SlotMap {
 
 #[derive(Debug)]
 pub struct StateCache<E: EthSpec> {
+    pub inner: Mutex<StateCacheInner<E>>,
+}
+
+#[derive(Debug)]
+pub struct StateCacheInner<E: EthSpec> {
     finalized_state: Option<FinalizedState<E>>,
     // Stores the tuple (state_root, state) as LruCache only returns the value on put and we need
     // the state_root
@@ -60,7 +68,8 @@ pub struct HotHDiffBufferCache {
     /// Cache of HDiffBuffers for states *prior* to the `finalized_state`.
     ///
     /// Maps state_root -> (slot, buffer).
-    hdiff_buffers: LruCache<Hash256, (Slot, HDiffBuffer)>,
+    // FIXME(sproul): put OnceCell around HDiffBuffer only?
+    hdiff_buffers: LruCache<Hash256, Arc<OnceCell<(Slot, HDiffBuffer)>>>,
 }
 
 #[derive(Debug)]
@@ -77,14 +86,67 @@ pub enum PutStateOutcome {
     New(Vec<Hash256>),
 }
 
-#[allow(clippy::len_without_is_empty)]
 impl<E: EthSpec> StateCache<E> {
     pub fn new(
         state_capacity: NonZeroUsize,
         headroom: NonZeroUsize,
         hdiff_capacity: NonZeroUsize,
     ) -> Self {
-        StateCache {
+        Self {
+            inner: Mutex::new(StateCacheInner::new(
+                state_capacity,
+                headroom,
+                hdiff_capacity,
+            )),
+        }
+    }
+
+    pub fn get_hdiff_buffer_by_state_root(&self, state_root: Hash256) -> Option<HDiffBuffer> {
+        let mut inner = self.inner.lock();
+
+        let buffer_cell = inner
+            .hdiff_buffers
+            .hdiff_buffers
+            .get_or_insert(state_root, || Arc::new(OnceCell::new()))
+            .clone();
+
+        if let Some((_, buffer)) = buffer_cell.get() {
+            drop(inner);
+
+            metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
+            let timer =
+                metrics::start_timer_vec(&metrics::BEACON_HDIFF_BUFFER_CLONE_TIME, HOT_METRIC);
+            let result = Some(buffer.clone());
+            drop(timer);
+            return result;
+        }
+
+        if let Some(state) = inner.get_by_state_root(state_root) {
+            // Drop the lock before performing the conversion from state to buffer, as this
+            // conversion is somewhat expensive.
+            drop(inner);
+
+            metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
+            let slot = state.slot();
+            let buffer = HDiffBuffer::from_state(state);
+
+            // Put the buffer back into the cache without re-locking, by using the OnceCell.
+            buffer_cell.get_or_init(|| (slot, buffer.clone()));
+            return Some(buffer);
+        }
+        metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, HOT_METRIC);
+        None
+    }
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl<E: EthSpec> StateCacheInner<E> {
+    pub fn new(
+        state_capacity: NonZeroUsize,
+        headroom: NonZeroUsize,
+        hdiff_capacity: NonZeroUsize,
+    ) -> Self {
+        StateCacheInner {
             finalized_state: None,
             states: LruCache::new(state_capacity),
             block_map: BlockMap::default(),
@@ -143,9 +205,12 @@ impl<E: EthSpec> StateCache<E> {
         // at some slots in the case of long forks without finality.
         let new_hdiff_cache = HotHDiffBufferCache::new(self.hdiff_buffers.cap());
         let old_hdiff_cache = std::mem::replace(&mut self.hdiff_buffers, new_hdiff_cache);
-        for (state_root, (slot, buffer)) in old_hdiff_cache.hdiff_buffers {
-            if pre_finalized_slots_to_retain.contains(&slot) {
-                self.hdiff_buffers.put(state_root, slot, buffer);
+        for (state_root, cell) in old_hdiff_cache.hdiff_buffers {
+            if let Some((slot, buffer)) = cell.get()
+                && pre_finalized_slots_to_retain.contains(slot)
+            {
+                // FIXME(sproul): this clone is not really optimal
+                self.hdiff_buffers.put(state_root, *slot, buffer.clone());
             }
         }
 
@@ -277,26 +342,6 @@ impl<E: EthSpec> StateCache<E> {
             return;
         }
         self.hdiff_buffers.put(state_root, slot, buffer.clone());
-    }
-
-    pub fn get_hdiff_buffer_by_state_root(&mut self, state_root: Hash256) -> Option<HDiffBuffer> {
-        if let Some(buffer) = self.hdiff_buffers.get(&state_root) {
-            metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
-            let timer =
-                metrics::start_timer_vec(&metrics::BEACON_HDIFF_BUFFER_CLONE_TIME, HOT_METRIC);
-            let result = Some(buffer.clone());
-            drop(timer);
-            return result;
-        }
-        if let Some(buffer) = self
-            .get_by_state_root(state_root)
-            .map(HDiffBuffer::from_state)
-        {
-            metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
-            return Some(buffer);
-        }
-        metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, HOT_METRIC);
-        None
     }
 
     #[instrument(skip_all, fields(?block_root, %slot), level = "debug")]
@@ -445,7 +490,8 @@ impl HotHDiffBufferCache {
 
     pub fn get(&mut self, state_root: &Hash256) -> Option<HDiffBuffer> {
         self.hdiff_buffers
-            .get(state_root)
+            .get(state_root)?
+            .get()
             .map(|(_, buffer)| buffer.clone())
     }
 
@@ -455,7 +501,8 @@ impl HotHDiffBufferCache {
     pub fn put(&mut self, state_root: Hash256, slot: Slot, buffer: HDiffBuffer) -> bool {
         // If the cache is not full, simply insert the value.
         if self.hdiff_buffers.len() != self.hdiff_buffers.cap().get() {
-            self.hdiff_buffers.put(state_root, (slot, buffer));
+            self.hdiff_buffers
+                .put(state_root, Arc::new(OnceCell::with_value((slot, buffer))));
             return true;
         }
 
@@ -466,28 +513,35 @@ impl HotHDiffBufferCache {
         //   cache. This is a simplified way of retaining the snapshot in the cache. We don't need
         //   to worry about inserting/retaining states older than the snapshot because these are
         //   pruned on finalization and never reinserted.
-        let Some(min_slot) = self.hdiff_buffers.iter().map(|(_, (slot, _))| *slot).min() else {
+        let Some(min_slot) = self
+            .hdiff_buffers
+            .iter()
+            .filter_map(|(_, cell)| cell.get().map(|(slot, _)| *slot))
+            .min()
+        else {
             // Unreachable: cache is full so should have >0 entries.
+            // FIXME(sproul): no longer true per se, could have slot-less entries
             return false;
         };
 
         if self.hdiff_buffers.cap().get() > 1 || slot < min_slot {
             // Remove LRU value. Cache is now at size `cap - 1`.
-            let Some((removed_state_root, (removed_slot, removed_buffer))) =
-                self.hdiff_buffers.pop_lru()
-            else {
+            let Some((removed_state_root, removed_cell)) = self.hdiff_buffers.pop_lru() else {
                 // Unreachable: cache is full so should have at least one entry to pop.
                 return false;
             };
 
             // Insert new value. Cache size is now at size `cap`.
-            self.hdiff_buffers.put(state_root, (slot, buffer));
+            self.hdiff_buffers
+                .put(state_root, Arc::new(OnceCell::with_value((slot, buffer))));
 
             // If the removed value had the min slot and we didn't intend to replace it (cap=1)
             // then we reinsert it.
-            if removed_slot == min_slot && slot >= min_slot {
-                self.hdiff_buffers
-                    .put(removed_state_root, (removed_slot, removed_buffer));
+            if let Some((removed_slot, _)) = removed_cell.get()
+                && *removed_slot == min_slot
+                && slot >= min_slot
+            {
+                self.hdiff_buffers.put(removed_state_root, removed_cell);
             }
             true
         } else {
@@ -508,7 +562,7 @@ impl HotHDiffBufferCache {
     pub fn mem_usage(&self) -> usize {
         self.hdiff_buffers
             .iter()
-            .map(|(_, (_, buffer))| buffer.size())
+            .filter_map(|(_, cell)| cell.get().map(|(_, buffer)| buffer.size()))
             .sum()
     }
 }

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -68,8 +68,7 @@ pub struct HotHDiffBufferCache {
     /// Cache of HDiffBuffers for states *prior* to the `finalized_state`.
     ///
     /// Maps state_root -> (slot, buffer).
-    // FIXME(sproul): put OnceCell around HDiffBuffer only?
-    hdiff_buffers: LruCache<Hash256, Arc<OnceCell<(Slot, HDiffBuffer)>>>,
+    hdiff_buffers: LruCache<Hash256, (Slot, Arc<OnceCell<HDiffBuffer>>)>,
 }
 
 #[derive(Debug)]
@@ -104,11 +103,11 @@ impl<E: EthSpec> StateCache<E> {
     pub fn get_hdiff_buffer_by_state_root(&self, state_root: Hash256) -> Option<HDiffBuffer> {
         let mut inner = self.inner.lock();
 
-        if let Some((_, buffer)) = inner
+        if let Some(buffer) = inner
             .hdiff_buffers
             .hdiff_buffers
             .get(&state_root)
-            .and_then(|cell| cell.get())
+            .and_then(|(_, cell)| cell.get())
             .cloned()
         {
             // If no entry exist for `state_root` no other thread is or has computed the value. If
@@ -126,10 +125,10 @@ impl<E: EthSpec> StateCache<E> {
             // inserted value.
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
 
-            let buffer_cell = inner
+            let (_, buffer_cell) = inner
                 .hdiff_buffers
                 .hdiff_buffers
-                .get_or_insert(state_root, || Arc::new(OnceCell::new()))
+                .get_or_insert(state_root, || (state.slot(), Arc::new(OnceCell::new())))
                 .clone();
             // Drop the lock before performing the conversion from state to buffer, as this
             // conversion is somewhat expensive.
@@ -138,11 +137,7 @@ impl<E: EthSpec> StateCache<E> {
             drop(inner);
 
             // Put the buffer back into the cache without re-locking, by using the OnceCell.
-            let (_, buffer) = buffer_cell.get_or_init(|| {
-                let slot = state.slot();
-                let buffer = HDiffBuffer::from_state(state);
-                (slot, buffer)
-            });
+            let buffer = buffer_cell.get_or_init(|| HDiffBuffer::from_state(state));
             Some(buffer.clone())
         } else {
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, HOT_METRIC);
@@ -217,12 +212,13 @@ impl<E: EthSpec> StateCacheInner<E> {
         // at some slots in the case of long forks without finality.
         let new_hdiff_cache = HotHDiffBufferCache::new(self.hdiff_buffers.cap());
         let old_hdiff_cache = std::mem::replace(&mut self.hdiff_buffers, new_hdiff_cache);
-        for (state_root, cell) in old_hdiff_cache.hdiff_buffers {
-            if let Some((slot, buffer)) = cell.get()
-                && pre_finalized_slots_to_retain.contains(slot)
-            {
-                // FIXME(sproul): this clone is not really optimal
-                self.hdiff_buffers.put(state_root, *slot, buffer.clone());
+        for (state_root, (slot, cell)) in old_hdiff_cache.hdiff_buffers {
+            if pre_finalized_slots_to_retain.contains(&slot) {
+                // We don't need to use `HotHDiffBufferCache::put` here because the new cache is by
+                // definition non-full by virtue of being created from the old cache.
+                self.hdiff_buffers
+                    .hdiff_buffers
+                    .put(state_root, (slot, cell));
             }
         }
 
@@ -502,9 +498,9 @@ impl HotHDiffBufferCache {
 
     pub fn get(&mut self, state_root: &Hash256) -> Option<HDiffBuffer> {
         self.hdiff_buffers
-            .get(state_root)?
-            .get()
-            .map(|(_, buffer)| buffer.clone())
+            .get(state_root)
+            .and_then(|(_, cell)| cell.get())
+            .cloned()
     }
 
     /// Put a value in the cache, making room for it if necessary.
@@ -514,7 +510,7 @@ impl HotHDiffBufferCache {
         // If the cache is not full, simply insert the value.
         if self.hdiff_buffers.len() != self.hdiff_buffers.cap().get() {
             self.hdiff_buffers
-                .put(state_root, Arc::new(OnceCell::with_value((slot, buffer))));
+                .put(state_root, (slot, Arc::new(OnceCell::with_value(buffer))));
             return true;
         }
 
@@ -525,35 +521,29 @@ impl HotHDiffBufferCache {
         //   cache. This is a simplified way of retaining the snapshot in the cache. We don't need
         //   to worry about inserting/retaining states older than the snapshot because these are
         //   pruned on finalization and never reinserted.
-        let Some(min_slot) = self
-            .hdiff_buffers
-            .iter()
-            .filter_map(|(_, cell)| cell.get().map(|(slot, _)| *slot))
-            .min()
-        else {
+        let Some(min_slot) = self.hdiff_buffers.iter().map(|(_, (slot, _))| *slot).min() else {
             // Unreachable: cache is full so should have >0 entries.
-            // FIXME(sproul): no longer true per se, could have slot-less entries
             return false;
         };
 
         if self.hdiff_buffers.cap().get() > 1 || slot < min_slot {
             // Remove LRU value. Cache is now at size `cap - 1`.
-            let Some((removed_state_root, removed_cell)) = self.hdiff_buffers.pop_lru() else {
+            let Some((removed_state_root, (removed_slot, removed_cell))) =
+                self.hdiff_buffers.pop_lru()
+            else {
                 // Unreachable: cache is full so should have at least one entry to pop.
                 return false;
             };
 
             // Insert new value. Cache size is now at size `cap`.
             self.hdiff_buffers
-                .put(state_root, Arc::new(OnceCell::with_value((slot, buffer))));
+                .put(state_root, (slot, Arc::new(OnceCell::with_value(buffer))));
 
             // If the removed value had the min slot and we didn't intend to replace it (cap=1)
             // then we reinsert it.
-            if let Some((removed_slot, _)) = removed_cell.get()
-                && *removed_slot == min_slot
-                && slot >= min_slot
-            {
-                self.hdiff_buffers.put(removed_state_root, removed_cell);
+            if removed_slot == min_slot && slot >= min_slot {
+                self.hdiff_buffers
+                    .put(removed_state_root, (removed_slot, removed_cell));
             }
             true
         } else {
@@ -574,7 +564,7 @@ impl HotHDiffBufferCache {
     pub fn mem_usage(&self) -> usize {
         self.hdiff_buffers
             .iter()
-            .filter_map(|(_, cell)| cell.get().map(|(_, buffer)| buffer.size()))
+            .filter_map(|(_, (_, cell))| cell.get().map(|buffer| buffer.size()))
             .sum()
     }
 }

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -104,9 +104,27 @@ impl<E: EthSpec> StateCache<E> {
     pub fn get_hdiff_buffer_by_state_root(&self, state_root: Hash256) -> Option<HDiffBuffer> {
         let mut inner = self.inner.lock();
 
-        let buffer_cell = inner.hdiff_buffers.hdiff_buffers.get(&state_root).clone();
-
-        if let Some((_, buffer)) = buffer_cell.get() {
+        if let Some((_, buffer)) = inner
+            .hdiff_buffers
+            .hdiff_buffers
+            .get(&state_root)
+            .and_then(|cell| cell.get_or_try_init(|| Err(())).ok())
+            .cloned()
+        {
+            // Gets an entry from the hdiff_buffers HashMap:
+            // - Some: Some thread has computed or is computing the buffer. Call
+            //         OnceCell::get_or_try_init to lock if the OnceCell is in RUNNING state. The
+            //         behaviour on each possible OnceCell state is:
+            //         - COMPLETE: Another thread has completed computing the value:
+            //           get_or_try_init returns Ok(T) and we move into this if branch
+            //         - RUNNING: Another thread is currently computing the value: get_or_try_init
+            //           will block and return Ok(T)
+            //         - INCOMPLETE: The cell exists but it's not initializing nor initialized. The
+            //           clousure of get_or_try_init will be invoked, return an immediate error
+            //           and we move into this if branch. The OnceCell returns to INCOMPLETE state.
+            //           If another thread was locking on `get_or_init` it will run the clousure and
+            //           compute the value.
+            // - None: No other thread is computing or has computed the buffer
             drop(inner);
 
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
@@ -116,24 +134,26 @@ impl<E: EthSpec> StateCache<E> {
         } else if let Some(state) = inner.get_by_state_root(state_root) {
             // Insert an empty cell to the cache. Use get_or_insert to get a reference of the
             // inserted value.
+            metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
+
             let buffer_cell = inner
                 .hdiff_buffers
                 .hdiff_buffers
-                .get_or_insert(&state_root, || Arc::new(OnceCell::new()))
+                .get_or_insert(state_root, || Arc::new(OnceCell::new()))
                 .clone();
             // Drop the lock before performing the conversion from state to buffer, as this
             // conversion is somewhat expensive.
+            // Drop after setting the metric to minimize the time the OnceCell is in INCOMPLETE
+            // state
             drop(inner);
-
-            metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);
 
             // Put the buffer back into the cache without re-locking, by using the OnceCell.
             let (_, buffer) = buffer_cell.get_or_init(|| {
                 let slot = state.slot();
                 let buffer = HDiffBuffer::from_state(state);
-                (slot, buffer.clone())
+                (slot, buffer)
             });
-            Some(buffer)
+            Some(buffer.clone())
         } else {
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS, HOT_METRIC);
             None

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -141,6 +141,83 @@ impl<E: EthSpec> StateCache<E> {
             None
         }
     }
+
+    pub fn update_finalized_state(
+        &self,
+        state_root: Hash256,
+        block_root: Hash256,
+        state: BeaconState<E>,
+        pre_finalized_slots_to_retain: &[Slot],
+    ) -> Result<(), Error> {
+        if state.slot() % E::slots_per_epoch() != 0 {
+            return Err(Error::FinalizedStateUnaligned);
+        }
+
+        let mut inner = self.inner.lock();
+
+        if inner
+            .finalized_state
+            .as_ref()
+            .is_some_and(|finalized_state| state.slot() < finalized_state.state.slot())
+        {
+            return Err(Error::FinalizedStateDecreasingSlot);
+        }
+
+        // Add to block map.
+        inner.block_map.insert(block_root, state.slot(), state_root);
+
+        // Prune block map.
+        let state_roots_to_prune = inner.block_map.prune(state.slot());
+
+        // Prune HDiffBuffers that are no longer required by the hdiff grid of the finalized state.
+        // We need to do this prior to copying in any new hdiff buffers, because the cache
+        // preferences older slots.
+        // NOTE: This isn't perfect as it prunes by slot: there could be multiple buffers
+        // at some slots in the case of long forks without finality.
+        let new_hdiff_cache = HotHDiffBufferCache::new(inner.hdiff_buffers.cap());
+        let old_hdiff_cache = std::mem::replace(&mut inner.hdiff_buffers, new_hdiff_cache);
+        for (state_root, (slot, cell)) in old_hdiff_cache.hdiff_buffers {
+            if pre_finalized_slots_to_retain.contains(&slot) {
+                // We don't need to use `HotHDiffBufferCache::put` here because the new cache is by
+                // definition non-full by virtue of being created from the old cache.
+                inner
+                    .hdiff_buffers
+                    .hdiff_buffers
+                    .put(state_root, (slot, cell));
+            }
+        }
+
+        // Delete states.
+        //
+        // Put some states in the hdiff buffer cache if we have room. Write these states to the
+        // cache through OnceCells after dropping the mutex on `inner`.
+        let mut hdiff_cache_updates = vec![];
+        for state_root in state_roots_to_prune {
+            if let Some((_, state)) = inner.states.pop(&state_root) {
+                // Add the hdiff buffer for this state to the hdiff cache if it is now part of
+                // the pre-finalized grid. The `put` method will take care of keeping the most
+                // useful buffers.
+                let slot = state.slot();
+                if pre_finalized_slots_to_retain.contains(&slot) {
+                    let (_, cell) = inner
+                        .hdiff_buffers
+                        .hdiff_buffers
+                        .get_or_insert(state_root, || (slot, Arc::new(OnceCell::new())));
+                    hdiff_cache_updates.push((cell.clone(), state));
+                }
+            }
+        }
+
+        // Update finalized state.
+        inner.finalized_state = Some(FinalizedState { state_root, state });
+        drop(inner);
+
+        for (cell, state) in hdiff_cache_updates {
+            cell.get_or_init(|| HDiffBuffer::from_state(state));
+        }
+
+        Ok(())
+    }
 }
 
 #[allow(clippy::len_without_is_empty)]
@@ -175,67 +252,6 @@ impl<E: EthSpec> StateCacheInner<E> {
 
     pub fn hdiff_buffer_mem_usage(&self) -> usize {
         self.hdiff_buffers.mem_usage()
-    }
-
-    pub fn update_finalized_state(
-        &mut self,
-        state_root: Hash256,
-        block_root: Hash256,
-        state: BeaconState<E>,
-        pre_finalized_slots_to_retain: &[Slot],
-    ) -> Result<(), Error> {
-        if state.slot() % E::slots_per_epoch() != 0 {
-            return Err(Error::FinalizedStateUnaligned);
-        }
-
-        if self
-            .finalized_state
-            .as_ref()
-            .is_some_and(|finalized_state| state.slot() < finalized_state.state.slot())
-        {
-            return Err(Error::FinalizedStateDecreasingSlot);
-        }
-
-        // Add to block map.
-        self.block_map.insert(block_root, state.slot(), state_root);
-
-        // Prune block map.
-        let state_roots_to_prune = self.block_map.prune(state.slot());
-
-        // Prune HDiffBuffers that are no longer required by the hdiff grid of the finalized state.
-        // We need to do this prior to copying in any new hdiff buffers, because the cache
-        // preferences older slots.
-        // NOTE: This isn't perfect as it prunes by slot: there could be multiple buffers
-        // at some slots in the case of long forks without finality.
-        let new_hdiff_cache = HotHDiffBufferCache::new(self.hdiff_buffers.cap());
-        let old_hdiff_cache = std::mem::replace(&mut self.hdiff_buffers, new_hdiff_cache);
-        for (state_root, (slot, cell)) in old_hdiff_cache.hdiff_buffers {
-            if pre_finalized_slots_to_retain.contains(&slot) {
-                // We don't need to use `HotHDiffBufferCache::put` here because the new cache is by
-                // definition non-full by virtue of being created from the old cache.
-                self.hdiff_buffers
-                    .hdiff_buffers
-                    .put(state_root, (slot, cell));
-            }
-        }
-
-        // Delete states.
-        for state_root in state_roots_to_prune {
-            if let Some((_, state)) = self.states.pop(&state_root) {
-                // Add the hdiff buffer for this state to the hdiff cache if it is now part of
-                // the pre-finalized grid. The `put` method will take care of keeping the most
-                // useful buffers.
-                let slot = state.slot();
-                if pre_finalized_slots_to_retain.contains(&slot) {
-                    let hdiff_buffer = HDiffBuffer::from_state(state);
-                    self.hdiff_buffers.put(state_root, slot, hdiff_buffer);
-                }
-            }
-        }
-
-        // Update finalized state.
-        self.finalized_state = Some(FinalizedState { state_root, state });
-        Ok(())
     }
 
     /// Update the state cache's view of the enshrined head block.

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -108,23 +108,13 @@ impl<E: EthSpec> StateCache<E> {
             .hdiff_buffers
             .hdiff_buffers
             .get(&state_root)
-            .and_then(|cell| cell.get_or_try_init(|| Err(())).ok())
+            .and_then(|cell| cell.get())
             .cloned()
         {
-            // Gets an entry from the hdiff_buffers HashMap:
-            // - Some: Some thread has computed or is computing the buffer. Call
-            //         OnceCell::get_or_try_init to lock if the OnceCell is in RUNNING state. The
-            //         behaviour on each possible OnceCell state is:
-            //         - COMPLETE: Another thread has completed computing the value:
-            //           get_or_try_init returns Ok(T) and we move into this if branch
-            //         - RUNNING: Another thread is currently computing the value: get_or_try_init
-            //           will block and return Ok(T)
-            //         - INCOMPLETE: The cell exists but it's not initializing nor initialized. The
-            //           clousure of get_or_try_init will be invoked, return an immediate error
-            //           and we move into this if branch. The OnceCell returns to INCOMPLETE state.
-            //           If another thread was locking on `get_or_init` it will run the clousure and
-            //           compute the value.
-            // - None: No other thread is computing or has computed the buffer
+            // If no entry exist for `state_root` no other thread is or has computed the value. If
+            // an entry exists for OnceCell::get returns None, another thread is about to start to
+            // compute the value or is currently computing the value. In those cases we jump to the
+            // next `else` condition and compute the value only if the cell is in INCOMPLETE state.
             drop(inner);
 
             metrics::inc_counter_vec(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT, HOT_METRIC);


### PR DESCRIPTION
## Issue Addressed

Partly addresses:

- https://github.com/sigp/lighthouse/issues/8147

## Proposed Changes

Use an `Arc` to avoid holding the `state_cache` lock while `HDiffBuffer::from_state` runs. This conversion function can take up to 1s, so it's good if we can release the lock while it runs. This can unblock other threads waiting on the lock.
