### PR TITLE
Bump gas limit to 60M

### DIFF
--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -29,7 +29,7 @@ use super::DEFAULT_TERMINAL_BLOCK;
 const TEST_BLOB_BUNDLE: &[u8] = include_bytes!("fixtures/mainnet/test_blobs_bundle.ssz");
 const TEST_BLOB_BUNDLE_V2: &[u8] = include_bytes!("fixtures/mainnet/test_blobs_bundle_v2.ssz");
 
-pub const DEFAULT_GAS_LIMIT: u64 = 45_000_000;
+pub const DEFAULT_GAS_LIMIT: u64 = 60_000_000;
 const GAS_USED: u64 = DEFAULT_GAS_LIMIT - 1;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -40,7 +40,7 @@ use warp::reply::{self, Reply};
 use warp::{Filter, Rejection};
 
 pub const DEFAULT_FEE_RECIPIENT: Address = Address::repeat_byte(42);
-pub const DEFAULT_GAS_LIMIT: u64 = 45_000_000;
+pub const DEFAULT_GAS_LIMIT: u64 = 60_000_000;
 pub const DEFAULT_BUILDER_PRIVATE_KEY: &str =
     "607a11b45a7219cc61a3d9c5fd08c7eebd602a6a19a977f8d3771d5711a550f2";
 

--- a/book/src/advanced_builders.md
+++ b/book/src/advanced_builders.md
@@ -60,7 +60,7 @@ relays, run one of the following services and configure lighthouse to use it wit
 ## Validator Client Configuration
 
 In the validator client you can configure gas limit and fee recipient on a per-validator basis. If no gas limit is
-configured, Lighthouse will use a default gas limit of 45,000,000, which is the current default value used in execution
+configured, Lighthouse will use a default gas limit of 60,000,000, which is the current default value used in execution
 engines.  You can also enable or disable use of external builders on a per-validator basis rather than using
 `--builder-proposals`, `--builder-boost-factor` or `--prefer-builder-proposals`, which apply builder related preferences for all validators.
 In order to manage these configurations per-validator, you can either make updates to the `validator_definitions.yml` file
@@ -75,7 +75,7 @@ transaction within the block to the fee recipient, so a discrepancy in fee recip
 is something afoot.
 
 > Note: The gas limit configured here is effectively a vote on block size, so the configuration should not be taken lightly.
-> 45,000,000 is currently seen as a value balancing block size with how expensive it is for
+> 60,000,000 is currently seen as a value balancing block size with how expensive it is for
 > the network to validate blocks. So if you don't feel comfortable making an informed "vote", using the default value is
 > encouraged. We will update the default value if the community reaches a rough consensus on a new value.
 

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -40,7 +40,7 @@ Options:
           The gas limit to be used in all builder proposals for all validators
           managed by this validator client. Note this will not necessarily be
           used if the gas limit set here moves too far from the previous block's
-          gas limit. [default: 45000000]
+          gas limit. [default: 60000000]
       --genesis-state-url <URL>
           A URL of a beacon-API compatible server from which to download the
           genesis state. Checkpoint sync server URLs can generally be used with

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -505,7 +505,7 @@ fn no_doppelganger_protection_flag() {
 fn no_gas_limit_flag() {
     CommandLineTest::new()
         .run()
-        .with_config(|config| assert!(config.validator_store.gas_limit == Some(45_000_000)));
+        .with_config(|config| assert!(config.validator_store.gas_limit == Some(60_000_000)));
 }
 #[test]
 fn gas_limit_flag() {

--- a/validator_client/lighthouse_validator_store/src/lib.rs
+++ b/validator_client/lighthouse_validator_store/src/lib.rs
@@ -56,7 +56,7 @@ const SLASHING_PROTECTION_HISTORY_EPOCHS: u64 = 512;
 /// Currently used as the default gas limit in execution clients.
 ///
 /// https://ethpandaops.io/posts/gaslimit-scaling/.
-pub const DEFAULT_GAS_LIMIT: u64 = 45_000_000;
+pub const DEFAULT_GAS_LIMIT: u64 = 60_000_000;
 
 pub struct LighthouseValidatorStore<T, E> {
     validators: Arc<RwLock<InitializedValidators>>,

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -388,7 +388,7 @@ pub struct ValidatorClient {
     #[clap(
         long,
         value_name = "INTEGER",
-        default_value_t = 45_000_000,
+        default_value_t = 60_000_000,
         requires = "builder_proposals",
         help = "The gas limit to be used in all builder proposals for all validators managed \
                 by this validator client. Note this will not necessarily be used if the gas limit \


### PR DESCRIPTION
## Issue Addressed

Bump gas limit to 60M as part of Fusaka mainnet release.