### PR TITLE
Re-introduce clearer variable names in beacon processor work queue

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -921,13 +921,13 @@ impl<E: EthSpec> BeaconProcessor<E> {
                         // and BlocksByRoot)
                         } else if let Some(item) = work_queues.status_queue.pop() {
                             Some(item)
-                        } else if let Some(item) = work_queues.bbrange_queue.pop() {
+                        } else if let Some(item) = work_queues.block_brange_queue.pop() {
                             Some(item)
-                        } else if let Some(item) = work_queues.bbroots_queue.pop() {
+                        } else if let Some(item) = work_queues.block_broots_queue.pop() {
                             Some(item)
-                        } else if let Some(item) = work_queues.blbrange_queue.pop() {
+                        } else if let Some(item) = work_queues.blob_brange_queue.pop() {
                             Some(item)
-                        } else if let Some(item) = work_queues.blbroots_queue.pop() {
+                        } else if let Some(item) = work_queues.blob_broots_queue.pop() {
                             Some(item)
                         } else if let Some(item) = work_queues.dcbroots_queue.pop() {
                             Some(item)
@@ -1114,13 +1114,13 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             }
                             Work::Status { .. } => work_queues.status_queue.push(work, work_id),
                             Work::BlocksByRangeRequest { .. } => {
-                                work_queues.bbrange_queue.push(work, work_id)
+                                work_queues.block_brange_queue.push(work, work_id)
                             }
                             Work::BlocksByRootsRequest { .. } => {
-                                work_queues.bbroots_queue.push(work, work_id)
+                                work_queues.block_broots_queue.push(work, work_id)
                             }
                             Work::BlobsByRangeRequest { .. } => {
-                                work_queues.blbrange_queue.push(work, work_id)
+                                work_queues.blob_brange_queue.push(work, work_id)
                             }
                             Work::LightClientBootstrapRequest { .. } => {
                                 work_queues.lc_bootstrap_queue.push(work, work_id)
@@ -1144,7 +1144,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
                                 .gossip_bls_to_execution_change_queue
                                 .push(work, work_id),
                             Work::BlobsByRootsRequest { .. } => {
-                                work_queues.blbroots_queue.push(work, work_id)
+                                work_queues.blob_broots_queue.push(work, work_id)
                             }
                             Work::DataColumnsByRootsRequest { .. } => {
                                 work_queues.dcbroots_queue.push(work, work_id)
@@ -1220,10 +1220,10 @@ impl<E: EthSpec> BeaconProcessor<E> {
                         WorkType::ChainSegment => work_queues.chain_segment_queue.len(),
                         WorkType::ChainSegmentBackfill => work_queues.backfill_chain_segment.len(),
                         WorkType::Status => work_queues.status_queue.len(),
-                        WorkType::BlocksByRangeRequest => work_queues.blbrange_queue.len(),
-                        WorkType::BlocksByRootsRequest => work_queues.blbroots_queue.len(),
-                        WorkType::BlobsByRangeRequest => work_queues.bbrange_queue.len(),
-                        WorkType::BlobsByRootsRequest => work_queues.bbroots_queue.len(),
+                        WorkType::BlocksByRangeRequest => work_queues.block_brange_queue.len(),
+                        WorkType::BlocksByRootsRequest => work_queues.block_broots_queue.len(),
+                        WorkType::BlobsByRangeRequest => work_queues.blob_brange_queue.len(),
+                        WorkType::BlobsByRootsRequest => work_queues.blob_broots_queue.len(),
                         WorkType::DataColumnsByRootsRequest => work_queues.dcbroots_queue.len(),
                         WorkType::DataColumnsByRangeRequest => work_queues.dcbrange_queue.len(),
                         WorkType::GossipBlsToExecutionChange => {

--- a/beacon_node/beacon_processor/src/scheduler/work_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_queue.rs
@@ -128,10 +128,10 @@ pub struct BeaconProcessorQueueLengths {
     gossip_data_column_queue: usize,
     delayed_block_queue: usize,
     status_queue: usize,
-    bbrange_queue: usize,
-    bbroots_queue: usize,
-    blbroots_queue: usize,
-    blbrange_queue: usize,
+    block_brange_queue: usize,
+    block_broots_queue: usize,
+    blob_broots_queue: usize,
+    blob_brange_queue: usize,
     dcbroots_queue: usize,
     dcbrange_queue: usize,
     gossip_bls_to_execution_change_queue: usize,
@@ -194,10 +194,10 @@ impl BeaconProcessorQueueLengths {
             gossip_data_column_queue: 1024,
             delayed_block_queue: 1024,
             status_queue: 1024,
-            bbrange_queue: 1024,
-            bbroots_queue: 1024,
-            blbroots_queue: 1024,
-            blbrange_queue: 1024,
+            block_brange_queue: 1024,
+            block_broots_queue: 1024,
+            blob_broots_queue: 1024,
+            blob_brange_queue: 1024,
             dcbroots_queue: 1024,
             dcbrange_queue: 1024,
             gossip_bls_to_execution_change_queue: 16384,
@@ -238,10 +238,10 @@ pub struct WorkQueues<E: EthSpec> {
     pub gossip_data_column_queue: FifoQueue<Work<E>>,
     pub delayed_block_queue: FifoQueue<Work<E>>,
     pub status_queue: FifoQueue<Work<E>>,
-    pub bbrange_queue: FifoQueue<Work<E>>,
-    pub bbroots_queue: FifoQueue<Work<E>>,
-    pub blbroots_queue: FifoQueue<Work<E>>,
-    pub blbrange_queue: FifoQueue<Work<E>>,
+    pub block_brange_queue: FifoQueue<Work<E>>,
+    pub block_broots_queue: FifoQueue<Work<E>>,
+    pub blob_broots_queue: FifoQueue<Work<E>>,
+    pub blob_brange_queue: FifoQueue<Work<E>>,
     pub dcbroots_queue: FifoQueue<Work<E>>,
     pub dcbrange_queue: FifoQueue<Work<E>>,
     pub gossip_bls_to_execution_change_queue: FifoQueue<Work<E>>,
@@ -300,10 +300,10 @@ impl<E: EthSpec> WorkQueues<E> {
         let delayed_block_queue = FifoQueue::new(queue_lengths.delayed_block_queue);
 
         let status_queue = FifoQueue::new(queue_lengths.status_queue);
-        let bbrange_queue = FifoQueue::new(queue_lengths.bbrange_queue);
-        let bbroots_queue = FifoQueue::new(queue_lengths.bbroots_queue);
-        let blbroots_queue = FifoQueue::new(queue_lengths.blbroots_queue);
-        let blbrange_queue = FifoQueue::new(queue_lengths.blbrange_queue);
+        let block_brange_queue = FifoQueue::new(queue_lengths.block_brange_queue);
+        let block_broots_queue = FifoQueue::new(queue_lengths.block_broots_queue);
+        let blob_broots_queue = FifoQueue::new(queue_lengths.blob_broots_queue);
+        let blob_brange_queue = FifoQueue::new(queue_lengths.blob_brange_queue);
         let dcbroots_queue = FifoQueue::new(queue_lengths.dcbroots_queue);
         let dcbrange_queue = FifoQueue::new(queue_lengths.dcbrange_queue);
 
@@ -350,10 +350,10 @@ impl<E: EthSpec> WorkQueues<E> {
             gossip_data_column_queue,
             delayed_block_queue,
             status_queue,
-            bbrange_queue,
-            bbroots_queue,
-            blbroots_queue,
-            blbrange_queue,
+            block_brange_queue,
+            block_broots_queue,
+            blob_broots_queue,
+            blob_brange_queue,
             dcbroots_queue,
             dcbrange_queue,
             gossip_bls_to_execution_change_queue,


### PR DESCRIPTION
## Issue Addressed

#8648

