### PR TITLE
Fix boot node CLI flag naming inconsistency

### DIFF
--- a/boot_node/src/cli.rs
+++ b/boot_node/src/cli.rs
@@ -76,7 +76,7 @@ pub fn cli_app() -> Command {
         )
         .arg(
             Arg::new("enr-udp-port")
-                .long("enr-port")
+                .long("enr-udp-port")
                 .value_name("PORT")
                 .help("The UDP port of the boot node's ENR. This is the port that external peers will dial to reach this boot node. Set this only if the external port differs from the listening port.")
                 .action(ArgAction::Set)


### PR DESCRIPTION

## Description

Fixes CLI flag naming inconsistency in boot node configuration.

## Proposed Changes

- Rename `--enr-port` flag to `--enr-udp-port` in `boot_node/src/cli.rs` to match the argument identifier and maintain consistency with the adjacent `--enr-udp6-port` flag

## Additional Info

The mismatch between the argument identifier (`"enr-udp-port"`) and the CLI flag name (`--enr-port`) prevented users from correctly setting the ENR UDP port, as the flag would not be recognized. This fix ensures the boot node CLI is consistent and functional.
