### PR TITLE
fix: ensure unique epochs in BlobSchedule initialization

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1179,7 +1179,8 @@ impl ChainSpec {
                     epoch: Epoch::new(419072),
                     max_blobs_per_block: 21,
                 },
-            ]),
+            ])
+            .expect("mainnet blob schedule has unique epochs"),
             min_epochs_for_data_column_sidecars_requests:
                 default_min_epochs_for_data_column_sidecars_requests(),
             max_data_columns_by_root_request: default_data_columns_by_root_request(),
@@ -1584,18 +1585,31 @@ impl<'de> Deserialize<'de> for BlobSchedule {
         D: Deserializer<'de>,
     {
         let vec = Vec::<BlobParameters>::deserialize(deserializer)?;
-        Ok(BlobSchedule::new(vec))
+        BlobSchedule::new(vec).map_err(serde::de::Error::custom)
     }
 }
 
 impl BlobSchedule {
-    pub fn new(mut vec: Vec<BlobParameters>) -> Self {
+    pub fn new(mut vec: Vec<BlobParameters>) -> Result<Self, String> {
         // reverse sort by epoch
         vec.sort_by(|a, b| b.epoch.cmp(&a.epoch));
-        Self {
+        
+        // Validate that all epochs are unique
+        for i in 0..vec.len() {
+            for j in (i + 1)..vec.len() {
+                if vec[i].epoch == vec[j].epoch {
+                    return Err(format!(
+                        "Duplicate epoch in blob schedule: epoch {}",
+                        vec[i].epoch
+                    ));
+                }
+            }
+        }
+        
+        Ok(Self {
             schedule: vec,
             skip_serializing: false,
-        }
+        })
     }
 
     pub fn is_empty(&self) -> bool {
@@ -1664,6 +1678,60 @@ impl IntoIterator for BlobSchedule {
 
     fn into_iter(self) -> Self::IntoIter {
         self.schedule.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod blob_schedule_tests {
+    use super::*;
+
+    #[test]
+    fn test_unique_epochs_accepted() {
+        let vec = vec![
+            BlobParameters {
+                epoch: Epoch::new(10),
+                max_blobs_per_block: 6,
+            },
+            BlobParameters {
+                epoch: Epoch::new(20),
+                max_blobs_per_block: 12,
+            },
+        ];
+        assert!(BlobSchedule::new(vec).is_ok());
+    }
+
+    #[test]
+    fn test_duplicate_epochs_rejected() {
+        let vec = vec![
+            BlobParameters {
+                epoch: Epoch::new(10),
+                max_blobs_per_block: 6,
+            },
+            BlobParameters {
+                epoch: Epoch::new(10),
+                max_blobs_per_block: 12,
+            },
+        ];
+        let result = BlobSchedule::new(vec);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Duplicate epoch in blob schedule"));
+    }
+
+    #[test]
+    fn test_empty_schedule() {
+        let vec = vec![];
+        assert!(BlobSchedule::new(vec).is_ok());
+    }
+
+    #[test]
+    fn test_single_entry() {
+        let vec = vec![BlobParameters {
+            epoch: Epoch::new(10),
+            max_blobs_per_block: 6,
+        }];
+        assert!(BlobSchedule::new(vec).is_ok());
     }
 }
 

--- a/consensus/types/src/fork_context.rs
+++ b/consensus/types/src/fork_context.rs
@@ -180,7 +180,8 @@ mod tests {
         spec.deneb_fork_epoch = Some(Epoch::new(4));
         spec.electra_fork_epoch = Some(Epoch::new(5));
         spec.fulu_fork_epoch = Some(Epoch::new(6));
-        spec.blob_schedule = BlobSchedule::new(blob_parameters);
+        spec.blob_schedule = BlobSchedule::new(blob_parameters)
+            .expect("test blob schedule has unique epochs");
         spec
     }
 


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/8400

## Proposed Changes

### 1. `consensus/types/src/chain_spec.rs` - `BlobSchedule::new()` Method

**Change**: Modified to return `Result<Self, String>` and validate epoch uniqueness.

**Before**:
```rust
pub fn new(mut vec: Vec<BlobParameters>) -> Self {
    // reverse sort by epoch
    vec.sort_by(|a, b| b.epoch.cmp(&a.epoch));
    Self {
        schedule: vec,
        skip_serializing: false,
    }
}
```

**After**:
```rust
pub fn new(mut vec: Vec<BlobParameters>) -> Result<Self, String> {
    // reverse sort by epoch
    vec.sort_by(|a, b| b.epoch.cmp(&a.epoch));
    
    // Validate that all epochs are unique
    for i in 0..vec.len() {
        for j in (i + 1)..vec.len() {
            if vec[i].epoch == vec[j].epoch {
                return Err(format!(
                    "Duplicate epoch in blob schedule: epoch {}",
                    vec[i].epoch
                ));
            }
        }
    }
    
    Ok(Self {
        schedule: vec,
        skip_serializing: false,
    })
}
```

### 2. `consensus/types/src/chain_spec.rs` - `Deserialize` Implementation

**Change**: Updated to properly handle and propagate validation errors from `BlobSchedule::new()`.

**Before**:
```rust
impl<'de> Deserialize<'de> for BlobSchedule {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
        D: Deserializer<'de>,
    {
        let vec = Vec::<BlobParameters>::deserialize(deserializer)?;
        Ok(BlobSchedule::new(vec))
    }
}
```

**After**:
```rust
impl<'de> Deserialize<'de> for BlobSchedule {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
        D: Deserializer<'de>,
    {
        let vec = Vec::<BlobParameters>::deserialize(deserializer)?;
        BlobSchedule::new(vec).map_err(serde::de::Error::custom)
    }
}
```

### 3. `consensus/types/src/chain_spec.rs` - `mainnet()` Method

**Change**: Updated to handle the `Result` return type from `BlobSchedule::new()`.

**Before**:
```rust
blob_schedule: BlobSchedule::new(vec![
    BlobParameters {
        epoch: Epoch::new(412672),
        max_blobs_per_block: 15,
    },
    BlobParameters {
        epoch: Epoch::new(419072),
        max_blobs_per_block: 21,
    },
]),
```

**After**:
```rust
blob_schedule: BlobSchedule::new(vec![
    BlobParameters {
        epoch: Epoch::new(412672),
        max_blobs_per_block: 15,
    },
    BlobParameters {
        epoch: Epoch::new(419072),
        max_blobs_per_block: 21,
    },
])
.expect("mainnet blob schedule has unique epochs"),
```

### 4. `consensus/types/src/fork_context.rs` - Test Helper

**Change**: Updated the test helper `make_chain_spec()` to handle the `Result` return type.

**Before**:
```rust
spec.blob_schedule = BlobSchedule::new(blob_parameters);
```

**After**:
```rust
spec.blob_schedule = BlobSchedule::new(blob_parameters)
    .expect("test blob schedule has unique epochs");
```

### 5. Added Comprehensive Test Suite

Added `blob_schedule_tests` module with 4 tests:

- `test_unique_epochs_accepted()` - Verifies that valid schedules with unique epochs are accepted
- `test_duplicate_epochs_rejected()` - Verifies that schedules with duplicate epochs are rejected with proper error message
- `test_empty_schedule()` - Verifies that empty schedules are accepted
- `test_single_entry()` - Verifies that single-entry schedules are accepted

## Additional Info

1. ✅ Config deserialization properly validates blob schedule uniqueness
2. ✅ Duplicate epochs are detected and rejected with clear error messages
3. ✅ Valid configurations pass without issue
4. ✅ Edge cases (empty, single entry) are handled correctly
5. ✅ Existing code paths that hardcode valid blob schedules continue to work

