### PR TITLE
feat: adding `telemetry-trace-sample-rate` cli arg and set default to 1%

### DIFF
--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -79,6 +79,7 @@ pub struct Config {
     pub genesis_state_url: Option<String>,
     pub genesis_state_url_timeout: Duration,
     pub allow_insecure_genesis_sync: bool,
+    pub telemetry_sample_ratio: f64, // for testing only
 }
 
 impl Default for Config {
@@ -107,6 +108,7 @@ impl Default for Config {
             // This default value should always be overwritten by the CLI default value.
             genesis_state_url_timeout: Duration::from_secs(60),
             allow_insecure_genesis_sync: false,
+            telemetry_sample_ratio: 0.01,
         }
     }
 }

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -399,6 +399,12 @@ Options:
           Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
           for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
           for other subcommands.
+      --telemetry-trace-sample-rate <PERCENT>
+          OpenTelemetry trace sampling rate as a percentage (0-100). A value of
+          1 means 1% of traces are sampled. Lower values reduce resource
+          consumption. For more info see
+          https://opentelemetry.io/docs/concepts/sampling/#why-sampling
+          [default: 1]
       --trusted-peers <TRUSTED_PEERS>
           One or more comma-delimited trusted peer ids which always have the
           highest score according to the peer scoring system.

--- a/book/src/help_general.md
+++ b/book/src/help_general.md
@@ -83,6 +83,12 @@ Options:
           Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
           for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
           for other subcommands.
+      --telemetry-trace-sample-rate <PERCENT>
+          OpenTelemetry trace sampling rate as a percentage (0-100). A value of
+          1 means 1% of traces are sampled. Lower values reduce resource
+          consumption. For more info see
+          https://opentelemetry.io/docs/concepts/sampling/#why-sampling
+          [default: 1]
   -V, --version
           Print version
 

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -141,6 +141,12 @@ Options:
           Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
           for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
           for other subcommands.
+      --telemetry-trace-sample-rate <PERCENT>
+          OpenTelemetry trace sampling rate as a percentage (0-100). A value of
+          1 means 1% of traces are sampled. Lower values reduce resource
+          consumption. For more info see
+          https://opentelemetry.io/docs/concepts/sampling/#why-sampling
+          [default: 1]
       --validator-registration-batch-size <INTEGER>
           Defines the number of validators per validator/register_validator
           request sent to the BN. This value can be reduced to avoid timeouts

--- a/book/src/help_vm.md
+++ b/book/src/help_vm.md
@@ -84,6 +84,12 @@ Options:
           Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
           for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
           for other subcommands.
+      --telemetry-trace-sample-rate <PERCENT>
+          OpenTelemetry trace sampling rate as a percentage (0-100). A value of
+          1 means 1% of traces are sampled. Lower values reduce resource
+          consumption. For more info see
+          https://opentelemetry.io/docs/concepts/sampling/#why-sampling
+          [default: 1]
 
 Flags:
       --disable-log-timestamp

--- a/book/src/help_vm_create.md
+++ b/book/src/help_vm_create.md
@@ -100,6 +100,12 @@ Options:
           Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
           for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
           for other subcommands.
+      --telemetry-trace-sample-rate <PERCENT>
+          OpenTelemetry trace sampling rate as a percentage (0-100). A value of
+          1 means 1% of traces are sampled. Lower values reduce resource
+          consumption. For more info see
+          https://opentelemetry.io/docs/concepts/sampling/#why-sampling
+          [default: 1]
 
 Flags:
       --disable-deposits

--- a/book/src/help_vm_import.md
+++ b/book/src/help_vm_import.md
@@ -80,6 +80,12 @@ Options:
           Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
           for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
           for other subcommands.
