### PR TITLE
Implement `/lighthouse/custody/info` API

### DIFF
--- a/beacon_node/http_api/src/custody.rs
+++ b/beacon_node/http_api/src/custody.rs
@@ -1,21 +1,12 @@
 use beacon_chain::{BeaconChain, BeaconChainTypes};
-use serde::{Deserialize, Serialize};
+use eth2::lighthouse::CustodyInfo;
 use std::sync::Arc;
-use types::{EthSpec, Slot};
+use types::EthSpec;
 use warp_utils::reject::{custom_bad_request, custom_server_error};
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct CustodyResponse {
-    pub earliest_custodied_data_column_slot: Slot,
-    #[serde(with = "serde_utils::quoted_u64")]
-    pub custody_group_count: u64,
-    #[serde(with = "serde_utils::quoted_u64_vec")]
-    pub custody_columns: Vec<u64>,
-}
 
 pub fn info<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
-) -> Result<CustodyResponse, warp::Rejection> {
+) -> Result<CustodyInfo, warp::Rejection> {
     if !chain.spec.is_fulu_scheduled() {
         return Err(custom_bad_request("Fulu is not scheduled".to_string()));
     }
@@ -54,7 +45,7 @@ pub fn info<T: BeaconChainTypes>(
     let custody_group_count = custody_context
         .custody_group_count_at_epoch(earliest_custodied_data_column_epoch, &chain.spec);
 
-    Ok(CustodyResponse {
+    Ok(CustodyInfo {
         earliest_custodied_data_column_slot,
         custody_group_count,
         custody_columns,

--- a/beacon_node/http_api/src/custody.rs
+++ b/beacon_node/http_api/src/custody.rs
@@ -1,0 +1,39 @@
+use beacon_chain::{BeaconChain, BeaconChainTypes};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use types::{EthSpec, Slot};
+use warp_utils::reject::{custom_bad_request, custom_server_error};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CustodyResponse {
+    pub earliest_custodied_data_column_slot: Slot,
+    // TODO: more fields
+}
+
+pub fn info<T: BeaconChainTypes>(
+    chain: Arc<BeaconChain<T>>,
+) -> Result<CustodyResponse, warp::Rejection> {
+    if !chain.spec.is_fulu_scheduled() {
+        return Err(custom_bad_request("Fulu is not scheduled".to_string()));
+    }
+
+    let data_column_custody_info = chain
+        .store
+        .get_data_column_custody_info()
+        .map_err(|e| custom_server_error(format!("error reading data column custody info: {e:?}")))?
+        .ok_or_else(|| custom_server_error("data column custody info missing".to_string()))?;
+
+    let column_data_availability_boundary = chain
+        .column_data_availability_boundary()
+        .ok_or_else(|| custom_server_error("unreachable: Fulu should be enabled".to_string()))?;
+
+    let earliest_custodied_data_column_slot = data_column_custody_info
+        .earliest_data_column_slot
+        .unwrap_or_else(|| {
+            column_data_availability_boundary.start_slot(T::EthSpec::slots_per_epoch())
+        });
+
+    Ok(CustodyResponse {
+        earliest_custodied_data_column_slot,
+    })
+}

--- a/beacon_node/http_api/src/custody.rs
+++ b/beacon_node/http_api/src/custody.rs
@@ -7,7 +7,10 @@ use warp_utils::reject::{custom_bad_request, custom_server_error};
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CustodyResponse {
     pub earliest_custodied_data_column_slot: Slot,
-    // TODO: more fields
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub custody_group_count: u64,
+    #[serde(with = "serde_utils::quoted_u64_vec")]
+    pub custody_columns: Vec<u64>,
 }
 
 pub fn info<T: BeaconChainTypes>(
@@ -32,8 +35,22 @@ pub fn info<T: BeaconChainTypes>(
         .unwrap_or_else(|| {
             column_data_availability_boundary.start_slot(T::EthSpec::slots_per_epoch())
         });
+    let earliest_custodied_data_column_epoch =
+        earliest_custodied_data_column_slot.epoch(T::EthSpec::slots_per_epoch());
+
+    // Compute the custody columns and the CGC *at the earliest custodied slot*. The node might
+    // have some columns prior to this, but this value is the most up-to-date view of the data the
+    // node is custodying.
+    let custody_context = chain.data_availability_checker.custody_context();
+    let custody_columns = custody_context
+        .custody_columns_for_epoch(Some(earliest_custodied_data_column_epoch), &chain.spec)
+        .to_vec();
+    let custody_group_count = custody_context
+        .custody_group_count_at_epoch(earliest_custodied_data_column_epoch, &chain.spec);
 
     Ok(CustodyResponse {
         earliest_custodied_data_column_slot,
+        custody_group_count,
+        custody_columns,
     })
 }

--- a/beacon_node/http_api/src/custody.rs
+++ b/beacon_node/http_api/src/custody.rs
@@ -20,20 +20,26 @@ pub fn info<T: BeaconChainTypes>(
         return Err(custom_bad_request("Fulu is not scheduled".to_string()));
     }
 
-    let data_column_custody_info = chain
+    let opt_data_column_custody_info = chain
         .store
         .get_data_column_custody_info()
-        .map_err(|e| custom_server_error(format!("error reading data column custody info: {e:?}")))?
-        .ok_or_else(|| custom_server_error("data column custody info missing".to_string()))?;
+        .map_err(|e| custom_server_error(format!("error reading DataColumnCustodyInfo: {e:?}")))?;
 
     let column_data_availability_boundary = chain
         .column_data_availability_boundary()
         .ok_or_else(|| custom_server_error("unreachable: Fulu should be enabled".to_string()))?;
 
-    let earliest_custodied_data_column_slot = data_column_custody_info
-        .earliest_data_column_slot
+    let earliest_custodied_data_column_slot = opt_data_column_custody_info
+        .and_then(|info| info.earliest_data_column_slot)
         .unwrap_or_else(|| {
-            column_data_availability_boundary.start_slot(T::EthSpec::slots_per_epoch())
+            // If there's no data column custody info/earliest data column slot, it means *column*
+            // backfill is not running. Block backfill could still be running, so our earliest
+            // available column is either the oldest block slot or the DA boundary, whichever is
+            // more recent.
+            let oldest_block_slot = chain.store.get_anchor_info().oldest_block_slot;
+            column_data_availability_boundary
+                .start_slot(T::EthSpec::slots_per_epoch())
+                .max(oldest_block_slot)
         });
     let earliest_custodied_data_column_epoch =
         earliest_custodied_data_column_slot.epoch(T::EthSpec::slots_per_epoch());

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -4591,9 +4591,10 @@ pub fn serve<T: BeaconChainTypes>(
             },
         );
 
-    // GET lighthouse/custody
-    let get_lighthouse_custody = warp::path("lighthouse")
+    // GET lighthouse/custody/info
+    let get_lighthouse_custody_info = warp::path("lighthouse")
         .and(warp::path("custody"))
+        .and(warp::path("info"))
         .and(warp::path::end())
         .and(task_spawner_filter.clone())
         .and(chain_filter.clone())
@@ -4904,7 +4905,7 @@ pub fn serve<T: BeaconChainTypes>(
                 .uor(get_lighthouse_validator_inclusion)
                 .uor(get_lighthouse_staking)
                 .uor(get_lighthouse_database_info)
-                .uor(get_lighthouse_custody)
+                .uor(get_lighthouse_custody_info)
                 .uor(get_lighthouse_block_rewards)
                 .uor(get_lighthouse_attestation_performance)
                 .uor(get_beacon_light_client_optimistic_update)

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -13,6 +13,7 @@ mod block_packing_efficiency;
 mod block_rewards;
 mod build_block_contents;
 mod builder_states;
+mod custody;
 mod database;
 mod light_client;
 mod metrics;
@@ -4590,6 +4591,18 @@ pub fn serve<T: BeaconChainTypes>(
             },
         );
 
+    // GET lighthouse/custody
+    let get_lighthouse_custody = warp::path("lighthouse")
+        .and(warp::path("custody"))
+        .and(warp::path::end())
+        .and(task_spawner_filter.clone())
+        .and(chain_filter.clone())
+        .then(
+            |task_spawner: TaskSpawner<T::EthSpec>, chain: Arc<BeaconChain<T>>| {
+                task_spawner.blocking_json_task(Priority::P1, move || custody::info(chain))
+            },
+        );
+
     // GET lighthouse/analysis/block_rewards
     let get_lighthouse_block_rewards = warp::path("lighthouse")
         .and(warp::path("analysis"))
@@ -4891,6 +4904,7 @@ pub fn serve<T: BeaconChainTypes>(
                 .uor(get_lighthouse_validator_inclusion)
                 .uor(get_lighthouse_staking)
                 .uor(get_lighthouse_database_info)
+                .uor(get_lighthouse_custody)
                 .uor(get_lighthouse_block_rewards)
                 .uor(get_lighthouse_attestation_performance)
                 .uor(get_beacon_light_client_optimistic_update)

--- a/common/eth2/src/lighthouse.rs
+++ b/common/eth2/src/lighthouse.rs
@@ -3,6 +3,7 @@
 mod attestation_performance;
 mod block_packing_efficiency;
 mod block_rewards;
+mod custody;
 pub mod sync_state;
 
 use crate::{
@@ -22,6 +23,7 @@ pub use block_packing_efficiency::{
     BlockPackingEfficiency, BlockPackingEfficiencyQuery, ProposerInfo, UniqueAttestation,
 };
 pub use block_rewards::{AttestationRewards, BlockReward, BlockRewardMeta, BlockRewardsQuery};
+pub use custody::CustodyInfo;
 
 // Define "legacy" implementations of `Option<T>` which use four bytes for encoding the union
 // selector.
@@ -189,6 +191,19 @@ impl BeaconNodeHttpClient {
             .map_err(|()| Error::InvalidUrl(self.server.clone()))?
             .push("lighthouse")
             .push("syncing");
+
+        self.get(path).await
+    }
+
+    /// `GET lighthouse/custody/info`
+    pub async fn get_lighthouse_custody_info(&self) -> Result<CustodyInfo, Error> {
+        let mut path = self.server.full.clone();
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("lighthouse")
+            .push("custody")
+            .push("info");
 
         self.get(path).await
     }

--- a/common/eth2/src/lighthouse/custody.rs
+++ b/common/eth2/src/lighthouse/custody.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+use types::Slot;
+
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+pub struct CustodyInfo {
+    pub earliest_custodied_data_column_slot: Slot,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub custody_group_count: u64,
+    #[serde(with = "serde_utils::quoted_u64_vec")]
+    pub custody_columns: Vec<u64>,
+}

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -255,7 +255,7 @@ pub struct ChainSpec {
      * Networking Fulu
      */
     pub(crate) blob_schedule: BlobSchedule,
-    min_epochs_for_data_column_sidecars_requests: u64,
+    pub min_epochs_for_data_column_sidecars_requests: u64,
 
     /*
      * Networking Gloas


### PR DESCRIPTION
## Issue Addressed

Closes:

- https://github.com/sigp/lighthouse/issues/8249

## Proposed Changes

New `/lighthouse/custody` API including:

- [x] Earliest custodied data column slot
- [x] Node CGC
- [x] Custodied columns

## Additional Info

Aiming for inclusion in v8.0.0 but not v8.0.0-rc.2

Needs:

- [x] Client code in `eth2`
- [x] Test
