### PR TITLE
Add nightly tests workflow to test prior forks

### DIFF
--- a/.github/workflows/nightly-fork-tests.yml
+++ b/.github/workflows/nightly-fork-tests.yml
@@ -1,0 +1,158 @@
+# We only run tests on `RECENT_FORKS` on CI. To make sure we don't break prior forks, we run nightly tests to cover all prior forks.
+name: nightly-fork-tests
+
+on:
+  schedule:
+    # Run at 8:30 AM UTC every day
+    - cron: '30 8 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Deny warnings in CI
+  # Disable debug info (see https://github.com/sigp/lighthouse/issues/4005)
+  RUSTFLAGS: "-D warnings -C debuginfo=0"
+  # Prevent Github API rate limiting.
+  LIGHTHOUSE_GITHUB_TOKEN: ${{ secrets.LIGHTHOUSE_GITHUB_TOKEN }}
+  # Enable self-hosted runners for the sigp repo only.
+  SELF_HOSTED_RUNNERS: ${{ github.repository == 'sigp/lighthouse' }}
+  # Disable incremental compilation
+  CARGO_INCREMENTAL: 0
+  # Enable portable to prevent issues with caching `blst` for the wrong CPU type
+  TEST_FEATURES: portable
+  # All prior forks to cover in nightly tests. This list should be updated when we remove a fork from `RECENT_FORKS`.
+  FORKS: '["phase0", "altair", "bellatrix", "capella", "deneb"]'
+
+jobs:
+  beacon-chain-tests-all-forks:
+    name: beacon-chain-tests-all-forks
+    # Use self-hosted runners only on the sigp repo.
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
+    env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      matrix:
+        fork: ${{ fromJson(env.FORKS) }}
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v5
+    - name: Get latest version of stable Rust
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      uses: moonrepo/setup-rust@v1
+      with:
+          channel: stable
+          cache-target: release
+          bins: cargo-nextest
+    - name: Run beacon_chain tests for ${{ matrix.fork }}
+      run: make test-beacon-chain-${{ matrix.fork }}
+      timeout-minutes: 60
+    - name: Show cache stats
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      continue-on-error: true
+      run: sccache --show-stats
+
+  http-api-tests-all-forks:
+    name: http-api-tests-all-forks
+    # Use self-hosted runners only on the sigp repo.
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
+    env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      matrix:
+        fork: ${{ fromJson(env.FORKS) }}
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v5
+    - name: Get latest version of stable Rust
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      uses: moonrepo/setup-rust@v1
+      with:
+          channel: stable
+          cache-target: release
+          bins: cargo-nextest
+    - name: Run http_api tests for ${{ matrix.fork }}
+      run: make test-http-api-${{ matrix.fork }}
+      timeout-minutes: 60
+    - name: Show cache stats
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      continue-on-error: true
+      run: sccache --show-stats
+
+  op-pool-tests-all-forks:
+    name: op-pool-tests-all-forks
+    runs-on: ubuntu-latest
+    env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      matrix:
+        fork: ${{ fromJson(env.FORKS) }}
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v5
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
+          channel: stable
+          cache-target: release
+          bins: cargo-nextest
+    - name: Run operation_pool tests for ${{ matrix.fork }}
+      run: make test-op-pool-${{ matrix.fork }}
+      timeout-minutes: 60
+
+  network-tests-all-forks:
+    name: network-tests-all-forks
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      matrix:
+        fork: ${{ fromJson(env.FORKS) }}
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v5
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
+        channel: stable
+        cache-target: release
+        bins: cargo-nextest
+    - name: Create CI logger dir
+      run: mkdir ${{ runner.temp }}/network_test_logs
+    - name: Run network tests for ${{ matrix.fork }}
+      run: make test-network-${{ matrix.fork }}
+      timeout-minutes: 60
+      env:
+        TEST_FEATURES: portable
+        CI_LOGGER_DIR: ${{ runner.temp }}/network_test_logs
+    - name: Upload logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: network_test_logs_${{ matrix.fork }}
+        path: ${{ runner.temp }}/network_test_logs
+
+  # Summary job to check overall status
+  nightly-fork-tests-success:
+    name: nightly-fork-tests-success
+    runs-on: ubuntu-latest
+    needs: [
+      'beacon-chain-tests-all-forks',
+      'http-api-tests-all-forks',
+      'op-pool-tests-all-forks',
+      'network-tests-all-forks',
+    ]
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.beacon-chain-tests-all-forks.result }}" != "success" ] || \
+             [ "${{ needs.http-api-tests-all-forks.result }}" != "success" ] || \
+             [ "${{ needs.op-pool-tests-all-forks.result }}" != "success" ] || \
+             [ "${{ needs.network-tests-all-forks.result }}" != "success" ]; then
+            echo "One or more nightly fork tests failed!"
+            exit 1
+          fi
+          echo "All nightly fork tests passed!"

