### PR TITLE
Ensure status v2 returns the earliest available block when custody requirements are satisified for the da retention period

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -7117,7 +7117,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         self.data_availability_checker.data_availability_boundary()
     }
 
-    /// The earliest epoch at which we require data column custody. 
+    /// The earliest epoch at which we require data column custody.
     /// It will just be the data availability boundary unless we are near the Fulu fork epoch.
     pub fn column_data_availability_boundary(&self) -> Option<Epoch> {
         match self.data_availability_boundary() {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -7117,6 +7117,25 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         self.data_availability_checker.data_availability_boundary()
     }
 
+    /// The earliest epoch at which we require data column custody. 
+    /// It will just be the data availability boundary unless we are near the Fulu fork epoch.
+    pub fn column_data_availability_boundary(&self) -> Option<Epoch> {
+        match self.data_availability_boundary() {
+            Some(da_boundary_epoch) => {
+                if let Some(fulu_fork_epoch) = self.spec.fulu_fork_epoch {
+                    if da_boundary_epoch < fulu_fork_epoch {
+                        Some(fulu_fork_epoch)
+                    } else {
+                        Some(da_boundary_epoch)
+                    }
+                } else {
+                    None
+                }
+            }
+            None => None,
+        }
+    }
+
     /// Returns true if epoch is within the data availability boundary
     pub fn da_check_required_for_epoch(&self, epoch: Epoch) -> bool {
         self.data_availability_checker

--- a/beacon_node/network/src/status.rs
+++ b/beacon_node/network/src/status.rs
@@ -37,21 +37,20 @@ pub(crate) fn status_message<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>)
         .flatten()
         .and_then(|info| info.earliest_data_column_slot);
 
-    let data_availability_boundary = beacon_chain.data_availability_boundary();
+    let column_data_availability_boundary = beacon_chain.column_data_availability_boundary();
 
     let oldest_block_slot = beacon_chain.store.get_anchor_info().oldest_block_slot;
 
     // If data_column_custody_info.earliest_data_column_slot is `None`,
     // no recent cgc changes have occurred and no cgc backfill is in progress.
-    // `data_availability_boundary` must be `Some` if `earliest_available_data_column_slot` is also `Some`.
     let earliest_available_slot = if let Some(earliest_available_data_column_slot) =
         earliest_available_data_column_slot
-        && let Some(data_availability_boundary) = data_availability_boundary
+        && let Some(column_data_availability_boundary) = column_data_availability_boundary
     {
         // If the earliest available data column slot is less than or equal to the DA boundary, we have satisfied
-        // our custody requirements for the data retention window and should return the `oldest_block_slot`.
+        // our column custody requirements for the data retention window and should return the `oldest_block_slot`.
         if earliest_available_data_column_slot
-            <= data_availability_boundary.start_slot(T::EthSpec::slots_per_epoch())
+            <= column_data_availability_boundary.start_slot(T::EthSpec::slots_per_epoch())
         {
             oldest_block_slot
         } else {

--- a/beacon_node/network/src/status.rs
+++ b/beacon_node/network/src/status.rs
@@ -37,14 +37,29 @@ pub(crate) fn status_message<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>)
         .flatten()
         .and_then(|info| info.earliest_data_column_slot);
 
+    let data_availability_boundary = beacon_chain.data_availability_boundary();
+
+    let oldest_block_slot = beacon_chain.store.get_anchor_info().oldest_block_slot;
+
     // If data_column_custody_info.earliest_data_column_slot is `None`,
     // no recent cgc changes have occurred and no cgc backfill is in progress.
-    let earliest_available_slot =
-        if let Some(earliest_available_data_column_slot) = earliest_available_data_column_slot {
-            earliest_available_data_column_slot
+    // `data_availability_boundary` must be `Some` if `earliest_available_data_column_slot` is also `Some`.
+    let earliest_available_slot = if let Some(earliest_available_data_column_slot) =
+        earliest_available_data_column_slot
+        && let Some(data_availability_boundary) = data_availability_boundary
+    {
+        // If the earliest available data column slot is less than or equal to the DA boundary, we have satisfied
+        // our custody requirements for to the data retention window and should return the `oldest_block_slot`.
+        if earliest_available_data_column_slot
+            <= data_availability_boundary.start_slot(T::EthSpec::slots_per_epoch())
+        {
+            oldest_block_slot
         } else {
-            beacon_chain.store.get_anchor_info().oldest_block_slot
-        };
+            earliest_available_data_column_slot
+        }
+    } else {
+        oldest_block_slot
+    };
     StatusMessage::V2(StatusMessageV2 {
         fork_digest,
         finalized_root: finalized_checkpoint.root,

--- a/beacon_node/network/src/status.rs
+++ b/beacon_node/network/src/status.rs
@@ -49,7 +49,7 @@ pub(crate) fn status_message<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>)
         && let Some(data_availability_boundary) = data_availability_boundary
     {
         // If the earliest available data column slot is less than or equal to the DA boundary, we have satisfied
-        // our custody requirements for to the data retention window and should return the `oldest_block_slot`.
+        // our custody requirements for the data retention window and should return the `oldest_block_slot`.
         if earliest_available_data_column_slot
             <= data_availability_boundary.start_slot(T::EthSpec::slots_per_epoch())
         {

--- a/beacon_node/network/src/status.rs
+++ b/beacon_node/network/src/status.rs
@@ -43,22 +43,24 @@ pub(crate) fn status_message<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>)
 
     // If data_column_custody_info.earliest_data_column_slot is `None`,
     // no recent cgc changes have occurred and no cgc backfill is in progress.
-    let earliest_available_slot = if let Some(earliest_available_data_column_slot) =
-        earliest_available_data_column_slot
-        && let Some(column_data_availability_boundary) = column_data_availability_boundary
-    {
-        // If the earliest available data column slot is less than or equal to the DA boundary, we have satisfied
-        // our column custody requirements for the data retention window and should return the `oldest_block_slot`.
-        if earliest_available_data_column_slot
-            <= column_data_availability_boundary.start_slot(T::EthSpec::slots_per_epoch())
-        {
-            oldest_block_slot
-        } else {
-            earliest_available_data_column_slot
+    let earliest_available_slot = match (
+        earliest_available_data_column_slot,
+        column_data_availability_boundary,
+    ) {
+        (Some(earliest_available_data_column_slot), Some(column_data_availability_boundary)) => {
+            // If the earliest available data column slot is less than or equal to the DA boundary, we have satisfied
+            // our column custody requirements for the data retention window and should return the `oldest_block_slot`.
+            if earliest_available_data_column_slot
+                <= column_data_availability_boundary.start_slot(T::EthSpec::slots_per_epoch())
+            {
+                oldest_block_slot
+            } else {
+                earliest_available_data_column_slot
+            }
         }
-    } else {
-        oldest_block_slot
+        _ => oldest_block_slot,
     };
+
     StatusMessage::V2(StatusMessageV2 {
         fork_digest,
         finalized_root: finalized_checkpoint.root,


### PR DESCRIPTION
When `DataColumnCustodyInfo::earliest_available_slot` is less than or equal to the data availability boundary, we should return the earliest block slot when serving status-v2 request

Thanks @pawanjay176 for the help

We could alternatively update/prune `DataColumnCustodyInfo` during our regular blob/column pruning routine but that doesn't seem worth the extra effort.