### PR TITLE
Reimport the checkpoint sync block

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1685,20 +1685,14 @@ fn check_block_against_finalized_slot<T: BeaconChainTypes>(
     //
     // Fork choice has the most up-to-date view of finalization and there's no point importing a
     // block which conflicts with the fork-choice view of finalization.
-    let finalized_checkpoint = chain.canonical_head.cached_head().finalized_checkpoint();
-    let finalized_slot = finalized_checkpoint
+    let finalized_slot = chain
+        .canonical_head
+        .cached_head()
+        .finalized_checkpoint()
         .epoch
         .start_slot(T::EthSpec::slots_per_epoch());
 
-    let would_revert_finalized_slot = if block.slot() < finalized_slot {
-        true
-    } else if block.slot() == finalized_slot {
-        block_root != finalized_checkpoint.root
-    } else {
-        false
-    };
-    // Allow to re-import the finalized block if it's the same
-    if would_revert_finalized_slot {
+    if block.slot() <= finalized_slot {
         chain.pre_finalization_block_rejected(block_root);
         Err(BlockError::WouldRevertFinalizedSlot {
             block_slot: block.slot(),

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1685,14 +1685,20 @@ fn check_block_against_finalized_slot<T: BeaconChainTypes>(
     //
     // Fork choice has the most up-to-date view of finalization and there's no point importing a
     // block which conflicts with the fork-choice view of finalization.
-    let finalized_slot = chain
-        .canonical_head
-        .cached_head()
-        .finalized_checkpoint()
+    let finalized_checkpoint = chain.canonical_head.cached_head().finalized_checkpoint();
+    let finalized_slot = finalized_checkpoint
         .epoch
         .start_slot(T::EthSpec::slots_per_epoch());
 
-    if block.slot() <= finalized_slot {
+    let would_revert_finalized_slot = if block.slot() < finalized_slot {
+        true
+    } else if block.slot() == finalized_slot {
+        block_root != finalized_checkpoint.root
+    } else {
+        false
+    };
+    // Allow to re-import the finalized block if it's the same
+    if would_revert_finalized_slot {
         chain.pre_finalization_block_rejected(block_root);
         Err(BlockError::WouldRevertFinalizedSlot {
             block_slot: block.slot(),

--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -75,12 +75,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let blob_info = self.store.get_blob_info();
         let data_column_info = self.store.get_data_column_info();
 
-        // Take all blocks with slots less than or equal to the oldest block slot.
+        // Take all blocks with slots less than the oldest block slot, or equal to the anchor slot.
         //
         // This allows for reimport of the blobs/columns for the finalized block after checkpoint
         // sync.
         let num_relevant = blocks.partition_point(|available_block| {
-            available_block.block().slot() <= anchor_info.oldest_block_slot
+            available_block.block().slot() < anchor_info.oldest_block_slot
+                || available_block.block().slot() == anchor_info.anchor_slot
         });
 
         let total_blocks = blocks.len();
@@ -114,7 +115,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         for available_block in blocks_to_import.into_iter().rev() {
             let (block_root, block, block_data) = available_block.deconstruct();
 
-            if block.slot() == anchor_info.oldest_block_slot {
+            if block.slot() == anchor_info.anchor_slot {
                 // When reimporting, verify that this is actually the same block (same block root).
                 let oldest_block_root = self
                     .block_root_at_slot(block.slot(), WhenSlotSkipped::None)

--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -1,5 +1,5 @@
 use crate::data_availability_checker::{AvailableBlock, AvailableBlockData};
-use crate::{BeaconChain, BeaconChainTypes, metrics};
+use crate::{BeaconChain, BeaconChainTypes, WhenSlotSkipped, metrics};
 use itertools::Itertools;
 use state_processing::{
     per_block_processing::ParallelSignatureSets,
@@ -34,6 +34,8 @@ pub enum HistoricalBlockError {
     ValidatorPubkeyCacheTimeout,
     /// Logic error: should never occur.
     IndexOutOfBounds,
+    /// Logic error: should never occur.
+    MissingOldestBlockRoot { slot: Slot },
     /// Internal store error
     StoreError(StoreError),
 }
@@ -65,37 +67,71 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     #[instrument(skip_all)]
     pub fn import_historical_block_batch(
         &self,
-        blocks: Vec<AvailableBlock<T::EthSpec>>,
+        mut blocks: Vec<AvailableBlock<T::EthSpec>>,
     ) -> Result<(), HistoricalBlockError> {
         let anchor_info = self.store.get_anchor_info();
         let blob_info = self.store.get_blob_info();
         let data_column_info = self.store.get_data_column_info();
 
-        // Take all blocks with slots less than the oldest block slot.
-        for block in &blocks {
-            if block.block().slot() >= anchor_info.oldest_block_slot {
-                debug!(
-                    oldest_block_slot = %anchor_info.oldest_block_slot,
-                    block_slot = %block.block().slot(),
-                    "Reimporting historic block"
-                );
-            }
+        // Take all blocks with slots less than or equal to the oldest block slot.
+        //
+        // This allows for reimport of the blobs/columns for the finalized block after checkpoint
+        // sync.
+        let num_relevant = blocks.partition_point(|available_block| {
+            available_block.block().slot() <= anchor_info.oldest_block_slot
+        });
+        let total_blocks = blocks.len();
+        blocks.truncate(num_relevant);
+
+        let blocks_to_import = blocks;
+        if blocks_to_import.len() != total_blocks {
+            debug!(
+                oldest_block_slot = %anchor_info.oldest_block_slot,
+                total_blocks,
+                ignored = total_blocks.saturating_sub(blocks_to_import.len()),
+                "Ignoring some historic blocks"
+            );
+        }
+
+        if blocks_to_import.is_empty() {
+            return Ok(());
         }
 
         let mut expected_block_root = anchor_info.oldest_block_parent;
+        let mut last_block_root = expected_block_root;
         let mut prev_block_slot = anchor_info.oldest_block_slot;
         let mut new_oldest_blob_slot = blob_info.oldest_blob_slot;
         let mut new_oldest_data_column_slot = data_column_info.oldest_data_column_slot;
 
         let mut blob_batch = Vec::<KeyValueStoreOp>::new();
-        let mut cold_batch = Vec::with_capacity(blocks.len());
-        let mut hot_batch = Vec::with_capacity(blocks.len());
-        let mut signed_blocks = Vec::with_capacity(blocks.len());
+        let mut cold_batch = Vec::with_capacity(blocks_to_import.len());
+        let mut hot_batch = Vec::with_capacity(blocks_to_import.len());
+        let mut signed_blocks = Vec::with_capacity(blocks_to_import.len());
 
-        for available_block in blocks.into_iter().rev() {
+        for available_block in blocks_to_import.into_iter().rev() {
             let (block_root, block, block_data) = available_block.deconstruct();
 
-            if block_root != expected_block_root {
+            if block.slot() == anchor_info.oldest_block_slot {
+                // When reimporting, verify that this is actually the same block (same block root).
+                let oldest_block_root = self
+                    .block_root_at_slot(block.slot(), WhenSlotSkipped::None)
+                    .ok()
+                    .flatten()
+                    .ok_or(HistoricalBlockError::MissingOldestBlockRoot { slot: block.slot() })?;
+                if block_root != oldest_block_root {
+                    return Err(HistoricalBlockError::MismatchedBlockRoot {
+                        block_root,
+                        expected_block_root: oldest_block_root,
+                    });
+                }
+
+                debug!(
+                    ?block_root,
+                    slot = %block.slot(),
+                    "Re-importing historic block"
+                );
+                last_block_root = block_root;
+            } else if block_root != expected_block_root {
                 return Err(HistoricalBlockError::MismatchedBlockRoot {
                     block_root,
                     expected_block_root,
@@ -186,7 +222,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .ok_or(HistoricalBlockError::IndexOutOfBounds)?
             .iter()
             .map(|block| block.parent_root())
-            .chain(iter::once(anchor_info.oldest_block_parent));
+            .chain(iter::once(last_block_root));
         let signature_set = signed_blocks
             .iter()
             .zip_eq(block_roots)

--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -75,13 +75,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let blob_info = self.store.get_blob_info();
         let data_column_info = self.store.get_data_column_info();
 
-        // Take all blocks with slots less than the oldest block slot, or equal to the anchor slot.
+        // Take all blocks with slots less than or equal to the oldest block slot.
         //
         // This allows for reimport of the blobs/columns for the finalized block after checkpoint
         // sync.
         let num_relevant = blocks.partition_point(|available_block| {
-            available_block.block().slot() < anchor_info.oldest_block_slot
-                || available_block.block().slot() == anchor_info.anchor_slot
+            available_block.block().slot() <= anchor_info.oldest_block_slot
         });
 
         let total_blocks = blocks.len();
@@ -115,7 +114,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         for available_block in blocks_to_import.into_iter().rev() {
             let (block_root, block, block_data) = available_block.deconstruct();
 
-            if block.slot() == anchor_info.anchor_slot {
+            if block.slot() == anchor_info.oldest_block_slot {
                 // When reimporting, verify that this is actually the same block (same block root).
                 let oldest_block_root = self
                     .block_root_at_slot(block.slot(), WhenSlotSkipped::None)

--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -56,42 +56,30 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// `SignatureSetError` or `InvalidSignature` will be returned.
     ///
     /// To align with sync we allow some excess blocks with slots greater than or equal to
-    /// `oldest_block_slot` to be provided. They will be ignored without being checked.
+    /// `oldest_block_slot` to be provided. They will be re-imported to fill the columns of the
+    /// checkpoint sync block.
     ///
     /// This function should not be called concurrently with any other function that mutates
     /// the anchor info (including this function itself). If a concurrent mutation occurs that
     /// would violate consistency then an `AnchorInfoConcurrentMutation` error will be returned.
-    ///
-    /// Return the number of blocks successfully imported.
     #[instrument(skip_all)]
     pub fn import_historical_block_batch(
         &self,
-        mut blocks: Vec<AvailableBlock<T::EthSpec>>,
-    ) -> Result<usize, HistoricalBlockError> {
+        blocks: Vec<AvailableBlock<T::EthSpec>>,
+    ) -> Result<(), HistoricalBlockError> {
         let anchor_info = self.store.get_anchor_info();
         let blob_info = self.store.get_blob_info();
         let data_column_info = self.store.get_data_column_info();
 
         // Take all blocks with slots less than the oldest block slot.
-        let num_relevant = blocks.partition_point(|available_block| {
-            available_block.block().slot() < anchor_info.oldest_block_slot
-        });
-
-        let total_blocks = blocks.len();
-        blocks.truncate(num_relevant);
-        let blocks_to_import = blocks;
-
-        if blocks_to_import.len() != total_blocks {
-            debug!(
-                oldest_block_slot = %anchor_info.oldest_block_slot,
-                total_blocks,
-                ignored = total_blocks.saturating_sub(blocks_to_import.len()),
-                "Ignoring some historic blocks"
-            );
-        }
-
-        if blocks_to_import.is_empty() {
-            return Ok(0);
+        for block in &blocks {
+            if block.block().slot() >= anchor_info.oldest_block_slot {
+                debug!(
+                    oldest_block_slot = %anchor_info.oldest_block_slot,
+                    block_slot = %block.block().slot(),
+                    "Reimporting historic block"
+                );
+            }
         }
 
         let mut expected_block_root = anchor_info.oldest_block_parent;
@@ -100,11 +88,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let mut new_oldest_data_column_slot = data_column_info.oldest_data_column_slot;
 
         let mut blob_batch = Vec::<KeyValueStoreOp>::new();
-        let mut cold_batch = Vec::with_capacity(blocks_to_import.len());
-        let mut hot_batch = Vec::with_capacity(blocks_to_import.len());
-        let mut signed_blocks = Vec::with_capacity(blocks_to_import.len());
+        let mut cold_batch = Vec::with_capacity(blocks.len());
+        let mut hot_batch = Vec::with_capacity(blocks.len());
+        let mut signed_blocks = Vec::with_capacity(blocks.len());
 
-        for available_block in blocks_to_import.into_iter().rev() {
+        for available_block in blocks.into_iter().rev() {
             let (block_root, block, block_data) = available_block.deconstruct();
 
             if block_root != expected_block_root {
@@ -286,6 +274,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             self.store_migrator.process_reconstruction();
         }
 
-        Ok(num_relevant)
+        Ok(())
     }
 }

--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -64,11 +64,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// This function should not be called concurrently with any other function that mutates
     /// the anchor info (including this function itself). If a concurrent mutation occurs that
     /// would violate consistency then an `AnchorInfoConcurrentMutation` error will be returned.
+    ///
+    /// Return the number of blocks successfully imported.
     #[instrument(skip_all)]
     pub fn import_historical_block_batch(
         &self,
         mut blocks: Vec<AvailableBlock<T::EthSpec>>,
-    ) -> Result<(), HistoricalBlockError> {
+    ) -> Result<usize, HistoricalBlockError> {
         let anchor_info = self.store.get_anchor_info();
         let blob_info = self.store.get_blob_info();
         let data_column_info = self.store.get_data_column_info();
@@ -95,7 +97,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         if blocks_to_import.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
 
         let mut expected_block_root = anchor_info.oldest_block_parent;
@@ -311,6 +313,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             self.store_migrator.process_reconstruction();
         }
 
-        Ok(())
+        Ok(num_relevant)
     }
 }

--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -80,10 +80,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let num_relevant = blocks.partition_point(|available_block| {
             available_block.block().slot() <= anchor_info.oldest_block_slot
         });
+
         let total_blocks = blocks.len();
         blocks.truncate(num_relevant);
-
         let blocks_to_import = blocks;
+
         if blocks_to_import.len() != total_blocks {
             debug!(
                 oldest_block_slot = %anchor_info.oldest_block_slot,

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -842,7 +842,7 @@ impl<E: EthSpec> MockBuilder<E> {
             .beacon_client
             .get_beacon_blocks::<E>(BlockId::Finalized)
             .await
-            .map_err(|_| "couldn't get finalized block".to_string())?
+            .map_err(|e| format!("couldn't get finalized block: {e:?}"))?
             .ok_or_else(|| "missing finalized block".to_string())?
             .data()
             .message()
@@ -855,7 +855,7 @@ impl<E: EthSpec> MockBuilder<E> {
             .beacon_client
             .get_beacon_blocks::<E>(BlockId::Justified)
             .await
-            .map_err(|_| "couldn't get justified block".to_string())?
+            .map_err(|e| format!("couldn't get justified block: {e:?}"))?
             .ok_or_else(|| "missing justified block".to_string())?
             .data()
             .message()

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -770,8 +770,9 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             );
         }
 
+        let imported_blocks = available_blocks.len();
         match self.chain.import_historical_block_batch(available_blocks) {
-            Ok(imported_blocks) => {
+            Ok(()) => {
                 metrics::inc_counter(
                     &metrics::BEACON_PROCESSOR_BACKFILL_CHAIN_SEGMENT_SUCCESS_TOTAL,
                 );

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -805,6 +805,16 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         // The peer is faulty if they bad signatures.
                         Some(PeerAction::LowToleranceError)
                     }
+                    HistoricalBlockError::MissingOldestBlockRoot { slot } => {
+                        warn!(
+                            %slot,
+                            error = "missing_oldest_block_root",
+                            "Backfill batch processing error"
+                        );
+                        // This is an internal error, do not penalize the peer.
+                        None
+                    }
+
                     HistoricalBlockError::ValidatorPubkeyCacheTimeout => {
                         warn!(
                             error = "pubkey_cache_timeout",

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -770,9 +770,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             );
         }
 
-        let imported_blocks = available_blocks.len();
         match self.chain.import_historical_block_batch(available_blocks) {
-            Ok(()) => {
+            Ok(imported_blocks) => {
                 metrics::inc_counter(
                     &metrics::BEACON_PROCESSOR_BACKFILL_CHAIN_SEGMENT_SUCCESS_TOTAL,
                 );

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -639,7 +639,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         let block = if blinded_block.message().execution_payload().is_err()
             || blinded_block.slot() >= split.slot
-            || *block_root == split.block_root
         {
             // Re-constructing the full block should always succeed here.
             let full_block = self.make_full_block(block_root, blinded_block)?;
@@ -650,7 +649,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 .inspect(|cache| cache.lock().put_block(*block_root, full_block.clone()));
 
             DatabaseBlock::Full(full_block)
-        } else if !self.config.prune_payloads {
+        } else if !self.config.prune_payloads || *block_root == split.block_root {
             // If payload pruning is disabled there's a chance we may have the payload of
             // this finalized block. Attempt to load it but don't error in case it's missing.
             let fork_name = blinded_block.fork_name(&self.spec)?;

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -639,6 +639,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         let block = if blinded_block.message().execution_payload().is_err()
             || blinded_block.slot() >= split.slot
+            || block_root == split.block_root
         {
             // Re-constructing the full block should always succeed here.
             let full_block = self.make_full_block(block_root, blinded_block)?;

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -652,6 +652,12 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         } else if !self.config.prune_payloads || *block_root == split.block_root {
             // If payload pruning is disabled there's a chance we may have the payload of
             // this finalized block. Attempt to load it but don't error in case it's missing.
+            //
+            // We also allow for the split block's payload to be loaded *if it exists*. This is
+            // necessary on startup when syncing from an unaligned checkpoint (a checkpoint state
+            // at a skipped slot), and then loading the canonical head (with payload). If we modify
+            // payload pruning in future so that it doesn't prune the split block's payload, then
+            // this case could move to the case above where we error if the payload is missing.
             let fork_name = blinded_block.fork_name(&self.spec)?;
             if let Some(payload) = self.get_execution_payload(block_root, fork_name)? {
                 DatabaseBlock::Full(

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -639,7 +639,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         let block = if blinded_block.message().execution_payload().is_err()
             || blinded_block.slot() >= split.slot
-            || block_root == split.block_root
+            || *block_root == split.block_root
         {
             // Re-constructing the full block should always succeed here.
             let full_block = self.make_full_block(block_root, blinded_block)?;


### PR DESCRIPTION
## Issue Addressed

We want to not require checkpoint sync starts to include the required custody data columns, and instead fetch them from p2p.


Closes https://github.com/sigp/lighthouse/issues/6837

## Proposed Changes

The checkpoint sync slot can:
1. Be the first slot in the epoch, such that the epoch of the block == the start checkpoint epoch
2. Be in an epoch prior to the start checkpoint epoch

In both cases backfill sync already fetches that epoch worth of blocks with current code. This PR modifies the backfill import filter function to allow to re-importing the oldest block slot in the DB.

I feel this solution is sufficient unless I'm missing something. ~~I have not tested this yet!~~ Michael has tested this and it works.