### PR TITLE
Add insecure-dep test task to Makefile and CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -329,6 +329,8 @@ jobs:
       run: make cargo-fmt
     - name: Lint code for quality and style with Clippy
       run: make lint-full
+    - name: Check dependencies for usage of an unencrypted HTTP
+      run: make insecure-deps
     - name: Certify Cargo.lock freshness
       run: git diff --exit-code Cargo.lock
     - name: Typecheck benchmark code without running it

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -329,7 +329,7 @@ jobs:
       run: make cargo-fmt
     - name: Lint code for quality and style with Clippy
       run: make lint-full
-    - name: Check dependencies for usage of an unencrypted HTTP
+    - name: Check dependencies for unencrypted HTTP links
       run: make insecure-deps
     - name: Certify Cargo.lock freshness
       run: git diff --exit-code Cargo.lock

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -327,10 +327,10 @@ jobs:
           bins: cargo-audit,cargo-deny
     - name: Check formatting with cargo fmt
       run: make cargo-fmt
-    - name: Lint code for quality and style with Clippy
-      run: make lint-full
     - name: Check dependencies for unencrypted HTTP links
       run: make insecure-deps
+    - name: Lint code for quality and style with Clippy
+      run: make lint-full
     - name: Certify Cargo.lock freshness
       run: git diff --exit-code Cargo.lock
     - name: Typecheck benchmark code without running it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ validator_test_rig = { path = "testing/validator_test_rig" }
 warp = { version = "0.3.7", default-features = false, features = ["tls"] }
 warp_utils = { path = "common/warp_utils" }
 workspace_members = { path = "common/workspace_members" }
-xdelta3 = { git = "http://github.com/sigp/xdelta3-rs", rev = "4db64086bb02e9febb584ba93b9d16bb2ae3825a" }
+xdelta3 = { git = "https://github.com/sigp/xdelta3-rs", rev = "4db64086bb02e9febb584ba93b9d16bb2ae3825a" }
 zeroize = { version = "1", features = ["zeroize_derive", "serde"] }
 zip = "0.6"
 zstd = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ validator_test_rig = { path = "testing/validator_test_rig" }
 warp = { version = "0.3.7", default-features = false, features = ["tls"] }
 warp_utils = { path = "common/warp_utils" }
 workspace_members = { path = "common/workspace_members" }
-xdelta3 = { git = "https://github.com/sigp/xdelta3-rs", rev = "4db64086bb02e9febb584ba93b9d16bb2ae3825a" }
+xdelta3 = { git = "http://github.com/sigp/xdelta3-rs", rev = "4db64086bb02e9febb584ba93b9d16bb2ae3825a" }
 zeroize = { version = "1", features = ["zeroize_derive", "serde"] }
 zip = "0.6"
 zstd = "0.13"

--- a/Makefile
+++ b/Makefile
@@ -343,11 +343,11 @@ vendor:
 udeps:
 	cargo +$(PINNED_NIGHTLY) udeps --tests --all-targets --release --features "$(TEST_FEATURES)"
 
-# Checks dependencies for unencrypted HTTP links
+# Checks Cargo.toml files for unencrypted HTTP links
 insecure-deps:
-	@ BAD_LINKS=`find -name Cargo.toml | xargs grep -P "git\s*=\s*[\"']http:"`; \
-	if [ -z "$$BAD_LINKS" ]; then echo "All Git dependencies use secure HTTPS"; \
-	else echo "$$BAD_LINKS"; echo "Using plain HTTP in dependencies is forbidden"; exit 1; fi
+	@ BAD_LINKS=$$(find . -name Cargo.toml | xargs grep -n "http://" || true); \
+	if [ -z "$$BAD_LINKS" ]; then echo "No insecure HTTP links found"; \
+	else echo "$$BAD_LINKS"; echo "Using plain HTTP in Cargo.toml files is forbidden"; exit 1; fi
 
 # Performs a `cargo` clean and cleans the `ef_tests` directory.
 clean:

--- a/Makefile
+++ b/Makefile
@@ -344,13 +344,10 @@ udeps:
 	cargo +$(PINNED_NIGHTLY) udeps --tests --all-targets --release --features "$(TEST_FEATURES)"
 
 # Checks dependencies for unencrypted HTTP links
-# Tee preserves output. If there are matches, print a message and return 1
-.ONESHELL:
-SHELL = /bin/bash
 insecure-deps:
-	BAD_LINKS=`find -name Cargo.toml | xargs grep -P 'git\s?=\s?["]http:'`;
-	if [ "_$$BAD_LINKS" == "_" ]; then echo "All Git dependencies use secure HTTPS"; \
-	else echo $$BAD_LINKS; echo "Using plain HTTP in dependencies is forbidden"; false; fi
+	BAD_LINKS=`find -name Cargo.toml | xargs grep -P "git\s?=\s?[\"']http:"`; \
+	if [ "_$$BAD_LINKS" = "_" ]; then echo "All Git dependencies use secure HTTPS"; \
+	else echo "$$BAD_LINKS"; echo "Using plain HTTP in dependencies is forbidden"; false; fi
 
 # Performs a `cargo` clean and cleans the `ef_tests` directory.
 clean:

--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,15 @@ vendor:
 udeps:
 	cargo +$(PINNED_NIGHTLY) udeps --tests --all-targets --release --features "$(TEST_FEATURES)"
 
+# Checks dependencies for usage of an unencrypted HTTP
+# Tee preserves output. If there are matches, print a message and return 1
+insecure-deps:
+	bash -c \
+	  "find -name Cargo.toml \
+			| xargs grep -P \"git\s?=\s?[\\\"']http:\" \
+			| tee /dev/tty \
+			| [ \`wc -l\` == 0 ] || (echo \"Using plain HTTP in dependencies is forbidden\" && false)"
+
 # Performs a `cargo` clean and cleans the `ef_tests` directory.
 clean:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -343,14 +343,15 @@ vendor:
 udeps:
 	cargo +$(PINNED_NIGHTLY) udeps --tests --all-targets --release --features "$(TEST_FEATURES)"
 
-# Checks dependencies for usage of an unencrypted HTTP
+# Checks dependencies for unencrypted HTTP links
 # Tee preserves output. If there are matches, print a message and return 1
 insecure-deps:
 	bash -c \
 	  "find -name Cargo.toml \
 			| xargs grep -P \"git\s?=\s?[\\\"']http:\" \
 			| tee /dev/tty \
-			| [ \`wc -l\` == 0 ] || (echo \"Using plain HTTP in dependencies is forbidden\" && false)"
+			| [ \`wc -l\` == 0 ] && echo \"All Git dependencies use secure HTTPS\" \
+			  || (echo \"Using plain HTTP in dependencies is forbidden\" && false)"
 
 # Performs a `cargo` clean and cleans the `ef_tests` directory.
 clean:

--- a/Makefile
+++ b/Makefile
@@ -345,9 +345,9 @@ udeps:
 
 # Checks dependencies for unencrypted HTTP links
 insecure-deps:
-	BAD_LINKS=`find -name Cargo.toml | xargs grep -P "git\s?=\s?[\"']http:"`; \
-	if [ "_$$BAD_LINKS" = "_" ]; then echo "All Git dependencies use secure HTTPS"; \
-	else echo "$$BAD_LINKS"; echo "Using plain HTTP in dependencies is forbidden"; false; fi
+	@ BAD_LINKS=`find -name Cargo.toml | xargs grep -P "git\s*=\s*[\"']http:"`; \
+	if [ -z "$$BAD_LINKS" ]; then echo "All Git dependencies use secure HTTPS"; \
+	else echo "$$BAD_LINKS"; echo "Using plain HTTP in dependencies is forbidden"; exit 1; fi
 
 # Performs a `cargo` clean and cleans the `ef_tests` directory.
 clean:

--- a/Makefile
+++ b/Makefile
@@ -345,13 +345,12 @@ udeps:
 
 # Checks dependencies for unencrypted HTTP links
 # Tee preserves output. If there are matches, print a message and return 1
+.ONESHELL:
+SHELL = /bin/bash
 insecure-deps:
-	bash -c \
-	  "find -name Cargo.toml \
-			| xargs grep -P \"git\s?=\s?[\\\"']http:\" \
-			| tee /dev/tty \
-			| [ \`wc -l\` == 0 ] && echo \"All Git dependencies use secure HTTPS\" \
-			  || (echo \"Using plain HTTP in dependencies is forbidden\" && false)"
+	BAD_LINKS=`find -name Cargo.toml | xargs grep -P 'git\s?=\s?["]http:'`;
+	if [ "_$$BAD_LINKS" == "_" ]; then echo "All Git dependencies use secure HTTPS"; \
+	else echo $$BAD_LINKS; echo "Using plain HTTP in dependencies is forbidden"; false; fi
 
 # Performs a `cargo` clean and cleans the `ef_tests` directory.
 clean:


### PR DESCRIPTION
## Issue Addressed

#8106

## Proposed Changes

I added `insecure-deps` target to Makefile and a new step into `check-code` section of test-suite CI workflow that uses the former.

That bash multiliner is not ideal, I'd prefer a cargo plugin instead but none exists.

I also changed Cargo.toml to test that the new CI check works. Once we see a pipeline fails, I revert the change.