### PR TITLE
Gloas modify get_pending_balance_to_withdraw

### DIFF
--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -2456,8 +2456,13 @@ impl<E: EthSpec> BeaconState<E> {
             .map_err(Into::into)
     }
 
+    // TODO(EIP-7732): The consensus spec PR for this change mentions that some EF tests will be needed but haven't been created yet.
+    // We should integrate them once they are available.
+    // https://github.com/ethereum/consensus-specs/pull/4513
     pub fn get_pending_balance_to_withdraw(&self, validator_index: usize) -> Result<u64, Error> {
         let mut pending_balance = 0;
+
+        // Sum pending partial withdrawals
         for withdrawal in self
             .pending_partial_withdrawals()?
             .iter()
@@ -2465,6 +2470,27 @@ impl<E: EthSpec> BeaconState<E> {
         {
             pending_balance.safe_add_assign(withdrawal.amount)?;
         }
+
+        // Sum builder pending withdrawals
+        if let Ok(builder_pending_withdrawals) = self.builder_pending_withdrawals() {
+            for withdrawal in builder_pending_withdrawals
+                .iter()
+                .filter(|withdrawal| withdrawal.builder_index as usize == validator_index)
+            {
+                pending_balance.safe_add_assign(withdrawal.amount)?;
+            }
+        }
+
+        // Sum builder pending payments
+        if let Ok(builder_pending_payments) = self.builder_pending_payments() {
+            for payment in builder_pending_payments
+                .iter()
+                .filter(|payment| payment.withdrawal.builder_index as usize == validator_index)
+            {
+                pending_balance.safe_add_assign(payment.withdrawal.amount)?;
+            }
+        }
+
         Ok(pending_balance)
     }
 


### PR DESCRIPTION
## Changes per [spec](https://ethereum.github.io/consensus-specs/specs/gloas/beacon-chain/#modified-get_pending_balance_to_withdraw)
- modified `get_pending_balance_to_withdraw`

## How this works
There are a couple places in the codebase where we want to verify that a validator has no pending balances to withdraw before allowing them to initiate an exit or consolidation.  Pre-gloas, we were calling `get_pending_balance_to_withdraw` to check whether their `BeaconState.pending_partial_withdrawals` was empty and if so, let them proceed.  Since gloas introduces `BeaconState.builder_pending_payments` and `BeaconState.builder_pending_withdrawals`, we now have to account for these pending validator balances as well before letting them proceed with an exit or consolidation.

@ethDreamer
@eserilev 