### PR TITLE
Allow LH to checkpoint sync into a non-finalized checkpoint

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5874,7 +5874,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     chain
                         .canonical_head
                         .fork_choice_read_lock()
-                        .get_justified_block()
+                        .get_justified_or_anchor_block()
                 },
                 "invalid_payload_fork_choice_get_justified",
             )

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -187,13 +187,8 @@ where
         if anchor_block_header.state_root.is_zero() {
             anchor_block_header.state_root = unadvanced_state_root;
         }
-        let anchor_block_root = anchor_block_header.canonical_root();
-        let anchor_epoch = anchor_state.current_epoch();
-        let justified_checkpoint = Checkpoint {
-            epoch: anchor_epoch,
-            root: anchor_block_root,
-        };
-        let finalized_checkpoint = justified_checkpoint;
+        let justified_checkpoint = anchor_state.current_justified_checkpoint();
+        let finalized_checkpoint = anchor_state.finalized_checkpoint();
         let justified_balances = JustifiedBalances::from_justified_state(&anchor_state)?;
         let justified_state_root = anchor_state.canonical_root()?;
 

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -222,6 +222,10 @@ impl<E: EthSpec> CachedHead<E> {
         self.justified_checkpoint
     }
 
+    pub fn finalized_checkpoint_from_state(&self) -> Checkpoint {
+        self.snapshot.beacon_state.finalized_checkpoint()
+    }
+
     /// Returns the cached values of `ForkChoice::forkchoice_update_parameters`.
     ///
     /// Useful for supplying to the execution layer.

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -115,6 +115,7 @@ pub struct CachedHead<E: EthSpec> {
     justified_hash: Option<ExecutionBlockHash>,
     /// The `execution_payload.block_hash` of the finalized block. Set to `None` before Bellatrix.
     finalized_hash: Option<ExecutionBlockHash>,
+    pub anchor_block: (Hash256, Slot),
 }
 
 impl<E: EthSpec> CachedHead<E> {
@@ -272,6 +273,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
             head_hash: forkchoice_update_params.head_hash,
             justified_hash: forkchoice_update_params.justified_hash,
             finalized_hash: forkchoice_update_params.finalized_hash,
+            anchor_block: fork_choice.get_anchor_block(),
         };
 
         Self {
@@ -323,6 +325,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
             head_hash: forkchoice_update_params.head_hash,
             justified_hash: forkchoice_update_params.justified_hash,
             finalized_hash: forkchoice_update_params.finalized_hash,
+            anchor_block: fork_choice.get_anchor_block(),
         };
 
         *fork_choice_write_lock = fork_choice;
@@ -610,6 +613,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // shut down Lighthouse.
         let finalized_proto_block = fork_choice_read_lock.get_finalized_or_anchor_block()?;
         check_finalized_payload_validity(self, &finalized_proto_block)?;
+        let anchor_block = fork_choice_read_lock.get_anchor_block();
 
         // Sanity check the finalized checkpoint.
         //
@@ -700,6 +704,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 head_hash: new_forkchoice_update_parameters.head_hash,
                 justified_hash: new_forkchoice_update_parameters.justified_hash,
                 finalized_hash: new_forkchoice_update_parameters.finalized_hash,
+                anchor_block,
             };
 
             let new_head = {
@@ -727,6 +732,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 head_hash: new_forkchoice_update_parameters.head_hash,
                 justified_hash: new_forkchoice_update_parameters.justified_hash,
                 finalized_hash: new_forkchoice_update_parameters.finalized_hash,
+                anchor_block,
             };
 
             let mut cached_head_write_lock = self.canonical_head.cached_head_write_lock();

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -608,7 +608,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Check to ensure that the finalized block hasn't been marked as invalid. If it has,
         // shut down Lighthouse.
-        let finalized_proto_block = fork_choice_read_lock.get_finalized_block()?;
+        let finalized_proto_block = fork_choice_read_lock.get_finalized_or_anchor_block()?;
         check_finalized_payload_validity(self, &finalized_proto_block)?;
 
         // Sanity check the finalized checkpoint.

