### PR TITLE
Update spec tests to v1.6.0-beta.1

### DIFF
--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,6 +1,6 @@
 # To download/extract nightly tests, run:
 # CONSENSUS_SPECS_TEST_VERSION=nightly make
-CONSENSUS_SPECS_TEST_VERSION ?= v1.6.0-alpha.6
+CONSENSUS_SPECS_TEST_VERSION ?= v1.6.0-beta.1
 REPO_NAME := consensus-spec-tests
 OUTPUT_DIR := ./$(REPO_NAME)
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -54,6 +54,8 @@ excluded_paths = [
     "tests/general/phase0/ssz_generic/basic_progressive_list",
     "tests/general/phase0/ssz_generic/containers/.*/ProgressiveBitsStruct.*",
     "tests/general/phase0/ssz_generic/containers/.*/ProgressiveTestStruct.*",
+    "tests/general/phase0/ssz_generic/progressive_containers/.*",
+    "tests/general/phase0/ssz_generic/compatible_unions/.*",
     # Ignore full epoch tests for now (just test the sub-transitions).
     "tests/.*/.*/epoch_processing/.*/pre_epoch.ssz_snappy",
     "tests/.*/.*/epoch_processing/.*/post_epoch.ssz_snappy",

--- a/testing/ef_tests/download_test_vectors.sh
+++ b/testing/ef_tests/download_test_vectors.sh
@@ -57,7 +57,7 @@ else
 		if [[ ! -e "${test}.tar.gz" ]]; then
 			echo "Downloading: ${version}/${test}.tar.gz"
 			curl --progress-bar --location --remote-name --show-error --retry 3 --retry-all-errors --fail \
-				"https://github.com/ethereum/consensus-spec-tests/releases/download/${version}/${test}.tar.gz" \
+				"https://github.com/ethereum/consensus-specs/releases/download/${version}/${test}.tar.gz" \
 				|| {
 					echo "Curl failed. Aborting"
 					rm -f "${test}.tar.gz"

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -1083,8 +1083,7 @@ impl<E: EthSpec + TypeName> Handler for LightClientUpdateHandler<E> {
 
     fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
         // Enabled in Altair
-        // No test in Fulu yet.
-        fork_name.altair_enabled() && fork_name != ForkName::Fulu
+        fork_name.altair_enabled()
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

Update the EF spec tests to v1.6.0-beta.1

There are a few new light client tests (which we pass), and some for progressive containers, which we haven't implemented (we ignore them).
