### PR TITLE
Send idontwant on publish

### DIFF
--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -507,6 +507,7 @@ pub fn gossipsub_config(
         .duplicate_cache_time(duplicate_cache_time)
         .message_id_fn(gossip_message_id)
         .allow_self_origin(true)
+        .idontwant_on_publish(true)
         .idontwant_message_size_threshold(idontwant_message_size_threshold)
         .build()
         .expect("valid gossipsub configuration")


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Send an idontwant after publishing on any topic. Normally, we would only expect idontwants to be useful for fanouts but I don't expect to see any significant improvement after merging https://github.com/sigp/lighthouse/pull/8269 . 

But regardless, I feel like sending idontwants on publish is the sensible default. I don't want to merge this until fulu is activated on mainnet and we can test it on a mainnet like network. I feel that testing this on devnets wouldn't be very representative.