### PR TITLE
Gracefully handle deleting states prior to anchor_slot

### DIFF
--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1308,8 +1308,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         state_root.as_slice().to_vec(),
                     ));
 
-                    if let Some(slot) = slot {
-                        match self.hot_storage_strategy(slot)? {
+                    // NOTE: `hot_storage_strategy` can error if there are states in the database
+                    // prior to the `anchor_slot`. This can happen if checkpoint sync has been
+                    // botched and left some states in the database prior to completing.
+                    if let Some(slot) = slot
+                        && let Ok(strategy) = self.hot_storage_strategy(slot)
+                    {
+                        match strategy {
                             StorageStrategy::Snapshot => {
                                 // Full state stored in this position
                                 key_value_batch.push(KeyValueStoreOp::DeleteKey(


### PR DESCRIPTION
## Issue Addressed

Fix an issue detected by @jimmygchen that occurs when checkpoint sync is aborted midway and then later restarted.

The characteristic error is something like:

> Nov 13 00:51:35.832 ERROR Database write failed                         error: Hdiff(LessThanStart(Slot(1728288), Slot(1728320))), action: "reverting blob DB changes"
Nov 13 00:51:35.833 WARN  Hot DB pruning failed                         error: DBError(HotColdDBError(Rollback))

This issue has existed since v7.1.0.

## Proposed Changes

Delete snapshot/diff in the case where `hot_storage_strategy` fails.

## Additional Info

Separately to this we could also make the writing of the checkpoint state more atomic. This bug is a counterexample to this comment:

https://github.com/sigp/lighthouse/blob/e3ee7febce64c1b5a85c3ab0be0619571ee92d58/beacon_node/beacon_chain/src/builder.rs#L562-L563
