### PR TITLE
Add cargo deny on CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -324,7 +324,7 @@ jobs:
           channel: stable
           cache-target: release
           components: rustfmt,clippy
-          bins: cargo-audit
+          bins: cargo-audit,cargo-deny
     - name: Check formatting with cargo fmt
       run: make cargo-fmt
     - name: Lint code for quality and style with Clippy
@@ -337,6 +337,8 @@ jobs:
       run:  make arbitrary-fuzz
     - name: Run cargo audit
       run: make audit-CI
+    - name: Run cargo deny
+      run: make deny-CI
     - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
       run:  CARGO_HOME=$(readlink -f $HOME) make vendor
     - name: Markdown-linter

--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,15 @@ install-audit:
 audit-CI:
 	cargo audit
 
+# Runs cargo deny (check for banned crates, duplicate versions, and source restrictions)
+deny: install-deny deny-CI
+
+install-deny:
+	cargo install --force cargo-deny --version 0.18.2
+
+deny-CI:
+	cargo deny check bans sources --hide-inclusion-graph
+
 # Runs `cargo vendor` to make sure dependencies can be vendored for packaging, reproducibility and archival purpose.
 vendor:
 	cargo vendor

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,23 @@
+# cargo-deny configuration for Lighthouse
+# See https://embarkstudios.github.io/cargo-deny/
+
+[bans]
+# Warn when multiple versions of the same crate are detected
+multiple-versions = "warn"
+deny = [
+    # Legacy Ethereum crates that have been replaced with alloy
+    { crate = "ethers", reason = "use alloy instead" },
+    { crate = "ethereum-types", reason = "use alloy-primitives instead" },
+    # Replaced by quick-protobuf
+    { crate = "protobuf", reason = "use quick-protobuf instead" },
+    # Prevent duplicate versions of reqwest - heavy crate with build scripts
+    { crate = "reqwest", deny-multiple-versions = true, reason = "prevent duplicate versions" },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+
+[sources.allow-org]
+github = ["sigp"]


### PR DESCRIPTION
## Issue Addressed

Closes:

- https://github.com/sigp/lighthouse/issues/8408

## Proposed Changes

Add `cargo deny` on CI with deprecated crates (`ethers` and `ethereum-types`) banned and duplicates banned for `reqwest`.
