### PR TITLE
Fix telemetry span export by propagating trace context to spawned tasks

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -28,7 +28,7 @@ use std::path::PathBuf;
 use std::process::exit;
 use std::sync::LazyLock;
 use task_executor::ShutdownReason;
-use tracing::{Level, info};
+use tracing::{Instrument, Level, info};
 use tracing_subscriber::{Layer, filter::EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 use types::{EthSpec, EthSpecId};
 use validator_client::ProductionValidatorClient;
@@ -832,9 +832,19 @@ fn run<E: EthSpec>(
                 return Ok(());
             }
 
+            // Capture the current OpenTelemetry context before spawning the task
+            // This ensures trace context (TraceId, SpanId) propagates to the spawned task
+            let parent_cx = opentelemetry::Context::current();
+
             executor.clone().spawn(
                 async move {
-                    if let Err(e) = ProductionBeaconNode::new(context.clone(), config).await {
+                    // Attach the parent context to this task so spans are properly linked
+                    let _guard = parent_cx.attach();
+
+                    if let Err(e) = ProductionBeaconNode::new(context.clone(), config)
+                        .instrument(tracing::debug_span!("start_beacon_node"))
+                        .await
+                    {
                         crit!(reason = ?e, "Failed to start beacon node");
                         // Ignore the error since it always occurs during normal operation when
                         // shutting down.


### PR DESCRIPTION
## Issue Addressed

Created by 🤖

The `start_beacon_node` and `start_networking` spans were not appearing in telemetry exports. When investigating, we found that even after removing the workspace filter, these spans still didn't show up, while dependency spans (libp2p) were visible but disconnected from any trace.

## Root Cause

The problem occurs at https://github.com/sigp/lighthouse/blob/261322c3e3ee467c9454fa160a00866439cbc62f/lighthouse/src/main.rs#L835-L847 where `ProductionBeaconNode::new()` is called inside `executor.spawn()`. When spawning a new async task, the OpenTelemetry trace context (TraceId, SpanId) stored in task-local storage is not automatically propagated to the spawned task. This causes all spans created within that task to be disconnected from any parent trace.

## Proposed Changes

* Capture the OpenTelemetry context before spawning the task using `opentelemetry::Context::current()`
* Attach the captured context inside the spawned task using `context.attach()`
* Add the `start_beacon_node` span with proper instrumentation using `.instrument(tracing::debug_span!("start_beacon_node"))`

This ensures the trace context propagates across the task boundary, allowing all child spans (including `start_networking` from the networking stack initialization) to be properly linked in the trace hierarchy.

## Testing

To verify the fix works:
1. Run lighthouse with telemetry enabled: `--telemetry-collector-url <your-otlp-endpoint>`
2. Check your telemetry backend (Jaeger, Tempo, etc.)
3. You should now see:
   - The `start_beacon_node` root span
   - The `start_networking` span as a child of `start_beacon_node`
   - All other initialization spans properly linked in the trace hierarchy
   - Dependency spans filtered out as intended by the workspace filter