### PR TITLE
Persist only custody columns in db

### DIFF
--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -140,7 +140,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
             // Store the blobs or data columns too
             if let Some(op) = self
-                .get_blobs_or_columns_store_op(block_root, block_data)
+                .get_blobs_or_columns_store_op(block_root, block.slot(), block_data)
                 .map_err(|e| {
                     HistoricalBlockError::StoreError(StoreError::DBError {
                         message: format!("get_blobs_or_columns_store_op error {e:?}"),

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -109,6 +109,7 @@ fn get_harness(validator_count: usize) -> BeaconChainHarness<EphemeralHarnessTyp
             ..ChainConfig::default()
         })
         .keypairs(KEYPAIRS[0..validator_count].to_vec())
+        .import_all_data_columns(true)
         .fresh_ephemeral_store()
         .mock_execution_layer()
         .build();

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -42,7 +42,10 @@ enum DataSidecars<E: EthSpec> {
 }
 
 async fn get_chain_segment() -> (Vec<BeaconSnapshot<E>>, Vec<Option<DataSidecars<E>>>) {
-    let harness = get_harness(VALIDATOR_COUNT);
+    // The assumption that you can re-import a block based on what you have in your DB
+    // is no longer true, as fullnodes stores less than what they sample.
+    // We use a supernode here to build a chain segment.
+    let harness = get_harness(VALIDATOR_COUNT, true);
 
     harness
         .extend_chain(
@@ -101,7 +104,10 @@ async fn get_chain_segment() -> (Vec<BeaconSnapshot<E>>, Vec<Option<DataSidecars
     (segment, segment_sidecars)
 }
 
-fn get_harness(validator_count: usize) -> BeaconChainHarness<EphemeralHarnessType<E>> {
+fn get_harness(
+    validator_count: usize,
+    supernode: bool,
+) -> BeaconChainHarness<EphemeralHarnessType<E>> {
     let harness = BeaconChainHarness::builder(MainnetEthSpec)
         .default_spec()
         .chain_config(ChainConfig {
@@ -109,7 +115,7 @@ fn get_harness(validator_count: usize) -> BeaconChainHarness<EphemeralHarnessTyp
             ..ChainConfig::default()
         })
         .keypairs(KEYPAIRS[0..validator_count].to_vec())
-        .import_all_data_columns(true)
+        .import_all_data_columns(supernode)
         .fresh_ephemeral_store()
         .mock_execution_layer()
         .build();
@@ -253,7 +259,7 @@ fn update_data_column_signed_header<E: EthSpec>(
 
 #[tokio::test]
 async fn chain_segment_full_segment() {
-    let harness = get_harness(VALIDATOR_COUNT);
+    let harness = get_harness(VALIDATOR_COUNT, false);
     let (chain_segment, chain_segment_blobs) = get_chain_segment().await;
     let blocks: Vec<RpcBlock<E>> = chain_segment_blocks(&chain_segment, &chain_segment_blobs)
         .into_iter()
@@ -291,7 +297,7 @@ async fn chain_segment_full_segment() {
 #[tokio::test]
 async fn chain_segment_varying_chunk_size() {
     for chunk_size in &[1, 2, 3, 5, 31, 32, 33, 42] {
-        let harness = get_harness(VALIDATOR_COUNT);
+        let harness = get_harness(VALIDATOR_COUNT, false);
         let (chain_segment, chain_segment_blobs) = get_chain_segment().await;
         let blocks: Vec<RpcBlock<E>> = chain_segment_blocks(&chain_segment, &chain_segment_blobs)
             .into_iter()
@@ -323,7 +329,7 @@ async fn chain_segment_varying_chunk_size() {
 
 #[tokio::test]
 async fn chain_segment_non_linear_parent_roots() {
-    let harness = get_harness(VALIDATOR_COUNT);
+    let harness = get_harness(VALIDATOR_COUNT, false);
     let (chain_segment, chain_segment_blobs) = get_chain_segment().await;
 
     harness
@@ -380,7 +386,7 @@ async fn chain_segment_non_linear_parent_roots() {
 
 #[tokio::test]
 async fn chain_segment_non_linear_slots() {
-    let harness = get_harness(VALIDATOR_COUNT);
+    let harness = get_harness(VALIDATOR_COUNT, false);
     let (chain_segment, chain_segment_blobs) = get_chain_segment().await;
     harness
         .chain
@@ -522,7 +528,7 @@ async fn assert_invalid_signature(
 async fn get_invalid_sigs_harness(
     chain_segment: &[BeaconSnapshot<E>],
 ) -> BeaconChainHarness<EphemeralHarnessType<E>> {
-    let harness = get_harness(VALIDATOR_COUNT);
+    let harness = get_harness(VALIDATOR_COUNT, false);
     harness
         .chain
         .slot_clock
@@ -980,7 +986,7 @@ fn unwrap_err<T, U>(result: Result<T, U>) -> U {
 
 #[tokio::test]
 async fn block_gossip_verification() {
-    let harness = get_harness(VALIDATOR_COUNT);
+    let harness = get_harness(VALIDATOR_COUNT, false);
     let (chain_segment, chain_segment_blobs) = get_chain_segment().await;
 
     let block_index = CHAIN_SEGMENT_LENGTH - 2;
@@ -1383,7 +1389,7 @@ async fn verify_block_for_gossip_slashing_detection() {
 
 #[tokio::test]
 async fn verify_block_for_gossip_doppelganger_detection() {
-    let harness = get_harness(VALIDATOR_COUNT);
+    let harness = get_harness(VALIDATOR_COUNT, false);
 
     let state = harness.get_current_state();
     let ((block, _), _) = harness.make_block(state.clone(), Slot::new(1)).await;

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -4196,10 +4196,8 @@ async fn test_custody_column_filtering_regular_node() {
         .expect("should get stored column keys");
 
     // Verify only custody columns were stored
-    let stored_column_indices: std::collections::HashSet<_> =
-        stored_column_keys.into_iter().collect();
-    let expected_column_indices: std::collections::HashSet<_> =
-        custody_columns.iter().copied().collect();
+    let stored_column_indices: HashSet<_> = stored_column_keys.into_iter().collect();
+    let expected_column_indices: HashSet<_> = custody_columns.iter().copied().collect();
 
     assert_eq!(
         stored_column_indices, expected_column_indices,
@@ -4225,15 +4223,10 @@ async fn test_custody_column_filtering_supernode() {
     let (signed_block, all_data_columns) =
         beacon_chain::test_utils::generate_rand_block_and_data_columns::<E>(
             fork_name,
-            beacon_chain::test_utils::NumBlobs::Number(3), // Generate 3 blobs to produce data columns
+            beacon_chain::test_utils::NumBlobs::Number(1),
             &mut rng,
             &harness.spec,
         );
-
-    // Skip test if no data columns are generated
-    if all_data_columns.is_empty() {
-        return;
-    }
 
     let block_root = signed_block.canonical_root();
 
@@ -4258,21 +4251,12 @@ async fn test_custody_column_filtering_supernode() {
         .expect("should get stored column keys");
 
     // Verify ALL data columns were stored for supernodes
-    let stored_column_indices: std::collections::HashSet<_> =
-        stored_column_keys.into_iter().collect();
-    let all_column_indices: std::collections::HashSet<_> =
-        all_data_columns.iter().map(|dc| dc.index).collect();
+    let stored_column_indices: HashSet<_> = stored_column_keys.into_iter().collect();
+    let all_column_indices: HashSet<_> = all_data_columns.iter().map(|dc| dc.index).collect();
 
     assert_eq!(
         stored_column_indices, all_column_indices,
         "Supernode should store ALL data columns"
-    );
-
-    // Verify the count matches
-    assert_eq!(
-        stored_column_indices.len(),
-        all_data_columns.len(),
-        "Supernode should store the same number of columns as generated"
     );
 
     // Verify each stored column can be retrieved and matches original data

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -4212,8 +4212,7 @@ async fn test_custody_column_filtering_supernode() {
         .await;
 
     // Supernodes are expected to store all data columns
-    let expected_custody_columns: HashSet<_> =
-        (0..E::number_of_columns() as u64).into_iter().collect();
+    let expected_custody_columns: HashSet<_> = (0..E::number_of_columns() as u64).collect();
 
     // Check what actually got stored in the database
     let stored_column_indices: HashSet<_> = store

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -13,8 +13,7 @@ use beacon_chain::test_utils::{
 use beacon_chain::{
     BeaconChain, BeaconChainError, BeaconChainTypes, BeaconSnapshot, BlockError, ChainConfig,
     NotifyExecutionLayer, ServerSentEventHandler, WhenSlotSkipped,
-    data_availability_checker::{AvailableBlockData, MaybeAvailableBlock},
-    historical_blocks::HistoricalBlockError,
+    data_availability_checker::MaybeAvailableBlock, historical_blocks::HistoricalBlockError,
     migrate::MigratorConfig,
 };
 use logging::create_test_tracing_subscriber;
@@ -4141,66 +4140,43 @@ async fn replay_from_split_state() {
 /// Test that regular nodes filter and store only custody columns when processing blocks with data columns.
 #[tokio::test]
 async fn test_custody_column_filtering_regular_node() {
+    // Skip test if PeerDAS is not scheduled
+    if !test_spec::<E>().is_peer_das_scheduled() {
+        return;
+    }
+
     let db_path = tempdir().unwrap();
     let store = get_store(&db_path);
     let harness = get_harness(store.clone(), LOW_VALIDATOR_COUNT);
 
-    // Skip test if PeerDAS is not scheduled
-    if !harness.spec.is_peer_das_scheduled() {
-        return;
-    }
-
-    // Generate a block with data columns using public test utils
-    let fork_name = harness.spec.fork_name_at_epoch(Epoch::new(0));
-    let mut rng = rand::rng();
-    let (signed_block, all_data_columns) =
-        beacon_chain::test_utils::generate_rand_block_and_data_columns::<E>(
-            fork_name,
-            beacon_chain::test_utils::NumBlobs::Number(1),
-            &mut rng,
-            &harness.spec,
-        );
-
-    let block_root = signed_block.canonical_root();
-    let slot = signed_block.slot();
+    // Generate a block with data columns
+    harness.execution_block_generator().set_min_blob_count(1);
+    let current_slot = harness.get_current_slot();
+    let block_root = harness
+        .extend_chain(
+            1,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
 
     // Get custody columns for this epoch - regular nodes only store a subset
-    let custody_columns = harness
+    let expected_custody_columns: HashSet<_> = harness
         .chain
-        .custody_columns_for_epoch(Some(slot.epoch(E::slots_per_epoch())));
-
-    // Verify that custody columns is a proper subset (not all columns for regular node)
-    assert!(
-        custody_columns.len() < harness.spec.number_of_custody_groups as usize,
-        "Regular node should not custody all columns"
-    );
-
-    // Create AvailableBlock with all data columns
-    let available_block_data = AvailableBlockData::DataColumns(all_data_columns.clone());
-    let available_block = AvailableBlock::__new_for_testing(
-        block_root,
-        Arc::new(signed_block),
-        available_block_data,
-        harness.spec.clone(),
-    );
-
-    // Import the block through the historical block batch import which calls the custody filtering internally
-    harness
-        .chain
-        .import_historical_block_batch(vec![available_block])
-        .expect("should import block with data columns");
+        .custody_columns_for_epoch(Some(current_slot.epoch(E::slots_per_epoch())))
+        .iter()
+        .copied()
+        .collect();
 
     // Check what actually got stored in the database
-    let stored_column_keys = store
+    let stored_column_indices: HashSet<_> = store
         .get_data_column_keys(block_root)
-        .expect("should get stored column keys");
-
-    // Verify only custody columns were stored
-    let stored_column_indices: HashSet<_> = stored_column_keys.into_iter().collect();
-    let expected_column_indices: HashSet<_> = custody_columns.iter().copied().collect();
+        .expect("should get stored column keys")
+        .into_iter()
+        .collect();
 
     assert_eq!(
-        stored_column_indices, expected_column_indices,
+        stored_column_indices, expected_custody_columns,
         "Regular node should only store custody columns"
     );
 }
@@ -4208,79 +4184,40 @@ async fn test_custody_column_filtering_regular_node() {
 /// Test that supernodes store all data columns when processing blocks with data columns.
 #[tokio::test]
 async fn test_custody_column_filtering_supernode() {
+    // Skip test if PeerDAS is not scheduled
+    if !test_spec::<E>().is_peer_das_scheduled() {
+        return;
+    }
+
     let db_path = tempdir().unwrap();
     let store = get_store(&db_path);
     let harness = get_harness_import_all_data_columns(store.clone(), LOW_VALIDATOR_COUNT);
 
-    // Skip test if PeerDAS is not scheduled
-    if !harness.spec.is_peer_das_scheduled() {
-        return;
-    }
+    // Generate a block with data columns
+    harness.execution_block_generator().set_min_blob_count(1);
+    let block_root = harness
+        .extend_chain(
+            1,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
 
-    // Generate a block with data columns using public test utils
-    let fork_name = harness.spec.fork_name_at_epoch(Epoch::new(0));
-    let mut rng = rand::rng();
-    let (signed_block, all_data_columns) =
-        beacon_chain::test_utils::generate_rand_block_and_data_columns::<E>(
-            fork_name,
-            beacon_chain::test_utils::NumBlobs::Number(1),
-            &mut rng,
-            &harness.spec,
-        );
-
-    let block_root = signed_block.canonical_root();
-
-    // Create AvailableBlock with all data columns
-    let available_block_data = AvailableBlockData::DataColumns(all_data_columns.clone());
-    let available_block = AvailableBlock::__new_for_testing(
-        block_root,
-        Arc::new(signed_block),
-        available_block_data,
-        harness.spec.clone(),
-    );
-
-    // Import the block through the historical block batch import
-    harness
-        .chain
-        .import_historical_block_batch(vec![available_block])
-        .expect("should import block with data columns");
+    // Supernodes are expected to store all data columns
+    let expected_custody_columns: HashSet<_> =
+        (0..E::number_of_columns() as u64).into_iter().collect();
 
     // Check what actually got stored in the database
-    let stored_column_keys = store
+    let stored_column_indices: HashSet<_> = store
         .get_data_column_keys(block_root)
-        .expect("should get stored column keys");
-
-    // Verify ALL data columns were stored for supernodes
-    let stored_column_indices: HashSet<_> = stored_column_keys.into_iter().collect();
-    let all_column_indices: HashSet<_> = all_data_columns.iter().map(|dc| dc.index).collect();
+        .expect("should get stored column keys")
+        .into_iter()
+        .collect();
 
     assert_eq!(
-        stored_column_indices, all_column_indices,
-        "Supernode should store ALL data columns"
+        stored_column_indices, expected_custody_columns,
+        "Supernode should store all custody columns"
     );
-
-    // Verify each stored column can be retrieved and matches original data
-    let stored_columns = store
-        .get_data_columns(&block_root)
-        .expect("should get data columns")
-        .expect("data columns should exist");
-
-    for original_column in &all_data_columns {
-        let stored_column = stored_columns
-            .iter()
-            .find(|stored| stored.index == original_column.index)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Column {} should be present in stored data",
-                    original_column.index
-                )
-            });
-        assert_eq!(
-            stored_column, original_column,
-            "Stored column {} should match original",
-            original_column.index
-        );
-    }
 }
 
 /// Checks that two chains are the same, for the purpose of these tests.

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -13,7 +13,8 @@ use beacon_chain::test_utils::{
 use beacon_chain::{
     BeaconChain, BeaconChainError, BeaconChainTypes, BeaconSnapshot, BlockError, ChainConfig,
     NotifyExecutionLayer, ServerSentEventHandler, WhenSlotSkipped,
-    data_availability_checker::MaybeAvailableBlock, historical_blocks::HistoricalBlockError,
+    data_availability_checker::{AvailableBlockData, MaybeAvailableBlock},
+    historical_blocks::HistoricalBlockError,
     migrate::MigratorConfig,
 };
 use logging::create_test_tracing_subscriber;
@@ -4135,6 +4136,195 @@ async fn replay_from_split_state() {
         .unwrap()
         .expect("split state should be present");
     assert_eq!(state.slot(), split.slot);
+}
+
+/// Test that regular nodes filter and store only custody columns when processing blocks with data columns.
+#[tokio::test]
+async fn test_custody_column_filtering_regular_node() {
+    let db_path = tempdir().unwrap();
+    let store = get_store(&db_path);
+    let harness = get_harness(store.clone(), LOW_VALIDATOR_COUNT);
+
+    // Skip test if PeerDAS is not scheduled
+    if !harness.spec.is_peer_das_scheduled() {
+        return;
+    }
+
+    // Generate a block with data columns using public test utils
+    let fork_name = harness.spec.fork_name_at_epoch(Epoch::new(0));
+    let mut rng = rand::rng();
+    let (signed_block, all_data_columns) =
+        beacon_chain::test_utils::generate_rand_block_and_data_columns::<E>(
+            fork_name,
+            beacon_chain::test_utils::NumBlobs::Number(3), // Generate 3 blobs to produce data columns
+            &mut rng,
+            &harness.spec,
+        );
+
+    // Skip test if no data columns are generated
+    if all_data_columns.is_empty() {
+        return;
+    }
+
+    let block_root = signed_block.canonical_root();
+    let slot = signed_block.slot();
+
+    // Get custody columns for this epoch - regular nodes only store a subset
+    let custody_columns = harness
+        .chain
+        .custody_columns_for_epoch(Some(slot.epoch(E::slots_per_epoch())));
+
+    // Verify that custody columns is a proper subset (not all columns for regular node)
+    assert!(
+        custody_columns.len() < harness.spec.number_of_custody_groups as usize,
+        "Regular node should not custody all columns"
+    );
+
+    // Create AvailableBlock with all data columns
+    let available_block_data = AvailableBlockData::DataColumns(all_data_columns.clone());
+    let available_block = AvailableBlock::__new_for_testing(
+        block_root,
+        Arc::new(signed_block),
+        available_block_data,
+        harness.spec.clone(),
+    );
+
+    // Import the block through the historical block batch import which calls the custody filtering internally
+    harness
+        .chain
+        .import_historical_block_batch(vec![available_block])
+        .expect("should import block with data columns");
+
+    // Check what actually got stored in the database
+    let stored_column_keys = store
+        .get_data_column_keys(block_root)
+        .expect("should get stored column keys");
+
+    // Verify only custody columns were stored
+    let stored_column_indices: std::collections::HashSet<_> =
+        stored_column_keys.into_iter().collect();
+    let expected_column_indices: std::collections::HashSet<_> =
+        custody_columns.iter().copied().collect();
+
+    assert_eq!(
+        stored_column_indices, expected_column_indices,
+        "Regular node should only store custody columns"
+    );
+
+    // Verify no non-custody columns are included
+    let all_column_indices: std::collections::HashSet<_> =
+        all_data_columns.iter().map(|dc| dc.index).collect();
+    let non_custody_columns: std::collections::HashSet<_> = all_column_indices
+        .difference(&expected_column_indices)
+        .collect();
+
+    for &non_custody_column in &non_custody_columns {
+        assert!(
+            !stored_column_indices.contains(&non_custody_column),
+            "Non-custody column {} should not be stored",
+            non_custody_column
+        );
+    }
+}
+
+/// Test that supernodes store all data columns when processing blocks with data columns.
+#[tokio::test]
+async fn test_custody_column_filtering_supernode() {
+    let db_path = tempdir().unwrap();
+    let store = get_store(&db_path);
+    let harness = get_harness_import_all_data_columns(store.clone(), LOW_VALIDATOR_COUNT);
+
+    // Skip test if PeerDAS is not scheduled
+    if !harness.spec.is_peer_das_scheduled() {
+        return;
+    }
+
+    // Generate a block with data columns using public test utils
+    let fork_name = harness.spec.fork_name_at_epoch(Epoch::new(0));
+    let mut rng = rand::rng();
+    let (signed_block, all_data_columns) =
+        beacon_chain::test_utils::generate_rand_block_and_data_columns::<E>(
+            fork_name,
+            beacon_chain::test_utils::NumBlobs::Number(3), // Generate 3 blobs to produce data columns
+            &mut rng,
+            &harness.spec,
+        );
+
+    // Skip test if no data columns are generated
+    if all_data_columns.is_empty() {
+        return;
+    }
+
+    let block_root = signed_block.canonical_root();
+
+    // Create AvailableBlock with all data columns
+    let available_block_data = AvailableBlockData::DataColumns(all_data_columns.clone());
+    let available_block = AvailableBlock::__new_for_testing(
+        block_root,
+        Arc::new(signed_block),
+        available_block_data,
+        harness.spec.clone(),
+    );
+
+    // Import the block through the historical block batch import
+    harness
+        .chain
+        .import_historical_block_batch(vec![available_block])
+        .expect("should import block with data columns");
+
+    // Check what actually got stored in the database
+    let stored_column_keys = store
+        .get_data_column_keys(block_root)
+        .expect("should get stored column keys");
+
+    // Verify ALL data columns were stored for supernodes
+    let stored_column_indices: std::collections::HashSet<_> =
+        stored_column_keys.into_iter().collect();
+    let all_column_indices: std::collections::HashSet<_> =
+        all_data_columns.iter().map(|dc| dc.index).collect();
+
+    assert_eq!(
+        stored_column_indices, all_column_indices,
+        "Supernode should store ALL data columns"
+    );
+
+    // Verify the count matches
+    assert_eq!(
+        stored_column_indices.len(),
+        all_data_columns.len(),
+        "Supernode should store the same number of columns as generated"
+    );
+
+    // Verify each stored column can be retrieved and matches original data
+    let stored_columns = store
+        .get_data_columns(&block_root)
+        .expect("should get data columns")
+        .expect("data columns should exist");
+
+    assert_eq!(
+        stored_columns.len(),
+        all_data_columns.len(),
+        "All data columns should be retrievable"
+    );
+
+    for original_column in &all_data_columns {
+        let matching_stored = stored_columns
+            .iter()
+            .find(|stored| stored.index == original_column.index);
+
+        assert!(
+            matching_stored.is_some(),
+            "Column {} should be present in stored data",
+            original_column.index
+        );
+
+        let stored_column = matching_stored.unwrap();
+        assert_eq!(
+            stored_column, original_column,
+            "Stored column {} should match original",
+            original_column.index
+        );
+    }
 }
 
 /// Checks that two chains are the same, for the purpose of these tests.

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -4220,7 +4220,7 @@ async fn test_custody_column_filtering_regular_node() {
 
     for &non_custody_column in &non_custody_columns {
         assert!(
-            !stored_column_indices.contains(&non_custody_column),
+            !stored_column_indices.contains(non_custody_column),
             "Non-custody column {} should not be stored",
             non_custody_column
         );

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2735,6 +2735,14 @@ async fn weak_subjectivity_sync_test(
         .rng(Box::new(StdRng::seed_from_u64(42)))
         .build()
         .expect("should build");
+    beacon_chain
+        .data_availability_checker
+        .custody_context()
+        .init_ordered_data_columns_from_custody_groups(
+            (0..spec.number_of_custody_groups).collect(),
+            &spec,
+        )
+        .unwrap();
 
     let beacon_chain = Arc::new(beacon_chain);
     let wss_block_root = wss_block.canonical_root();

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -4156,15 +4156,10 @@ async fn test_custody_column_filtering_regular_node() {
     let (signed_block, all_data_columns) =
         beacon_chain::test_utils::generate_rand_block_and_data_columns::<E>(
             fork_name,
-            beacon_chain::test_utils::NumBlobs::Number(3), // Generate 3 blobs to produce data columns
+            beacon_chain::test_utils::NumBlobs::Number(1),
             &mut rng,
             &harness.spec,
         );
-
-    // Skip test if no data columns are generated
-    if all_data_columns.is_empty() {
-        return;
-    }
 
     let block_root = signed_block.canonical_root();
     let slot = signed_block.slot();
@@ -4210,21 +4205,6 @@ async fn test_custody_column_filtering_regular_node() {
         stored_column_indices, expected_column_indices,
         "Regular node should only store custody columns"
     );
-
-    // Verify no non-custody columns are included
-    let all_column_indices: std::collections::HashSet<_> =
-        all_data_columns.iter().map(|dc| dc.index).collect();
-    let non_custody_columns: std::collections::HashSet<_> = all_column_indices
-        .difference(&expected_column_indices)
-        .collect();
-
-    for &non_custody_column in &non_custody_columns {
-        assert!(
-            !stored_column_indices.contains(non_custody_column),
-            "Non-custody column {} should not be stored",
-            non_custody_column
-        );
-    }
 }
 
 /// Test that supernodes store all data columns when processing blocks with data columns.
@@ -4301,24 +4281,16 @@ async fn test_custody_column_filtering_supernode() {
         .expect("should get data columns")
         .expect("data columns should exist");
 
-    assert_eq!(
-        stored_columns.len(),
-        all_data_columns.len(),
-        "All data columns should be retrievable"
-    );
-
     for original_column in &all_data_columns {
-        let matching_stored = stored_columns
+        let stored_column = stored_columns
             .iter()
-            .find(|stored| stored.index == original_column.index);
-
-        assert!(
-            matching_stored.is_some(),
-            "Column {} should be present in stored data",
-            original_column.index
-        );
-
-        let stored_column = matching_stored.unwrap();
+            .find(|stored| stored.index == original_column.index)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Column {} should be present in stored data",
+                    original_column.index
+                )
+            });
         assert_eq!(
             stored_column, original_column,
             "Stored column {} should match original",


### PR DESCRIPTION
## Issue Addressed

Resolves #8129 

## Proposed Changes

Persist only the custody columns and not sampling columns like before.
