### PR TITLE
Gloas - add get_payload_attestation_endpoint

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2121,6 +2121,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let beacon_block_root = head.beacon_block_root;
 
+        // TODO(gloas) the spec only requires that the payload be seen. right
+        // now we are setting payload_present to `true` if the envelope was imported
+        // into fork choice which is a stricter requirement than the spec requires.
         let payload_present = self
             .canonical_head
             .fork_choice_read_lock()

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2121,8 +2121,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let beacon_block_root = head.beacon_block_root;
 
-        // TODO(gloas) this isn't really what the `envelope_times_cache` is meant for.
-        // We should use a dedicated payload envelope cache instead (maybe the new Gloas DA cache?)
+        // TODO(gloas) do we want to use a dedicated envelope cache instead?
+        // Maybe the new gloas DA cache? (Or should the gloas DA cache use 
+        // the envelopes_times_cache internally?)
         let payload_present = self
             .envelope_times_cache
             .read()

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2121,12 +2121,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let beacon_block_root = head.beacon_block_root;
 
-        // TODO(EIP-7732): Check if we've seen a SignedExecutionPayloadEnvelope
-        // referencing this block root. For now, default to false.
-        let payload_present = false;
+        let payload_present = self
+            .canonical_head
+            .fork_choice_read_lock()
+            .contains_payload(&beacon_block_root);
 
-        // TODO(EIP-7732): Check blob data availability. For now, default to false.
-        let blob_data_available = false;
+        // TODO(EIP-7732): Check blob data availability. For now, default to true.
+        let blob_data_available = true;
 
         Ok(PayloadAttestationData {
             beacon_block_root,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2122,7 +2122,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let beacon_block_root = head.beacon_block_root;
 
         // TODO(gloas) do we want to use a dedicated envelope cache instead?
-        // Maybe the new gloas DA cache? (Or should the gloas DA cache use 
+        // Maybe the new gloas DA cache? (Or should the gloas DA cache use
         // the envelopes_times_cache internally?)
         let payload_present = self
             .envelope_times_cache

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2097,6 +2097,45 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         )?)
     }
 
+    /// Produce a `PayloadAttestationData` for a PTC validator to sign.
+    ///
+    /// This is used by PTC (Payload Timeliness Committee) validators to attest to the
+    /// presence/absence of an execution payload and blobs for a given slot.
+    pub fn produce_payload_attestation_data(
+        &self,
+        request_slot: Slot,
+    ) -> Result<PayloadAttestationData, Error> {
+        let _timer = metrics::start_timer(&metrics::PAYLOAD_ATTESTATION_PRODUCTION_SECONDS);
+
+        // Payload attestations are only valid for the current slot
+        let current_slot = self.slot()?;
+        if request_slot != current_slot {
+            return Err(Error::InvalidSlot(request_slot));
+        }
+
+        // Check if we've seen a block for this slot from the canonical head
+        let head = self.head_snapshot();
+        if head.beacon_block.slot() != request_slot {
+            return Err(Error::NoBlockForSlot(request_slot));
+        }
+
+        let beacon_block_root = head.beacon_block_root;
+
+        // TODO(EIP-7732): Check if we've seen a SignedExecutionPayloadEnvelope
+        // referencing this block root. For now, default to false.
+        let payload_present = false;
+
+        // TODO(EIP-7732): Check blob data availability. For now, default to false.
+        let blob_data_available = false;
+
+        Ok(PayloadAttestationData {
+            beacon_block_root,
+            slot: head.beacon_block.slot(),
+            payload_present,
+            blob_data_available,
+        })
+    }
+
     /// Performs the same validation as `Self::verify_unaggregated_attestation_for_gossip`, but for
     /// multiple attestations using batch BLS verification. Batch verification can provide
     /// significant CPU-time savings compared to individual verification.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2121,13 +2121,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let beacon_block_root = head.beacon_block_root;
 
-        // TODO(gloas) the spec only requires that the payload be seen. right
-        // now we are setting payload_present to `true` if the envelope was imported
-        // into fork choice which is a stricter requirement than the spec requires.
+        // TODO(gloas) this isn't really what the `envelope_times_cache` is meant for.
+        // We should use a dedicated payload envelope cache instead (maybe the new Gloas DA cache?)
         let payload_present = self
