### PR TITLE
Update docs on Siren port and other small updates

### DIFF
--- a/book/src/advanced_blobs.md
+++ b/book/src/advanced_blobs.md
@@ -17,7 +17,7 @@ While both `--supernode` and `--semi-supernode` can serve blobs, a supernode wil
 
 Combining `--prune-blobs false` and `--supernode` (or `--semi-supernode`) implies that no data columns will be pruned, and the node will be able to serve blobs since using the flag.
 
-If you want historical blob data beyond the data availability period (18 days), you can backfill blobs or data columns with the experimental flag `--complete-blob-backfill`. However, do note that this is an experimental feature and it only works when the flag is present during a fresh checkpoint sync when the database is initialised. The flag will have no effect if the node is already running (with an existing database). During blob backfill, the feature may cause some issues, e.g., the node may block most of its peers.
+If you want historical blob data beyond the data availability period (18 days), you can backfill blobs or data columns with the experimental flag `--complete-blob-backfill`. However, do note that this is an experimental feature and it only works when the flag is present during a fresh checkpoint sync when the database is initialised. The flag will not backfill blobs if the node is already running (with an existing database). During blob backfill, the feature may cause some issues, e.g., the node may block most of its peers.
 
 **⚠️ The following section on Blobs is archived and not maintained as blobs are stored in the form of data columns after the Fulu fork ⚠️**
 

--- a/book/src/advanced_checkpoint_sync.md
+++ b/book/src/advanced_checkpoint_sync.md
@@ -160,7 +160,7 @@ curl -H "Accept: application/octet-stream" "http://localhost:5052/eth/v1/beacon/
 
 where `$SLOT` is the slot number. A slot which is an epoch boundary slot (i.e., first slot of an epoch) should always be used for manual checkpoint sync.
 
-If the block contains blobs, all state, block and blobs must be provided and must point to the same slot. The
+If the block contains blobs, all state, block and blobs must be provided and must point to the same slot (only applies for slots before Fulu). The
 state may be from the same slot as the block (unadvanced), or advanced to an epoch boundary,
 in which case it will be assumed to be finalized at that epoch.
 

--- a/book/src/ui_installation.md
+++ b/book/src/ui_installation.md
@@ -138,13 +138,13 @@ Navigate to the backend directory `cd backend`. Install all required Node packag
 
 After initializing the backend, return to the root directory. Install all frontend dependencies by executing `yarn`. Build the frontend using `yarn build`. Start the frontend production server with `yarn start`.
 
-This will allow you to access siren at `http://localhost:3000` by default.
+This will allow you to access siren at `http://localhost:3300` by default.
 
 ## Advanced configuration
 
 ### About self-signed SSL certificates
 
-By default, internally, Siren is running on port 80 (plain, behind nginx), port 3000 (plain, direct) and port 443 (with SSL, behind nginx)). Siren will generate and use a self-signed certificate on startup. This will generate a security warning when you try to access the interface. We recommend to only disable SSL if you would access Siren over a local LAN or otherwise highly trusted or encrypted network (i.e. VPN).
+By default, internally, Siren is running on port 80 (plain, behind nginx), port 3300 (plain, direct) and port 443 (with SSL, behind nginx)). Siren will generate and use a self-signed certificate on startup. This will generate a security warning when you try to access the interface. We recommend to only disable SSL if you would access Siren over a local LAN or otherwise highly trusted or encrypted network (i.e. VPN).
 
 #### Generating persistent SSL certificates and installing them to your system
 


### PR DESCRIPTION
As Siren now uses port 3300 by default, update this info in Lighthouse book

Also small updates about blobs related information, see: https://github.com/sigp/lighthouse/pull/8413#pullrequestreview-3463104583