### PR TITLE
Move deposit contract artifacts to /target

### DIFF
--- a/common/deposit_contract/build.rs
+++ b/common/deposit_contract/build.rs
@@ -153,14 +153,13 @@ fn verify_checksum(bytes: &[u8], expected_checksum: &str) {
 
 /// Returns the directory that will be used to store the deposit contract ABI.
 fn abi_dir() -> PathBuf {
-    let base = env::var("CARGO_MANIFEST_DIR")
-        .expect("should know manifest dir")
+    let base = env::var("OUT_DIR")
+        .expect("should know out dir")
         .parse::<PathBuf>()
-        .expect("should parse manifest dir as path")
-        .join("contracts");
+        .expect("should parse out dir as path");
 
     std::fs::create_dir_all(base.clone())
-        .expect("should be able to create abi directory in manifest");
+        .expect("should be able to create abi directory in out dir");
 
     base
 }

--- a/common/deposit_contract/src/lib.rs
+++ b/common/deposit_contract/src/lib.rs
@@ -44,15 +44,25 @@ impl From<SszDecodeError> for Error {
 
 pub const CONTRACT_DEPLOY_GAS: usize = 4_000_000;
 pub const DEPOSIT_GAS: usize = 400_000;
-pub const ABI: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/v0.12.1_validator_registration.json"));
-pub const BYTECODE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/v0.12.1_validator_registration.bytecode"));
+pub const ABI: &[u8] = include_bytes!(concat!(
+    env!("OUT_DIR"),
+    "/v0.12.1_validator_registration.json"
+));
+pub const BYTECODE: &[u8] = include_bytes!(concat!(
+    env!("OUT_DIR"),
+    "/v0.12.1_validator_registration.bytecode"
+));
 pub const DEPOSIT_DATA_LEN: usize = 420; // lol
 
 pub mod testnet {
-    pub const ABI: &[u8] =
-        include_bytes!(concat!(env!("OUT_DIR"), "/v0.12.1_testnet_validator_registration.json"));
-    pub const BYTECODE: &[u8] =
-        include_bytes!(concat!(env!("OUT_DIR"), "/v0.12.1_testnet_validator_registration.bytecode"));
+    pub const ABI: &[u8] = include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/v0.12.1_testnet_validator_registration.json"
+    ));
+    pub const BYTECODE: &[u8] = include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/v0.12.1_testnet_validator_registration.bytecode"
+    ));
 }
 
 pub fn encode_eth1_tx_data(deposit_data: &DepositData) -> Result<Vec<u8>, Error> {

--- a/common/deposit_contract/src/lib.rs
+++ b/common/deposit_contract/src/lib.rs
@@ -44,15 +44,15 @@ impl From<SszDecodeError> for Error {
 
 pub const CONTRACT_DEPLOY_GAS: usize = 4_000_000;
 pub const DEPOSIT_GAS: usize = 400_000;
-pub const ABI: &[u8] = include_bytes!("../contracts/v0.12.1_validator_registration.json");
-pub const BYTECODE: &[u8] = include_bytes!("../contracts/v0.12.1_validator_registration.bytecode");
+pub const ABI: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/v0.12.1_validator_registration.json"));
+pub const BYTECODE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/v0.12.1_validator_registration.bytecode"));
 pub const DEPOSIT_DATA_LEN: usize = 420; // lol
 
 pub mod testnet {
     pub const ABI: &[u8] =
-        include_bytes!("../contracts/v0.12.1_testnet_validator_registration.json");
+        include_bytes!(concat!(env!("OUT_DIR"), "/v0.12.1_testnet_validator_registration.json"));
     pub const BYTECODE: &[u8] =
-        include_bytes!("../contracts/v0.12.1_testnet_validator_registration.bytecode");
+        include_bytes!(concat!(env!("OUT_DIR"), "/v0.12.1_testnet_validator_registration.bytecode"));
 }
 
 pub fn encode_eth1_tx_data(deposit_data: &DepositData) -> Result<Vec<u8>, Error> {


### PR DESCRIPTION
## Issue Addressed

Alternative to:

- https://github.com/sigp/lighthouse/pull/8488

## Proposed Changes

Refactors deposit_contract crate to comply with Rust build conventions by placing generated artifacts in the build output directory.
