### PR TITLE
Fix testnet script

### DIFF
--- a/scripts/tests/genesis-sync-config-electra.yaml
+++ b/scripts/tests/genesis-sync-config-electra.yaml
@@ -6,11 +6,9 @@ participants:
   # nodes without validators, used for testing sync.
   - cl_type: lighthouse
     cl_image: lighthouse:local
-    supernode: true # no supernode in Electra, this is for future proof
     validator_count: 0
   - cl_type: lighthouse
     cl_image: lighthouse:local
-    supernode: false
     validator_count: 0
 network_params:
   seconds_per_slot: 6

--- a/scripts/tests/genesis-sync-config-electra.yaml
+++ b/scripts/tests/genesis-sync-config-electra.yaml
@@ -2,23 +2,18 @@
 participants:
   - cl_type: lighthouse
     cl_image: lighthouse:local
-    el_type: geth
-    el_image: ethpandaops/geth:master
     count: 2
   # nodes without validators, used for testing sync.
   - cl_type: lighthouse
     cl_image: lighthouse:local
-    el_type: geth
-    el_image: ethpandaops/geth:master
     validator_count: 0
   - cl_type: lighthouse
     cl_image: lighthouse:local
-    el_type: geth
-    el_image: ethpandaops/geth:master
     validator_count: 0
 network_params:
   seconds_per_slot: 6
   electra_fork_epoch: 0
+  fulu_fork_epoch: 100000 # a really big number so this test stays in electra
   preset: "minimal"
 additional_services:
   - tx_fuzz

--- a/scripts/tests/genesis-sync-config-electra.yaml
+++ b/scripts/tests/genesis-sync-config-electra.yaml
@@ -2,13 +2,19 @@
 participants:
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    el_type: geth
+    el_image: ethpandaops/geth:master
     count: 2
   # nodes without validators, used for testing sync.
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    el_type: geth
+    el_image: ethpandaops/geth:master
     validator_count: 0
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    el_type: geth
+    el_image: ethpandaops/geth:master
     validator_count: 0
 network_params:
   seconds_per_slot: 6

--- a/scripts/tests/genesis-sync-config-fulu.yaml
+++ b/scripts/tests/genesis-sync-config-fulu.yaml
@@ -21,8 +21,7 @@ participants:
     validator_count: 0
 network_params:
   seconds_per_slot: 6
-  electra_fork_epoch: 0
-  fulu_fork_epoch: 1
+  fulu_fork_epoch: 0
   preset: "minimal"
 additional_services:
   - tx_fuzz

--- a/scripts/tests/network_params.yaml
+++ b/scripts/tests/network_params.yaml
@@ -9,7 +9,7 @@ participants:
     supernode: true
     count: 4
 network_params:
-  electra_fork_epoch: 0
+  fulu_fork_epoch: 0
   seconds_per_slot: 3
   num_validator_keys_per_node: 20
 global_log_level: debug

--- a/scripts/tests/network_params.yaml
+++ b/scripts/tests/network_params.yaml
@@ -9,7 +9,6 @@ participants:
     supernode: true
     count: 4
 network_params:
-
   electra_fork_epoch: 0
   seconds_per_slot: 3
   num_validator_keys_per_node: 20

--- a/scripts/tests/network_params.yaml
+++ b/scripts/tests/network_params.yaml
@@ -9,6 +9,7 @@ participants:
     supernode: true
     count: 4
 network_params:
+
   electra_fork_epoch: 0
   seconds_per_slot: 3
   num_validator_keys_per_node: 20

--- a/scripts/tests/network_params.yaml
+++ b/scripts/tests/network_params.yaml
@@ -6,6 +6,7 @@ participants:
     cl_image: lighthouse:local
     cl_extra_params:
       - --target-peers=3
+    supernode: true
     count: 4
 network_params:
   electra_fork_epoch: 0


### PR DESCRIPTION
## Issue Addressed
 
 Fix an issue where a kurtosis testnet script was failing because no supernodes were provided


```
There was an error interpreting Starlark code 
Evaluation error: fail: Fulu fork is enabled (epoch: 0) but no supernodes are configured, no nodes have 128 or more validators, and perfect_peerdas_enabled is not enabled. Either configure a supernode, ensure at least one node has 128+ validators, or enable perfect_peerdas_enabled in network_params with 16 participants.
	at [github.com/ethpandaops/ethereum-package/main.star:83:57]: run
	at [github.com/ethpandaops/ethereum-package/src/package_io/input_parser.star:377:17]: input_parser
	at [0:0]: fail
```