-            .canonical_head
-            .fork_choice_read_lock()
-            .contains_payload(&beacon_block_root);
+            .envelope_times_cache
+            .read()
+            .cache
+            .contains_key(&beacon_block_root);
 
         // TODO(EIP-7732): Check blob data availability. For now, default to true.
         let blob_data_available = true;

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -54,6 +54,7 @@ pub enum BeaconChainError {
     },
     SlotClockDidNotStart,
     NoStateForSlot(Slot),
+    NoBlockForSlot(Slot),
     BeaconStateError(BeaconStateError),
     EpochCacheError(EpochCacheError),
     DBInconsistent(String),

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -512,6 +512,17 @@ pub static ATTESTATION_PRODUCTION_HEAD_SCRAPE_SECONDS: LazyLock<Result<Histogram
     });
 
 /*
+ * Payload Attestation Production
+ */
+pub static PAYLOAD_ATTESTATION_PRODUCTION_SECONDS: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram(
+            "beacon_payload_attestation_production_seconds",
+            "Full runtime of payload attestation production",
+        )
+    });
+
+/*
  * Fork Choice
  */
 pub static FORK_CHOICE_REQUESTS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2536,6 +2536,46 @@ pub fn serve<T: BeaconChainTypes>(
         task_spawner_filter.clone(),
     );
 