--- a/.github/workflows/nightly-fork-tests.yml
+++ b/.github/workflows/nightly-fork-tests.yml
@@ -35,8 +35,8 @@ jobs:
           # All prior forks to cover in nightly tests. This list should be updated when we remove a fork from `RECENT_FORKS`.
           echo 'forks=["phase0", "altair", "bellatrix", "capella", "deneb"]' >> $GITHUB_OUTPUT
 
-  beacon-chain-tests-all-forks:
-    name: beacon-chain-tests-all-forks
+  beacon-chain-tests:
+    name: beacon-chain-tests
     needs: setup-matrix
     runs-on: 'ubuntu-latest'
     env:
@@ -57,8 +57,8 @@ jobs:
       run: make test-beacon-chain-${{ matrix.fork }}
       timeout-minutes: 60
 
-  http-api-tests-all-forks:
-    name: http-api-tests-all-forks
+  http-api-tests:
+    name: http-api-tests
     needs: setup-matrix
     runs-on: 'ubuntu-latest'
     env:
@@ -79,8 +79,8 @@ jobs:
       run: make test-http-api-${{ matrix.fork }}
       timeout-minutes: 60
 
-  op-pool-tests-all-forks:
-    name: op-pool-tests-all-forks
+  op-pool-tests:
+    name: op-pool-tests
     needs: setup-matrix
     runs-on: ubuntu-latest
     env:
@@ -101,8 +101,8 @@ jobs:
       run: make test-op-pool-${{ matrix.fork }}
       timeout-minutes: 60
 
-  network-tests-all-forks:
-    name: network-tests-all-forks
+  network-tests:
+    name: network-tests
     needs: setup-matrix
     runs-on: ubuntu-latest
     env:
@@ -139,19 +139,19 @@ jobs:
     name: nightly-fork-tests-success
     runs-on: ubuntu-latest
     needs: [
-      'beacon-chain-tests-all-forks',
-      'http-api-tests-all-forks',
-      'op-pool-tests-all-forks',
-      'network-tests-all-forks',
+      'beacon-chain-tests',
+      'http-api-tests',
+      'op-pool-tests',
+      'network-tests',
     ]
     if: always()
     steps:
       - name: Check test results
         run: |
-          if [ "${{ needs.beacon-chain-tests-all-forks.result }}" != "success" ] || \
-             [ "${{ needs.http-api-tests-all-forks.result }}" != "success" ] || \
-             [ "${{ needs.op-pool-tests-all-forks.result }}" != "success" ] || \
-             [ "${{ needs.network-tests-all-forks.result }}" != "success" ]; then
+          if [ "${{ needs.beacon-chain-tests.result }}" != "success" ] || \
+             [ "${{ needs.http-api-tests.result }}" != "success" ] || \
+             [ "${{ needs.op-pool-tests.result }}" != "success" ] || \
+             [ "${{ needs.network-tests.result }}" != "success" ]; then
             echo "One or more nightly fork tests failed!"
             exit 1
           fi

--- a/.github/workflows/nightly-fork-tests.yml
+++ b/.github/workflows/nightly-fork-tests.yml
@@ -17,8 +17,6 @@ env:
   RUSTFLAGS: "-D warnings -C debuginfo=0"
   # Prevent Github API rate limiting.
   LIGHTHOUSE_GITHUB_TOKEN: ${{ secrets.LIGHTHOUSE_GITHUB_TOKEN }}
-  # Enable self-hosted runners for the sigp repo only.
-  SELF_HOSTED_RUNNERS: ${{ github.repository == 'sigp/lighthouse' }}
   # Disable incremental compilation
   CARGO_INCREMENTAL: 0
   # Enable portable to prevent issues with caching `blst` for the wrong CPU type
@@ -40,8 +38,7 @@ jobs:
   beacon-chain-tests-all-forks:
     name: beacon-chain-tests-all-forks
     needs: setup-matrix
-    # Use self-hosted runners only on the sigp repo.
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
+    runs-on: 'ubuntu-latest'
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
@@ -51,7 +48,6 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
-      if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1
       with:
           channel: stable
@@ -60,16 +56,11 @@ jobs:
     - name: Run beacon_chain tests for ${{ matrix.fork }}
       run: make test-beacon-chain-${{ matrix.fork }}
       timeout-minutes: 60
-    - name: Show cache stats
-      if: env.SELF_HOSTED_RUNNERS == 'true'
-      continue-on-error: true
-      run: sccache --show-stats
 
   http-api-tests-all-forks:
     name: http-api-tests-all-forks
     needs: setup-matrix
-    # Use self-hosted runners only on the sigp repo.
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
+    runs-on: 'ubuntu-latest'
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
@@ -79,7 +70,6 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Get latest version of stable Rust
-      if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1
       with:
           channel: stable
