### PR TITLE
Download execution engine release binaries instead of building locally on CI

### DIFF
--- a/testing/execution_engine_integration/src/build_utils.rs
+++ b/testing/execution_engine_integration/src/build_utils.rs
@@ -1,8 +1,20 @@
 use crate::SUPPRESS_LOGS;
+use serde_json::Value;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+
+pub fn get_platform_arch() -> Result<(&'static str, &'static str), String> {
+    let os = env::consts::OS;
+    let arch = env::consts::ARCH;
+
+    match (os, arch) {
+        ("linux", "x86_64") => Ok(("linux", "amd64")),
+        ("linux", "aarch64") => Ok(("linux", "arm64")),
+        _ => Err(format!("Unsupported platform: {}-{}", os, arch)),
+    }
+}
 
 pub fn prepare_dir() -> PathBuf {
     let manifest_dir: PathBuf = env::var("CARGO_MANIFEST_DIR").unwrap().into();
@@ -135,4 +147,114 @@ pub fn build_stdio() -> Stdio {
     } else {
         Stdio::inherit()
     }
+}
+
+pub fn download_file(url: &str, dest_path: &Path) -> Result<(), String> {
+    println!("Downloading from {}", url);
+
+    let output = Command::new("curl")
+        .arg("-L")
+        .arg("-f")
+        .arg("-o")
+        .arg(dest_path)
+        .arg(url)
+        .output()
+        .map_err(|e| format!("Failed to execute curl: {}", e))?;
+
+    output_to_result(output, |_| {}).map_err(|e| format!("Failed to download from {}: {}", url, e))
+}
+
+pub fn extract_tar_gz(archive_path: &Path, dest_dir: &Path) -> Result<(), String> {
+    println!("Extracting {:?} to {:?}", archive_path, dest_dir);
+
+    let output = Command::new("tar")
+        .arg("-xzf")
+        .arg(archive_path)
+        .arg("-C")
+        .arg(dest_dir)
+        .output()
+        .map_err(|e| format!("Failed to execute tar: {}", e))?;
+
+    output_to_result(output, |_| {}).map_err(|e| format!("Failed to extract tar.gz: {}", e))
+}
+
+pub fn extract_zip(archive_path: &Path, dest_dir: &Path) -> Result<(), String> {
+    println!("Extracting {:?} to {:?}", archive_path, dest_dir);
+
+    let output = Command::new("unzip")
+        .arg("-q")
+        .arg("-o")
+        .arg(archive_path)
+        .arg("-d")
+        .arg(dest_dir)
+        .output()
+        .map_err(|e| format!("Failed to execute unzip: {}", e))?;
+
+    output_to_result(output, |_| {}).map_err(|e| format!("Failed to extract zip: {}", e))
+}
+
+pub fn make_executable(file_path: &Path) -> Result<(), String> {
+    let output = Command::new("chmod")
+        .arg("+x")
+        .arg(file_path)
+        .output()
+        .map_err(|e| format!("Failed to execute chmod: {}", e))?;
+
+    output_to_result(output, |_| {}).map_err(|e| format!("Failed to make file executable: {}", e))
+}
+
+pub fn download_github_release_asset(
+    repo_owner: &str,
+    repo_name: &str,
+    asset_name_pattern: &str,
+    dest_path: &Path,
+) -> Result<String, String> {
+    println!(
+        "Fetching latest release asset matching '{}' for {}/{}",
+        asset_name_pattern, repo_owner, repo_name
+    );
+
+    let api_url = format!(
+        "https://api.github.com/repos/{}/{}/releases/latest",
+        repo_owner, repo_name
+    );
+
+    let output = Command::new("curl")
+        .arg("-sL")
+        .arg(&api_url)
+        .output()
+        .map_err(|e| format!("Failed to execute curl: {}", e))?;
+
+    let json: Value = output_to_result(output, |stdout| {
+        serde_json::from_slice(&stdout).map_err(|e| format!("Failed to parse JSON response: {}", e))
+    })
+    .map_err(|e| format!("Failed to get GitHub API response: {}", e))??;
+
+    let assets = json["assets"]
+        .as_array()
+        .ok_or_else(|| "No assets array in response".to_string())?;
+
+    let matching_asset = assets
+        .iter()
+        .find(|asset| {
+            asset["name"]
+                .as_str()
+                .map(|name| name.contains(asset_name_pattern))
+                .unwrap_or(false)
+        })
+        .ok_or_else(|| {
+            format!(
+                "No asset found matching '{}' in latest release",
+                asset_name_pattern
+            )
+        })?;
+
+    let download_url = matching_asset["browser_download_url"]
+        .as_str()
+        .ok_or_else(|| "Missing browser_download_url in asset".to_string())?
+        .to_string();
+
+    download_file(&download_url, dest_path)?;
+
+    Ok(download_url)
 }

--- a/testing/execution_engine_integration/src/geth.rs
+++ b/testing/execution_engine_integration/src/geth.rs
@@ -2,6 +2,7 @@ use crate::build_utils;
 use crate::execution_engine::GenericExecutionEngine;
 use crate::genesis_json::geth_genesis_json;
 use network_utils::unused_port::unused_tcp4_port;