+    // GET validator/payload_attestation_data/{slot}
+    let get_validator_payload_attestation_data = eth_v1
+        .clone()
+        .and(warp::path("validator"))
+        .and(warp::path("payload_attestation_data"))
+        .and(warp::path::param::<Slot>().or_else(|_| async {
+            Err(warp_utils::reject::custom_bad_request(
+                "Invalid slot".to_string(),
+            ))
+        }))
+        .and(warp::path::end())
+        .and(not_while_syncing_filter.clone())
+        .and(task_spawner_filter.clone())
+        .and(chain_filter.clone())
+        .then(
+            |slot: Slot,
+             not_synced_filter: Result<(), Rejection>,
+             task_spawner: TaskSpawner<T::EthSpec>,
+             chain: Arc<BeaconChain<T>>| {
+                task_spawner.blocking_response_task(Priority::P0, move || {
+                    not_synced_filter?;
+
+                    let fork_name = chain.spec.fork_name_at_slot::<T::EthSpec>(slot);
+
+                    let payload_attestation_data = chain
+                        .produce_payload_attestation_data(slot)
+                        .map_err(warp_utils::reject::unhandled_error)?;
+
+                    Ok(add_consensus_version_header(
+                        warp::reply::json(&beacon_response(
+                            ResponseIncludesVersion::Yes(fork_name),
+                            payload_attestation_data,
+                        ))
+                        .into_response(),
+                        fork_name,
+                    ))
+                })
+            },
+        );
+
     // GET validator/aggregate_attestation?attestation_data_root,slot
     let get_validator_aggregate_attestation = get_validator_aggregate_attestation(
         any_version.clone(),
@@ -3347,6 +3387,7 @@ pub fn serve<T: BeaconChainTypes>(
                 .uor(get_validator_blinded_blocks)
                 .uor(get_validator_execution_payload_envelope)
                 .uor(get_validator_attestation_data)
+                .uor(get_validator_payload_attestation_data)
                 .uor(get_validator_aggregate_attestation)
                 .uor(get_validator_sync_committee_contribution)
                 .uor(get_lighthouse_health)

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2537,44 +2537,12 @@ pub fn serve<T: BeaconChainTypes>(
     );
 
     // GET validator/payload_attestation_data/{slot}
-    let get_validator_payload_attestation_data = eth_v1
-        .clone()
-        .and(warp::path("validator"))
-        .and(warp::path("payload_attestation_data"))
-        .and(warp::path::param::<Slot>().or_else(|_| async {
-            Err(warp_utils::reject::custom_bad_request(
-                "Invalid slot".to_string(),
-            ))
-        }))
-        .and(warp::path::end())
-        .and(not_while_syncing_filter.clone())
-        .and(task_spawner_filter.clone())
-        .and(chain_filter.clone())
-        .then(
-            |slot: Slot,
-             not_synced_filter: Result<(), Rejection>,
-             task_spawner: TaskSpawner<T::EthSpec>,
-             chain: Arc<BeaconChain<T>>| {
-                task_spawner.blocking_response_task(Priority::P0, move || {
-                    not_synced_filter?;
-
-                    let fork_name = chain.spec.fork_name_at_slot::<T::EthSpec>(slot);
-
-                    let payload_attestation_data = chain
-                        .produce_payload_attestation_data(slot)
-                        .map_err(warp_utils::reject::unhandled_error)?;
-
-                    Ok(add_consensus_version_header(
-                        warp::reply::json(&beacon_response(
-                            ResponseIncludesVersion::Yes(fork_name),
-                            payload_attestation_data,
-                        ))
-                        .into_response(),
-                        fork_name,
-                    ))
-                })
-            },
-        );
+    let get_validator_payload_attestation_data = get_validator_payload_attestation_data(
+        eth_v1.clone(),
+        chain_filter.clone(),
+        not_while_syncing_filter.clone(),
+        task_spawner_filter.clone(),
+    );
 
     // GET validator/aggregate_attestation?attestation_data_root,slot
     let get_validator_aggregate_attestation = get_validator_aggregate_attestation(

--- a/beacon_node/http_api/src/validator/mod.rs
+++ b/beacon_node/http_api/src/validator/mod.rs
@@ -248,6 +248,65 @@ pub fn get_validator_attestation_data<T: BeaconChainTypes>(
         .boxed()
 }
 
+// GET validator/payload_attestation_data/{slot}
+pub fn get_validator_payload_attestation_data<T: BeaconChainTypes>(
+    eth_v1: EthV1Filter,
+    chain_filter: ChainFilter<T>,
+    not_while_syncing_filter: NotWhileSyncingFilter,
+    task_spawner_filter: TaskSpawnerFilter<T>,
+) -> ResponseFilter {
+    use crate::version::{ResponseIncludesVersion, add_consensus_version_header, beacon_response};
+
+    eth_v1
+        .and(warp::path("validator"))
+        .and(warp::path("payload_attestation_data"))
+        .and(warp::path::param::<Slot>().or_else(|_| async {
+            Err(warp_utils::reject::custom_bad_request(
+                "Invalid slot".to_string(),
+            ))
+        }))
+        .and(warp::path::end())
+        .and(not_while_syncing_filter)
+        .and(task_spawner_filter)
+        .and(chain_filter)
+        .then(
+            |slot: Slot,
+             not_synced_filter: Result<(), Rejection>,
+             task_spawner: TaskSpawner<T::EthSpec>,
+             chain: Arc<BeaconChain<T>>| {
+                task_spawner.blocking_response_task(Priority::P0, move || {
+                    not_synced_filter?;
+
+                    let fork_name = chain.spec.fork_name_at_slot::<T::EthSpec>(slot);
+
+                    // Payload attestations are only valid for Gloas and later forks
+                    if !fork_name.gloas_enabled() {
+                        return Err(warp_utils::reject::custom_bad_request(format!(
+                            "Payload attestations are not supported for fork: {fork_name}"
+                        )));
+                    }
+
+                    let payload_attestation_data =
+                        chain.produce_payload_attestation_data(slot).map_err(|e| {
+                            warp_utils::reject::custom_server_error(format!(
+                                "Unable to produce payload attestation data: {e:?}"
+                            ))
+                        })?;
+
+                    Ok(add_consensus_version_header(
+                        warp::reply::json(&beacon_response(
+                            ResponseIncludesVersion::Yes(fork_name),
+                            payload_attestation_data,
+                        ))
+                        .into_response(),
+                        fork_name,
+                    ))
+                })
+            },
+        )
+        .boxed()
+}
+
 // GET validator/blinded_blocks/{slot}
 pub fn get_validator_blinded_blocks<T: BeaconChainTypes>(
     eth_v1: EthV1Filter,

--- a/beacon_node/http_api/src/validator/mod.rs
+++ b/beacon_node/http_api/src/validator/mod.rs
@@ -255,7 +255,9 @@ pub fn get_validator_payload_attestation_data<T: BeaconChainTypes>(
     not_while_syncing_filter: NotWhileSyncingFilter,
     task_spawner_filter: TaskSpawnerFilter<T>,
 ) -> ResponseFilter {
-    use crate::version::{ResponseIncludesVersion, add_consensus_version_header, beacon_response};
+    use eth2::beacon_response::{EmptyMetadata, ForkVersionedResponse};
+    use ssz::Encode;
+    use warp::http::Response;
 
     eth_v1
         .and(warp::path("validator"))
@@ -266,11 +268,13 @@ pub fn get_validator_payload_attestation_data<T: BeaconChainTypes>(
             ))
         }))
         .and(warp::path::end())
+        .and(warp::header::optional::<Accept>("accept"))
         .and(not_while_syncing_filter)
         .and(task_spawner_filter)
         .and(chain_filter)
         .then(
             |slot: Slot,
+             accept_header: Option<Accept>,
              not_synced_filter: Result<(), Rejection>,
              task_spawner: TaskSpawner<T::EthSpec>,
              chain: Arc<BeaconChain<T>>| {
@@ -286,21 +290,58 @@ pub fn get_validator_payload_attestation_data<T: BeaconChainTypes>(
                         )));
                     }
 
