### PR TITLE
Remove `http-api` tests from nightly and run tests on `unstable` by default

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -6,6 +6,11 @@ on:
     # Run at 8:30 AM UTC every day
     - cron: '30 8 * * *'
   workflow_dispatch: # Allow manual triggering
+    inputs:
+      branch:
+        description: 'Branch to test'
+        required: false
+        default: 'unstable'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -47,6 +52,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{ inputs.branch || 'unstable' }}
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -55,28 +62,6 @@ jobs:
           bins: cargo-nextest
     - name: Run beacon_chain tests for ${{ matrix.fork }}
       run: make test-beacon-chain-${{ matrix.fork }}
-      timeout-minutes: 60
-
-  http-api-tests:
-    name: http-api-tests
-    needs: setup-matrix
-    runs-on: 'ubuntu-latest'
-    env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    strategy:
-      matrix:
-        fork: ${{ fromJson(needs.setup-matrix.outputs.forks) }}
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@v5
-    - name: Get latest version of stable Rust
-      uses: moonrepo/setup-rust@v1
-      with:
-          channel: stable
-          cache-target: release
-          bins: cargo-nextest
-    - name: Run http_api tests for ${{ matrix.fork }}
-      run: make test-http-api-${{ matrix.fork }}
       timeout-minutes: 60
 
   op-pool-tests:
@@ -91,6 +76,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{ inputs.branch || 'unstable' }}
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
@@ -113,6 +100,8 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{ inputs.branch || 'unstable' }}
     - name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:


### PR DESCRIPTION
`http-api` tests are failing for earlier forks, but I think we might be able to just remove them for  earlier forks in the nightly tests as they're no longer relevant.

https://github.com/sigp/lighthouse/actions/runs/20869883982/job/59969302898

I've also updated the workflow to run on `unstable` by default, and allow for override when the workflow is manually triggered.

This PR points to the `stable` branch, as GitHub actions only schedule workflows from the `stable` branch.
