### PR TITLE
fix: use second_payload for head in execution engine test

### DIFF
--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -557,7 +557,7 @@ impl<Engine: GenericExecutionEngine> TestRig<Engine> {
          *
          * Indicate that the payload is the head of the chain, providing payload attributes.
          */
-        let head_block_hash = valid_payload.block_hash();
+        let head_block_hash = second_payload.block_hash();
         let finalized_block_hash = ExecutionBlockHash::zero();
         // To save sending proposer preparation data, just set the fee recipient
         // to the fee recipient configured for EE A.


### PR DESCRIPTION
Fix copy-paste bug where valid_payload was incorrectly used instead of second_payload when setting head block hash after creating and validating the second payload.

The test validates a second payload built on top of the first, but then mistakenly referenced the old valid_payload when updating the head. This matches the pattern used correctly in the EE B section.