### PR TITLE
Run CI tests only recent forks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,6 @@ TEST_FEATURES ?=
 # Cargo profile for regular builds.
 PROFILE ?= release
 
-# List of all hard forks. This list is used to set env variables for several tests so that
-# they run for different forks.
-FORKS=phase0 altair bellatrix capella deneb electra fulu gloas
-
 # List of all recent hard forks. This list is used to set env variables for http_api tests
 RECENT_FORKS=electra fulu gloas
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ PROFILE ?= release
 FORKS=phase0 altair bellatrix capella deneb electra fulu gloas
 
 # List of all recent hard forks. This list is used to set env variables for http_api tests
-RECENT_FORKS=electra fulu
+RECENT_FORKS=electra fulu gloas
 
 # Extra flags for Cargo
 CARGO_INSTALL_EXTRA_FLAGS?=
@@ -170,8 +170,8 @@ run-ef-tests:
 	cargo nextest run --release -p ef_tests --features "ef_tests,$(EF_TEST_FEATURES),fake_crypto"
 	./$(EF_TESTS)/check_all_files_accessed.py $(EF_TESTS)/.accessed_file_log.txt $(EF_TESTS)/consensus-spec-tests
 
-# Run the tests in the `beacon_chain` crate for all known forks.
-test-beacon-chain: $(patsubst %,test-beacon-chain-%,$(FORKS))
+# Run the tests in the `beacon_chain` crate for recent forks.
+test-beacon-chain: $(patsubst %,test-beacon-chain-%,$(RECENT_FORKS))
 
 test-beacon-chain-%:
 	env FORK_NAME=$* cargo nextest run --release --features "fork_from_env,slasher/lmdb,$(TEST_FEATURES)" -p beacon_chain
@@ -184,15 +184,16 @@ test-http-api-%:
 
 
 # Run the tests in the `operation_pool` crate for all known forks.
-test-op-pool: $(patsubst %,test-op-pool-%,$(FORKS))
+test-op-pool: $(patsubst %,test-op-pool-%,$(RECENT_FORKS))
 
 test-op-pool-%:
 	env FORK_NAME=$* cargo nextest run --release \
 		--features "beacon_chain/fork_from_env,$(TEST_FEATURES)"\
 		-p operation_pool
 
-# Run the tests in the `network` crate for all known forks.
-test-network: $(patsubst %,test-network-%,$(FORKS))
+# Run the tests in the `network` crate for recent forks.
+test-network: $(patsubst %,test-network-%,$(RECENT
+    _FORKS))
 
 test-network-%:
 	env FORK_NAME=$* cargo nextest run --release \

--- a/Makefile
+++ b/Makefile
@@ -192,8 +192,7 @@ test-op-pool-%:
 		-p operation_pool
 
 # Run the tests in the `network` crate for recent forks.
-test-network: $(patsubst %,test-network-%,$(RECENT
-    _FORKS))
+test-network: $(patsubst %,test-network-%,$(RECENT_FORKS))
 
 test-network-%:
 	env FORK_NAME=$* cargo nextest run --release \


### PR DESCRIPTION
## Issue Addressed

Partially addresses #8248

## Proposed Changes

Run the beacon chain, http and network tests only for recent forks instead of everything from phase 0.
Also added gloas also to the recent forks list. I thought that would be a good way to know if changes in the current fork affect future forks.

Not completely sure if we should run for future forks, but added it so that we can discuss here.
