### PR TITLE
Downgrade and remove unnecessary logs

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -735,12 +735,11 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         // Data column is available via either the EL or reconstruction.
                         // Do not penalise the peer.
                         // Gossip filter should filter any duplicates received after this.
-                        debug!(
-                            %slot,
-                            %block_root,
-                            %index,
-                            "Received already available column sidecar. Ignoring the column sidecar"
-                        )
+                        self.propagate_validation_result(
+                            message_id,
+                            peer_id,
+                            MessageAcceptance::Ignore,
+                        );
                     }
                     GossipDataColumnError::FutureSlot { .. }
                     | GossipDataColumnError::PastFinalizedSlot { .. } => {

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -864,6 +864,9 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "Reconstruction not required for block"
                 );
             }
+            Err(BlockError::DuplicateFullyImported(_)) => {
+                debug!("Block has already been imported");
+            }
             Err(e) => {
                 error!(
                     %block_root,

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -865,7 +865,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 );
             }
             Err(BlockError::DuplicateFullyImported(_)) => {
-                debug!("Block has already been imported");
+                debug!("Block already imported in parallel with reconstruction");
             }
             Err(e) => {
                 error!(


### PR DESCRIPTION
## Issue Addressed

### Downgrade a non error to `Debug`

I noticed this error on one of our hoodi nodes:

```
Nov 04 05:13:38.892 ERROR Error during data column reconstruction       block_root: 0x4271b9efae7deccec3989bd2418e998b83ce8144210c2b17200abb62b7951190, error: DuplicateFullyImported(0x4271b9efae7deccec3989bd2418e998b83ce8144210c2b17200abb62b7951190)
```

This shouldn't be logged as an error and it's due to a normal race condition, and it doesn't impact the node negatively.

### Remove spammy logs

This logs is filling up the log files quite quickly and it is also something we'd expect during normal operation - getting columns via EL before gossip. We haven't found this debug log to be useful, so I propose we remove it to avoid spamming debug logs.

```
Received already available column sidecar. Ignoring the column sidecar
```

In the process of removing this, I noticed we aren't propagating the validation result, which I think we should so I've added this. The impact should be quite minimal - the message will stay in the gossip memcache for a bit longer but should be evicted in the next heartbeat.