### PR TITLE
Separate fullnode & supernode devnet checkpoint sync into two separate jobs

### DIFF
--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -179,7 +179,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        network: [sepolia, devnet]
+        network: [sepolia, devnet-fullnode, devnet-supernode]
     steps:
       - uses: actions/checkout@v5
 

--- a/scripts/tests/checkpoint-sync-config-devnet-fullnode.yaml
+++ b/scripts/tests/checkpoint-sync-config-devnet-fullnode.yaml
@@ -6,13 +6,6 @@ participants:
     el_image: ethpandaops/geth:master
     cl_extra_params:
       - --disable-backfill-rate-limiting
-    supernode: true
-  - cl_type: lighthouse
-    cl_image: lighthouse:local
-    el_type: geth
-    el_image: ethpandaops/geth:master
-    cl_extra_params:
-      - --disable-backfill-rate-limiting
     supernode: false
 
 checkpoint_sync_enabled: true

--- a/scripts/tests/checkpoint-sync-config-devnet-supernode.yaml
+++ b/scripts/tests/checkpoint-sync-config-devnet-supernode.yaml
@@ -1,0 +1,17 @@
+# Kurtosis config file to checkpoint sync to a running devnet supported by ethPandaOps and `ethereum-package`.
+participants:
+  - cl_type: lighthouse
+    cl_image: lighthouse:local
+    el_type: geth
+    el_image: ethpandaops/geth:master
+    cl_extra_params:
+      - --disable-backfill-rate-limiting
+    supernode: true
+
+checkpoint_sync_enabled: true
+checkpoint_sync_url: "https://checkpoint-sync.fusaka-devnet-3.ethpandaops.io"
+
+global_log_level: debug
+
+network_params:
+  network: fusaka-devnet-3


### PR DESCRIPTION
## Issue Addressed

The supernode checkpoint sync test was failing to backfill, it seems like the blob count on devnet-3 may be too high for a github hosted runner to run _both_ a supernode and a fullnode. 

Separating it into a separate test to see if it passes. Devnet-3 is probably going to be removed soon but I think it's worth try this out as we may want to test supernode sync on sepolia.