-                    let payload_attestation_data =
-                        chain.produce_payload_attestation_data(slot).map_err(|e| {
-                            warp_utils::reject::custom_server_error(format!(
+                    let payload_attestation_data = chain
+                        .produce_payload_attestation_data(slot)
+                        .map_err(|e| match e {
+                            BeaconChainError::InvalidSlot(_)
+                            | BeaconChainError::NoBlockForSlot(_) => {
+                                warp_utils::reject::custom_bad_request(format!(
+                                    "Unable to produce payload attestation data: {e:?}"
+                                ))
+                            }
+                            _ => warp_utils::reject::custom_server_error(format!(
                                 "Unable to produce payload attestation data: {e:?}"
-                            ))
+                            )),
                         })?;
 
-                    Ok(add_consensus_version_header(
-                        warp::reply::json(&beacon_response(
-                            ResponseIncludesVersion::Yes(fork_name),
-                            payload_attestation_data,
-                        ))
-                        .into_response(),
-                        fork_name,
-                    ))
+                    match accept_header {
+                        Some(Accept::Ssz) => Response::builder()
+                            .status(200)
+                            .header("Content-Type", "application/octet-stream")
+                            .header("Eth-Consensus-Version", fork_name.to_string())
+                            .body(payload_attestation_data.as_ssz_bytes().into())
+                            .map(|res: Response<warp::hyper::Body>| res)
+                            .map_err(|e| {
+                                warp_utils::reject::custom_server_error(format!(
+                                    "Failed to build SSZ response: {e}"
+                                ))
+                            }),
+                        _ => {
+                            let json_response = ForkVersionedResponse {
+                                version: fork_name,
+                                metadata: EmptyMetadata {},
+                                data: payload_attestation_data,
+                            };
+                            Response::builder()
+                                .status(200)
+                                .header("Content-Type", "application/json")
+                                .header("Eth-Consensus-Version", fork_name.to_string())
+                                .body(
+                                    serde_json::to_string(&json_response)
+                                        .map_err(|e| {
+                                            warp_utils::reject::custom_server_error(format!(
+                                                "Failed to serialize response: {e}"
+                                            ))
+                                        })?
+                                        .into(),
+                                )
+                                .map_err(|e| {
+                                    warp_utils::reject::custom_server_error(format!(
+                                        "Failed to build JSON response: {e}"
+                                    ))
+                                })
+                        }
+                    }
                 })
             },
         )

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -3,7 +3,8 @@ use beacon_chain::test_utils::RelativeSyncCommittee;
 use beacon_chain::{
     BeaconChain, ChainConfig, StateSkipConfig, WhenSlotSkipped,
     test_utils::{
-        AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType, test_spec,
+        AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
+        fork_name_from_env, test_spec,
     },
 };
 use bls::{AggregateSignature, Keypair, PublicKeyBytes, SecretKey, Signature, SignatureBytes};