+use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output};
 use std::{env, fs};
@@ -38,6 +39,148 @@ pub fn build(execution_clients_dir: &Path) {
     build_utils::check_command_output(build_result(&repo_dir), || {
         format!("geth make failed using release {last_release}")
     });
+}
+
+fn get_geth_latest_version() -> Result<(String, String), String> {
+    let api_url = "https://api.github.com/repos/ethereum/go-ethereum/releases/latest";
+
+    let output = Command::new("curl")
+        .arg("-sL")
+        .arg(api_url)
+        .output()
+        .map_err(|e| format!("Failed to execute curl: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to get GitHub API response: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse JSON response: {}", e))?;
+
+    let tag_name = json["tag_name"]
+        .as_str()
+        .ok_or_else(|| "Missing tag_name in response".to_string())?;
+
+    let version = tag_name.trim_start_matches('v');
+
+    // Get the commit SHA for this tag
+    let tag_api_url = format!(
+        "https://api.github.com/repos/ethereum/go-ethereum/git/refs/tags/{}",
+        tag_name
+    );
+
+    let tag_output = Command::new("curl")
+        .arg("-sL")
+        .arg(&tag_api_url)
+        .output()
+        .map_err(|e| format!("Failed to execute curl for tag info: {}", e))?;
+
+    if !tag_output.status.success() {
+        return Err(format!(
+            "Failed to get tag info: {}",
+            String::from_utf8_lossy(&tag_output.stderr)
+        ));
+    }
+
+    let tag_json: Value = serde_json::from_slice(&tag_output.stdout)
+        .map_err(|e| format!("Failed to parse tag JSON response: {}", e))?;
+
+    let commit_sha = tag_json["object"]["sha"]
+        .as_str()
+        .ok_or_else(|| "Missing commit SHA in tag response".to_string())?;
+
+    let short_hash = &commit_sha[..8.min(commit_sha.len())];
+
+    Ok((version.to_string(), short_hash.to_string()))
+}
+
+fn try_download_binary(execution_clients_dir: &Path) -> Result<(), String> {
+    let (os, arch) = build_utils::get_platform_arch()?;
+
+    // Geth only provides pre-built binaries for Linux platforms
+    if os != "linux" {
+        return Err(format!(
+            "Pre-built Geth binaries not available for {os}-{arch}",
+        ));
+    }
+
+    let geth_binary = GethEngine::binary_path();
+    let geth_dir = geth_binary.parent().unwrap();
+    fs::create_dir_all(geth_dir).map_err(|e| format!("Failed to create directory: {}", e))?;
+
+    println!("Downloading latest Geth binary for {}-{}", os, arch);
+
+    let (version, short_hash) = get_geth_latest_version()?;
+
+    // Construct gethstore URL: https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-{version}-{commit}.tar.gz
+    let download_url = format!(
+        "https://gethstore.blob.core.windows.net/builds/geth-{}-{}-{}-{}.tar.gz",
+        os, arch, version, short_hash
+    );
+
+    let archive_path = execution_clients_dir.join(format!("geth-{}.tar.gz", version));
+    build_utils::download_file(&download_url, &archive_path)?;
+
+    let temp_extract_dir = execution_clients_dir.join("geth-temp");
+    let _ = fs::remove_dir_all(&temp_extract_dir);
+    fs::create_dir_all(&temp_extract_dir)
+        .map_err(|e| format!("Failed to create temp directory: {}", e))?;
+    build_utils::extract_tar_gz(&archive_path, &temp_extract_dir)?;
+
+    let extracted_dir = fs::read_dir(&temp_extract_dir)
+        .map_err(|e| format!("Failed to read temp directory: {}", e))?
+        .find_map(|entry| {
+            let entry = entry.ok()?;
+            if entry.file_type().ok()?.is_dir() {
+                Some(entry.path())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| "Failed to find extracted Geth directory".to_string())?;
+
+    let extracted_geth = extracted_dir.join("geth");
+    if !extracted_geth.exists() {
+        return Err(format!(
+            "Geth binary not found in extracted archive at {}",
+            extracted_geth.display()
+        ));
+    }
+
+    fs::copy(&extracted_geth, &geth_binary)
+        .map_err(|e| format!("Failed to copy geth binary: {}", e))?;
+    build_utils::make_executable(&geth_binary)?;
+
+    fs::remove_file(&archive_path).unwrap_or_default();
+    fs::remove_dir_all(&temp_extract_dir).unwrap_or_default();
+
+    println!("Geth downloaded and installed successfully");
+
+    Ok(())
+}
+
+pub fn download_or_build(execution_clients_dir: &Path) {
+    let geth_binary = GethEngine::binary_path();
+    if geth_binary.exists() {
+        println!("Geth binary already exists, skipping");
+        return;
+    }
+
+    println!("Attempting to download Geth binary...");
+
+    if let Err(e) = try_download_binary(execution_clients_dir) {
+        println!("Failed to download Geth binary: {}", e);
+        println!("Falling back to building from source...");
+
+        // Clean up any partial download directories that might conflict with git clone
+        let geth_dir = geth_binary.parent().unwrap();
+        let _ = fs::remove_dir_all(geth_dir);
+
+        build(execution_clients_dir);
+    }
 }
 
 pub fn clean(execution_clients_dir: &Path) {

--- a/testing/execution_engine_integration/src/main.rs
+++ b/testing/execution_engine_integration/src/main.rs
@@ -31,13 +31,13 @@ fn main() {
 
 fn test_geth() {
     let test_dir = build_utils::prepare_dir();
-    geth::build(&test_dir);
+    geth::download_or_build(&test_dir);
     TestRig::new(GethEngine, true).perform_tests_blocking();
     geth::clean(&test_dir);
 }
 
 fn test_nethermind() {
     let test_dir = build_utils::prepare_dir();
-    nethermind::build(&test_dir);
+    nethermind::download_or_build(&test_dir);
     TestRig::new(NethermindEngine, false).perform_tests_blocking();
 }

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -35,7 +35,7 @@ pub fn build(execution_clients_dir: &Path) {
 
     // Get the latest tag
     let last_release = build_utils::get_latest_release(&repo_dir, NETHERMIND_BRANCH).unwrap();
-    build_utils::checkout(&repo_dir, dbg!(&last_release)).unwrap();
+    build_utils::checkout(&repo_dir, &last_release).unwrap();
 
     // Build nethermind
     build_utils::check_command_output(build_result(&repo_dir), || {
@@ -52,6 +52,81 @@ pub fn build(execution_clients_dir: &Path) {
     let tests_dir = execution_clients_dir.join("nethermind/src/tests");
     if let Err(e) = fs::remove_dir_all(tests_dir) {
         eprintln!("Error while deleting folder: {}", e);
+    }
+}
+
+fn try_download_binary(execution_clients_dir: &Path) -> Result<(), String> {
+    let (os, arch) = build_utils::get_platform_arch()?;
+
+    let platform = match (os, arch) {
+        ("linux", "amd64") => "linux-x64",
+        ("linux", "arm64") => "linux-arm64",
+        _ => {
+            return Err(format!(
+                "Pre-built Nethermind binaries not available for {os}-{arch}"
+            ));
+        }
+    };
+
+    let nethermind_binary = NethermindEngine::binary_path();
+    let nethermind_dir = nethermind_binary.parent().unwrap();
+    fs::create_dir_all(nethermind_dir).map_err(|e| format!("Failed to create directory: {}", e))?;
+
+    println!("Downloading latest Nethermind binary for {platform}");
+
+    let asset_pattern = format!("{}.zip", platform);
+    let archive_path = execution_clients_dir.join("nethermind-latest.zip");
+    build_utils::download_github_release_asset(
+        "NethermindEth",
+        "nethermind",
+        &asset_pattern,
+        &archive_path,
+    )?;
+
+    let temp_extract_dir = execution_clients_dir.join("nethermind-temp");
+    let _ = fs::remove_dir_all(&temp_extract_dir);
+    fs::create_dir_all(&temp_extract_dir)
+        .map_err(|e| format!("Failed to create temp directory: {}", e))?;
+    build_utils::extract_zip(&archive_path, &temp_extract_dir)?;
+
+    let extracted_binary = temp_extract_dir.join("nethermind");
+    if !extracted_binary.exists() {
+        return Err(format!(
+            "Nethermind binary not found in extracted archive at {}",
+            extracted_binary.display()
+        ));
+    }
+
+    fs::copy(&extracted_binary, &nethermind_binary)
+        .map_err(|e| format!("Failed to copy nethermind binary: {}", e))?;
+    build_utils::make_executable(&nethermind_binary)?;
+
+    fs::remove_file(&archive_path).unwrap_or_default();
+    fs::remove_dir_all(&temp_extract_dir).unwrap_or_default();
+
+    println!("Nethermind downloaded and installed successfully");
+
+    Ok(())
+}
+
+pub fn download_or_build(execution_clients_dir: &Path) {
+    let nethermind_binary = NethermindEngine::binary_path();
+    if nethermind_binary.exists() {
+        println!("Nethermind binary already exists, skipping");
+        return;
+    }
+
+    println!("Attempting to download Nethermind binary...");
+
+    if let Err(e) = try_download_binary(execution_clients_dir) {
+        println!("Failed to download Nethermind binary: {}", e);
+        println!("Falling back to building from source...");
+
+        // Clean up any partial download directories that might conflict with git clone
+        let nethermind_dir = nethermind_binary.parent().unwrap();
+        let _ = fs::remove_dir_all(nethermind_dir);
+
+        build(execution_clients_dir);
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

The execution engine tests on CI have been failing intermittently and the flakiness have been a pain for CI stability
https://github.com/sigp/lighthouse/actions/runs/19085741237/job/54525434394

This PR attempts to improve this by downloading the release binaries instead of building them locally. This should also improve the time it takes to run this CI job.

If it fails to download binaries from the URL, it would fallback to the existing approach to build the binaries locally.

TODO:
- detect platform and download the correct file or just fallback to building locally if not on CI