### PR TITLE
fix: improve error for insufficient blob data columns

### DIFF
--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -483,8 +483,9 @@ impl BlockId {
                 },
             )
         } else {
-            Err(warp_utils::reject::custom_server_error(format!(
-                "Insufficient data columns to reconstruct blobs: required {num_required_columns}, but only {num_found_column_keys} were found."
+            Err(warp_utils::reject::custom_bad_request(format!(
+                "Insufficient data columns to reconstruct blobs: required {num_required_columns}, but only {num_found_column_keys} were found. \
+                You may need to run the beacon node with --supernode or --semi-supernode."
             )))
         }
     }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1970,8 +1970,8 @@ impl ApiTester {
             .await
         {
             Ok(result) => panic!("Full node are unable to return blobs post-Fulu: {result:?}"),
-            // Post-Fulu, full nodes don't store blobs and return error 500
-            Err(e) => assert_eq!(e.status().unwrap(), 500),
+            // Post-Fulu, full nodes don't store blobs and return error 400 (Bad Request)
+            Err(e) => assert_eq!(e.status().unwrap(), 400),
         };
 
         self


### PR DESCRIPTION
## Issue Addressed

Closes #8569

## Proposed Changes

Updates the HTTP API error when the node cannot reconstruct blobs due to "Insufficient data columns".

Changes the response from 500 Internal Server Error to 400 Bad Request and adds a hint to run with --supernode or --semi-supernode.
