### PR TITLE
Fix panic on a rare startup race condition

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -7137,25 +7137,30 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     /// Compare columns custodied for `epoch` versus columns custodied for the head of the chain
     /// and return any column indices that are missing.
-    pub fn get_missing_columns_for_epoch(&self, epoch: Epoch) -> HashSet<ColumnIndex> {
+    pub fn get_missing_columns_for_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> Result<HashSet<ColumnIndex>, String> {
         let custody_context = self.data_availability_checker.custody_context();
 
         let columns_required = custody_context
-            .custody_columns_for_epoch(None, &self.spec)
+            .custody_columns_for_epoch(None, &self.spec)?
             .iter()
             .cloned()
             .collect::<HashSet<_>>();
 
         let current_columns_at_epoch = custody_context
-            .custody_columns_for_epoch(Some(epoch), &self.spec)
+            .custody_columns_for_epoch(Some(epoch), &self.spec)?
             .iter()
             .cloned()
             .collect::<HashSet<_>>();
 
-        columns_required
+        let missing_columns = columns_required
             .difference(&current_columns_at_epoch)
             .cloned()
-            .collect::<HashSet<_>>()
+            .collect::<HashSet<_>>();
+
+        Ok(missing_columns)
     }
 
     /// The da boundary for custodying columns. It will just be the DA boundary unless we are near the Fulu fork epoch.
@@ -7442,7 +7447,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             AvailableBlockData::DataColumns(mut data_columns) => {
                 let columns_to_custody = self.custody_columns_for_epoch(Some(
                     block_slot.epoch(T::EthSpec::slots_per_epoch()),
-                ));
+                ))?;
                 // Supernodes need to persist all sampled custody columns
                 if columns_to_custody.len() != self.spec.number_of_custody_groups as usize {
                     data_columns
@@ -7485,7 +7490,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     /// Returns a list of column indices that should be sampled for a given epoch.
     /// Used for data availability sampling in PeerDAS.
-    pub fn sampling_columns_for_epoch(&self, epoch: Epoch) -> &[ColumnIndex] {
+    pub fn sampling_columns_for_epoch(&self, epoch: Epoch) -> Result<&[ColumnIndex], String> {
         self.data_availability_checker
             .custody_context()
             .sampling_columns_for_epoch(epoch, &self.spec)
@@ -7496,7 +7501,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// serve them to peers.
     ///
     /// If epoch is `None`, this function computes the custody columns at head.
-    pub fn custody_columns_for_epoch(&self, epoch_opt: Option<Epoch>) -> &[ColumnIndex] {
+    pub fn custody_columns_for_epoch(
+        &self,
+        epoch_opt: Option<Epoch>,
+    ) -> Result<&[ColumnIndex], String> {
         self.data_availability_checker
             .custody_context()
             .custody_columns_for_epoch(epoch_opt, &self.spec)

--- a/beacon_node/beacon_chain/src/custody_context.rs
+++ b/beacon_node/beacon_chain/src/custody_context.rs
@@ -313,9 +313,7 @@ impl<E: EthSpec> CustodyContext<E> {
                 let old_custody_group_count = validator_custody_at_head;
                 validator_custody_at_head = cgc_from_cli;
 
-                let sampling_count = spec
-                    .sampling_size_custody_groups(cgc_from_cli)
-                    .expect("should compute node sampling size from valid chain spec");
+                let sampling_count = spec.sampling_size_custody_groups(cgc_from_cli);
 
                 epoch_validator_custody_requirements.push((effective_epoch, cgc_from_cli));
 
@@ -469,14 +467,16 @@ impl<E: EthSpec> CustodyContext<E> {
     pub fn num_of_custody_groups_to_sample(&self, epoch: Epoch, spec: &ChainSpec) -> u64 {
         let custody_group_count = self.custody_group_count_at_epoch(epoch, spec);
         spec.sampling_size_custody_groups(custody_group_count)
-            .expect("should compute node sampling size from valid chain spec")
     }
 
     /// Returns the count of columns this node must _sample_ for a block at `epoch` to import.
-    pub fn num_of_data_columns_to_sample(&self, epoch: Epoch, spec: &ChainSpec) -> usize {
+    pub fn num_of_data_columns_to_sample(
+        &self,
+        epoch: Epoch,
+        spec: &ChainSpec,
+    ) -> Result<usize, String> {
         let custody_group_count = self.custody_group_count_at_epoch(epoch, spec);
         spec.sampling_size_columns::<E>(custody_group_count)
-            .expect("should compute node sampling size from valid chain spec")
     }
 
     /// Returns whether the node should attempt reconstruction at a given epoch.
@@ -484,7 +484,8 @@ impl<E: EthSpec> CustodyContext<E> {
         let min_columns_for_reconstruction = E::number_of_columns() / 2;
         // performing reconstruction is not necessary if sampling column count is exactly 50%,
         // because the node doesn't need the remaining columns.
-        self.num_of_data_columns_to_sample(epoch, spec) > min_columns_for_reconstruction
+        self.num_of_data_columns_to_sample(epoch, spec)
+            .is_ok_and(|sample_count| sample_count > min_columns_for_reconstruction)
     }
 
     /// Returns the ordered list of column indices that should be sampled for data availability checking at the given epoch.
@@ -495,13 +496,17 @@ impl<E: EthSpec> CustodyContext<E> {
     ///
     /// # Returns
     /// A slice of ordered column indices that should be sampled for this epoch based on the node's custody configuration
-    pub fn sampling_columns_for_epoch(&self, epoch: Epoch, spec: &ChainSpec) -> &[ColumnIndex] {
-        let num_of_columns_to_sample = self.num_of_data_columns_to_sample(epoch, spec);
+    pub fn sampling_columns_for_epoch(
+        &self,
+        epoch: Epoch,
+        spec: &ChainSpec,
+    ) -> Result<&[ColumnIndex], String> {
+        let num_of_columns_to_sample = self.num_of_data_columns_to_sample(epoch, spec)?;
         let all_columns_ordered = self
             .all_custody_columns_ordered
             .get()
-            .expect("all_custody_columns_ordered should be initialized");
-        &all_columns_ordered[..num_of_columns_to_sample]
+            .ok_or("Custody context has not been initialised")?;
+        Ok(&all_columns_ordered[..num_of_columns_to_sample])
     }
 
     /// Returns the ordered list of column indices that the node is assigned to custody
@@ -521,7 +526,7 @@ impl<E: EthSpec> CustodyContext<E> {
         &self,
         epoch_opt: Option<Epoch>,
         spec: &ChainSpec,
-    ) -> &[ColumnIndex] {
+    ) -> Result<&[ColumnIndex], String> {
         let custody_group_count = if let Some(epoch) = epoch_opt {
             self.custody_group_count_at_epoch(epoch, spec) as usize
         } else {
@@ -531,9 +536,9 @@ impl<E: EthSpec> CustodyContext<E> {
         let all_columns_ordered = self
             .all_custody_columns_ordered
             .get()
-            .expect("all_custody_columns_ordered should be initialized");
+            .ok_or("Custody context has not been initialised")?;
 
-        &all_columns_ordered[..custody_group_count]
+        Ok(&all_columns_ordered[..custody_group_count])
     }
 
     /// The node has completed backfill for this epoch. Update the internal records so the function
@@ -699,8 +704,7 @@ mod tests {
         );
         assert_eq!(
             cgc_changed.sampling_count,
-            spec.sampling_size_custody_groups(expected_new_cgc)
-                .expect("should compute sampling size"),
+            spec.sampling_size_custody_groups(expected_new_cgc),
             "sampling_count should match expected value"
         );
 
@@ -1025,7 +1029,9 @@ mod tests {
     fn should_init_ordered_data_columns_and_return_sampling_columns() {
         let spec = E::default_spec();
         let custody_context = CustodyContext::<E>::new(NodeCustodyType::Fullnode, &spec);
-        let sampling_size = custody_context.num_of_data_columns_to_sample(Epoch::new(0), &spec);
+        let sampling_size = custody_context
+            .num_of_data_columns_to_sample(Epoch::new(0), &spec)
+            .unwrap();
 
         // initialise ordered columns
         let mut all_custody_groups_ordered = (0..spec.number_of_custody_groups).collect::<Vec<_>>();
@@ -1038,8 +1044,9 @@ mod tests {
             )
             .expect("should initialise ordered data columns");
 
-        let actual_sampling_columns =
-            custody_context.sampling_columns_for_epoch(Epoch::new(0), &spec);
+        let actual_sampling_columns = custody_context
+            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .unwrap();
 
         let expected_sampling_columns = &all_custody_groups_ordered
             .iter()
@@ -1085,7 +1092,10 @@ mod tests {
             .expect("should initialise ordered data columns");
 
         assert_eq!(
-            custody_context.custody_columns_for_epoch(None, &spec).len(),
+            custody_context
+                .custody_columns_for_epoch(None, &spec)
+                .unwrap()
+                .len(),
             spec.custody_requirement as usize
         );
     }
@@ -1101,7 +1111,10 @@ mod tests {
             .expect("should initialise ordered data columns");
 
         assert_eq!(
-            custody_context.custody_columns_for_epoch(None, &spec).len(),
+            custody_context
+                .custody_columns_for_epoch(None, &spec)
+                .unwrap()
+                .len(),
             spec.number_of_custody_groups as usize
         );
     }
@@ -1127,7 +1140,10 @@ mod tests {
         );
 
         assert_eq!(
-            custody_context.custody_columns_for_epoch(None, &spec).len(),
+            custody_context
+                .custody_columns_for_epoch(None, &spec)
+                .unwrap()
+                .len(),
             val_custody_units as usize
         );
     }
@@ -1147,6 +1163,7 @@ mod tests {
         assert_eq!(
             custody_context
                 .custody_columns_for_epoch(Some(test_epoch), &spec)
+                .unwrap()
                 .len(),
             expected_cgc as usize
         );
@@ -1413,6 +1430,7 @@ mod tests {
         assert_eq!(
             custody_context
                 .custody_columns_for_epoch(Some(Epoch::new(15)), &spec)
+                .unwrap()
                 .len(),
             final_cgc as usize,
         );

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -258,7 +258,8 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         let epoch = slot.epoch(T::EthSpec::slots_per_epoch());
         let sampling_columns = self
             .custody_context
-            .sampling_columns_for_epoch(epoch, &self.spec);
+            .sampling_columns_for_epoch(epoch, &self.spec)
+            .map_err(AvailabilityCheckError::CustodyContextError)?;
         let verified_custody_columns = kzg_verified_columns
             .into_iter()
             .filter(|col| sampling_columns.contains(&col.index()))
@@ -315,7 +316,8 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         let epoch = slot.epoch(T::EthSpec::slots_per_epoch());
         let sampling_columns = self
             .custody_context
-            .sampling_columns_for_epoch(epoch, &self.spec);
+            .sampling_columns_for_epoch(epoch, &self.spec)
+            .map_err(AvailabilityCheckError::CustodyContextError)?;
         let custody_columns = data_columns
             .into_iter()
             .filter(|col| sampling_columns.contains(&col.index()))
@@ -624,7 +626,8 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
 
         let columns_to_sample = self
             .custody_context()
-            .sampling_columns_for_epoch(slot.epoch(T::EthSpec::slots_per_epoch()), &self.spec);
+            .sampling_columns_for_epoch(slot.epoch(T::EthSpec::slots_per_epoch()), &self.spec)
+            .map_err(AvailabilityCheckError::CustodyContextError)?;
 
         // We only need to import and publish columns that we need to sample
         // and columns that we haven't already received
@@ -904,7 +907,9 @@ mod test {
             &spec,
         );
         assert_eq!(
-            custody_context.num_of_data_columns_to_sample(epoch, &spec),
+            custody_context
+                .num_of_data_columns_to_sample(epoch, &spec)
+                .unwrap(),
             spec.validator_custody_requirement as usize,
             "sampling size should be the minimal custody requirement == 8"
         );
@@ -939,7 +944,9 @@ mod test {
             .expect("should put rpc custody columns");
 
         // THEN the sampling size for the end slot of the same epoch remains unchanged
-        let sampling_columns = custody_context.sampling_columns_for_epoch(epoch, &spec);
+        let sampling_columns = custody_context
+            .sampling_columns_for_epoch(epoch, &spec)
+            .unwrap();
         assert_eq!(
             sampling_columns.len(),
             spec.validator_custody_requirement as usize // 8
@@ -983,7 +990,9 @@ mod test {
             &spec,
         );
         assert_eq!(
-            custody_context.num_of_data_columns_to_sample(epoch, &spec),
+            custody_context
+                .num_of_data_columns_to_sample(epoch, &spec)
+                .unwrap(),
             spec.validator_custody_requirement as usize,
             "sampling size should be the minimal custody requirement == 8"
         );
@@ -1017,7 +1026,9 @@ mod test {
             .expect("should put gossip custody columns");
 
         // THEN the sampling size for the end slot of the same epoch remains unchanged
-        let sampling_columns = custody_context.sampling_columns_for_epoch(epoch, &spec);
+        let sampling_columns = custody_context
+            .sampling_columns_for_epoch(epoch, &spec)
+            .unwrap();
         assert_eq!(
             sampling_columns.len(),
             spec.validator_custody_requirement as usize // 8
@@ -1106,7 +1117,9 @@ mod test {
             Slot::new(0),
             &spec,
         );
-        let sampling_requirement = custody_context.num_of_data_columns_to_sample(epoch, &spec);
+        let sampling_requirement = custody_context
+            .num_of_data_columns_to_sample(epoch, &spec)
+            .unwrap();
         assert_eq!(
             sampling_requirement, 65,
             "sampling requirement should be 65"
@@ -1164,7 +1177,9 @@ mod test {
         );
 
         // Only the columns required for custody (65) should be imported into the cache
-        let sampling_columns = custody_context.sampling_columns_for_epoch(epoch, &spec);
+        let sampling_columns = custody_context
+            .sampling_columns_for_epoch(epoch, &spec)
+            .unwrap();
         let actual_cached: HashSet<ColumnIndex> = da_checker
             .cached_data_column_indexes(&block_root)
             .expect("should have cached data columns")

--- a/beacon_node/beacon_chain/src/data_availability_checker/error.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
         blob_commitment: KzgCommitment,
         block_commitment: KzgCommitment,
     },
+    CustodyContextError(String),
     Unexpected(String),
     SszTypes(ssz_types::Error),
     MissingBlobs,
@@ -44,6 +45,7 @@ impl Error {
             | Error::ParentStateMissing(_)
             | Error::BlockReplayError(_)
             | Error::RebuildingStateCaches(_)
+            | Error::CustodyContextError(_)
             | Error::SlotClockError => ErrorCategory::Internal,
             Error::InvalidBlobs { .. }
             | Error::InvalidColumn { .. }

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -6,6 +6,7 @@ use crate::blob_verification::KzgVerifiedBlob;
 use crate::block_verification_types::{
     AvailabilityPendingExecutedBlock, AvailableBlock, AvailableExecutedBlock,
 };
+use crate::data_availability_checker::AvailabilityCheckError::CustodyContextError;
 use crate::data_availability_checker::{Availability, AvailabilityCheckError};
 use crate::data_column_verification::KzgVerifiedCustodyDataColumn;
 use crate::{BeaconChainTypes, BlockProcessStatus};
@@ -558,7 +559,8 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
 
         let num_expected_columns = self
             .custody_context
-            .num_of_data_columns_to_sample(epoch, &self.spec);
+            .num_of_data_columns_to_sample(epoch, &self.spec)
+            .map_err(AvailabilityCheckError::CustodyContextError)?;
 
         pending_components.span.in_scope(|| {
             debug!(
@@ -664,9 +666,13 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         };
 
         let total_column_count = T::EthSpec::number_of_columns();
-        let sampling_column_count = self
+        let Ok(sampling_column_count) = self
             .custody_context
-            .num_of_data_columns_to_sample(epoch, &self.spec);
+            .num_of_data_columns_to_sample(epoch, &self.spec)
+        else {
+            return ReconstructColumnsDecision::No("custody context not initialised");
+        };
+
         let received_column_count = pending_components.verified_data_columns.len();
 
         if pending_components.reconstruction_started {
@@ -709,7 +715,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
                 Ok(())
             })?;
 
-        let num_expected_columns_opt = self.get_num_expected_columns(epoch);
+        let num_expected_columns_opt = self.get_num_expected_columns(epoch)?;
 
         pending_components.span.in_scope(|| {
             debug!(
@@ -751,7 +757,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
                 Ok(())
             })?;
 
-        let num_expected_columns_opt = self.get_num_expected_columns(epoch);
+        let num_expected_columns_opt = self.get_num_expected_columns(epoch)?;
 
         pending_components.span.in_scope(|| {
             debug!(
@@ -768,14 +774,18 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         )
     }
 
-    fn get_num_expected_columns(&self, epoch: Epoch) -> Option<usize> {
+    fn get_num_expected_columns(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Option<usize>, AvailabilityCheckError> {
         if self.spec.is_peer_das_enabled_for_epoch(epoch) {
             let num_of_column_samples = self
                 .custody_context
-                .num_of_data_columns_to_sample(epoch, &self.spec);
-            Some(num_of_column_samples)
+                .num_of_data_columns_to_sample(epoch, &self.spec)
+                .map_err(CustodyContextError)?;
+            Ok(Some(num_of_column_samples))
         } else {
-            None
+            Ok(None)
         }
     }
 

--- a/beacon_node/beacon_chain/src/fetch_blobs/fetch_blobs_beacon_adapter.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs/fetch_blobs_beacon_adapter.rs
@@ -8,7 +8,7 @@ use mockall::automock;
 use std::collections::HashSet;
 use std::sync::Arc;
 use task_executor::TaskExecutor;
-use types::{ChainSpec, ColumnIndex, Hash256, Slot};
+use types::{ChainSpec, ColumnIndex, Epoch, Hash256, Slot};
 
 /// An adapter to the `BeaconChain` functionalities to remove `BeaconChain` from direct dependency to enable testing fetch blobs logic.
 pub(crate) struct FetchBlobsBeaconAdapter<T: BeaconChainTypes> {
@@ -120,5 +120,14 @@ impl<T: BeaconChainTypes> FetchBlobsBeaconAdapter<T> {
             .canonical_head
             .fork_choice_read_lock()
             .contains_block(block_root)
+    }
+
+    pub(crate) fn sampling_columns_for_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Vec<ColumnIndex>, String> {
+        self.chain
+            .sampling_columns_for_epoch(epoch)
+            .map(|column_indices| column_indices.to_vec())
     }
 }

--- a/beacon_node/beacon_chain/src/fetch_blobs/mod.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs/mod.rs
@@ -36,7 +36,7 @@ use tracing::{Span, debug, instrument, warn};
 use types::blob_sidecar::BlobSidecarError;
 use types::data_column_sidecar::DataColumnSidecarError;
 use types::{
-    BeaconStateError, Blob, BlobSidecar, ColumnIndex, EthSpec, FullPayload, Hash256, KzgProofs,
+    BeaconStateError, Blob, BlobSidecar, EthSpec, FullPayload, Hash256, KzgProofs,
     SignedBeaconBlock, SignedBeaconBlockHeader, VersionedHash,
 };
 
@@ -62,6 +62,7 @@ pub enum FetchEngineBlobError {
     GossipBlob(GossipBlobError),
     KzgError(kzg::Error),
     RequestFailed(ExecutionLayerError),
+    CustodyContextError(String),
     RuntimeShutdown,
     TokioJoin(tokio::task::JoinError),
 }
@@ -73,14 +74,12 @@ pub async fn fetch_and_process_engine_blobs<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
     block_root: Hash256,
     block: Arc<SignedBeaconBlock<T::EthSpec, FullPayload<T::EthSpec>>>,
-    custody_columns: &[ColumnIndex],
     publish_fn: impl Fn(EngineGetBlobsOutput<T>) + Send + 'static,
 ) -> Result<Option<AvailabilityProcessingStatus>, FetchEngineBlobError> {
     fetch_and_process_engine_blobs_inner(
         FetchBlobsBeaconAdapter::new(chain),
         block_root,
         block,
-        custody_columns,
         publish_fn,
     )
     .await
@@ -92,7 +91,6 @@ async fn fetch_and_process_engine_blobs_inner<T: BeaconChainTypes>(
     chain_adapter: FetchBlobsBeaconAdapter<T>,
     block_root: Hash256,
     block: Arc<SignedBeaconBlock<T::EthSpec, FullPayload<T::EthSpec>>>,
-    custody_columns: &[ColumnIndex],
     publish_fn: impl Fn(EngineGetBlobsOutput<T>) + Send + 'static,
 ) -> Result<Option<AvailabilityProcessingStatus>, FetchEngineBlobError> {
     let versioned_hashes = if let Some(kzg_commitments) = block
@@ -125,7 +123,6 @@ async fn fetch_and_process_engine_blobs_inner<T: BeaconChainTypes>(
             block_root,
             block,
             versioned_hashes,
-            custody_columns,
             publish_fn,
         )
         .await
@@ -240,7 +237,6 @@ async fn fetch_and_process_blobs_v2<T: BeaconChainTypes>(
     block_root: Hash256,
     block: Arc<SignedBeaconBlock<T::EthSpec>>,
     versioned_hashes: Vec<VersionedHash>,
-    custody_columns_indices: &[ColumnIndex],
     publish_fn: impl Fn(EngineGetBlobsOutput<T>) + Send + 'static,
 ) -> Result<Option<AvailabilityProcessingStatus>, FetchEngineBlobError> {
     let num_expected_blobs = versioned_hashes.len();
@@ -296,15 +292,9 @@ async fn fetch_and_process_blobs_v2<T: BeaconChainTypes>(
     }
 
     let chain_adapter = Arc::new(chain_adapter);
-    let custody_columns_to_import = compute_custody_columns_to_import(
-        &chain_adapter,
-        block_root,
-        block.clone(),
-        blobs,
-        proofs,
-        custody_columns_indices,
-    )
-    .await?;
+    let custody_columns_to_import =
+        compute_custody_columns_to_import(&chain_adapter, block_root, block.clone(), blobs, proofs)
+            .await?;
 
     if custody_columns_to_import.is_empty() {
         debug!(
@@ -339,12 +329,10 @@ async fn compute_custody_columns_to_import<T: BeaconChainTypes>(
     block: Arc<SignedBeaconBlock<T::EthSpec, FullPayload<T::EthSpec>>>,
     blobs: Vec<Blob<T::EthSpec>>,
     proofs: Vec<KzgProofs<T::EthSpec>>,
-    custody_columns_indices: &[ColumnIndex],
 ) -> Result<Vec<KzgVerifiedCustodyDataColumn<T::EthSpec>>, FetchEngineBlobError> {
     let kzg = chain_adapter.kzg().clone();
     let spec = chain_adapter.spec().clone();
     let chain_adapter_cloned = chain_adapter.clone();
-    let custody_columns_indices = custody_columns_indices.to_vec();
     let current_span = Span::current();
     chain_adapter
         .executor()
@@ -366,11 +354,15 @@ async fn compute_custody_columns_to_import<T: BeaconChainTypes>(
                 // This filtering ensures we only import and publish the custody columns.
                 // `DataAvailabilityChecker` requires a strict match on custody columns count to
                 // consider a block available.
+                let block_epoch = block.slot().epoch(T::EthSpec::slots_per_epoch());
+                let custody_column_indices = chain_adapter_cloned
+                    .sampling_columns_for_epoch(block_epoch)
+                    .map_err(FetchEngineBlobError::CustodyContextError)?;
                 let mut custody_columns = data_columns_result
                     .map(|data_columns| {
                         data_columns
                             .into_iter()
-                            .filter(|col| custody_columns_indices.contains(&col.index))
+                            .filter(|col| custody_column_indices.contains(&col.index))
                             .map(|col| {
                                 KzgVerifiedCustodyDataColumn::from_asserted_custody(
                                     KzgVerifiedDataColumn::from_execution_verified(col),

--- a/beacon_node/beacon_chain/src/fetch_blobs/tests.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs/tests.rs
@@ -139,6 +139,7 @@ mod get_blobs_v2 {
             .returning(|_| Some(hashset![0, 1, 2]));
         // No blobs should be processed
         mock_adapter.expect_process_engine_blobs().times(0);
+        mock_sampling_columns_for_epoch(&mut mock_adapter, vec![0, 1, 2]);
 
         // **WHEN**: Trigger `fetch_blobs` on the block
         let processing_status =

--- a/beacon_node/beacon_chain/src/fetch_blobs/tests.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs/tests.rs
@@ -12,8 +12,8 @@ use maplit::hashset;
 use std::sync::{Arc, Mutex};
 use task_executor::test_utils::TestRuntime;
 use types::{
-    BeaconBlock, BeaconBlockFulu, EmptyBlock, EthSpec, ForkName, Hash256, MainnetEthSpec,
-    SignedBeaconBlock, SignedBeaconBlockFulu,
+    BeaconBlock, BeaconBlockFulu, ColumnIndex, EmptyBlock, EthSpec, ForkName, Hash256,
+    MainnetEthSpec, SignedBeaconBlock, SignedBeaconBlockFulu,
 };
 
 type E = MainnetEthSpec;
@@ -21,7 +21,6 @@ type T = EphemeralHarnessType<E>;
 
 mod get_blobs_v2 {
     use super::*;
-    use types::ColumnIndex;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_fetch_blobs_v2_no_blobs_in_block() {
@@ -37,12 +36,10 @@ mod get_blobs_v2 {
         mock_adapter.expect_get_blobs_v2().times(0);
         mock_adapter.expect_process_engine_blobs().times(0);
 
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
         let processing_status = fetch_and_process_engine_blobs_inner(
             mock_adapter,
             block_root,
             Arc::new(block),
-            &custody_columns,
             publish_fn,
         )
         .await
@@ -62,16 +59,10 @@ mod get_blobs_v2 {
         mock_get_blobs_v2_response(&mut mock_adapter, None);
 
         // Trigger fetch blobs on the block
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
-        let processing_status = fetch_and_process_engine_blobs_inner(
-            mock_adapter,
-            block_root,
-            block,
-            &custody_columns,
-            publish_fn,
-        )
-        .await
-        .expect("fetch blobs should succeed");
+        let processing_status =
+            fetch_and_process_engine_blobs_inner(mock_adapter, block_root, block, publish_fn)
+                .await
+                .expect("fetch blobs should succeed");
 
         assert_eq!(processing_status, None);
     }
@@ -90,16 +81,10 @@ mod get_blobs_v2 {
         mock_adapter.expect_process_engine_blobs().times(0);
 
         // Trigger fetch blobs on the block
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
-        let processing_status = fetch_and_process_engine_blobs_inner(
-            mock_adapter,
-            block_root,
-            block,
-            &custody_columns,
-            publish_fn,
-        )
-        .await
-        .expect("fetch blobs should succeed");
+        let processing_status =
+            fetch_and_process_engine_blobs_inner(mock_adapter, block_root, block, publish_fn)
+                .await
+                .expect("fetch blobs should succeed");
 
         assert_eq!(processing_status, None);
         assert_eq!(
@@ -123,16 +108,10 @@ mod get_blobs_v2 {
         mock_adapter.expect_process_engine_blobs().times(0);
 
         // Trigger fetch blobs on the block
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
-        let processing_status = fetch_and_process_engine_blobs_inner(
-            mock_adapter,
-            block_root,
-            block,
-            &custody_columns,
-            publish_fn,
-        )
-        .await
-        .expect("fetch blobs should succeed");
+        let processing_status =
+            fetch_and_process_engine_blobs_inner(mock_adapter, block_root, block, publish_fn)
+                .await
+                .expect("fetch blobs should succeed");
 
         assert_eq!(processing_status, None);
         assert_eq!(
@@ -162,16 +141,10 @@ mod get_blobs_v2 {
         mock_adapter.expect_process_engine_blobs().times(0);
 
         // **WHEN**: Trigger `fetch_blobs` on the block
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
-        let processing_status = fetch_and_process_engine_blobs_inner(
-            mock_adapter,
-            block_root,
-            block,
-            &custody_columns,
-            publish_fn,
-        )
-        .await
-        .expect("fetch blobs should succeed");
+        let processing_status =
+            fetch_and_process_engine_blobs_inner(mock_adapter, block_root, block, publish_fn)
+                .await
+                .expect("fetch blobs should succeed");
 
         // **THEN**: Should NOT be processed and no columns should be published.
         assert_eq!(processing_status, None);
@@ -202,18 +175,14 @@ mod get_blobs_v2 {
             &mut mock_adapter,
             Ok(AvailabilityProcessingStatus::Imported(block_root)),
         );
+        let custody_columns = vec![0u64, 1, 2];
+        mock_sampling_columns_for_epoch(&mut mock_adapter, custody_columns.clone());
 
         // Trigger fetch blobs on the block
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
-        let processing_status = fetch_and_process_engine_blobs_inner(
-            mock_adapter,
-            block_root,
-            block,
-            &custody_columns,
-            publish_fn,
-        )
-        .await
-        .expect("fetch blobs should succeed");
+        let processing_status =
+            fetch_and_process_engine_blobs_inner(mock_adapter, block_root, block, publish_fn)
+                .await
+                .expect("fetch blobs should succeed");
 
         assert_eq!(
             processing_status,
@@ -253,7 +222,6 @@ mod get_blobs_v1 {
     use super::*;
     use crate::block_verification_types::AsBlock;
     use std::collections::HashSet;
-    use types::ColumnIndex;
 
     const ELECTRA_FORK: ForkName = ForkName::Electra;
 
@@ -270,12 +238,10 @@ mod get_blobs_v1 {
         mock_adapter.expect_get_blobs_v1().times(0);
 
         // WHEN: Trigger fetch blobs on the block
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
         let processing_status = fetch_and_process_engine_blobs_inner(
             mock_adapter,
             block_root,
             Arc::new(block_no_blobs),
-            &custody_columns,
             publish_fn,
         )
         .await
@@ -297,16 +263,10 @@ mod get_blobs_v1 {
         mock_get_blobs_v1_response(&mut mock_adapter, vec![None; expected_blob_count]);
 
         // WHEN: Trigger fetch blobs on the block
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
-        let processing_status = fetch_and_process_engine_blobs_inner(
-            mock_adapter,
-            block_root,
-            block,
-            &custody_columns,
-            publish_fn,
-        )
-        .await
-        .expect("fetch blobs should succeed");
+        let processing_status =
+            fetch_and_process_engine_blobs_inner(mock_adapter, block_root, block, publish_fn)
+                .await
+                .expect("fetch blobs should succeed");
 
         // THEN: No blob is processed
         assert_eq!(processing_status, None);
@@ -343,16 +303,10 @@ mod get_blobs_v1 {
         );
 
         // WHEN: Trigger fetch blobs on the block
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
-        let processing_status = fetch_and_process_engine_blobs_inner(
-            mock_adapter,
-            block_root,
-            block,
-            &custody_columns,
-            publish_fn,
-        )
-        .await
-        .expect("fetch blobs should succeed");
+        let processing_status =
+            fetch_and_process_engine_blobs_inner(mock_adapter, block_root, block, publish_fn)
+                .await
+                .expect("fetch blobs should succeed");
 
         // THEN: Returned blobs are processed and published
         assert_eq!(
@@ -383,16 +337,10 @@ mod get_blobs_v1 {
         mock_fork_choice_contains_block(&mut mock_adapter, vec![block.canonical_root()]);
 
         // WHEN: Trigger fetch blobs on the block
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
-        let processing_status = fetch_and_process_engine_blobs_inner(
-            mock_adapter,
-            block_root,
-            block,
-            &custody_columns,
-            publish_fn,
-        )
-        .await
-        .expect("fetch blobs should succeed");
+        let processing_status =
+            fetch_and_process_engine_blobs_inner(mock_adapter, block_root, block, publish_fn)
+                .await
+                .expect("fetch blobs should succeed");
 
         // THEN: Returned blobs should NOT be processed or published.
         assert_eq!(processing_status, None);
@@ -431,16 +379,10 @@ mod get_blobs_v1 {
             .returning(move |_, _| Some(all_blob_indices.clone()));
 
         // **WHEN**: Trigger `fetch_blobs` on the block
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
-        let processing_status = fetch_and_process_engine_blobs_inner(
-            mock_adapter,
-            block_root,
-            block,
-            &custody_columns,
-            publish_fn,
-        )
-        .await
-        .expect("fetch blobs should succeed");
+        let processing_status =
+            fetch_and_process_engine_blobs_inner(mock_adapter, block_root, block, publish_fn)
+                .await
+                .expect("fetch blobs should succeed");
 
         // **THEN**: Should NOT be processed and no blobs should be published.
         assert_eq!(processing_status, None);
@@ -475,16 +417,10 @@ mod get_blobs_v1 {
         );
 
         // Trigger fetch blobs on the block
-        let custody_columns: [ColumnIndex; 3] = [0, 1, 2];
-        let processing_status = fetch_and_process_engine_blobs_inner(
-            mock_adapter,
-            block_root,
-            block,
-            &custody_columns,
-            publish_fn,
-        )
-        .await
-        .expect("fetch blobs should succeed");
+        let processing_status =
+            fetch_and_process_engine_blobs_inner(mock_adapter, block_root, block, publish_fn)
+                .await
+                .expect("fetch blobs should succeed");
 
         // THEN all fetched blobs are processed and published
         assert_eq!(
@@ -537,6 +473,15 @@ fn mock_process_engine_blobs_result(
     mock_adapter
         .expect_process_engine_blobs()
         .return_once(move |_, _, _| result);
+}
+
+fn mock_sampling_columns_for_epoch(
+    mock_adapter: &mut MockFetchBlobsBeaconAdapter<T>,
+    sampling_indices: Vec<ColumnIndex>,
+) {
+    mock_adapter
+        .expect_sampling_columns_for_epoch()
+        .return_const(Ok(sampling_indices));
 }
 
 fn mock_fork_choice_contains_block(

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -2455,7 +2455,7 @@ where
     ) -> Result<RpcBlock<E>, BlockError> {
         Ok(if self.spec.is_peer_das_enabled_for_epoch(block.epoch()) {
             let epoch = block.slot().epoch(E::slots_per_epoch());
-            let sampling_columns = self.chain.sampling_columns_for_epoch(epoch);
+            let sampling_columns = self.chain.sampling_columns_for_epoch(epoch).unwrap();
 
             if blob_items.is_some_and(|(_, blobs)| !blobs.is_empty()) {
                 // Note: this method ignores the actual custody columns and just take the first
@@ -3196,6 +3196,7 @@ where
                 let epoch = block.slot().epoch(E::slots_per_epoch());
                 self.chain
                     .sampling_columns_for_epoch(epoch)
+                    .unwrap()
                     .iter()
                     .copied()
                     .collect()

--- a/beacon_node/beacon_chain/tests/events.rs
+++ b/beacon_node/beacon_chain/tests/events.rs
@@ -78,7 +78,7 @@ async fn data_column_sidecar_event_on_process_gossip_data_column() {
         let slot = Slot::new(10);
         let epoch = slot.epoch(E::slots_per_epoch());
         random_sidecar.signed_block_header.message.slot = slot;
-        random_sidecar.index = harness.chain.sampling_columns_for_epoch(epoch)[0];
+        random_sidecar.index = harness.chain.sampling_columns_for_epoch(epoch).unwrap()[0];
         random_sidecar
     };
     let gossip_verified_data_column =

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -5092,6 +5092,7 @@ async fn test_custody_column_filtering_regular_node() {
     let expected_custody_columns: HashSet<_> = harness
         .chain
         .custody_columns_for_epoch(Some(current_slot.epoch(E::slots_per_epoch())))
+        .unwrap()
         .iter()
         .copied()
         .collect();
@@ -5183,7 +5184,8 @@ async fn test_missing_columns_after_cgc_change() {
 
     let missing_columns = harness
         .chain
-        .get_missing_columns_for_epoch(epoch_before_increase);
+        .get_missing_columns_for_epoch(epoch_before_increase)
+        .unwrap();
 
     // We should have no missing columns
     assert_eq!(missing_columns.len(), 0);
@@ -5205,14 +5207,16 @@ async fn test_missing_columns_after_cgc_change() {
     // We should have missing columns from before the cgc increase
     let missing_columns = harness
         .chain
-        .get_missing_columns_for_epoch(epoch_before_increase);
+        .get_missing_columns_for_epoch(epoch_before_increase)
+        .unwrap();
 
     assert!(!missing_columns.is_empty());
 
     // We should have no missing columns after the cgc increase
     let missing_columns = harness
         .chain
-        .get_missing_columns_for_epoch(epoch_after_increase);
+        .get_missing_columns_for_epoch(epoch_after_increase)
+        .unwrap();
 
     assert!(missing_columns.is_empty());
 }

--- a/beacon_node/http_api/src/custody.rs
+++ b/beacon_node/http_api/src/custody.rs
@@ -41,6 +41,9 @@ pub fn info<T: BeaconChainTypes>(
     let custody_context = chain.data_availability_checker.custody_context();
     let custody_columns = custody_context
         .custody_columns_for_epoch(Some(earliest_custodied_data_column_epoch), &chain.spec)
+        .map_err(|e| {
+            custom_server_error(format!("custody context has not been initialised: {e:?}"))
+        })?
         .to_vec();
     let custody_group_count = custody_context
         .custody_group_count_at_epoch(earliest_custodied_data_column_epoch, &chain.spec);

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -237,7 +237,12 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlock<T>>(
             warp_utils::reject::custom_server_error("unable to publish data column sidecars".into())
         })?;
         let epoch = block.slot().epoch(T::EthSpec::slots_per_epoch());
-        let sampling_columns_indices = chain.sampling_columns_for_epoch(epoch);
+        let sampling_columns_indices = chain.sampling_columns_for_epoch(epoch).map_err(|_| {
+            // This is unreachable as beacon chain must have been initialised before http server starts
+            warp_utils::reject::custom_server_error(
+                "beacon chain has not been initialised correctly".into(),
+            )
+        })?;
         let sampling_columns = gossip_verified_columns
             .into_iter()
             .filter(|data_column| sampling_columns_indices.contains(&data_column.index()))

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -2031,6 +2031,7 @@ fn get_custody_columns(tester: &InteractiveTester<E>, slot: Slot) -> HashSet<Col
         .as_ref()
         .unwrap()
         .sampling_columns_for_epoch(epoch)
+        .unwrap()
         .iter()
         .copied()
         .collect()

--- a/beacon_node/lighthouse_network/src/types/globals.rs
+++ b/beacon_node/lighthouse_network/src/types/globals.rs
@@ -66,9 +66,7 @@ impl<E: EthSpec> NetworkGlobals<E> {
 
         // The below `expect` calls will panic on start up if the chain spec config values used
         // are invalid
-        let sampling_size = spec
-            .sampling_size_custody_groups(custody_group_count)
-            .expect("should compute node sampling size from valid chain spec");
+        let sampling_size = spec.sampling_size_custody_groups(custody_group_count);
         let custody_groups = get_custody_groups(node_id, sampling_size, &spec)
             .expect("should compute node custody groups");
 
@@ -277,9 +275,7 @@ mod test {
         spec.fulu_fork_epoch = Some(Epoch::new(0));
 
         let custody_group_count = spec.number_of_custody_groups / 2;
-        let sampling_size_custody_groups = spec
-            .sampling_size_custody_groups(custody_group_count)
-            .unwrap();
+        let sampling_size_custody_groups = spec.sampling_size_custody_groups(custody_group_count);
         let expected_sampling_subnet_count = sampling_size_custody_groups
             * spec.data_column_sidecar_subnet_count
             / spec.number_of_custody_groups;

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -761,8 +761,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         if self.chain.config.disable_get_blobs {
             return;
         }
-        let epoch = block.slot().epoch(T::EthSpec::slots_per_epoch());
-        let custody_columns = self.chain.sampling_columns_for_epoch(epoch);
         let self_cloned = self.clone();
         let publish_fn = move |blobs_or_data_column| {
             if publish_blobs {
@@ -787,7 +785,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             self.chain.clone(),
             block_root,
             block.clone(),
-            custody_columns,
             publish_fn,
         )
         .await

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -438,14 +438,15 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     ) -> Result<(), (RpcErrorResponse, &'static str)> {
         let mut send_data_column_count = 0;
         // Only attempt lookups for columns the node has advertised and is responsible for maintaining custody of.
-        let available_columns = self.chain.custody_columns_for_epoch(None);
+        // Note: this may not be available during startup. This case is rare. We skip filtering to avoid getting penalised.
+        let available_columns_opt = self.chain.custody_columns_for_epoch(None).ok();
 
         for data_column_ids_by_root in request.data_column_ids.as_slice() {
             let indices_to_retrieve = data_column_ids_by_root
                 .columns
                 .iter()
                 .copied()
-                .filter(|c| available_columns.contains(c))
+                .filter(|c| available_columns_opt.is_none_or(|columns| columns.contains(c)))
                 .collect::<Vec<_>>();
             match self.chain.get_data_columns_checking_all_caches(
                 data_column_ids_by_root.block_root,
@@ -1258,15 +1259,17 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
         // Only attempt lookups for columns the node has advertised and is responsible for maintaining custody of.
         let request_start_epoch = request_start_slot.epoch(T::EthSpec::slots_per_epoch());
-        let available_columns = self
+        // Note: this may not be available during startup. This case is rare. We skip filtering to avoid getting penalised.
+        let available_columns_opt = self
             .chain
-            .custody_columns_for_epoch(Some(request_start_epoch));
+            .custody_columns_for_epoch(Some(request_start_epoch))
+            .ok();
 
         let indices_to_retrieve = req
             .columns
             .iter()
             .copied()
-            .filter(|c| available_columns.contains(c))
+            .filter(|c| available_columns_opt.is_none_or(|columns| columns.contains(c)))
             .collect::<Vec<_>>();
 
         for root in block_roots {
@@ -1374,17 +1377,18 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         epoch_opt: Option<Epoch>,
         span: Span,
     ) {
-        let non_custody_indices = {
-            let custody_columns = self
-                .chain
-                .data_availability_checker
-                .custody_context()
-                .custody_columns_for_epoch(epoch_opt, &self.chain.spec);
-            requested_indices
-                .iter()
-                .filter(|subnet_id| !custody_columns.contains(subnet_id))
-                .collect::<Vec<_>>()
-        };
+        let non_custody_indices = self
+            .chain
+            .data_availability_checker
+            .custody_context()
+            .custody_columns_for_epoch(epoch_opt, &self.chain.spec)
+            .map(|custody_columns| {
+                requested_indices
+                    .iter()
+                    .filter(|subnet_id| !custody_columns.contains(subnet_id))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
         // This field is used to identify if peers are sending requests on columns we don't custody.
         span.record("non_custody_indices", field::debug(non_custody_indices));
 

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -298,7 +298,7 @@ impl TestRig {
             if chain.spec.is_peer_das_enabled_for_epoch(block.epoch()) {
                 let kzg = get_kzg(&chain.spec);
                 let epoch = block.slot().epoch(E::slots_per_epoch());
-                let sampling_indices = chain.sampling_columns_for_epoch(epoch);
+                let sampling_indices = chain.sampling_columns_for_epoch(epoch).unwrap();
                 let custody_columns: DataColumnSidecarList<E> = blobs_to_data_column_sidecars(
                     &blobs.iter().collect_vec(),
                     kzg_proofs.clone().into_iter().collect_vec(),
@@ -1936,7 +1936,8 @@ async fn test_data_columns_by_range_request_only_returns_requested_columns() {
 
     let all_custody_columns = rig
         .chain
-        .sampling_columns_for_epoch(rig.chain.epoch().unwrap());
+        .sampling_columns_for_epoch(rig.chain.epoch().unwrap())
+        .unwrap();
     let available_columns: Vec<u64> = all_custody_columns.to_vec();
 
     let requested_columns = vec![available_columns[0], available_columns[2]];

--- a/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
@@ -173,9 +173,13 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
         };
 
         // Check if we have missing columns between the da boundary and `earliest_data_column_epoch`
-        let missing_columns = self
+        let Ok(missing_columns) = self
             .beacon_chain
-            .get_missing_columns_for_epoch(da_boundary_epoch);
+            .get_missing_columns_for_epoch(da_boundary_epoch)
+        else {
+            // If custody context has not been initialised, we cannot determine if backfill is required.
+            return false;
+        };
 
         if !missing_columns.is_empty() {
             let latest_finalized_epoch = self
@@ -384,7 +388,9 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
 
         // Skip all batches (Epochs) that don't have missing columns.
         for epoch in Epoch::range_inclusive_rev(self.to_be_downloaded, column_da_boundary) {
-            let missing_columns = self.beacon_chain.get_missing_columns_for_epoch(epoch);
+            let Ok(missing_columns) = self.beacon_chain.get_missing_columns_for_epoch(epoch) else {
+                return None;
+            };
 
             if !missing_columns.is_empty() {
                 self.to_be_downloaded = epoch;
@@ -443,7 +449,11 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
                 self.include_next_batch()
             }
             Entry::Vacant(entry) => {
-                let missing_columns = self.beacon_chain.get_missing_columns_for_epoch(batch_id);
+                let Ok(missing_columns) = self.beacon_chain.get_missing_columns_for_epoch(batch_id)
+                else {
+                    // This is unreachable as we have already called this function earlier, so custody context must be initialised.
+                    return None;
+                };
                 entry.insert(BatchInfo::new(
                     &batch_id,
                     CUSTODY_BACKFILL_EPOCHS_PER_BATCH,

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -583,6 +583,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 let column_indexes = self
                     .chain
                     .sampling_columns_for_epoch(epoch)
+                    .map_err(RpcRequestSendError::InternalError)?
                     .iter()
                     .cloned()
                     .collect();
@@ -659,15 +660,15 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .transpose()?;
 
         let epoch = Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch());
+        let sampling_columns = self
+            .chain
+            .sampling_columns_for_epoch(epoch)
+            .map_err(RpcRequestSendError::InternalError)?;
         let info = RangeBlockComponentsRequest::new(
             blocks_req_id,
             blobs_req_id,
-            data_column_requests.map(|data_column_requests| {
-                (
-                    data_column_requests,
-                    self.chain.sampling_columns_for_epoch(epoch).to_vec(),
-                )
-            }),
+            data_column_requests
+                .map(|data_column_requests| (data_column_requests, sampling_columns.to_vec())),
             range_request_span,
         );
         self.components_by_range_requests.insert(id, info);
@@ -1096,6 +1097,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         let custody_indexes_to_fetch = self
             .chain
             .sampling_columns_for_epoch(current_epoch)
+            .map_err(RpcRequestSendError::InternalError)?
             .iter()
             .copied()
             .filter(|index| !custody_indexes_imported.contains(index))
@@ -1700,6 +1702,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             let column_indexes = self
                 .chain
                 .sampling_columns_for_epoch(batch_id.epoch)
+                .map_err(RpcRequestSendError::InternalError)?
                 .iter()
                 .cloned()
                 .collect();

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -817,7 +817,7 @@ impl ChainSpec {
         &self,
         custody_group_count: u64,
     ) -> Result<usize, String> {
-        let sampling_size_groups = self.sampling_size_custody_groups(custody_group_count)?;
+        let sampling_size_groups = self.sampling_size_custody_groups(custody_group_count);
         let columns_per_custody_group = self.data_columns_per_group::<E>();
 
         let sampling_size_columns = columns_per_custody_group
@@ -828,8 +828,8 @@ impl ChainSpec {
     }
 
     /// Returns the number of custody groups to sample per slot.
-    pub fn sampling_size_custody_groups(&self, custody_group_count: u64) -> Result<u64, String> {
-        Ok(std::cmp::max(custody_group_count, self.samples_per_slot))
+    pub fn sampling_size_custody_groups(&self, custody_group_count: u64) -> u64 {
+        std::cmp::max(custody_group_count, self.samples_per_slot)
     }
 
     /// Returns the min epoch for blob / data column sidecar requests based on the current epoch.


### PR DESCRIPTION
## Issue Addressed

A [discord user reported](https://discord.com/channels/605577013327167508/605577013331361793/1436490679256612884) a panic during startup and it wasn't recurring. This seems like a rare race condition that wasn't possible until custody backfill was introduced, and this queried custody context before it was initialised:

https://github.com/sigp/lighthouse/blob/51ad47f5dbdb5c6fa4064133f623b02c297369ef/beacon_node/network/src/sync/custody_backfill_sync/mod.rs#L262

custody context initialised here:
https://github.com/sigp/lighthouse/blob/43c5e924d74003d9eab0ca7fdf58f1c8b5e5db7a/beacon_node/client/src/builder.rs#L488

I've been thinking about fixing the race condition but thought this may be a simpler fix, however this end up being quite tedious and requiring a lot of changes.

I'm going to look into the alternatives of fixing the race conditions properly and compare the solutions.

NOTE: This currently targets `unstable`, but I can rebase this into the release branch if we want to include this in v8.0.1. 