### PR TITLE
gloas - temporary proposer_boost_re_org_test test fixes

### DIFF
--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -396,7 +396,10 @@ pub async fn proposer_boost_re_org_test(
     assert!(head_slot > 0);
 
     // Test using the latest fork so that we simulate conditions as similar to mainnet as possible.
-    let mut spec = ForkName::latest().make_genesis_spec(E::default_spec());
+    // TODO(EIP-7732): extend test for Gloas by reverting back to using ForkName::latest()
+    // Issue is that `get_validator_blocks_v3` below expects to be able to use `state.latest_execution_payload_header` during `produce_block_on_state` -> `produce_partial_beacon_block` -> `get_execution_payload`, but gloas will no longer support this state field
+    // This will be resolved in a subsequent block processing PR
+    let mut spec = ForkName::Fulu.make_genesis_spec(E::default_spec());
     spec.terminal_total_difficulty = Uint256::from(1);
 
     // Ensure there are enough validators to have `attesters_per_slot`.


### PR DESCRIPTION
## Changes
Current `gloas-containers` [PR](https://github.com/sigp/lighthouse/pull/7923) tests are failing because re-org tests trigger block production, which expects `state.latest_execution_payload_header()` during `get_execution_payload` as to be able to verify the parent payload hash, but gloas no longer supports this state field.  Proper fix will be implemented in a subsequent block processing PR.

@ethDreamer 