### PR TITLE
Gloas containers http api temp fixes

### DIFF
--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -57,7 +57,10 @@ async fn state_by_root_pruned_from_fork_choice() {
     type E = MinimalEthSpec;
 
     let validator_count = 24;
-    let spec = ForkName::latest().make_genesis_spec(E::default_spec());
+    // TODO(EIP-7732): extend test for Gloas by reverting back to using `ForkName::latest()`
+    // Issue is that this test does block production via `extend_chain_with_sync` which expects to be able to use `state.latest_execution_payload_header` during block production, but Gloas uses `latest_execution_bid` instead
+    // This will be resolved in a subsequent block processing PR
+    let spec = ForkName::Fulu.make_genesis_spec(E::default_spec());
 
     let tester = InteractiveTester::<E>::new_with_initializer_and_mutator(
         Some(spec.clone()),
@@ -396,7 +399,7 @@ pub async fn proposer_boost_re_org_test(
     assert!(head_slot > 0);
 
     // Test using the latest fork so that we simulate conditions as similar to mainnet as possible.
-    // TODO(EIP-7732): extend test for Gloas by reverting back to using ForkName::latest()
+    // TODO(EIP-7732): extend test for Gloas by reverting back to using `ForkName::latest()`
     // Issue is that `get_validator_blocks_v3` below expects to be able to use `state.latest_execution_payload_header` during `produce_block_on_state` -> `produce_partial_beacon_block` -> `get_execution_payload`, but gloas will no longer support this state field
     // This will be resolved in a subsequent block processing PR
     let mut spec = ForkName::Fulu.make_genesis_spec(E::default_spec());

--- a/beacon_node/http_api/tests/status_tests.rs
+++ b/beacon_node/http_api/tests/status_tests.rs
@@ -12,8 +12,10 @@ type E = MinimalEthSpec;
 
 /// Create a new test environment that is post-merge with `chain_depth` blocks.
 async fn post_merge_tester(chain_depth: u64, validator_count: u64) -> InteractiveTester<E> {
-    // Test using latest fork so that we simulate conditions as similar to mainnet as possible.
-    let mut spec = ForkName::latest().make_genesis_spec(E::default_spec());
+    // TODO(EIP-7732): extend tests for Gloas by reverting back to using `ForkName::latest()`
+    // Issue is that these tests do block production via `extend_chain_with_sync` which expects to be able to use `state.latest_execution_payload_header` during block production, but Gloas uses `latest_execution_bid` instead
+    // This will be resolved in a subsequent block processing PR
+    let mut spec = ForkName::Fulu.make_genesis_spec(E::default_spec());
     spec.terminal_total_difficulty = Uint256::from(1);
 
     let tester = InteractiveTester::<E>::new(Some(spec), validator_count as usize).await;


### PR DESCRIPTION
## Changes
- same as https://github.com/sigp/lighthouse/pull/8214 but resolving some other tests that were failing for basically the same reason.  Verified that tests passed via running `make test-http-api` locally

@ethDreamer 