@@ -4438,11 +4439,6 @@ impl ApiTester {
         let slot = self.chain.slot().unwrap();
         let fork_name = self.chain.spec.fork_name_at_slot::<E>(slot);
 
-        // Payload attestation data is only available in Gloas fork.
-        if !fork_name.gloas_enabled() {
-            return self;
-        }
-
         let response = self
             .client
             .get_validator_payload_attestation_data(slot)
@@ -4459,38 +4455,19 @@ impl ApiTester {
         assert_eq!(result.payload_present, expected.payload_present);
         assert_eq!(result.blob_data_available, expected.blob_data_available);
 
-        self
-    }
-
-    pub async fn test_get_validator_payload_attestation_data_ssz(self) -> Self {
-        let slot = self.chain.slot().unwrap();
-        let fork_name = self.chain.spec.fork_name_at_slot::<E>(slot);
-
-        if !fork_name.gloas_enabled() {
-            return self;
-        }
-
-        let result = self
+        let ssz_result = self
             .client
             .get_validator_payload_attestation_data_ssz(slot)
             .await
             .unwrap();
 
-        let expected = self.chain.produce_payload_attestation_data(slot).unwrap();
-
-        assert_eq!(result, expected);
+        assert_eq!(ssz_result, expected);
 
         self
     }
 
     pub async fn test_get_validator_payload_attestation_data_pre_gloas(self) -> Self {
         let slot = self.chain.slot().unwrap();
-        let fork_name = self.chain.spec.fork_name_at_slot::<E>(slot);
-
-        // This test is for pre-Gloas forks
-        if fork_name.gloas_enabled() {
-            return self;
-        }
 
         // The endpoint should return a 400 error for pre-Gloas forks
         match self
@@ -8132,24 +8109,20 @@ async fn get_validator_attestation_data_with_skip_slots() {
 #[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_validator_payload_attestation_data() {
+    if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
     ApiTester::new()
         .await
         .test_get_validator_payload_attestation_data()
         .await;
 }
 
-// TODO(EIP-7732): Remove `#[ignore]` once gloas block production is implemented
-#[ignore]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn get_validator_payload_attestation_data_ssz() {
-    ApiTester::new()
-        .await
-        .test_get_validator_payload_attestation_data_ssz()
-        .await;
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_validator_payload_attestation_data_pre_gloas() {
+    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
     ApiTester::new()
         .await
         .test_get_validator_payload_attestation_data_pre_gloas()

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -3,7 +3,8 @@ use beacon_chain::test_utils::RelativeSyncCommittee;
 use beacon_chain::{
     BeaconChain, ChainConfig, StateSkipConfig, WhenSlotSkipped,
     test_utils::{
-        AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType, test_spec,
+        AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
+        fork_name_from_env, test_spec,
     },
 };
 use bls::{AggregateSignature, Keypair, PublicKeyBytes, SecretKey, Signature, SignatureBytes};
@@ -4433,6 +4434,54 @@ impl ApiTester {
         self
     }
 
+    pub async fn test_get_validator_payload_attestation_data(self) -> Self {
+        let slot = self.chain.slot().unwrap();
+        let fork_name = self.chain.spec.fork_name_at_slot::<E>(slot);
+
+        // Payload attestation data is only available in Gloas fork.
+        if !fork_name.gloas_enabled() {
+            return self;
+        }
+
+        let result = self
+            .client
+            .get_validator_payload_attestation_data(slot)
+            .await
+            .unwrap()
+            .into_data();
+
+        let expected = self.chain.produce_payload_attestation_data(slot).unwrap();
+
+        assert_eq!(result.beacon_block_root, expected.beacon_block_root);
+        assert_eq!(result.slot, expected.slot);
+        assert_eq!(result.payload_present, expected.payload_present);
+        assert_eq!(result.blob_data_available, expected.blob_data_available);
+
+        self
+    }
+
+    pub async fn test_get_validator_payload_attestation_data_pre_gloas(self) -> Self {
+        let slot = self.chain.slot().unwrap();
+        let fork_name = self.chain.spec.fork_name_at_slot::<E>(slot);
+
+        // This test is for pre-Gloas forks
+        if fork_name.gloas_enabled() {
+            return self;
+        }
+
+        // The endpoint should return a 400 error for pre-Gloas forks
+        match self
+            .client
+            .get_validator_payload_attestation_data(slot)
+            .await
+        {
+            Ok(result) => panic!("query for pre-Gloas slot should fail, got: {result:?}"),
+            Err(e) => assert_eq!(e.status().unwrap(), 400),
+        }
+
+        self
+    }
+
     #[allow(clippy::await_holding_lock)] // This is a test, so it should be fine.
     pub async fn test_get_validator_aggregate_attestation_v1(self) -> Self {
         let attestation = self
@@ -8053,6 +8102,27 @@ async fn get_validator_attestation_data_with_skip_slots() {
         .await
         .skip_slots(E::slots_per_epoch() * 2)
         .test_get_validator_attestation_data()
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_validator_payload_attestation_data() {
+    // TODO(EIP-7732): Remove this conditional once gloas block production is implemented
+    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
+
+    ApiTester::new_with_hard_forks()
+        .await
+        .test_get_validator_payload_attestation_data()
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_validator_payload_attestation_data_pre_gloas() {
+    ApiTester::new()
+        .await
+        .test_get_validator_payload_attestation_data_pre_gloas()
         .await;
 }
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -4443,19 +4443,42 @@ impl ApiTester {
             return self;
         }
 
-        let result = self
+        let response = self
             .client
             .get_validator_payload_attestation_data(slot)
             .await
-            .unwrap()
-            .into_data();
+            .unwrap();
 
+        assert_eq!(response.version(), Some(fork_name));
+
+        let result = response.into_data();
         let expected = self.chain.produce_payload_attestation_data(slot).unwrap();
 
         assert_eq!(result.beacon_block_root, expected.beacon_block_root);
         assert_eq!(result.slot, expected.slot);
         assert_eq!(result.payload_present, expected.payload_present);
         assert_eq!(result.blob_data_available, expected.blob_data_available);
+
+        self
+    }
+
+    pub async fn test_get_validator_payload_attestation_data_ssz(self) -> Self {
+        let slot = self.chain.slot().unwrap();
+        let fork_name = self.chain.spec.fork_name_at_slot::<E>(slot);
+
+        if !fork_name.gloas_enabled() {
+            return self;
+        }
+
+        let result = self
+            .client
+            .get_validator_payload_attestation_data_ssz(slot)
+            .await
+            .unwrap();
+
+        let expected = self.chain.produce_payload_attestation_data(slot).unwrap();
+
+        assert_eq!(result, expected);
 
         self
     }
@@ -8109,32 +8132,25 @@ async fn get_validator_attestation_data_with_skip_slots() {
 #[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_validator_payload_attestation_data() {
-    let mut config = ApiTesterConfig::default();
-    config.spec.altair_fork_epoch = Some(Epoch::new(0));
-    config.spec.bellatrix_fork_epoch = Some(Epoch::new(0));
-    config.spec.capella_fork_epoch = Some(Epoch::new(0));
-    config.spec.deneb_fork_epoch = Some(Epoch::new(0));
-    config.spec.electra_fork_epoch = Some(Epoch::new(0));
-    config.spec.fulu_fork_epoch = Some(Epoch::new(0));
-    config.spec.gloas_fork_epoch = Some(Epoch::new(0));
-
-    ApiTester::new_from_config(config)
+    ApiTester::new()
         .await
         .test_get_validator_payload_attestation_data()
         .await;
 }
 
+// TODO(EIP-7732): Remove `#[ignore]` once gloas block production is implemented
+#[ignore]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_validator_payload_attestation_data_ssz() {
+    ApiTester::new()
+        .await
+        .test_get_validator_payload_attestation_data_ssz()
+        .await;
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_validator_payload_attestation_data_pre_gloas() {
-    let mut config = ApiTesterConfig::default();
-    config.spec.altair_fork_epoch = Some(Epoch::new(0));
-    config.spec.bellatrix_fork_epoch = Some(Epoch::new(0));
-    config.spec.capella_fork_epoch = Some(Epoch::new(0));
-    config.spec.deneb_fork_epoch = Some(Epoch::new(0));
-    config.spec.electra_fork_epoch = Some(Epoch::new(0));
-    config.spec.fulu_fork_epoch = Some(Epoch::new(0));
-
-    ApiTester::new_from_config(config)
+    ApiTester::new()
         .await
         .test_get_validator_payload_attestation_data_pre_gloas()
         .await;

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -3,8 +3,7 @@ use beacon_chain::test_utils::RelativeSyncCommittee;
 use beacon_chain::{
     BeaconChain, ChainConfig, StateSkipConfig, WhenSlotSkipped,
     test_utils::{
-        AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
-        fork_name_from_env, test_spec,
+        AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType, test_spec,
     },
 };
 use bls::{AggregateSignature, Keypair, PublicKeyBytes, SecretKey, Signature, SignatureBytes};
@@ -8105,14 +8104,20 @@ async fn get_validator_attestation_data_with_skip_slots() {
         .await;
 }
 
+// TODO(EIP-7732): Remove `#[ignore]` once gloas block production is implemented
+#[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_validator_payload_attestation_data() {
-    // TODO(EIP-7732): Remove this conditional once gloas block production is implemented
-    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
-        return;
-    }
+    let mut config = ApiTesterConfig::default();
+    config.spec.altair_fork_epoch = Some(Epoch::new(0));
+    config.spec.bellatrix_fork_epoch = Some(Epoch::new(0));
+    config.spec.capella_fork_epoch = Some(Epoch::new(0));
+    config.spec.deneb_fork_epoch = Some(Epoch::new(0));
+    config.spec.electra_fork_epoch = Some(Epoch::new(0));
+    config.spec.fulu_fork_epoch = Some(Epoch::new(0));
+    config.spec.gloas_fork_epoch = Some(Epoch::new(0));
 
-    ApiTester::new_with_hard_forks()
+    ApiTester::new_from_config(config)
         .await
         .test_get_validator_payload_attestation_data()
         .await;
@@ -8120,7 +8125,15 @@ async fn get_validator_payload_attestation_data() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_validator_payload_attestation_data_pre_gloas() {
-    ApiTester::new()
+    let mut config = ApiTesterConfig::default();
+    config.spec.altair_fork_epoch = Some(Epoch::new(0));
+    config.spec.bellatrix_fork_epoch = Some(Epoch::new(0));
+    config.spec.capella_fork_epoch = Some(Epoch::new(0));
+    config.spec.deneb_fork_epoch = Some(Epoch::new(0));
+    config.spec.electra_fork_epoch = Some(Epoch::new(0));
+    config.spec.fulu_fork_epoch = Some(Epoch::new(0));
+
+    ApiTester::new_from_config(config)
         .await
         .test_get_validator_payload_attestation_data_pre_gloas()
         .await;

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -8105,7 +8105,7 @@ async fn get_validator_attestation_data_with_skip_slots() {
         .await;
 }
 
-// TODO(EIP-7732): Remove `#[ignore]` once gloas block production is implemented
+// TODO(EIP-7732): Remove `#[ignore]` once gloas beacon chain harness is implemented
 #[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_validator_payload_attestation_data() {

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -46,6 +46,7 @@ use ssz::{Decode, Encode};
 use std::fmt;
 use std::future::Future;
 use std::time::Duration;
+use types::PayloadAttestationData;
 
 pub const V1: EndpointVersion = EndpointVersion(1);
 pub const V2: EndpointVersion = EndpointVersion(2);
@@ -77,6 +78,7 @@ const HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT: u32 = 4;
 const HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT: u32 = 4;
 const HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT: u32 = 4;
+const HTTP_PAYLOAD_ATTESTATION_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_DEFAULT_TIMEOUT_QUOTIENT: u32 = 4;
 
 /// A struct to define a variety of different timeouts for different validator tasks to ensure
@@ -97,6 +99,7 @@ pub struct Timeouts {
     pub get_debug_beacon_states: Duration,
     pub get_deposit_snapshot: Duration,
     pub get_validator_block: Duration,
+    pub payload_attestation: Duration,
     pub default: Duration,
 }
 
@@ -117,6 +120,7 @@ impl Timeouts {
             get_debug_beacon_states: timeout,
             get_deposit_snapshot: timeout,
             get_validator_block: timeout,
+            payload_attestation: timeout,
             default: timeout,
         }
     }
@@ -139,6 +143,7 @@ impl Timeouts {
             get_debug_beacon_states: base_timeout / HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT,
             get_deposit_snapshot: base_timeout / HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT,
             get_validator_block: base_timeout / HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT,
+            payload_attestation: base_timeout / HTTP_PAYLOAD_ATTESTATION_TIMEOUT_QUOTIENT,
             default: base_timeout / HTTP_DEFAULT_TIMEOUT_QUOTIENT,
         }
     }
@@ -2935,6 +2940,24 @@ impl BeaconNodeHttpClient {
             .append_pair("committee_index", &committee_index.to_string());
 
         self.get_with_timeout(path, self.timeouts.attestation).await
+    }
+
+    /// `GET validator/payload_attestation_data/{slot}`
+    pub async fn get_validator_payload_attestation_data(
+        &self,
+        slot: Slot,
+    ) -> Result<BeaconResponse<PayloadAttestationData>, Error> {
+        let mut path = self.eth_path(V1)?;
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("validator")
+            .push("payload_attestation_data")
+            .push(&slot.to_string());
+
+        self.get_with_timeout(path, self.timeouts.payload_attestation)
+            .await
+            .map(BeaconResponse::ForkVersioned)
     }
 
     /// `GET v1/validator/aggregate_attestation?slot,attestation_data_root`

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -2965,6 +2965,28 @@ impl BeaconNodeHttpClient {
             .map(BeaconResponse::ForkVersioned)
     }
 
+    /// `GET validator/payload_attestation_data/{slot}` in SSZ format
+    pub async fn get_validator_payload_attestation_data_ssz(
+        &self,
+        slot: Slot,
+    ) -> Result<PayloadAttestationData, Error> {
+        let mut path = self.eth_path(V1)?;
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("validator")
+            .push("payload_attestation_data")
+            .push(&slot.to_string());
+
+        let opt_response = self
+            .get_bytes_opt_accept_header(path, Accept::Ssz, self.timeouts.payload_attestation)
+            .await?;
+
+        let response_bytes = opt_response.ok_or(Error::StatusCode(StatusCode::NOT_FOUND))?;
+
+        PayloadAttestationData::from_ssz_bytes(&response_bytes).map_err(Error::InvalidSsz)
+    }
+
     /// `GET v1/validator/aggregate_attestation?slot,attestation_data_root`
     pub async fn get_validator_aggregate_attestation_v1<E: EthSpec>(
         &self,

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1484,12 +1484,6 @@ where
             && self.is_finalized_checkpoint_or_descendant(*block_root)
     }
 
-    /// Returns `true` if the payload is known **and** a descendant of the finalized root.
-    pub fn contains_payload(&self, block_root: &Hash256) -> bool {
-        self.proto_array.is_payload_received(block_root)
-            && self.is_finalized_checkpoint_or_descendant(*block_root)
-    }
-
     /// Returns a `ProtoBlock` if the block is known **and** a descendant of the finalized root.
     pub fn get_block(&self, block_root: &Hash256) -> Option<ProtoBlock> {
         if self.is_finalized_checkpoint_or_descendant(*block_root) {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1484,6 +1484,12 @@ where
             && self.is_finalized_checkpoint_or_descendant(*block_root)
     }
 
+    // Returns `true` if the payload is known **and** a descendant of the finalized root.
+    pub fn contains_payload(&self, block_root: &Hash256) -> bool {
+        self.proto_array.is_payload_received(block_root)
+            && self.is_finalized_checkpoint_or_descendant(*block_root)
+    }
+
     /// Returns a `ProtoBlock` if the block is known **and** a descendant of the finalized root.
     pub fn get_block(&self, block_root: &Hash256) -> Option<ProtoBlock> {
         if self.is_finalized_checkpoint_or_descendant(*block_root) {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1484,7 +1484,7 @@ where
             && self.is_finalized_checkpoint_or_descendant(*block_root)
     }
 
-    // Returns `true` if the payload is known **and** a descendant of the finalized root.
+    /// Returns `true` if the payload is known **and** a descendant of the finalized root.
     pub fn contains_payload(&self, block_root: &Hash256) -> bool {
         self.proto_array.is_payload_received(block_root)
             && self.is_finalized_checkpoint_or_descendant(*block_root)


### PR DESCRIPTION
## Changes
Add `GET /eth/v1/validator/payload_attestation_data/{slot}]` per beacon api [spec](https://github.com/ethereum/beacon-APIs/pull/552)

## TODO
- Implement actual payload_present check once  envelope tracking is all set
 - Implement actual `blob_data_available` check once da checker changes are all set
 - Enable tests once gloas block production is functional