### PR TITLE
Allow get_beacon_proposer_index at next epoch

### DIFF
--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1190,19 +1190,29 @@ impl<E: EthSpec> BeaconState<E> {
         // Proposer indices are only known for the current epoch, due to the dependence on the
         // effective balances of validators, which change at every epoch transition.
         let epoch = slot.epoch(E::slots_per_epoch());
-        // TODO(EIP-7917): Explore allowing this function to be called with a slot one epoch in the future.
-        if epoch != self.current_epoch() {
+        if epoch != self.current_epoch() && epoch != self.next_epoch()? {
             return Err(Error::SlotOutOfBounds);
         }
 
         if let Ok(proposer_lookahead) = self.proposer_lookahead() {
             // Post-Fulu
-            let index = slot.as_usize().safe_rem(E::slots_per_epoch() as usize)?;
+            let slots_per_epoch = E::slots_per_epoch() as usize;
+            let start_offset = if epoch == self.current_epoch() {
+                0
+            } else {
+                slots_per_epoch
+            };
+            let index = start_offset.safe_add(slot.as_usize().safe_rem(slots_per_epoch)?)?;
             proposer_lookahead
                 .get(index)
                 .ok_or(Error::ProposerLookaheadOutOfBounds { i: index })
                 .map(|index| *index as usize)
         } else {
+            // Only allow next epoch computations after Fulu.
+            if epoch != self.current_epoch() {
+                return Err(Error::SlotOutOfBounds);
+            }
+
             // Pre-Fulu
             let seed = self.get_beacon_proposer_seed(slot, spec)?;
             let indices = self.get_active_validator_indices(epoch, spec)?;


### PR DESCRIPTION
## Proposed Changes

Continued cleanup of proposer index logic, this PR allows `get_beacon_proposer_index` to be called at the next epoch (post-Fulu), bringing it in line with `get_beacon_proposer_indices` after the changes in:

- https://github.com/sigp/lighthouse/pull/8130

This is a safe change for Fulu due to the newly introduced lookahead.

## Additional Info

- [ ] Needs new/updated tests to cover this newly added case. I think it would be simplest to extend the tests added in #8130, so will wait for that to merge.

This change is non-essential for correctness, as `get_beacon_proposer_index` is currently only called for the current epoch (`state.slot()` or `block.slot()` after state advance), and in tests.
