### PR TITLE
Add `version` to the response of beacon API `getPendingConsolidations` 

### DIFF
--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -943,7 +943,7 @@ impl BeaconNodeHttpClient {
     pub async fn get_beacon_states_pending_consolidations(
         &self,
         state_id: StateId,
-    ) -> Result<Option<ExecutionOptimisticFinalizedResponse<Vec<PendingConsolidation>>>, Error>
+    ) -> Result<Option<ExecutionOptimisticFinalizedBeaconResponse<Vec<PendingConsolidation>>>, Error>
     {
         let mut path = self.eth_path(V1)?;
 
@@ -954,7 +954,9 @@ impl BeaconNodeHttpClient {
             .push(&state_id.to_string())
             .push("pending_consolidations");
 
-        self.get_opt(path).await
+        self.get_fork_contextual(path, |fork| fork)
+            .await
+            .map(|opt| opt.map(BeaconResponse::ForkVersioned))
     }
 
     /// `GET beacon/light_client/updates`


### PR DESCRIPTION
## Issue Addressed

* #7440 

## Additional Info

Tested to confirm it works:

Before:
`{"execution_optimistic":true,"finalized":false,"data":[]}`

After:
`{"version":"electra","execution_optimistic":true,"finalized":false,"data":[]}`