### PR TITLE
Update `syn` to `2.0.110`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8948,7 +8948,7 @@ name = "test_random_derive"
 version = "0.2.0"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ store = { path = "beacon_node/store" }
 strum = { version = "0.24", features = ["derive"] }
 superstruct = "0.10"
 swap_or_not_shuffle = { path = "consensus/swap_or_not_shuffle" }
-syn = "1"
+syn = "2"
 sysinfo = "0.26"
 system_health = { path = "common/system_health" }
 task_executor = { path = "common/task_executor" }

--- a/common/test_random_derive/src/lib.rs
+++ b/common/test_random_derive/src/lib.rs
@@ -8,7 +8,8 @@ use syn::{DeriveInput, parse_macro_input};
 /// The field attribute is: `#[test_random(default)]`
 fn should_use_default(field: &syn::Field) -> bool {
     field.attrs.iter().any(|attr| {
-        attr.path.is_ident("test_random") && attr.tokens.to_string().replace(' ', "") == "(default)"
+        attr.path().is_ident("test_random")
+            && matches!(&attr.meta, syn::Meta::List(list) if list.tokens.to_string().replace(' ', "") == "default")
     })
 }
 


### PR DESCRIPTION
## Issue Addressed

#8547

## Proposed Changes

We are currently using an older version of `syn` in `test_random_derive`. Updating this removes one of the sources of `syn` `1.0.109` in our dependency tree. 
