### PR TITLE
Fix flaky test_same_subnet_unsubscription()

### DIFF
--- a/beacon_node/network/src/subnet_service/mod.rs
+++ b/beacon_node/network/src/subnet_service/mod.rs
@@ -198,13 +198,6 @@ impl<T: BeaconChainTypes> SubnetService<T> {
         self.permanent_attestation_subscriptions.iter()
     }
 
-    /// Returns whether we are subscribed to a subnet for testing purposes.
-    #[cfg(test)]
-    pub(crate) fn is_subscribed(&self, subnet: &Subnet) -> bool {
-        self.subscriptions.contains_key(subnet)
-            || self.permanent_attestation_subscriptions.contains(subnet)
-    }
-
     /// Returns whether we are subscribed to a permanent subnet for testing purposes.
     #[cfg(test)]
     pub(crate) fn is_subscribed_permanent(&self, subnet: &Subnet) -> bool {

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -338,7 +338,7 @@ mod test {
         // Unsubscription event should happen at slot 2 (since subnet id's are the same, unsubscription event should be at higher slot + 1)
         let expected = SubnetServiceMessage::Subscribe(Subnet::Attestation(subnet_id1));
 
-        if subnet_service.is_subscribed(&Subnet::Attestation(subnet_id1)) {
+        if subnet_service.is_subscribed_permanent(&Subnet::Attestation(subnet_id1)) {
             // If we are permanently subscribed to this subnet, we won't see a subscribe message
             let _ = get_events_until_num_slots(&mut subnet_service, None, 1).await;
         } else {

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -356,6 +356,9 @@ mod test {
             assert_eq!([expected], unsubscribe_event[..]);
         }
 
+        // Ensure the subscription has been fully removed
+        let _ = get_events_until_num_slots(&mut subnet_service, None, 0).await;
+
         // Should  no longer be subscribed to any short lived subnets after unsubscription.
         assert_eq!(subnet_service.subscriptions().count(), 0);
     }

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -335,31 +335,27 @@ mod test {
         // submit the subscriptions
         subnet_service.validator_subscriptions(vec![sub1, sub2].into_iter());
 
-        // Unsubscription event should happen at slot 2 (since subnet id's are the same, unsubscription event should be at higher slot + 1)
-        let expected = SubnetServiceMessage::Subscribe(Subnet::Attestation(subnet_id1));
+        let subnet = Subnet::Attestation(subnet_id1);
 
-        if subnet_service.is_subscribed_permanent(&Subnet::Attestation(subnet_id1)) {
-            // If we are permanently subscribed to this subnet, we won't see a subscribe message
-            let _ = get_events_until_num_slots(&mut subnet_service, None, 1).await;
+        // If permanently subscribed, no Subscribe/Unsubscribe events will be generated
+        if subnet_service.is_subscribed_permanent(&subnet) {
+            let _ = get_events_until_num_slots(&mut subnet_service, None, 3).await;
         } else {
-            let subscription = get_events_until_num_slots(&mut subnet_service, None, 1).await;
-            assert_eq!(subscription, [expected]);
+            // Wait for exactly 2 events (Subscribe + Unsubscribe) with a generous timeout
+            let expected = [
+                SubnetServiceMessage::Subscribe(subnet),
+                SubnetServiceMessage::Unsubscribe(subnet),
+            ];
+            let events = get_events_until_num_slots(
+                &mut subnet_service,
+                Some(2),
+                (MainnetEthSpec::slots_per_epoch()) as u32,
+            )
+            .await;
+            assert_eq!(events, expected);
         }
 
-        // Get event for 1 more slot duration, we should get the unsubscribe event now.
-        let unsubscribe_event = get_events_until_num_slots(&mut subnet_service, None, 1).await;
-
-        // If the long lived and short lived subnets are different, we should get an unsubscription
-        // event.
-        let expected = SubnetServiceMessage::Unsubscribe(Subnet::Attestation(subnet_id1));
-        if !subnet_service.is_subscribed(&Subnet::Attestation(subnet_id1)) {
-            assert_eq!([expected], unsubscribe_event[..]);
-        }
-
-        // Ensure the subscription has been fully removed
-        let _ = get_events_until_num_slots(&mut subnet_service, None, 0).await;
-
-        // Should  no longer be subscribed to any short lived subnets after unsubscription.
+        // Should no longer be subscribed to any short lived subnets after unsubscription.
         assert_eq!(subnet_service.subscriptions().count(), 0);
     }
 


### PR DESCRIPTION
## Issue Addressed
#7573 
```bash
thread 'subnet_service::tests::test::test_same_subnet_unsubscription' (1640572) panicked at beacon_node/network/src/subnet_service/tests/mod.rs:356:13:
assertion `left == right` failed
  left: [Unsubscribe(Attestation(SubnetId(3)))]
 right: []
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Why
the race condition seems due to the usage of `is_subscribed()` instead of `is_subscribed_permanent()`, which was not following the comment's desired behaviour since `is_subscribed()` considers both permanent and temporary subscriptions.

```rust
// If we are permanently subscribed to this subnet, we won't see a subscribe message
```

so, previously, we could be taking the `if` branch for a temporary subscription
```rust
        if subnet_service.is_subscribed(&Subnet::Attestation(subnet_id1)) {
            // If we are permanently subscribed to this subnet, we won't see a subscribe message
            let _ = get_events_until_num_slots(&mut subnet_service, None, 1).await;
```
discarding `Subscribe` and potentially `Unsubscribe` events; thus, when reaching

```rust
        // Get event for 1 more slot duration, we should get the unsubscribe event now.
        let unsubscribe_event = get_events_until_num_slots(&mut subnet_service, None, 1).await;
```

the expected `Unsubscribe` could have been discarded already, resulting in [].

## Fix
refactored the test to use a more deterministic approach following the other tests and removed `is_subscribed()` since we take the same route by checking `is_subscribed_permanent()` first

## Results
```bash
Run #2000
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.77s
warning: the following packages contain code that will be rejected by a future version of Rust: num-bigint-dig v0.8.4
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running unittests src/lib.rs (target/debug/deps/network-ecf0aa6b04bd6e2d)

running 1 test
test subnet_service::tests::test::test_same_subnet_unsubscription ... ok

successes:

successes:
    subnet_service::tests::test::test_same_subnet_unsubscription

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 71 filtered out; finished in 6.11s
```

