### PR TITLE
chore(validator_client): Read genesis time and genesis validators root from eth2_network_config

### DIFF
--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -33,6 +33,8 @@ const HOLESKY_GENESIS_STATE_SOURCE: GenesisStateSource = GenesisStateSource::Url
     checksum: "0xd750639607c337bbb192b15c27f447732267bf72d1650180a0e44c2d93a80741",
     genesis_validators_root: "0x9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1",
     genesis_state_root: "0x0ea3f6f9515823b59c863454675fefcd1d8b4f2dbe454db166206a41fda060a0",
+    // ref: https://github.com/eth-clients/holesky/blob/main/README.md - Launch Epoch time
+    genesis_time: 1695902400,
 };
 
 const HOODI_GENESIS_STATE_SOURCE: GenesisStateSource = GenesisStateSource::Url {
@@ -44,6 +46,8 @@ const HOODI_GENESIS_STATE_SOURCE: GenesisStateSource = GenesisStateSource::Url {
     checksum: "0x7f42257ef69e055496c964a753bb07e54001ccd57ab467ef72d67af086bcfce7",
     genesis_validators_root: "0x212f13fc4df078b6cb7db228f1c8307566dcecf900867401a92023d7ba99cb5f",
     genesis_state_root: "0x2683ebc120f91f740c7bed4c866672d01e1ba51b4cc360297138465ee5df40f0",
+    // ref: https://github.com/eth-clients/hoodi/blob/main/README.md - Launch Epoch time
+    genesis_time: 1742213400,
 };
 
 const CHIADO_GENESIS_STATE_SOURCE: GenesisStateSource = GenesisStateSource::Url {
@@ -52,6 +56,8 @@ const CHIADO_GENESIS_STATE_SOURCE: GenesisStateSource = GenesisStateSource::Url 
     checksum: "0xd4a039454c7429f1dfaa7e11e397ef3d0f50d2d5e4c0e4dc04919d153aa13af1",
     genesis_validators_root: "0x9d642dac73058fbf39c0ae41ab1e34e4d889043cb199851ded7095bc99eb4c1e",
     genesis_state_root: "0xa48419160f8f146ecaa53d12a5d6e1e6af414a328afdc56b60d5002bb472a077",
+    // ref: https://github.com/gnosischain/configs/blob/main/chiado/genesis.ssz
+    genesis_time: 1665396300,
 };
 
 /// The core configuration of a Lighthouse beacon node.
@@ -117,6 +123,10 @@ pub enum GenesisStateSource {
         ///
         /// The format should be 0x-prefixed ASCII bytes.
         genesis_state_root: &'static str,
+        /// The genesis time.
+        ///
+        /// The format should be u64.
+        genesis_time: u64,
     },
 }
 

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -135,10 +135,9 @@ impl Eth2NetworkConfig {
 
     /// The `genesis_time` of the genesis time.
     pub fn genesis_time<E: EthSpec>(&self) -> Result<Option<u64>, String> {
-        Ok(
-            self.get_genesis_state_from_bytes::<E>()
-                .map(|state| Some(state.genesis_time()))?
-        )
+        Ok(self
+            .get_genesis_state_from_bytes::<E>()
+            .map(|state| Some(state.genesis_time()))?)
     }
 
     /// The `genesis_validators_root` of the genesis state.

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -135,9 +135,8 @@ impl Eth2NetworkConfig {
 
     /// The `genesis_time` of the genesis time.
     pub fn genesis_time<E: EthSpec>(&self) -> Result<Option<u64>, String> {
-        Ok(self
-            .get_genesis_state_from_bytes::<E>()
-            .map(|state| Some(state.genesis_time()))?)
+        self.get_genesis_state_from_bytes::<E>()
+            .map(|state| Some(state.genesis_time()))
     }
 
     /// The `genesis_validators_root` of the genesis state.

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -133,6 +133,14 @@ impl Eth2NetworkConfig {
         self.genesis_state_source != GenesisStateSource::Unknown
     }
 
+    /// The `genesis_time` of the genesis time.
+    pub fn genesis_time<E: EthSpec>(&self) -> Result<Option<u64>, String> {
+        Ok(
+            self.get_genesis_state_from_bytes::<E>()
+                .map(|state| Some(state.genesis_time()))?
+        )
+    }
+
     /// The `genesis_validators_root` of the genesis state.
     pub fn genesis_validators_root<E: EthSpec>(&self) -> Result<Option<Hash256>, String> {
         if let GenesisStateSource::Url {

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -135,8 +135,12 @@ impl Eth2NetworkConfig {
 
     /// The `genesis_time` of the genesis state.
     pub fn genesis_time<E: EthSpec>(&self) -> Result<Option<u64>, String> {
-        self.get_genesis_state_from_bytes::<E>()
-            .map(|state| Some(state.genesis_time()))
+        if let GenesisStateSource::Url { genesis_time, .. } = self.genesis_state_source {
+            Ok(Some(genesis_time))
+        } else {
+            self.get_genesis_state_from_bytes::<E>()
+                .map(|state| Some(state.genesis_time()))
+        }
     }
 
     /// The `genesis_validators_root` of the genesis state.

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -133,7 +133,7 @@ impl Eth2NetworkConfig {
         self.genesis_state_source != GenesisStateSource::Unknown
     }
 
-    /// The `genesis_time` of the genesis time.
+    /// The `genesis_time` of the genesis state.
     pub fn genesis_time<E: EthSpec>(&self) -> Result<Option<u64>, String> {
         self.get_genesis_state_from_bytes::<E>()
             .map(|state| Some(state.genesis_time()))

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -364,11 +364,22 @@ impl<E: EthSpec> ProductionValidatorClient<E> {
             context.eth2_config.spec.clone(),
         );
 
-        // Perform some potentially long-running initialization tasks.
-        let (genesis_time, genesis_validators_root) = tokio::select! {
-            tuple = init_from_beacon_node::<E>(&beacon_nodes, &proposer_nodes) => tuple?,
-            () = context.executor.exit() => return Err("Shutting down".to_string())
-        };
+        let (genesis_time, genesis_validators_root) =
+            if let Some(eth2_network_config) = context.eth2_network_config.as_ref() {
+                let time = eth2_network_config
+                    .genesis_time::<E>()?
+                    .ok_or("no genesis time")?;
+                let root = eth2_network_config
+                    .genesis_validators_root::<E>()?
+                    .ok_or("no genesis validators root")?;
+                (time, root)
+            } else {
+                // Perform some potentially long-running initialization tasks.
+                tokio::select! {
+                    tuple = init_from_beacon_node::<E>(&beacon_nodes, &proposer_nodes) => tuple?,
+                    () = context.executor.exit() => return Err("Shutting down".to_string()),
+                }
+            };
 
         // Update the metrics server.
         if let Some(ctx) = &validator_metrics_ctx {


### PR DESCRIPTION
## Issue Addressed

#5019 

## Proposed Changes

If there is a known eth2_network_config, we read the genesis time and validators root from the config.

## Other

@chong-he I made the code update, pretty much following [your comment](https://github.com/sigp/lighthouse/issues/5019#issuecomment-3708653511). Please take a look. Also, let me know if there is any protocol that I should follow when making PR to lighthouse repo. Thanks.