### PR TITLE
Remove Windows in the documentation

### DIFF
--- a/book/src/advanced_networking.md
+++ b/book/src/advanced_networking.md
@@ -69,7 +69,6 @@ The steps to do port forwarding depends on the router, but the general steps are
 
     - On Linux: open a terminal and run `ip route | grep default`, the result should look something similar to `default via 192.168.50.1 dev wlp2s0 proto dhcp metric 600`. The `192.168.50.1` is your router management default gateway IP.
     - On macOS: open a terminal and run `netstat -nr|grep default` and it should return the default gateway IP.
-    - On Windows: open a command prompt and run `ipconfig` and look for the `Default Gateway` which will show you the gateway IP.
 
     The default gateway IP usually looks like 192.168.X.X. Once you obtain the IP, enter it to a web browser and it will lead you to the router management page.
 

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -4,7 +4,6 @@ Lighthouse runs on Linux, macOS, and Windows*.
 
 > \* Lighthouse does not officially support Windows platform. However, Lighthouse can still run natively on Windows until it does not at some point in the future. Windows users may also switch to using Docker, Windows Subsystem for Linux or other supported operating systems.
 
-
 There are three core methods to obtain the Lighthouse application:
 
 - [Pre-built binaries](./installation_binaries.md).

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -1,6 +1,9 @@
 # 📦 Installation
 
-Lighthouse runs on Linux, macOS, and Windows.
+Lighthouse runs on Linux, macOS, and Windows*.
+
+> \* Lighthouse does not officially support Windows platform. However, Lighthouse can still run natively on Windows until it does not at some point in the future. Windows users may also switch to using Docker, Windows Subsystem for Linux or other supported operating systems.
+
 
 There are three core methods to obtain the Lighthouse application:
 

--- a/book/src/installation_binaries.md
+++ b/book/src/installation_binaries.md
@@ -11,7 +11,6 @@ Binaries are supplied for the following platforms:
 - `x86_64-unknown-linux-gnu`: AMD/Intel 64-bit processors (most desktops, laptops, servers)
 - `aarch64-unknown-linux-gnu`: 64-bit ARM processors (Raspberry Pi 4)
 - `aarch64-apple-darwin`: macOS with ARM chips
-- `x86_64-windows`: Windows with 64-bit processors
 
 ## Usage
 
@@ -32,5 +31,3 @@ a `x86_64` binary.
 
 1. Test the binary with `./lighthouse --version` (it should print the version).
 1. (Optional) Move the `lighthouse` binary to a location in your `PATH`, so the `lighthouse` command can be called from anywhere. For example, to copy `lighthouse` from the current directory to `usr/bin`, run `sudo cp lighthouse /usr/bin`.
-
-> Windows users will need to execute the commands in Step 2 from PowerShell.

--- a/book/src/installation_source.md
+++ b/book/src/installation_source.md
@@ -69,6 +69,8 @@ After this, you are ready to [build Lighthouse](#build-lighthouse).
 
 ### Windows
 
+> Note: Lighthouse no longer officially supports Windows binary. However, users will still be able to build the binary from source according to the instructions below. The instructions may no longer work at some point in the future.
+
 1. Install [Git](https://git-scm.com/download/win).
 1. Install the [Chocolatey](https://chocolatey.org/install) package manager for Windows.
     > Tips:

--- a/book/src/validator_doppelganger.md
+++ b/book/src/validator_doppelganger.md
@@ -106,7 +106,6 @@ The steps to solving a doppelganger vary depending on the case, but some places 
 
 1. Is there another validator process running on this host?
     - Unix users can check by running the command `ps aux | grep lighthouse`
-    - Windows users can check the Task Manager.
 1. Has this validator recently been moved from another host? Check to ensure it's not running.
 1. Has this validator been delegated to a staking service?
 


### PR DESCRIPTION
Remove most of the mention of `Windows` OS where unnecessary, and added a note about Windows build from source