### PR TITLE
Compute missing_columns correctly

### DIFF
--- a/beacon_node/network/src/sync/range_data_column_batch_request.rs
+++ b/beacon_node/network/src/sync/range_data_column_batch_request.rs
@@ -268,8 +268,8 @@ impl<T: BeaconChainTypes> RangeDataColumnBatchRequest<T> {
 
             let received_columns = columns.iter().map(|c| c.index).collect::<HashSet<_>>();
 
-            let missing_columns = received_columns
-                .difference(expected_custody_columns)
+            let missing_columns = expected_custody_columns
+                .difference(&received_columns)
                 .collect::<HashSet<_>>();
 
             // blobs are expected for this slot but there is at least one missing columns


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

The difference is computed by taking the difference of expected with received. We were doing the inverse.

Thanks to Yassine for finding the issue. 