### PR TITLE
Revised log when all validators have exited

### DIFF
--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -11,6 +11,7 @@ use crate::sync::SyncDutiesMap;
 use crate::sync::poll_sync_committee_duties;
 use beacon_node_fallback::{ApiTopic, BeaconNodeFallback};
 use bls::PublicKeyBytes;
+use eth2::types::ValidatorStatus::{ExitedSlashed, ExitedUnslashed};
 use eth2::types::{
     AttesterData, BeaconCommitteeSelection, BeaconCommitteeSubscription, DutiesResponse,
     ProposerData, StateId, ValidatorId,
@@ -394,6 +395,7 @@ impl<S, T> DutiesServiceBuilder<S, T> {
             enable_high_validator_count_metrics: self.enable_high_validator_count_metrics,
             selection_proof_config: self.attestation_selection_proof_config,
             disable_attesting: self.disable_attesting,
+            exited_validators: Default::default(),
         })
     }
 }
@@ -424,6 +426,7 @@ pub struct DutiesService<S, T> {
     /// Pass the config for distributed or non-distributed mode.
     pub selection_proof_config: SelectionProofConfig,
     pub disable_attesting: bool,
+    pub exited_validators: RwLock<HashSet<PublicKeyBytes>>,
 }
 
 impl<S: ValidatorStore, T: SlotClock + 'static> DutiesService<S, T> {
@@ -526,6 +529,10 @@ impl<S: ValidatorStore, T: SlotClock + 'static> DutiesService<S, T> {
     pub fn per_validator_metrics(&self) -> bool {
         self.enable_high_validator_count_metrics
             || self.total_validator_count() <= VALIDATOR_METRICS_MIN_COUNT
+    }
+
+    pub fn exited_count(&self) -> usize {
+        self.exited_validators.read().len()
     }
 }
 
@@ -743,6 +750,11 @@ async fn poll_validator_indices<S: ValidatorStore, T: SlotClock + 'static>(
                         .unknown_validator_next_poll_slots
                         .write()
                         .remove(&pubkey);
+
+                    let validator_status = response.data.status;
+                    if validator_status == ExitedUnslashed || validator_status == ExitedSlashed {
+                        duties_service.exited_validators.write().insert(pubkey);
+                    }
                 }
                 // This is not necessarily an error, it just means the validator is not yet known to
                 // the beacon chain.

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -11,7 +11,6 @@ use crate::sync::SyncDutiesMap;
 use crate::sync::poll_sync_committee_duties;
 use beacon_node_fallback::{ApiTopic, BeaconNodeFallback};
 use bls::PublicKeyBytes;
-use eth2::types::ValidatorStatus::{ExitedSlashed, ExitedUnslashed};
 use eth2::types::{
     AttesterData, BeaconCommitteeSelection, BeaconCommitteeSubscription, DutiesResponse,
     ProposerData, StateId, ValidatorId,
@@ -395,7 +394,6 @@ impl<S, T> DutiesServiceBuilder<S, T> {
             enable_high_validator_count_metrics: self.enable_high_validator_count_metrics,
             selection_proof_config: self.attestation_selection_proof_config,
             disable_attesting: self.disable_attesting,
-            exited_validators: Default::default(),
         })
     }
 }
@@ -426,7 +424,6 @@ pub struct DutiesService<S, T> {
     /// Pass the config for distributed or non-distributed mode.
     pub selection_proof_config: SelectionProofConfig,
     pub disable_attesting: bool,
-    pub exited_validators: RwLock<HashSet<PublicKeyBytes>>,
 }
 
 impl<S: ValidatorStore, T: SlotClock + 'static> DutiesService<S, T> {
@@ -529,10 +526,6 @@ impl<S: ValidatorStore, T: SlotClock + 'static> DutiesService<S, T> {
     pub fn per_validator_metrics(&self) -> bool {
         self.enable_high_validator_count_metrics
             || self.total_validator_count() <= VALIDATOR_METRICS_MIN_COUNT
-    }
-
-    pub fn exited_count(&self) -> usize {
-        self.exited_validators.read().len()
     }
 }
 
@@ -750,11 +743,6 @@ async fn poll_validator_indices<S: ValidatorStore, T: SlotClock + 'static>(
                         .unknown_validator_next_poll_slots
                         .write()
                         .remove(&pubkey);