@@ -88,10 +78,6 @@ jobs:
     - name: Run http_api tests for ${{ matrix.fork }}
       run: make test-http-api-${{ matrix.fork }}
       timeout-minutes: 60
-    - name: Show cache stats
-      if: env.SELF_HOSTED_RUNNERS == 'true'
-      continue-on-error: true
-      run: sccache --show-stats
 
   op-pool-tests-all-forks:
     name: op-pool-tests-all-forks

--- a/.github/workflows/nightly-fork-tests.yml
+++ b/.github/workflows/nightly-fork-tests.yml
@@ -23,19 +23,30 @@ env:
   CARGO_INCREMENTAL: 0
   # Enable portable to prevent issues with caching `blst` for the wrong CPU type
   TEST_FEATURES: portable
-  # All prior forks to cover in nightly tests. This list should be updated when we remove a fork from `RECENT_FORKS`.
-  FORKS: '["phase0", "altair", "bellatrix", "capella", "deneb"]'
 
 jobs:
+  setup-matrix:
+    name: setup-matrix
+    runs-on: ubuntu-latest
+    outputs:
+      forks: ${{ steps.set-matrix.outputs.forks }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          # All prior forks to cover in nightly tests. This list should be updated when we remove a fork from `RECENT_FORKS`.
+          echo 'forks=["phase0", "altair", "bellatrix", "capella", "deneb"]' >> $GITHUB_OUTPUT
+
   beacon-chain-tests-all-forks:
     name: beacon-chain-tests-all-forks
+    needs: setup-matrix
     # Use self-hosted runners only on the sigp repo.
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        fork: ${{ fromJson(env.FORKS) }}
+        fork: ${{ fromJson(needs.setup-matrix.outputs.forks) }}
       fail-fast: false
     steps:
     - uses: actions/checkout@v5
@@ -56,13 +67,14 @@ jobs:
 
   http-api-tests-all-forks:
     name: http-api-tests-all-forks
+    needs: setup-matrix
     # Use self-hosted runners only on the sigp repo.
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        fork: ${{ fromJson(env.FORKS) }}
+        fork: ${{ fromJson(needs.setup-matrix.outputs.forks) }}
       fail-fast: false
     steps:
     - uses: actions/checkout@v5
@@ -83,12 +95,13 @@ jobs:
 
   op-pool-tests-all-forks:
     name: op-pool-tests-all-forks
+    needs: setup-matrix
     runs-on: ubuntu-latest
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        fork: ${{ fromJson(env.FORKS) }}
+        fork: ${{ fromJson(needs.setup-matrix.outputs.forks) }}
       fail-fast: false
     steps:
     - uses: actions/checkout@v5
@@ -104,12 +117,13 @@ jobs:
 
   network-tests-all-forks:
     name: network-tests-all-forks
+    needs: setup-matrix
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        fork: ${{ fromJson(env.FORKS) }}
+        fork: ${{ fromJson(needs.setup-matrix.outputs.forks) }}
       fail-fast: false
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,5 +1,5 @@
 # We only run tests on `RECENT_FORKS` on CI. To make sure we don't break prior forks, we run nightly tests to cover all prior forks.
-name: nightly-fork-tests
+name: nightly-tests
 
 on:
   schedule:
@@ -133,26 +133,3 @@ jobs:
       with:
         name: network_test_logs_${{ matrix.fork }}
         path: ${{ runner.temp }}/network_test_logs
-
-  # Summary job to check overall status
-  nightly-fork-tests-success:
-    name: nightly-fork-tests-success
-    runs-on: ubuntu-latest
-    needs: [
-      'beacon-chain-tests',
-      'http-api-tests',
-      'op-pool-tests',
-      'network-tests',
-    ]
-    if: always()
-    steps:
-      - name: Check test results
-        run: |
-          if [ "${{ needs.beacon-chain-tests.result }}" != "success" ] || \
-             [ "${{ needs.http-api-tests.result }}" != "success" ] || \
-             [ "${{ needs.op-pool-tests.result }}" != "success" ] || \
-             [ "${{ needs.network-tests.result }}" != "success" ]; then
-            echo "One or more nightly fork tests failed!"
-            exit 1
-          fi
-          echo "All nightly fork tests passed!"


### PR DESCRIPTION
## Issue Addressed

Once #8271 is merged, CI will only cover tests for `RECENT_FORKS` (prev, current, next)

To make sure functionalities aren't broken for prior forks, we run tests for these forks nightly. They can also be manually triggered.

Tested via manual trigger here: https://github.com/jimmygchen/lighthouse/actions/runs/18896690117

<img width="826" height="696" alt="image" src="https://github.com/user-attachments/assets/afdfb03b-a037-4094-9f1b-7466c0800f6b" />

