### PR TITLE
fix: remove redundant rpc_custody_column_queue pop

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -1041,8 +1041,6 @@ impl<E: EthSpec> BeaconProcessor<E> {
                                 Some(item)
                             } else if let Some(item) = rpc_custody_column_queue.pop() {
                                 Some(item)
-                            } else if let Some(item) = rpc_custody_column_queue.pop() {
-                                Some(item)
                             // Check delayed blocks before gossip blocks, the gossip blocks might rely
                             // on the delayed ones.
                             } else if let Some(item) = delayed_block_queue.pop() {


### PR DESCRIPTION
The work selection chain in BeaconProcessor::spawn_manager called rpc_custody_column_queue.pop() twice in a row. The second branch could never change the outcome (the first either returned Some and short-circuited, or both saw an empty queue), so it was effectively dead code. This change removes the redundant branch to make the queue prioritisation logic clearer without altering behaviour.