### PR TITLE
Tweak a log message for mock-el

### DIFF
--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -754,7 +754,7 @@ pub fn serve<E: EthSpec>(
 
     info!(
         listen_address = listening_socket.to_string(),
-        "Metrics HTTP server started"
+        "Mock Execution Client started"
     );
 
     Ok((listening_socket, server))

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -754,7 +754,7 @@ pub fn serve<E: EthSpec>(
 
     info!(
         listen_address = listening_socket.to_string(),
-        "Mock Execution Client started"
+        "Mock execution client started"
     );
 
     Ok((listening_socket, server))


### PR DESCRIPTION
Apologies for the small PR, this only tweaks a log message. 😅 

## Issue Addressed

```bash
$ lcli mock-el ....
...
...
Dec 15 11:52:06.002 INFO  Metrics HTTP server started                   listen_address: "127.0.0.1:8551"
...
```

The log message "Metrics HTTP server" was misleading, as the server is actually a Mock Execution Client that provides a JSON-RPC API for testing purposes, not a metrics server.

<!--
Which issue # does this PR address?

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->