### PR TITLE
Feature gate test CLI flags

### DIFF
--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 write_ssz_files = [
     "beacon_chain/write_ssz_files",
 ] # Writes debugging .ssz files to /tmp during block processing.
+testing = [] # Enables testing-only CLI flags
 
 [dependencies]
 account_utils = { workspace = true }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -60,22 +60,22 @@ pub fn cli_app() -> Command {
                 .display_order(0)
         )
         .arg(
-            // TODO(das): remove this before PeerDAS release
             Arg::new("malicious-withhold-count")
                 .long("malicious-withhold-count")
                 .action(ArgAction::Set)
                 .help_heading(FLAG_HEADER)
-                .help("TESTING ONLY do not use this")
+                .help("TESTING ONLY: Withholds a subset of data columns during publishing. \
+                          Do not use in production. Requires the 'testing' feature to be enabled.")
                 .hide(true)
                 .display_order(0)
         )
         .arg(
-            // TODO(das): remove this before PeerDAS release
             Arg::new("advertise-false-custody-group-count")
                 .long("advertise-false-custody-group-count")
                 .action(ArgAction::Set)
                 .help_heading(FLAG_HEADER)
-                .help("Advertises a false CGC for testing PeerDAS. Do NOT use in production.")
+                .help("TESTING ONLY: Advertises a false custody group count for testing PeerDAS. \
+                          Do not use in production. Requires the 'testing' feature to be enabled.")
                 .hide(true)
                 .display_order(0)
         )
@@ -1594,9 +1594,9 @@ pub fn cli_app() -> Command {
                 .value_name("SECONDS")
                 .action(ArgAction::Set)
                 .help_heading(FLAG_HEADER)
-                .help("TESTING ONLY: Artificially delay block publishing by the specified number of seconds. \
-                        This only works for if `BroadcastValidation::Gossip` is used (default). \
-                        DO NOT USE IN PRODUCTION.")
+                .help("TESTING ONLY: Artificially delays block publishing by the specified number of seconds. \
+                       This only works if BroadcastValidation::Gossip is used (default). \
+                       Do not use in production. Requires the 'testing' feature to be enabled.")
                 .hide(true)
                 .display_order(0)
         )
@@ -1606,10 +1606,10 @@ pub fn cli_app() -> Command {
                 .value_name("SECONDS")
                 .action(ArgAction::Set)
                 .help_heading(FLAG_HEADER)
-                .help("TESTING ONLY: Artificially delay data column publishing by the specified number of seconds. \
-                       Limitation: If `delay-block-publishing` is also used, data columns will be delayed for a \
-                       minimum of `delay-block-publishing` seconds.
-                       DO NOT USE IN PRODUCTION.")
+                .help("TESTING ONLY: Artificially delays data column publishing by the specified number of seconds. \
+                       Limitation: If delay-block-publishing is also used, data columns will be delayed for a \
+                       minimum of delay-block-publishing seconds. \
+                       Do not use in production. Requires the 'testing' feature to be enabled.")
                 .hide(true)
                 .display_order(0)
         )

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -421,6 +421,7 @@ pub fn get_config<E: EthSpec>(
         client_config.store.blob_prune_margin_epochs = blob_prune_margin_epochs;
     }
 
+    #[cfg(any(test, feature = "testing"))]
     if let Some(malicious_withhold_count) =
         clap_utils::parse_optional(cli_args, "malicious-withhold-count")?
     {
@@ -835,10 +836,12 @@ pub fn get_config<E: EthSpec>(
         .max_gossip_aggregate_batch_size =
         clap_utils::parse_required(cli_args, "beacon-processor-aggregate-batch-size")?;
 
+    #[cfg(any(test, feature = "testing"))]
     if let Some(delay) = clap_utils::parse_optional(cli_args, "delay-block-publishing")? {
         client_config.chain.block_publishing_delay = Some(Duration::from_secs_f64(delay));
     }
 
+    #[cfg(any(test, feature = "testing"))]
     if let Some(delay) = clap_utils::parse_optional(cli_args, "delay-data-column-publishing")? {
         client_config.chain.data_column_publishing_delay = Some(Duration::from_secs_f64(delay));
     }
@@ -1145,6 +1148,7 @@ pub fn set_network_config(
         config.import_all_attestations = true;
     }
 
+    #[cfg(any(test, feature = "testing"))]
     if let Some(advertise_false_custody_group_count) =
         parse_optional(cli_args, "advertise-false-custody-group-count")?
     {

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -421,7 +421,7 @@ pub fn get_config<E: EthSpec>(
         client_config.store.blob_prune_margin_epochs = blob_prune_margin_epochs;
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "testing")]
     if let Some(malicious_withhold_count) =
         clap_utils::parse_optional(cli_args, "malicious-withhold-count")?
     {
@@ -836,12 +836,12 @@ pub fn get_config<E: EthSpec>(
         .max_gossip_aggregate_batch_size =
         clap_utils::parse_required(cli_args, "beacon-processor-aggregate-batch-size")?;
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "testing")]
     if let Some(delay) = clap_utils::parse_optional(cli_args, "delay-block-publishing")? {
         client_config.chain.block_publishing_delay = Some(Duration::from_secs_f64(delay));
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "testing")]
     if let Some(delay) = clap_utils::parse_optional(cli_args, "delay-data-column-publishing")? {
         client_config.chain.data_column_publishing_delay = Some(Duration::from_secs_f64(delay));
     }
@@ -1148,7 +1148,7 @@ pub fn set_network_config(
         config.import_all_attestations = true;
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "testing")]
     if let Some(advertise_false_custody_group_count) =
         clap_utils::parse_optional(cli_args, "advertise-false-custody-group-count")?
     {

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -7,7 +7,7 @@ use beacon_chain::chain_config::{
 use beacon_chain::graffiti_calculator::GraffitiOrigin;
 use clap::{ArgMatches, Id, parser::ValueSource};
 use clap_utils::flags::DISABLE_MALLOC_TUNING_FLAG;
-use clap_utils::{parse_flag, parse_optional, parse_required};
+use clap_utils::{parse_flag, parse_required};
 use client::{ClientConfig, ClientGenesis};
 use directory::{DEFAULT_BEACON_NODE_DIR, DEFAULT_NETWORK_DIR, DEFAULT_ROOT_DIR};
 use environment::RuntimeContext;
@@ -1150,7 +1150,7 @@ pub fn set_network_config(
 
     #[cfg(any(test, feature = "testing"))]
     if let Some(advertise_false_custody_group_count) =
-        parse_optional(cli_args, "advertise-false-custody-group-count")?
+        clap_utils::parse_optional(cli_args, "advertise-false-custody-group-count")?
     {
         config.advertise_false_custody_group_count = Some(advertise_false_custody_group_count);
     }

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -81,6 +81,7 @@ malloc_utils = { workspace = true, features = ["jemalloc"] }
 malloc_utils = { workspace = true, features = [] }
 
 [dev-dependencies]
+beacon_node = { workspace = true, features = ["testing"] }
 beacon_node_fallback = { workspace = true }
 beacon_processor = { workspace = true }
 eth2 = { workspace = true }


### PR DESCRIPTION
## Issue Addressed

Closes #6980

## Proposed Changes

I think these flags may be useful in future peerdas / das testing, and would be useful to keep. Hence I've gated them behind a `testing` feature flag.