### PR TITLE
Update `ForkName::latest_stable` to Fulu for tests

### DIFF
--- a/consensus/types/src/fork_name.rs
+++ b/consensus/types/src/fork_name.rs
@@ -51,7 +51,7 @@ impl ForkName {
     /// This fork serves as the baseline for many tests, and the goal
     /// is to ensure features are passing on this fork.
     pub fn latest_stable() -> ForkName {
-        ForkName::Electra
+        ForkName::Fulu
     }
 
     /// Set the activation slots in the given `ChainSpec` so that the fork named by `self`


### PR DESCRIPTION
## Proposed Changes

Update `ForkName::latest_stable` to Fulu, reflecting our plan to stabilise Fulu in the immediate future!

This will lead to some more tests running with Fulu rather than Electra.