### PR TITLE
Gloas add off protocol payment field to bid

### DIFF
--- a/consensus/state_processing/src/upgrade/gloas.rs
+++ b/consensus/state_processing/src/upgrade/gloas.rs
@@ -70,7 +70,10 @@ pub fn upgrade_state_to_gloas<E: EthSpec>(
         current_sync_committee: pre.current_sync_committee.clone(),
         next_sync_committee: pre.next_sync_committee.clone(),
         // Execution Bid
-        latest_execution_payload_bid: ExecutionPayloadBid::default(),
+        latest_execution_payload_bid: ExecutionPayloadBid {
+            block_hash: pre.latest_execution_payload_header.block_hash,
+            ..Default::default()
+        },
         // Capella
         next_withdrawal_index: pre.next_withdrawal_index,
         next_withdrawal_validator_index: pre.next_withdrawal_validator_index,

--- a/consensus/types/src/execution/execution_payload_bid.rs
+++ b/consensus/types/src/execution/execution_payload_bid.rs
@@ -27,6 +27,8 @@ pub struct ExecutionPayloadBid {
     pub slot: Slot,
     #[serde(with = "serde_utils::quoted_u64")]
     pub value: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub execution_payment: u64,
     pub blob_kzg_commitments_root: Hash256,
 }
 

--- a/consensus/types/src/execution/execution_payload_bid.rs
+++ b/consensus/types/src/execution/execution_payload_bid.rs
@@ -18,6 +18,7 @@ pub struct ExecutionPayloadBid {
     pub parent_block_hash: ExecutionBlockHash,
     pub parent_block_root: Hash256,
     pub block_hash: ExecutionBlockHash,
+    pub prev_randao: Hash256,
     #[serde(with = "serde_utils::address_hex")]
     pub fee_recipient: Address,
     #[serde(with = "serde_utils::quoted_u64")]


### PR DESCRIPTION
## Changes
Super small PR to add off protocol payments field to `ExecutionPayloadBid` per spec [PR](https://github.com/ethereum/consensus-specs/pull/4733)

Reasoning for now field discussed in [discord](https://discord.com/channels/595666850260713488/874767108809031740/1428427871310975107). TLDR is that adding the off protocol payment field in protocol enables verifying that the off protocol builder actually pays the proposer

Additionally, we add the `prev_randao` field to `ExecutionPayloadBid` per spec [PR](https://github.com/ethereum/consensus-specs/pull/4728)

Additionally, we set the `latest_execution_payload_bid`'s `block_hash` field to `latest_execution_payload_header.block_hash` during `upgrade_state_to_gloas` per spec [PR](https://github.com/ethereum/consensus-specs/pull/4739)

@ethDreamer
@eserilev

Note that these are the same commits from PR  https://github.com/sigp/lighthouse/pull/8466, which was closed since the PR was pointing at `gloas-containers`, which has now been merged to `unstable`