+      --telemetry-trace-sample-rate <PERCENT>
+          OpenTelemetry trace sampling rate as a percentage (0-100). A value of
+          1 means 1% of traces are sampled. Lower values reduce resource
+          consumption. For more info see
+          https://opentelemetry.io/docs/concepts/sampling/#why-sampling
+          [default: 1]
       --validators-file <PATH_TO_JSON_FILE>
           The path to a JSON file containing a list of validators to be imported
           to the validator client. This file is usually named "validators.json".

--- a/book/src/help_vm_move.md
+++ b/book/src/help_vm_move.md
@@ -89,6 +89,12 @@ Options:
           Override the OpenTelemetry service name. Defaults to 'lighthouse-bn'
           for beacon node, 'lighthouse-vc' for validator client, or 'lighthouse'
           for other subcommands.
+      --telemetry-trace-sample-rate <PERCENT>
+          OpenTelemetry trace sampling rate as a percentage (0-100). A value of
+          1 means 1% of traces are sampled. Lower values reduce resource
+          consumption. For more info see
+          https://opentelemetry.io/docs/concepts/sampling/#why-sampling
+          [default: 1]
       --validators <STRING>
           The validators to be moved. Either a list of 0x-prefixed validator
           pubkeys or the keyword "all".

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -295,6 +295,23 @@ fn main() {
                 .display_order(0)
         )
         .arg(
+            Arg::new("telemetry-trace-sample-rate")
+                .long("telemetry-trace-sample-rate")
+                .value_name("PERCENT")
+                .help(
+                    "OpenTelemetry trace sampling rate as a percentage (0-100). \
+                    A value of 1 means 1% of traces are sampled. \
+                    Lower values reduce resource consumption. \
+                    For more info see https://opentelemetry.io/docs/concepts/sampling/#why-sampling"
+                )
+                .requires("telemetry-collector-url")
+                .value_parser(clap::value_parser!(u8).range(0..=100))
+                .default_value("1")
+                .action(ArgAction::Set)
+                .global(true)
+                .display_order(0)
+        )
+        .arg(
             Arg::new("datadir")
                 .long("datadir")
                 .short('d')
@@ -657,6 +674,7 @@ fn run<E: EthSpec>(
         .eth2_network_config(eth2_network_config)?
         .build()?;
 
+    let mut telemetry_sample_ratio = 0.01; // default to 1%
     if let Some(telemetry_collector_url) = matches.get_one::<String>("telemetry-collector-url") {
         let telemetry_layer = environment.runtime().block_on(async {
             let exporter = opentelemetry_otlp::SpanExporter::builder()
@@ -675,8 +693,19 @@ fn run<E: EthSpec>(
                     _ => "lighthouse".to_string(),
                 });
 
+            // Calculate sample percent as a ratio (percentage / 100)
+            telemetry_sample_ratio = (matches
+                .get_one::<u8>("telemetry-trace-sample-rate")
+                .copied()
+                .unwrap_or(1) as f64)
+                / 100.0;
+            let sampler = opentelemetry_sdk::trace::Sampler::ParentBased(Box::new(
+                opentelemetry_sdk::trace::Sampler::TraceIdRatioBased(telemetry_sample_ratio),
+            ));
+
             let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
                 .with_batch_exporter(exporter)
+                .with_sampler(sampler)
                 .with_resource(
                     opentelemetry_sdk::Resource::builder()
                         .with_service_name(service_name)
@@ -824,6 +853,7 @@ fn run<E: EthSpec>(
             let executor = context.executor.clone();
             let mut config = beacon_node::get_config::<E>(matches, &context)?;
             config.logger_config = logger_config;
+            config.telemetry_sample_ratio = telemetry_sample_ratio;
             // Dump configs if `dump-config` or `dump-chain-config` flags are set
             clap_utils::check_dump_configs::<_, E>(matches, &config, &context.eth2_config.spec)?;
 

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2839,3 +2839,42 @@ fn invalid_block_roots_default_mainnet() {
             assert!(config.chain.invalid_block_roots.is_empty());
         })
 }
+
+#[test]
+fn telemetry_sample_rate_default() {
+    let float_tolerance: f64 = 1e-3;
+    let expected_ratio = 0.01;
+
+    CommandLineTest::new()
+        .flag("telemetry-collector-url", Some("http://localhost:4317"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            let actual_ratio = config.telemetry_sample_ratio;
+            assert!(
+                (actual_ratio - expected_ratio).abs() < float_tolerance,
+                "Expected {}, got {}",
+                expected_ratio,
+                actual_ratio
+            );
+        });
+}
+
+#[test]
+fn telemetry_sample_rate_custom() {
+    let float_tolerance: f64 = 1e-3;
+    let expected_ratio = 0.05;
+
+    CommandLineTest::new()
+        .flag("telemetry-trace-sample-rate", Some("5"))
+        .flag("telemetry-collector-url", Some("http://localhost:4317"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            let actual_ratio = config.telemetry_sample_ratio;
+            assert!(
+                (actual_ratio - expected_ratio).abs() < float_tolerance,
+                "Expected {}, got {}",
+                expected_ratio,
+                actual_ratio
+            );
+        });
+}


### PR DESCRIPTION
Adding a new `telemetry-trace-sample-rate` cli arg for both VC and BN to adjust sampling rate for OpenTelemetry tracing spans. Default will now be 1%.

https://github.com/sigp/lighthouse/issues/8554

## Proposed Changes

Simply add the cli arg then set the sampler arg in the open telemetry object constructor via below variant  
https://docs.rs/opentelemetry_sdk/0.30.0/opentelemetry_sdk/trace/enum.Sampler.html#variant.TraceIdRatioBased

## Additional Info

Didn't add unit tests for this given low risk and low ROI to added meaningfully test in this case

## Testing

ran cargo nextest run -p lighthouse --release and all tests passed, see below
```
...
        PASS [   0.021s] lighthouse::lighthouse_tests validator_manager::validator_import_defaults
        PASS [   0.022s] lighthouse::lighthouse_tests validator_manager::validator_import_misc_flags
        PASS [   0.013s] lighthouse::lighthouse_tests validator_manager::validator_import_missing_both_file_flags
        PASS [   0.017s] lighthouse::lighthouse_tests validator_manager::validator_import_missing_token
        PASS [   0.014s] lighthouse::lighthouse_tests validator_manager::validator_import_using_both_file_flags
        PASS [   0.019s] lighthouse::lighthouse_tests validator_manager::validator_list_defaults
        PASS [   0.019s] lighthouse::lighthouse_tests validator_manager::validator_move_count
        PASS [   0.019s] lighthouse::lighthouse_tests validator_manager::validator_move_defaults
        PASS [   0.021s] lighthouse::lighthouse_tests validator_manager::validator_move_misc_flags_0
        PASS [   0.021s] lighthouse::lighthouse_tests validator_manager::validator_move_misc_flags_1
        PASS [   0.023s] lighthouse::lighthouse_tests validator_manager::validator_move_misc_flags_2
        PASS [  25.886s] lighthouse::lighthouse_tests beacon_node::validator_monitor_file_flag
        PASS [  26.837s] lighthouse::lighthouse_tests beacon_node::validator_monitor_metrics_threshold_custom
        PASS [  26.960s] lighthouse::lighthouse_tests beacon_node::validator_monitor_metrics_threshold_default
        PASS [  23.081s] lighthouse::lighthouse_tests beacon_node::validator_monitor_pubkeys_flag
        PASS [  47.206s] lighthouse::lighthouse_tests beacon_node::test_builder_disable_ssz_flag
        PASS [  20.507s] lighthouse::lighthouse_tests beacon_node::wss_checkpoint_flag
        PASS [  15.336s] lighthouse::lighthouse_tests beacon_node::zero_ports_flag
────────────
     Summary [ 696.662s] 310 tests run: 310 passed, 0 skipped
```
