### PR TITLE
Optimize AttesterCache::maybe_cache_state to reduce lock contention

### DIFF
--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -279,9 +279,19 @@ impl AttesterCache {
         spec: &ChainSpec,
     ) -> Result<(), Error> {
         let key = AttesterCacheKey::new(state.current_epoch(), state, latest_block_root)?;
+
+        // Fast path: check with read lock first to avoid write lock contention.
+        if self.cache.read().contains_key(&key) {
+            return Ok(());
+        }
+
+        // Slow path: create cache item outside of lock to avoid holding write lock during
+        // expensive committee cache initialization.
+        let cache_item = AttesterCacheValue::new(state, spec)?;
+
         let mut cache = self.cache.write();
+        // Check again in case another thread inserted while we were creating the cache item.
         if !cache.contains_key(&key) {
-            let cache_item = AttesterCacheValue::new(state, spec)?;
             Self::insert_respecting_max_len(&mut cache, key, cache_item);
         }
         Ok(())


### PR DESCRIPTION
## Issue Addressed

Addresses performance issues with `AttesterCache::maybe_cache_state` identified through tracing, where the method appeared slow due to lock contention.

## Proposed Changes

Implements double-checked locking pattern in `maybe_cache_state` to reduce write lock contention:

1. **Fast path (cache hit)**: Check with read lock first. If key exists, return immediately without taking write lock.
2. **Slow path (cache miss)**: Create `AttesterCacheValue` **outside** the write lock to avoid blocking other operations during expensive committee cache initialization.
3. **Write lock with double-check**: Only take write lock for insertion, with a second `contains_key` check to handle race conditions where another thread may have inserted while we were computing.

**Files changed:**
- `beacon_node/beacon_chain/src/attester_cache.rs`

## Additional Info

### Performance Benefits
- **Eliminates write lock contention** for cache hits (the common case in production)
- **Removes expensive computation from critical section**: Committee cache initialization (`CommitteeLengths::new()` → `state.initialize_committee_cache()`) no longer blocks all other cache operations
- **Maintains correctness**: Properly handles race conditions with double-checked locking pattern

### Pattern Consistency
This optimization follows the same pattern already used in `load_and_cache_state` (lines 317-326), which explicitly documents this approach in its comments to avoid duplicate state reads.

### Testing
Verified with `cargo check -p beacon_chain` - compiles successfully with no issues.