### PR TITLE
fix visual bug on visualize_batch_state leading to a non-wanted comma

### DIFF
--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -1331,7 +1331,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 .get(&(self.processing_target + batch_index as u64 * EPOCHS_PER_BATCH))
             {
                 visualization_string.push(batch.visualize());
-                if batch_index != BATCH_BUFFER_SIZE {
+                if batch_index < BATCH_BUFFER_SIZE - 1 {
                     // Add a comma in between elements
                     visualization_string.push(',');
                 }


### PR DESCRIPTION
## Issue Addressed

Which issue # does this PR address?
None

## Proposed Changes

The `visualize_batch_state`  functions uses the following loop `for mut batch_index in 0..BATCH_BUFFER_SIZE`, making it from `0` to `BATCH_BUFFER_SIZE - 1` (behind the scenes). 

Hence we would never hit the following condition:

```rust
if batch_index != BATCH_BUFFER_SIZE {
    visualization_string.push(',');
}
```

Replacing `!=` with `<` & `BATCH_BUFFER_SIZE -1` allows for the following change:

`[A,B,C,D,E,]` to become: `[A,B,C,D,E]`

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
