### PR TITLE
fix(beacon_node): add pruning of observed_column_sidecars

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -951,6 +951,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .start_slot(T::EthSpec::slots_per_epoch()),
         );
 
+        self.observed_column_sidecars.write().prune(
+            new_view
+                .finalized_checkpoint
+                .epoch
+                .start_slot(T::EthSpec::slots_per_epoch()),
+        );
+
         self.observed_slashable.write().prune(
             new_view
                 .finalized_checkpoint


### PR DESCRIPTION
## Issue Addressed

None

## Proposed Changes

 I noticed that `observed_column_sidecars` is missing its prune call in the finalization handler, which results in a memory leak on long-running nodes (very slow (**7MB/day**)) :

https://github.com/sigp/lighthouse/blob/13dfa9200f822c41ccd81b95a3f052df54c888e9/beacon_node/beacon_chain/src/canonical_head.rs#L940-L959

Both caches use the same generic type `ObservedDataSidecars<T>:`
  https://github.com/sigp/lighthouse/blob/22ec4b327186c4a4a87d2c8c745caf3b36cb6dd6/beacon_node/beacon_chain/src/beacon_chain.rs#L413-L416

The type's documentation explicitly requires manual pruning:

 >  "*The cache supports pruning based upon the finalized epoch. It does not automatically prune, you must call Self::prune manually.*"


  https://github.com/sigp/lighthouse/blob/b4704eab4ac8edf0ea0282ed9a5758b784038dd2/beacon_node/beacon_chain/src/observed_data_sidecars.rs#L66-L74

  Currently:
  - `observed_blob_sidecars` => pruned 
  - `observed_column_sidecars` => **NOT** pruned

  Without pruning, the underlying HashMap accumulates entries indefinitely, causing continuous memory growth until the node restarts.

## Additional Info

None