--- a/beacon_node/beacon_chain/src/fork_revert.rs
+++ b/beacon_node/beacon_chain/src/fork_revert.rs
@@ -98,59 +98,49 @@ pub fn reset_fork_choice_to_finalization<E: EthSpec, Hot: ItemStore<E>, Cold: It
     current_slot: Option<Slot>,
     spec: &ChainSpec,
 ) -> Result<ForkChoice<BeaconForkChoiceStore<E, Hot, Cold>, E>, String> {
-    // Fetch finalized block.
-    let finalized_checkpoint = head_state.finalized_checkpoint();
-    let finalized_block_root = finalized_checkpoint.root;
-    let finalized_block = store
-        .get_full_block(&finalized_block_root)
-        .map_err(|e| format!("Error loading finalized block: {:?}", e))?
+    // Fetch the store split as the most recent state internally considered finalized. If the node
+    // started with checkpoint sync and before its first finalization the split state does not equal
+    // to the last finalized state; and the last finalized state is unavailable.
+    let split = store.get_split_info();
+    let new_anchor_block_root = split.block_root;
+    let new_anchor_slot = split.slot;
+    let new_anchor_block = store
+        .get_full_block(&new_anchor_block_root)
+        .map_err(|e| format!("Error loading split block: {:?}", e))?
         .ok_or_else(|| {
             format!(
-                "Finalized block missing for revert: {:?}",
-                finalized_block_root
+                "Split block missing for revert: {:?}",
+                new_anchor_block_root
             )
         })?;
 
     // Advance finalized state to finalized epoch (to handle skipped slots).
-    let finalized_state_root = finalized_block.state_root();
+    let new_anchor_state_root = split.state_root;
     // The enshrined finalized state should be in the state cache.
-    let mut finalized_state = store
-        .get_state(&finalized_state_root, Some(finalized_block.slot()), true)
-        .map_err(|e| format!("Error loading finalized state: {:?}", e))?
+    let new_anchor_state = store
+        .get_state(&new_anchor_state_root, Some(new_anchor_slot), true)
+        .map_err(|e| format!("Error loading split state: {:?}", e))?
         .ok_or_else(|| {
             format!(
-                "Finalized block state missing from database: {:?}",
-                finalized_state_root
+                "Split block state missing from database: {:?}",
+                new_anchor_state_root
             )
         })?;
-    let finalized_slot = finalized_checkpoint.epoch.start_slot(E::slots_per_epoch());
-    complete_state_advance(
-        &mut finalized_state,
-        Some(finalized_state_root),
-        finalized_slot,
-        spec,
-    )
-    .map_err(|e| {
-        format!(
-            "Error advancing finalized state to finalized epoch: {:?}",
-            e
-        )
-    })?;
-    let finalized_snapshot = BeaconSnapshot {
-        beacon_block_root: finalized_block_root,
-        beacon_block: Arc::new(finalized_block),
-        beacon_state: finalized_state,
+    let new_anchor_snapshot = BeaconSnapshot {
+        beacon_block_root: new_anchor_block_root,
+        beacon_block: Arc::new(new_anchor_block),
+        beacon_state: new_anchor_state,
     };
 
     let fc_store =
-        BeaconForkChoiceStore::get_forkchoice_store(store.clone(), finalized_snapshot.clone())
+        BeaconForkChoiceStore::get_forkchoice_store(store.clone(), new_anchor_snapshot.clone())
             .map_err(|e| format!("Unable to reset fork choice store for revert: {e:?}"))?;
 
     let mut fork_choice = ForkChoice::from_anchor(
         fc_store,
-        finalized_block_root,
-        &finalized_snapshot.beacon_block,
-        &finalized_snapshot.beacon_state,
+        new_anchor_block_root,
+        &new_anchor_snapshot.beacon_block,
+        &new_anchor_snapshot.beacon_state,
         current_slot,
         spec,
     )
@@ -160,10 +150,10 @@ pub fn reset_fork_choice_to_finalization<E: EthSpec, Hot: ItemStore<E>, Cold: It
     // We do not replay attestations presently, relying on the absence of other blocks
     // to guarantee `head_block_root` as the head.
     let blocks = store
-        .load_blocks_to_replay(finalized_slot + 1, head_state.slot(), head_block_root)
+        .load_blocks_to_replay(new_anchor_slot + 1, head_state.slot(), head_block_root)
         .map_err(|e| format!("Error loading blocks to replay for fork choice: {:?}", e))?;
 
-    let mut state = finalized_snapshot.beacon_state;
+    let mut state = new_anchor_snapshot.beacon_state;
     for block in blocks {
         complete_state_advance(&mut state, None, block.slot(), spec)
             .map_err(|e| format!("State advance failed: {:?}", e))?;

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -120,7 +120,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
             let cached_head = beacon_chain.canonical_head.cached_head();
             let head_slot = cached_head.head_slot();
             let head_root = cached_head.head_block_root();
-            let finalized_checkpoint = cached_head.finalized_checkpoint();
+            let finalized_checkpoint = cached_head.finalized_checkpoint_from_state();
             let finalized_root_str = {
                 let finalized_slot = finalized_checkpoint
                     .epoch

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -121,6 +121,23 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
             let head_slot = cached_head.head_slot();
             let head_root = cached_head.head_block_root();
             let finalized_checkpoint = cached_head.finalized_checkpoint();
+            let finalized_root_str = {
+                let finalized_slot = finalized_checkpoint
+                    .epoch
+                    .start_slot(T::EthSpec::slots_per_epoch());
+                if cached_head.anchor_block.1 > finalized_slot {
+                    // Anchor block ahead of finalized checkpoint, the node has a subjective concept
+                    // of finality and will reject blocks that other nodes in the network will
+                    // accept
+                    format!(
+                        "{}/anchor/{}",
+                        finalized_checkpoint.root, cached_head.anchor_block.0
+                    )
+                } else {
+                    // Regular mode
+                    format!("{}", finalized_checkpoint.root)
+                }
+            };
 
             metrics::set_gauge(&metrics::NOTIFIER_HEAD_SLOT, head_slot.as_u64() as i64);
 
@@ -179,7 +196,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
 
             debug!(
                 peers = peer_count_pretty(connected_peer_count),
-                finalized_root = %finalized_checkpoint.root,
+                finalized_root = finalized_root_str,
                 finalized_epoch = %finalized_checkpoint.epoch,
                 head_block = %head_root,
                 %head_slot,
@@ -298,7 +315,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                 info!(
                     peers = peer_count_pretty(connected_peer_count),
                     exec_hash = block_hash,
-                    finalized_root = %finalized_checkpoint.root,
+                    finalized_root = finalized_root_str,
                     finalized_epoch = %finalized_checkpoint.epoch,
                     epoch = %current_epoch,
                     block = block_info,
@@ -309,7 +326,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                 metrics::set_gauge(&metrics::IS_SYNCED, 0);
                 info!(
                     peers = peer_count_pretty(connected_peer_count),
-                    finalized_root = %finalized_checkpoint.root,
+                    finalized_root = finalized_root_str,
                     finalized_epoch = %finalized_checkpoint.epoch,
                     %head_slot,
                     %current_slot,

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -270,6 +270,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                         speed = sync_speed_pretty(speed),
                         est_time =
                             estimated_time_pretty(speedo.estimated_time_till_slot(current_slot)),
+                        finalized_root = finalized_root_str,
                         "Syncing"
                     );
                 } else {
@@ -278,6 +279,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                         distance,
                         est_time =
                             estimated_time_pretty(speedo.estimated_time_till_slot(current_slot)),
+                        finalized_root = finalized_root_str,
                         "Syncing"
                     );
                 }

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -108,11 +108,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         } else {
             // Remote finalized epoch is less than ours.
             let remote_finalized_slot = start_slot(*remote.finalized_epoch());
-            if remote_finalized_slot < self.chain.store.get_oldest_block_slot() {
-                // Peer's finalized checkpoint is older than anything in our DB. We are unlikely
-                // to be able to help them sync.
-                Some("Old finality out of range".to_string())
-            } else if remote_finalized_slot < self.chain.store.get_split_slot() {
+            if remote_finalized_slot < self.chain.store.get_split_slot() {
                 // Peer's finalized slot is in range for a quick block root check in our freezer DB.
                 // If that block root check fails, reject them as they're on a different finalized
                 // chain.

--- a/beacon_node/network/src/status.rs
+++ b/beacon_node/network/src/status.rs
@@ -20,7 +20,7 @@ impl<T: BeaconChainTypes> ToStatusMessage for BeaconChain<T> {
 pub(crate) fn status_message<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>) -> StatusMessage {
     let fork_digest = beacon_chain.enr_fork_id().fork_digest;
     let cached_head = beacon_chain.canonical_head.cached_head();
-    let mut finalized_checkpoint = cached_head.finalized_checkpoint();
+    let mut finalized_checkpoint = cached_head.finalized_checkpoint_from_state();
 
     // Alias the genesis checkpoint root to `0x00`.
     let spec = &beacon_chain.spec;

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -147,11 +147,19 @@ where
                 let target_head_slot =
                     remote_finalized_slot + (2 * T::EthSpec::slots_per_epoch()) + 1;
 
+                // If the node started with checkpoint sync, local_info.finalized_epoch might be
+                // older than the current store split.
+                let start_epoch = self
+                    .beacon_chain
+                    .store
+                    .get_split_slot()
+                    .epoch(T::EthSpec::slots_per_epoch());
+
                 // Note: We keep current head chains. These can continue syncing whilst we complete
                 // this new finalized chain.
 
                 self.chains.add_peer_or_create_chain(
-                    local_info.finalized_epoch,
+                    start_epoch,
                     remote_info.finalized_root,
                     target_head_slot,
                     peer_id,

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -516,6 +516,9 @@ where
         let finalized_hash = self
             .get_block(&finalized_root)
             .and_then(|b| b.execution_status.block_hash());
+        // What happens if justified_hash, finalized_hash are None?
+        // Does the EL need it for some important reason? Can it wait for the next finality event?
+        // What if we send the anchor block instead?
         self.forkchoice_update_parameters = ForkchoiceUpdateParameters {
             head_root,
             head_hash,
@@ -724,6 +727,7 @@ where
         // `self.proto_array` to do this search. See:
         //
         // https://github.com/ethereum/eth2.0-specs/pull/1884
+        // TODO: Manual implementation of descendant, fix
         let block_ancestor = self.get_ancestor(block.parent_root(), finalized_slot)?;
         let finalized_root = self.fc_store.finalized_checkpoint().root;
         if block_ancestor != Some(finalized_root) {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -320,6 +320,12 @@ pub struct ForkChoice<T, E> {
     queued_attestations: Vec<QueuedAttestation>,
     /// Stores a cache of the values required to be sent to the execution layer.
     forkchoice_update_parameters: ForkchoiceUpdateParameters,
+    /// The block hash of the block used to initialize the ForkChoice. Invariants:
+    /// - At initialization there is always a ProtoNode for `anchor_block_root`
+    /// - After pruning there may not be a ProtoNode for `anchor_block_root`
+    /// - At any point there is either or both ProtoNodes for `anchor_block_root` and
+    ///   `finalized_checkpoint.root`
+    anchor_block_root: Hash256,
     _phantom: PhantomData<E>,
 }
 
@@ -414,6 +420,7 @@ where
                 // This will be updated during the next call to `Self::get_head`.
                 head_root: Hash256::zero(),
             },
+            anchor_block_root,
             _phantom: PhantomData,
         };
 
@@ -1269,23 +1276,29 @@ where
     }
 
     /// Returns the `ProtoBlock` for the justified checkpoint.
+    /// If the node started with checkpoint sync and has not justified yet, it returns the
+    /// `ProtoBlock` of the anchor block.
     ///
     /// ## Notes
     ///
     /// This does *not* return the "best justified checkpoint". It returns the justified checkpoint
     /// that is used for computing balances.
-    pub fn get_justified_block(&self) -> Result<ProtoBlock, Error<T::Error>> {
+    pub fn get_justified_or_anchor_block(&self) -> Result<ProtoBlock, Error<T::Error>> {
         let justified_checkpoint = self.justified_checkpoint();
         self.get_block(&justified_checkpoint.root)
+            .ok_or_else(|| self.get_block(&self.anchor_block_root))
             .ok_or(Error::MissingJustifiedBlock {
                 justified_checkpoint,
             })
     }
 
     /// Returns the `ProtoBlock` for the finalized checkpoint.
-    pub fn get_finalized_block(&self) -> Result<ProtoBlock, Error<T::Error>> {
+    /// If the node started with checkpoint sync and has not finalized yet, it returns the
+    /// `ProtoBlock` of the anchor block.
+    pub fn get_finalized_or_anchor_block(&self) -> Result<ProtoBlock, Error<T::Error>> {
         let finalized_checkpoint = self.finalized_checkpoint();
         self.get_block(&finalized_checkpoint.root)
+            .ok_or_else(|| self.get_block(&self.anchor_block_root))
             .ok_or(Error::MissingFinalizedBlock {
                 finalized_checkpoint,
             })

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -341,6 +341,12 @@ where
     E: EthSpec,
 {
     /// Instantiates `Self` from an anchor (genesis or another finalized checkpoint).
+    ///
+    /// # Parameters
+    /// - `anchor_block_root`: Hash of the `anchor_block`.
+    /// - `anchor_block`: The most recent block for `anchor_state` (the block that produced it).
+    /// - `anchor_state`: Beacon state **after** applying `anchor_block` and advanced to the closest
+    ///                   epoch boundary.
     pub fn from_anchor(
         fc_store: T,
         anchor_block_root: Hash256,
@@ -357,16 +363,16 @@ where
             });
         }
 
-        let finalized_block_slot = anchor_block.slot();
-        let finalized_block_state_root = anchor_block.state_root();
-        let current_epoch_shuffling_id =
+        let anchor_block_slot = anchor_block.slot();
+        let anchor_block_state_root = anchor_block.state_root();
+        let anchor_block_current_epoch_shuffling_id =
             AttestationShufflingId::new(anchor_block_root, anchor_state, RelativeEpoch::Current)
                 .map_err(Error::BeaconStateError)?;
-        let next_epoch_shuffling_id =
+        let anchor_block_next_epoch_shuffling_id =
             AttestationShufflingId::new(anchor_block_root, anchor_state, RelativeEpoch::Next)
                 .map_err(Error::BeaconStateError)?;
 
-        let execution_status = anchor_block.message().execution_payload().map_or_else(
+        let anchor_block_execution_status = anchor_block.message().execution_payload().map_or_else(
             // If the block doesn't have an execution payload then it can't have
             // execution enabled.
             |_| ExecutionStatus::irrelevant(),
@@ -387,13 +393,13 @@ where
 
         let proto_array = ProtoArrayForkChoice::new::<E>(
             current_slot,
-            finalized_block_slot,
-            finalized_block_state_root,
+            anchor_block_slot,
+            anchor_block_state_root,
             *fc_store.justified_checkpoint(),
             *fc_store.finalized_checkpoint(),
-            current_epoch_shuffling_id,
-            next_epoch_shuffling_id,
-            execution_status,
+            anchor_block_current_epoch_shuffling_id,
+            anchor_block_next_epoch_shuffling_id,
+            anchor_block_execution_status,
         )?;
 
         let mut fork_choice = Self {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1278,6 +1278,10 @@ where
         self.proto_array.get_weight(block_root)
     }
 
+    pub fn get_anchor_block(&self) -> (Hash256, Slot) {
+        self.proto_array.get_anchor_block()
+    }
+
     /// Returns the `ProtoBlock` for the justified checkpoint.
     /// If the node started with checkpoint sync and has not justified yet, it returns the
     /// `ProtoBlock` of the anchor block.
@@ -1289,7 +1293,7 @@ where
     pub fn get_justified_or_anchor_block(&self) -> Result<ProtoBlock, Error<T::Error>> {
         let justified_checkpoint = self.justified_checkpoint();
         self.get_block(&justified_checkpoint.root)
-            .or_else(|| self.get_anchor_block())
+            .or_else(|| self.get_block(&self.proto_array.get_anchor_block_root()))
             .ok_or(Error::MissingJustifiedBlock {
                 justified_checkpoint,
             })
@@ -1301,16 +1305,10 @@ where
     pub fn get_finalized_or_anchor_block(&self) -> Result<ProtoBlock, Error<T::Error>> {
         let finalized_checkpoint = self.finalized_checkpoint();
         self.get_block(&finalized_checkpoint.root)
-            .or_else(|| self.get_anchor_block())
+            .or_else(|| self.get_block(&self.proto_array.get_anchor_block_root()))
             .ok_or(Error::MissingFinalizedBlock {
                 finalized_checkpoint,
             })
-    }
-
-    /// Returns the `ProtoBlock` of `anchor_block_root`. May return None after the fork-choice has
-    /// finalized and been pruned.
-    fn get_anchor_block(&self) -> Option<ProtoBlock> {
-        self.get_block(&self.proto_array.get_anchor_block_root())
     }
 
     /// Return `true` if `block_root` is equal to the finalized checkpoint, or a known descendant of it.

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1436,7 +1436,7 @@ where
         reset_payload_statuses: ResetPayloadStatuses,
         spec: &ChainSpec,
     ) -> Result<ProtoArrayForkChoice, Error<T::Error>> {
-        let mut proto_array = ProtoArrayForkChoice::from_container(
+        let mut proto_array = ProtoArrayForkChoice::from_container::<E>(
             persisted_proto_array.clone(),
             justified_balances.clone(),
         )
@@ -1468,7 +1468,7 @@ where
                 info = "please report this error",
                 "Failed to reset payload statuses"
             );
-            ProtoArrayForkChoice::from_container(persisted_proto_array, justified_balances)
+            ProtoArrayForkChoice::from_container::<E>(persisted_proto_array, justified_balances)
                 .map_err(Error::InvalidProtoArrayBytes)
         } else {
             debug!("Successfully reset all payload statuses");

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -320,12 +320,6 @@ pub struct ForkChoice<T, E> {
     queued_attestations: Vec<QueuedAttestation>,
     /// Stores a cache of the values required to be sent to the execution layer.
     forkchoice_update_parameters: ForkchoiceUpdateParameters,
-    /// The block hash of the block used to initialize the ForkChoice. Invariants:
-    /// - At initialization there is always a ProtoNode for `anchor_block_root`
-    /// - After pruning there may not be a ProtoNode for `anchor_block_root`
-    /// - At any point there is either or both ProtoNodes for `anchor_block_root` and
-    ///   `finalized_checkpoint.root`
-    anchor_block_root: Hash256,
     _phantom: PhantomData<E>,
 }
 
@@ -352,7 +346,7 @@ where
     /// - `anchor_block_root`: Hash of the `anchor_block`.
     /// - `anchor_block`: The most recent block for `anchor_state` (the block that produced it).
     /// - `anchor_state`: Beacon state **after** applying `anchor_block` and advanced to the closest
-    ///                   epoch boundary.
+    ///   epoch boundary.
     pub fn from_anchor(
         fc_store: T,
         anchor_block_root: Hash256,
@@ -400,6 +394,7 @@ where
         let proto_array = ProtoArrayForkChoice::new::<E>(
             current_slot,
             anchor_block_slot,
+            anchor_block_root,
             anchor_block_state_root,
             *fc_store.justified_checkpoint(),
             *fc_store.finalized_checkpoint(),
@@ -420,7 +415,6 @@ where
                 // This will be updated during the next call to `Self::get_head`.
                 head_root: Hash256::zero(),
             },
-            anchor_block_root,
             _phantom: PhantomData,
         };
 
@@ -1286,7 +1280,7 @@ where
     pub fn get_justified_or_anchor_block(&self) -> Result<ProtoBlock, Error<T::Error>> {
         let justified_checkpoint = self.justified_checkpoint();
         self.get_block(&justified_checkpoint.root)
-            .ok_or_else(|| self.get_block(&self.anchor_block_root))
+            .or_else(|| self.get_anchor_block())
             .ok_or(Error::MissingJustifiedBlock {
                 justified_checkpoint,
             })
@@ -1298,10 +1292,16 @@ where
     pub fn get_finalized_or_anchor_block(&self) -> Result<ProtoBlock, Error<T::Error>> {
         let finalized_checkpoint = self.finalized_checkpoint();
         self.get_block(&finalized_checkpoint.root)
-            .ok_or_else(|| self.get_block(&self.anchor_block_root))
+            .or_else(|| self.get_anchor_block())
             .ok_or(Error::MissingFinalizedBlock {
                 finalized_checkpoint,
             })
+    }
+
+    /// Returns the `ProtoBlock` of `anchor_block_root`. May return None after the fork-choice has
+    /// finalized and been pruned.
+    fn get_anchor_block(&self) -> Option<ProtoBlock> {
+        self.get_block(&self.proto_array.get_anchor_block_root())
     }
 
     /// Return `true` if `block_root` is equal to the finalized checkpoint, or a known descendant of it.
@@ -1332,7 +1332,7 @@ where
             Ok(status.is_optimistic_or_invalid())
         } else {
             Ok(self
-                .get_finalized_block()?
+                .get_finalized_or_anchor_block()?
                 .execution_status
                 .is_optimistic_or_invalid())
         }

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -508,17 +508,18 @@ where
         let head_hash = self
             .get_block(&head_root)
             .and_then(|b| b.execution_status.block_hash());
-        let justified_root = self.justified_checkpoint().root;
-        let finalized_root = self.finalized_checkpoint().root;
+        // After starting with checkpoint sync and before finalizing the finalized and justified
+        // ProtoNodes are not available.
+        // TODO(non-fin): Is it safe to tell the EL that the anchor block is finalized? Should we
+        // pass zero in that case?
         let justified_hash = self
-            .get_block(&justified_root)
+            .get_justified_or_anchor_block()
+            .ok()
             .and_then(|b| b.execution_status.block_hash());
         let finalized_hash = self
-            .get_block(&finalized_root)
+            .get_finalized_or_anchor_block()
+            .ok()
             .and_then(|b| b.execution_status.block_hash());
-        // What happens if justified_hash, finalized_hash are None?
-        // Does the EL need it for some important reason? Can it wait for the next finality event?
-        // What if we send the anchor block instead?
         self.forkchoice_update_parameters = ForkchoiceUpdateParameters {
             head_root,
             head_hash,
@@ -726,13 +727,17 @@ where
         // (trivial), but more importantly, it means we don't need to have added `block` to
         // `self.proto_array` to do this search. See:
         //
+        // After starting with checkpoint sync and before finalizing there is no ProtoNode for the
+        // finalized root. Use the anchor block (initial block) are root to assert this new block is
+        // descendant of it.
+        //
         // https://github.com/ethereum/eth2.0-specs/pull/1884
-        // TODO: Manual implementation of descendant, fix
-        let block_ancestor = self.get_ancestor(block.parent_root(), finalized_slot)?;
-        let finalized_root = self.fc_store.finalized_checkpoint().root;
-        if block_ancestor != Some(finalized_root) {
+        let finalized_or_anchor_block = self.get_finalized_or_anchor_block()?;
+        let block_ancestor =
+            self.get_ancestor(block.parent_root(), finalized_or_anchor_block.slot)?;
+        if block_ancestor != Some(finalized_or_anchor_block.root) {
             return Err(Error::InvalidBlock(InvalidBlock::NotFinalizedDescendant {
-                finalized_root,
+                finalized_root: finalized_or_anchor_block.root,
                 block_ancestor,
             }));
         }

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -524,12 +524,12 @@ fn justified_and_finalized_blocks() {
     let justified_checkpoint = fork_choice.justified_checkpoint();
     assert_eq!(justified_checkpoint.epoch, 0);
     assert!(justified_checkpoint.root != Hash256::zero());
-    assert!(fork_choice.get_justified_block().is_ok());
+    assert!(fork_choice.get_justified_or_anchor_block().is_ok());
 
     let finalized_checkpoint = fork_choice.finalized_checkpoint();
     assert_eq!(finalized_checkpoint.epoch, 0);
     assert!(finalized_checkpoint.root != Hash256::zero());
-    assert!(fork_choice.get_finalized_block().is_ok());
+    assert!(fork_choice.get_finalized_or_anchor_block().is_ok());
 }
 
 /// - The new justified checkpoint descends from the current. Near genesis.

--- a/consensus/proto_array/src/error.rs
+++ b/consensus/proto_array/src/error.rs
@@ -54,6 +54,7 @@ pub enum Error {
     },
     InvalidEpochOffset(u64),
     Arith(ArithError),
+    EmptyNodes,
 }
 
 impl From<ArithError> for Error {

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -17,6 +17,8 @@ pub use ffg_updates::*;
 pub use no_votes::*;
 pub use votes::*;
 
+type E = MainnetEthSpec;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Operation {
     FindHead {
@@ -123,7 +125,7 @@ impl ForkChoiceTestDefinition {
                         "Operation at index {} failed head check. Operation: {:?}",
                         op_index, op
                     );
-                    check_bytes_round_trip(&fork_choice);
+                    check_bytes_round_trip::<E>(&fork_choice);
                 }
                 Operation::ProposerBoostFindHead {
                     justified_checkpoint,
@@ -154,7 +156,7 @@ impl ForkChoiceTestDefinition {
                         "Operation at index {} failed head check. Operation: {:?}",
                         op_index, op
                     );
-                    check_bytes_round_trip(&fork_choice);
+                    check_bytes_round_trip::<E>(&fork_choice);
                 }
                 Operation::InvalidFindHead {
                     justified_checkpoint,
@@ -180,7 +182,7 @@ impl ForkChoiceTestDefinition {
                         op_index,
                         op
                     );
-                    check_bytes_round_trip(&fork_choice);
+                    check_bytes_round_trip::<E>(&fork_choice);
                 }
                 Operation::ProcessBlock {
                     slot,
@@ -220,7 +222,7 @@ impl ForkChoiceTestDefinition {
                                 op_index, e
                             )
                         });
-                    check_bytes_round_trip(&fork_choice);
+                    check_bytes_round_trip::<E>(&fork_choice);
                 }
                 Operation::ProcessAttestation {
                     validator_index,
@@ -235,7 +237,7 @@ impl ForkChoiceTestDefinition {
                                 op_index
                             )
                         });
-                    check_bytes_round_trip(&fork_choice);
+                    check_bytes_round_trip::<E>(&fork_choice);
                 }
                 Operation::Prune {
                     finalized_root,
@@ -305,9 +307,9 @@ fn get_checkpoint(i: u64) -> Checkpoint {
     }
 }
 
-fn check_bytes_round_trip(original: &ProtoArrayForkChoice) {
+fn check_bytes_round_trip<E: EthSpec>(original: &ProtoArrayForkChoice) {
     let bytes = original.as_bytes();
-    let decoded = ProtoArrayForkChoice::from_bytes(&bytes, original.balances.clone())
+    let decoded = ProtoArrayForkChoice::from_bytes::<E>(&bytes, original.balances.clone())
         .expect("fork choice should decode from bytes");
     assert!(
         *original == decoded,

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -82,6 +82,7 @@ impl ForkChoiceTestDefinition {
         let mut fork_choice = ProtoArrayForkChoice::new::<MainnetEthSpec>(
             self.finalized_block_slot,
             self.finalized_block_slot,
+            self.finalized_checkpoint.root,
             Hash256::zero(),
             self.justified_checkpoint,
             self.finalized_checkpoint,

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -135,6 +135,12 @@ pub struct ProtoArray {
     pub nodes: Vec<ProtoNode>,
     pub indices: HashMap<Hash256, usize>,
     pub previous_proposer_boost: ProposerBoost,
+    /// The block hash of the block used to initialize the ProtoArray. Invariants:
+    /// - At initialization there is always a ProtoNode for `anchor_block_root`
+    /// - After pruning there may not be a ProtoNode for `anchor_block_root`
+    /// - At any point there is either or both ProtoNodes for `anchor_block_root` and
+    ///   `finalized_checkpoint.root`
+    pub anchor_block_root: Hash256,
 }
 
 impl ProtoArray {

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -140,7 +140,7 @@ pub struct ProtoArray {
     /// - After pruning there may not be a ProtoNode for `anchor_block_root`
     /// - At any point there is either or both ProtoNodes for `anchor_block_root` and
     ///   `finalized_checkpoint.root`
-    pub anchor_block_root: Hash256,
+    pub anchor_block: (Hash256, Slot),
 }
 
 impl ProtoArray {
@@ -969,10 +969,16 @@ impl ProtoArray {
     /// *checkpoint* not the finalized *block*.
     pub fn is_finalized_checkpoint_or_descendant<E: EthSpec>(&self, root: Hash256) -> bool {
         let finalized_root = self.finalized_checkpoint.root;
-        let finalized_slot = self
-            .finalized_checkpoint
-            .epoch
-            .start_slot(E::slots_per_epoch());
+        let (finalized_root, finalized_slot) = if self.indices.contains_key(&finalized_root) {
+            (
+                finalized_root,
+                self.finalized_checkpoint
+                    .epoch
+                    .start_slot(E::slots_per_epoch()),
+            )
+        } else {
+            self.anchor_block
+        };
 
         let Some(mut node) = self
             .indices

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -966,6 +966,10 @@ impl ProtoArrayForkChoice {
     pub fn get_anchor_block_root(&self) -> Hash256 {
         self.proto_array.anchor_block.0
     }
+
+    pub fn get_anchor_block(&self) -> (Hash256, Slot) {
+        self.proto_array.anchor_block
+    }
 }
 
 /// Returns a list of `deltas`, where there is one delta for each of the indices in

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -414,13 +414,13 @@ impl ProtoArrayForkChoice {
     #[allow(clippy::too_many_arguments)]
     pub fn new<E: EthSpec>(
         current_slot: Slot,
-        finalized_block_slot: Slot,
-        finalized_block_state_root: Hash256,
+        anchor_block_slot: Slot,
+        anchor_block_state_root: Hash256,
         justified_checkpoint: Checkpoint,
         finalized_checkpoint: Checkpoint,
-        current_epoch_shuffling_id: AttestationShufflingId,
-        next_epoch_shuffling_id: AttestationShufflingId,
-        execution_status: ExecutionStatus,
+        anchor_block_current_epoch_shuffling_id: AttestationShufflingId,
+        anchor_block_next_epoch_shuffling_id: AttestationShufflingId,
+        anchor_block_execution_status: ExecutionStatus,
     ) -> Result<Self, String> {
         let mut proto_array = ProtoArray {
             prune_threshold: DEFAULT_PRUNE_THRESHOLD,
@@ -432,18 +432,18 @@ impl ProtoArrayForkChoice {
         };
 
         let block = Block {
-            slot: finalized_block_slot,
+            slot: anchor_block_slot,
             root: finalized_checkpoint.root,
             parent_root: None,
-            state_root: finalized_block_state_root,
+            state_root: anchor_block_state_root,
             // We are using the finalized_root as the target_root, since it always lies on an
             // epoch boundary.
             target_root: finalized_checkpoint.root,
-            current_epoch_shuffling_id,
-            next_epoch_shuffling_id,
+            current_epoch_shuffling_id: anchor_block_current_epoch_shuffling_id,
+            next_epoch_shuffling_id: anchor_block_next_epoch_shuffling_id,
             justified_checkpoint,
             finalized_checkpoint,
-            execution_status,
+            execution_status: anchor_block_execution_status,
             unrealized_justified_checkpoint: Some(justified_checkpoint),
             unrealized_finalized_checkpoint: Some(finalized_checkpoint),
         };

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -415,6 +415,7 @@ impl ProtoArrayForkChoice {
     pub fn new<E: EthSpec>(
         current_slot: Slot,
         anchor_block_slot: Slot,
+        anchor_block_root: Hash256,
         anchor_block_state_root: Hash256,
         justified_checkpoint: Checkpoint,
         finalized_checkpoint: Checkpoint,
@@ -429,11 +430,12 @@ impl ProtoArrayForkChoice {
             nodes: Vec::with_capacity(1),
             indices: HashMap::with_capacity(1),
             previous_proposer_boost: ProposerBoost::default(),
+            anchor_block_root,
         };
 
         let block = Block {
             slot: anchor_block_slot,
-            root: finalized_checkpoint.root,
+            root: anchor_block_root,
             parent_root: None,
             state_root: anchor_block_state_root,
             // We are using the finalized_root as the target_root, since it always lies on an
@@ -957,6 +959,11 @@ impl ProtoArrayForkChoice {
     pub fn heads_descended_from_finalization<E: EthSpec>(&self) -> Vec<&ProtoNode> {
         self.proto_array.heads_descended_from_finalization::<E>()
     }
+
+    /// Returns the anchor_block_root
+    pub fn get_anchor_block_root(&self) -> Hash256 {
+        self.proto_array.anchor_block_root
+    }
 }
 
 /// Returns a list of `deltas`, where there is one delta for each of the indices in
@@ -1098,6 +1105,7 @@ mod test_compute_deltas {
         let mut fc = ProtoArrayForkChoice::new::<MainnetEthSpec>(
             genesis_slot,
             genesis_slot,
+            genesis_checkpoint.root,
             state_root,
             genesis_checkpoint,
             genesis_checkpoint,
@@ -1224,6 +1232,7 @@ mod test_compute_deltas {
         let mut fc = ProtoArrayForkChoice::new::<MainnetEthSpec>(
             genesis_slot,
             genesis_slot,
+            genesis_checkpoint.root,
             junk_state_root,
             genesis_checkpoint,
             genesis_checkpoint,

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -430,7 +430,7 @@ impl ProtoArrayForkChoice {
             nodes: Vec::with_capacity(1),
             indices: HashMap::with_capacity(1),
             previous_proposer_boost: ProposerBoost::default(),
-            anchor_block_root,
+            anchor_block: (anchor_block_root, anchor_block_slot),
         };
 
         let block = Block {
@@ -926,18 +926,20 @@ impl ProtoArrayForkChoice {
         SszContainer::from(self).as_ssz_bytes()
     }
 
-    pub fn from_bytes(bytes: &[u8], balances: JustifiedBalances) -> Result<Self, String> {
+    pub fn from_bytes<E: EthSpec>(
+        bytes: &[u8],
+        balances: JustifiedBalances,
+    ) -> Result<Self, String> {
         let container = SszContainer::from_ssz_bytes(bytes)
             .map_err(|e| format!("Failed to decode ProtoArrayForkChoice: {:?}", e))?;
-        Self::from_container(container, balances)
+        Self::from_container::<E>(container, balances)
     }
 
-    pub fn from_container(
+    pub fn from_container<E: EthSpec>(
         container: SszContainer,
         balances: JustifiedBalances,
     ) -> Result<Self, String> {
-        (container, balances)
-            .try_into()
+        Self::from_ssz::<E>(container, balances)
             .map_err(|e| format!("Failed to initialize ProtoArrayForkChoice: {e:?}"))
     }
 
@@ -962,7 +964,7 @@ impl ProtoArrayForkChoice {
 
     /// Returns the anchor_block_root
     pub fn get_anchor_block_root(&self) -> Hash256 {
-        self.proto_array.anchor_block_root
+        self.proto_array.anchor_block.0
     }
 }
 

--- a/consensus/proto_array/src/ssz_container.rs
+++ b/consensus/proto_array/src/ssz_container.rs
@@ -8,7 +8,7 @@ use ssz::{Encode, four_byte_option_impl};
 use ssz_derive::{Decode, Encode};
 use std::collections::HashMap;
 use superstruct::superstruct;
-use types::{Checkpoint, Hash256};
+use types::{Checkpoint, EthSpec, Hash256};
 
 // Define a "legacy" implementation of `Option<usize>` which uses four bytes for encoding the union
 // selector.
@@ -49,21 +49,28 @@ impl From<&ProtoArrayForkChoice> for SszContainer {
     }
 }
 
-impl TryFrom<(SszContainer, JustifiedBalances)> for ProtoArrayForkChoice {
-    type Error = Error;
-
-    fn try_from((from, balances): (SszContainer, JustifiedBalances)) -> Result<Self, Error> {
-        let anchor_block_root = if from
+impl ProtoArrayForkChoice {
+    pub fn from_ssz<E: EthSpec>(
+        from: SszContainer,
+        balances: JustifiedBalances,
+    ) -> Result<Self, Error> {
+        let anchor_block = if from
             .nodes
             .iter()
             .any(|node| node.root == from.finalized_checkpoint.root)
         {
             // There's a node for the finalized checkpoint, use that as anchor block
-            from.finalized_checkpoint.root
+            (
+                from.finalized_checkpoint.root,
+                from.finalized_checkpoint
+                    .epoch
+                    .start_slot(E::slots_per_epoch()),
+            )
         } else {
             // Otherwise we initialized fork-choice from a block more recent than finalization and
             // have not finalized yet. Use the first node as anchor block.
-            from.nodes.first().ok_or(Error::EmptyNodes)?.root
+            let anchor_node = from.nodes.first().ok_or(Error::EmptyNodes)?;
+            (anchor_node.root, anchor_node.slot)
         };
 
         let proto_array = ProtoArray {
@@ -73,7 +80,7 @@ impl TryFrom<(SszContainer, JustifiedBalances)> for ProtoArrayForkChoice {
             nodes: from.nodes,
             indices: from.indices.into_iter().collect::<HashMap<_, _>>(),
             previous_proposer_boost: from.previous_proposer_boost,
-            anchor_block_root,
+            anchor_block,
         };
 
         Ok(Self {

--- a/consensus/proto_array/src/ssz_container.rs
+++ b/consensus/proto_array/src/ssz_container.rs
@@ -53,6 +53,19 @@ impl TryFrom<(SszContainer, JustifiedBalances)> for ProtoArrayForkChoice {
     type Error = Error;
 
     fn try_from((from, balances): (SszContainer, JustifiedBalances)) -> Result<Self, Error> {
+        let anchor_block_root = if from
+            .nodes
+            .iter()
+            .any(|node| node.root == from.finalized_checkpoint.root)
+        {
+            // There's a node for the finalized checkpoint, use that as anchor block
+            from.finalized_checkpoint.root
+        } else {
+            // Otherwise we initialized fork-choice from a block more recent than finalization and
+            // have not finalized yet. Use the first node as anchor block.
+            from.nodes.first().ok_or(Error::EmptyNodes)?.root
+        };
+
         let proto_array = ProtoArray {
             prune_threshold: from.prune_threshold,
             justified_checkpoint: from.justified_checkpoint,
@@ -60,6 +73,7 @@ impl TryFrom<(SszContainer, JustifiedBalances)> for ProtoArrayForkChoice {
             nodes: from.nodes,
             indices: from.indices.into_iter().collect::<HashMap<_, _>>(),
             previous_proposer_boost: from.previous_proposer_boost,
+            anchor_block_root,
         };
 
         Ok(Self {


### PR DESCRIPTION
## Issue Addressed

We want to allow Lighthouse nodes to start from a non-finalized checkpoint as a way to allow nodes to get un-stuck during long finality. See issue below for more details:

- https://github.com/sigp/lighthouse/issues/7089

Closes https://github.com/sigp/lighthouse/issues/7089

## Proposed Changes

Consider a network where epoch 1000 is finalized, epoch 1001 is justified but we start the node from a state at epoch 2000. The node needs to advertise to its peers and construct attestations setting its finalized checkpoint to epoch 1000 and justified checkpoint to epoch 1001. However, the states of those checkpoints are not available.

I have reviewed all places where that can be a problem, let's go one by one.

**Attestation production**
- From `EarlyAttesterCache` on `add_head_block` we use the checkpoints in the post state as source of truth
- Else reads the justified checkpoint from the head state or an advanced state

**State cache**
- The finalized state will become the anchor state. We never read the finalized state by "name", instead we check if the root of the stored finalized state matches the one being requested
- Pruning is not affected

**ReqResp Status**
- Produced from the head state, not affected

**Fork-choice internals**
- `is_finalized_checkpoint_or_descendant` needs updating as it assumes the finalized node exist
- Some code paths need updating as they assume the finalized and justified ProtoNodes exist
- Pruning is fine as it only acts on the new finalized checkpoint

**EL fork_choice_updated**
- Needs updating as we don't known the execution hash of the finalized and justified blocks.

**DB migration**
- Not affected, never reads the previous finalized checkpoint, migration is independent of it.

**fork_revert**
- Updated to use either the anchor block or finalized block

## Testing

**In progress**

- Started a kurtosis devnet of 6 lighthouse nodes
- Let it run for 5000 slots, then stop 50% of the validators, let it run for 10000 slots (non-finality)
- Run a new node without validators and start with checkpoint sync a recent checkpoint. The node synced to the head and started following the head
- Start the stopped validators and let the network finalize again