-
-                    let validator_status = response.data.status;
-                    if validator_status == ExitedUnslashed || validator_status == ExitedSlashed {
-                        duties_service.exited_validators.write().insert(pubkey);
-                    }
                 }
                 // This is not necessarily an error, it just means the validator is not yet known to
                 // the beacon chain.

--- a/validator_client/validator_services/src/notifier_service.rs
+++ b/validator_client/validator_services/src/notifier_service.rs
@@ -146,7 +146,7 @@ pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
                 validators = total_validators,
                 %epoch,
                 %slot,
-                "Awaiting activation"
+                "All validators inactive"
             );
         }
     } else {

--- a/validator_client/validator_services/src/notifier_service.rs
+++ b/validator_client/validator_services/src/notifier_service.rs
@@ -165,9 +165,7 @@ pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
 
                 match validator_data {
                     Ok(Some(response)) => validator_status.push(response.data.status),
-                    Ok(None) => {
-                        error!("Validator not found in beacon chain")
-                    }
+                    Ok(None) => {}
                     Err(e) => {
                         error!(%e, "Error checking if validator exists in beacon chain");
                     }
@@ -175,9 +173,10 @@ pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
             }
 
             // Log a different log if all validators have exited
-            if validator_status
-                .iter()
-                .all(|status| *status == ExitedUnslashed || *status == ExitedSlashed)
+            if !validator_status.is_empty()
+                && validator_status
+                    .iter()
+                    .all(|status| *status == ExitedUnslashed || *status == ExitedSlashed)
             {
                 info!(
                     validators = total_validators,

--- a/validator_client/validator_services/src/notifier_service.rs
+++ b/validator_client/validator_services/src/notifier_service.rs
@@ -1,7 +1,4 @@
 use crate::duties_service::DutiesService;
-use bls::PublicKeyBytes;
-use eth2::types::ValidatorStatus::{ExitedSlashed, ExitedUnslashed};
-use eth2::types::{StateId, ValidatorId};
 use slot_clock::SlotClock;
 use std::sync::Arc;
 use task_executor::TaskExecutor;
@@ -9,7 +6,7 @@ use tokio::time::{Duration, sleep};
 use tracing::{debug, error, info};
 use types::{ChainSpec, EthSpec};
 use validator_metrics::set_gauge;
-use validator_store::{DoppelgangerStatus, ValidatorStore};
+use validator_store::ValidatorStore;
 
 /// Spawns a notifier service which periodically logs information about the node.
 pub fn spawn_notifier<S: ValidatorStore + 'static, T: SlotClock + 'static>(
@@ -121,6 +118,8 @@ pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
             )
         }
 
+        let exited_validators = duties_service.exited_count();
+
         if total_validators == 0 {
             info!(
                 msg = "see `lighthouse vm create --help` or the HTTP API documentation",
@@ -138,48 +137,18 @@ pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
         } else if attesting_validators > 0 {
             info!(
                 current_epoch_proposers = proposing_validators,
-                active_validators = attesting_validators,
                 total_validators = total_validators,
+                active = attesting_validators,
+                exited = exited_validators,
                 %epoch,
                 %slot,
                 "Some validators active"
             );
         } else {
-            let pubkeys: Vec<PublicKeyBytes> = duties_service
-                .validator_store
-                .voting_pubkeys(DoppelgangerStatus::ignored);
-
-            let mut validator_status = Vec::new();
-            for pubkey in pubkeys {
-                let validator_data = duties_service
-                    .beacon_nodes
-                    .first_success(|beacon_node| async move {
-                        beacon_node
-                            .get_beacon_states_validator_id(
-                                StateId::Head,
-                                &ValidatorId::PublicKey(pubkey),
-                            )
-                            .await
-                    })
-                    .await;
-
-                match validator_data {
-                    Ok(Some(response)) => validator_status.push(response.data.status),
-                    Ok(None) => {}
-                    Err(e) => {
-                        error!(%e, "Error checking if validator exists in beacon chain");
-                    }
-                }
-            }
-
             // Log a different log if all validators have exited
-            if !validator_status.is_empty()
-                && validator_status
-                    .iter()
-                    .all(|status| *status == ExitedUnslashed || *status == ExitedSlashed)
-            {
+            if exited_validators == total_validators {
                 info!(
-                    validators = total_validators,
+                    exited_validators = total_validators,
                     %epoch,
                     %slot,
                     "All validators have exited")

--- a/validator_client/validator_services/src/notifier_service.rs
+++ b/validator_client/validator_services/src/notifier_service.rs
@@ -1,4 +1,7 @@
 use crate::duties_service::DutiesService;
+use bls::PublicKeyBytes;
+use eth2::types::ValidatorStatus::{ExitedSlashed, ExitedUnslashed};
+use eth2::types::{StateId, ValidatorId};
 use slot_clock::SlotClock;
 use std::sync::Arc;
 use task_executor::TaskExecutor;
@@ -6,7 +9,7 @@ use tokio::time::{Duration, sleep};
 use tracing::{debug, error, info};
 use types::{ChainSpec, EthSpec};
 use validator_metrics::set_gauge;
-use validator_store::ValidatorStore;
+use validator_store::{DoppelgangerStatus, ValidatorStore};
 
 /// Spawns a notifier service which periodically logs information about the node.
 pub fn spawn_notifier<S: ValidatorStore + 'static, T: SlotClock + 'static>(
@@ -142,12 +145,53 @@ pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
                 "Some validators active"
             );
         } else {
-            info!(
-                validators = total_validators,
-                %epoch,
-                %slot,
-                "Awaiting activation"
-            );
+            let pubkeys: Vec<PublicKeyBytes> = duties_service
+                .validator_store
+                .voting_pubkeys(DoppelgangerStatus::ignored);
+
+            let mut validator_status = Vec::new();
+            for pubkey in pubkeys {
+                let validator_data = duties_service
+                    .beacon_nodes
+                    .first_success(|beacon_node| async move {
+                        beacon_node
+                            .get_beacon_states_validator_id(
+                                StateId::Head,
+                                &ValidatorId::PublicKey(pubkey),
+                            )
+                            .await
+                    })
+                    .await;
+
+                match validator_data {
+                    Ok(Some(response)) => validator_status.push(response.data.status),
+                    Ok(None) => {
+                        error!("Validator not found in beacon chain")
+                    }
+                    Err(e) => {
+                        error!(%e, "Error checking if validator exists in beacon chain");
+                    }
+                }
+            }
+
+            // Log a different log if all validators have exited
+            if validator_status
+                .iter()
+                .all(|status| *status == ExitedUnslashed || *status == ExitedSlashed)
+            {
+                info!(
+                    validators = total_validators,
+                    %epoch,
+                    %slot,
+                    "All validators have exited")
+            } else {
+                info!(
+                    validators = total_validators,
+                    %epoch,
+                    %slot,
+                    "Awaiting activation"
+                );
+            }
         }
     } else {
         error!("Unable to read slot clock");

--- a/validator_client/validator_services/src/notifier_service.rs
+++ b/validator_client/validator_services/src/notifier_service.rs
@@ -118,8 +118,6 @@ pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
             )
         }
 
-        let exited_validators = duties_service.exited_count();
-
         if total_validators == 0 {
             info!(
                 msg = "see `lighthouse vm create --help` or the HTTP API documentation",
@@ -137,29 +135,19 @@ pub async fn notify<S: ValidatorStore, T: SlotClock + 'static>(
         } else if attesting_validators > 0 {
             info!(
                 current_epoch_proposers = proposing_validators,
+                active_validators = attesting_validators,
                 total_validators = total_validators,
-                active = attesting_validators,
-                exited = exited_validators,
                 %epoch,
                 %slot,
                 "Some validators active"
             );
         } else {
-            // Log a different log if all validators have exited
-            if exited_validators == total_validators {
-                info!(
-                    exited_validators = total_validators,
-                    %epoch,
-                    %slot,
-                    "All validators have exited")
-            } else {
-                info!(
-                    validators = total_validators,
-                    %epoch,
-                    %slot,
-                    "Awaiting activation"
-                );
-            }
+            info!(
+                validators = total_validators,
+                %epoch,
+                %slot,
+                "Awaiting activation"
+            );
         }
     } else {
         error!("Unable to read slot clock");


### PR DESCRIPTION
Lighthouse VC logs `Awaiting activation` as long as no validators are active. This includes the case of validators pending activation or all validators have exited the beacon chain. This log is confusing in the latter case when all validators have exited (reported a few times on Discord).

This PR checks the validator status when no validators are active, and logs a different one.

Not sure if there is a cleaner way to do this? I am open to suggestions

Edit: resolve to tweaking the log, see comment below