### PR TITLE
Fix flaky reconstruction test

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -931,21 +931,19 @@ async fn data_column_reconstruction_at_deadline() {
         .slot_clock
         .set_current_time(slot_start + Duration::from_secs(3));
 
-    let num_data_columns = rig.next_data_columns.as_ref().map(|c| c.len()).unwrap_or(0);
-    for i in 0..num_data_columns {
+    let min_columns_for_reconstruction = E::number_of_columns() / 2;
+    for i in 0..min_columns_for_reconstruction {
         rig.enqueue_gossip_data_columns(i);
         rig.assert_event_journal_completes(&[WorkType::GossipDataColumnSidecar])
             .await;
     }
 
     // Since we're at the reconstruction deadline, reconstruction should be triggered immediately
-    if num_data_columns > 0 {
-        rig.assert_event_journal_completes_with_timeout(
-            &[WorkType::ColumnReconstruction],
-            Duration::from_millis(50),
-        )
-        .await;
-    }
+    rig.assert_event_journal_completes_with_timeout(
+        &[WorkType::ColumnReconstruction],
+        Duration::from_millis(50),
+    )
+    .await;
 }
 
 // Test the column reconstruction is delayed for columns that arrive for a previous slot.

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -916,20 +916,13 @@ async fn data_column_reconstruction_at_deadline() {
         .start_of(rig.next_block.slot())
         .unwrap();
 
-    rig.chain
-        .slot_clock
-        .set_current_time(slot_start - rig.chain.spec.maximum_gossip_clock_disparity());
-
-    assert_eq!(
-        rig.chain.slot().unwrap(),
-        rig.next_block.slot() - 1,
-        "chain should be at the correct slot"
-    );
-
     // We push the slot clock to 3 seconds into the slot, this is the deadline to trigger reconstruction.
+    let slot_duration = rig.chain.slot_clock.slot_duration().as_millis() as u64;
+    let reconstruction_deadline_millis =
+        (slot_duration * RECONSTRUCTION_DEADLINE.0) / RECONSTRUCTION_DEADLINE.1;
     rig.chain
         .slot_clock
-        .set_current_time(slot_start + Duration::from_secs(3));
+        .set_current_time(slot_start + Duration::from_millis(reconstruction_deadline_millis));
 
     let min_columns_for_reconstruction = E::number_of_columns() / 2;
     for i in 0..min_columns_for_reconstruction {
@@ -939,9 +932,11 @@ async fn data_column_reconstruction_at_deadline() {
     }
 
     // Since we're at the reconstruction deadline, reconstruction should be triggered immediately
-    rig.assert_event_journal_completes_with_timeout(
-        &[WorkType::ColumnReconstruction],
+    rig.assert_event_journal_with_timeout(
+        &[WorkType::ColumnReconstruction.into()],
         Duration::from_millis(50),
+        false,
+        false,
     )
     .await;
 }


### PR DESCRIPTION
## Issue Addressed

FIx flaky tests that depends on timing. Previously the test processes all 128 columns and expect reconstruction to happen after all columns are processed. There is a race here, and reconstruction could be triggered before all columns are processed.

I've updated the tests to process 64 columns, just enough for reconstruction and wait for 50ms for reconstruction to be triggered.

This PR requires the change made in https://github.com/sigp/lighthouse/pull/8194 for the test to pass consistently (blob count set to 1 for all blocks instead of random blob count between 0..max)