### PR TITLE
Add `/lighthouse/custody/info` to Lighthouse book

### DIFF
--- a/book/src/api_lighthouse.md
+++ b/book/src/api_lighthouse.md
@@ -447,6 +447,26 @@ indicating that all states with slots `>= 0` are available, i.e., full state his
 on the specific meanings of these fields see the docs on [Checkpoint
 Sync](./advanced_checkpoint_sync.md#how-to-run-an-archived-node).
 
+## `/lighthouse/custody/info`
+
+Information about data columns custody info.
+
+```bash
+curl "http://localhost:5052/lighthouse/custody/info" | jq
+```
+
+```json
+  "earliest_custodied_data_column_slot": "8823040",
+  "custody_group_count": "4",
+  "custody_columns": [
+    "117",
+    "72",
+    "31",
+    "79"
+  ]
+}
+```
+
 ## `/lighthouse/merge_readiness`
 
 Returns the current difficulty and terminal total difficulty of the network. Before [The Merge](https://ethereum.org/en/roadmap/merge/) on 15<sup>th</sup> September 2022, you will see that the current difficulty is less than the terminal total difficulty, An example is shown below:

--- a/book/src/api_lighthouse.md
+++ b/book/src/api_lighthouse.md
@@ -456,6 +456,7 @@ curl "http://localhost:5052/lighthouse/custody/info" | jq
 ```
 
 ```json
+{
   "earliest_custodied_data_column_slot": "8823040",
   "custody_group_count": "4",
   "custody_columns": [


### PR DESCRIPTION
Add the documentation to the endpoint `/lighthouse/custody/info`