### PR TITLE
Remove remaining facade module re-exports from `consensus/types`

### DIFF
--- a/beacon_node/beacon_chain/benches/benches.rs
+++ b/beacon_node/beacon_chain/benches/benches.rs
@@ -8,7 +8,7 @@ use bls::Signature;
 use kzg::{KzgCommitment, KzgProof};
 use types::{
     BeaconBlock, BeaconBlockFulu, Blob, BlobsList, ChainSpec, EmptyBlock, EthSpec, KzgProofs,
-    MainnetEthSpec, SignedBeaconBlock, beacon_block_body::KzgCommitments,
+    MainnetEthSpec, SignedBeaconBlock, kzg_ext::KzgCommitments,
 };
 
 fn create_test_block_and_blobs<E: EthSpec>(

--- a/beacon_node/beacon_chain/src/beacon_proposer_cache.rs
+++ b/beacon_node/beacon_chain/src/beacon_proposer_cache.rs
@@ -19,7 +19,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tracing::instrument;
 use typenum::Unsigned;
-use types::non_zero_usize::new_non_zero_usize;
+use types::new_non_zero_usize;
 use types::{BeaconState, BeaconStateError, ChainSpec, Epoch, EthSpec, Fork, Hash256, Slot};
 
 /// The number of sets of proposer indices that should be cached.

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -39,7 +39,7 @@ use crate::metrics::{
 };
 use crate::observed_data_sidecars::ObservationStrategy;
 pub use error::{Error as AvailabilityCheckError, ErrorCategory as AvailabilityCheckErrorCategory};
-use types::non_zero_usize::new_non_zero_usize;
+use types::new_non_zero_usize;
 
 /// The LRU Cache stores `PendingComponents`, which store block and its associated blob data:
 ///

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -17,8 +17,8 @@ use std::cmp::Ordering;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tracing::{Span, debug, debug_span};
-use types::beacon_block_body::KzgCommitments;
 use types::data::BlobIdentifier;
+use types::kzg_ext::KzgCommitments;
 use types::{
     BlobSidecar, BlockImportSource, ChainSpec, ColumnIndex, DataColumnSidecar,
     DataColumnSidecarList, Epoch, EthSpec, Hash256, SignedBeaconBlock,
@@ -839,7 +839,7 @@ mod test {
     use store::{HotColdDB, ItemStore, StoreConfig, database::interface::BeaconNodeBackend};
     use tempfile::{TempDir, tempdir};
     use tracing::{debug_span, info};
-    use types::non_zero_usize::new_non_zero_usize;
+    use types::new_non_zero_usize;
     use types::{ExecPayload, MinimalEthSpec};
 
     const LOW_VALIDATOR_COUNT: usize = 32;

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -6,8 +6,8 @@ use rayon::prelude::*;
 use ssz_types::{FixedVector, VariableList};
 use std::sync::Arc;
 use tracing::instrument;
-use types::beacon_block_body::KzgCommitments;
 use types::data::{Cell, DataColumn, DataColumnSidecarError};
+use types::kzg_ext::KzgCommitments;
 use types::{
     Blob, BlobSidecar, BlobSidecarList, ChainSpec, DataColumnSidecar, DataColumnSidecarList,
     EthSpec, Hash256, KzgCommitment, KzgProof, SignedBeaconBlock, SignedBeaconBlockHeader,
@@ -448,8 +448,7 @@ mod test {
     use kzg::{Kzg, KzgCommitment, trusted_setup::get_trusted_setup};
     use types::{
         BeaconBlock, BeaconBlockFulu, BlobsList, ChainSpec, EmptyBlock, EthSpec, ForkName,
-        FullPayload, KzgProofs, MainnetEthSpec, SignedBeaconBlock,
-        beacon_block_body::KzgCommitments,
+        FullPayload, KzgProofs, MainnetEthSpec, SignedBeaconBlock, kzg_ext::KzgCommitments,
     };
 
     type E = MainnetEthSpec;

--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -9,7 +9,7 @@ use store::DBColumn;
 use store::KeyValueStore;
 use tracing::debug;
 use tree_hash::TreeHash;
-use types::non_zero_usize::new_non_zero_usize;
+use types::new_non_zero_usize;
 use types::{
     BeaconBlockRef, BeaconState, ChainSpec, Checkpoint, EthSpec, ForkName, Hash256,
     LightClientBootstrap, LightClientFinalityUpdate, LightClientOptimisticUpdate,

--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use tree_hash::{MerkleHasher, TreeHash, TreeHashType};
 use types::SlotData;
 use types::consts::altair::SYNC_COMMITTEE_SUBNET_COUNT;
-use types::sync_committee_contribution::SyncContributionData;
+use types::sync_committee::SyncContributionData;
 use types::{
     Attestation, AttestationData, AttestationRef, CommitteeIndex, EthSpec, Hash256, Slot,
     SyncCommitteeContribution,

--- a/beacon_node/beacon_chain/src/pre_finalization_cache.rs
+++ b/beacon_node/beacon_chain/src/pre_finalization_cache.rs
@@ -6,7 +6,7 @@ use std::num::NonZeroUsize;
 use std::time::Duration;
 use tracing::debug;
 use types::Hash256;
-use types::non_zero_usize::new_non_zero_usize;
+use types::new_non_zero_usize;
 
 const BLOCK_ROOT_CACHE_LIMIT: NonZeroUsize = new_non_zero_usize(512);
 const LOOKUP_LIMIT: NonZeroUsize = new_non_zero_usize(8);

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -6,7 +6,7 @@ use oneshot_broadcast::{Receiver, Sender, oneshot};
 use tracing::debug;
 use types::{
     AttestationShufflingId, BeaconState, Epoch, EthSpec, Hash256, RelativeEpoch,
-    beacon_state::CommitteeCache,
+    state::CommitteeCache,
 };
 
 use crate::{BeaconChainError, metrics};

--- a/beacon_node/beacon_chain/src/sync_committee_verification.rs
+++ b/beacon_node/beacon_chain/src/sync_committee_verification.rs
@@ -54,7 +54,7 @@ use types::sync_committee::SyncCommitteeError;
 use types::{
     BeaconStateError, EthSpec, Hash256, SignedContributionAndProof, Slot,
     SyncCommitteeContribution, SyncCommitteeMessage, SyncSelectionProof, SyncSubnetId,
-    sync_committee_contribution::Error as ContributionError,
+    sync_committee::SyncCommitteeContributionError as ContributionError,
 };
 
 /// Returned when a sync committee contribution was not successfully verified. It might not have been verified for

--- a/beacon_node/builder_client/src/lib.rs
+++ b/beacon_node/builder_client/src/lib.rs
@@ -2,7 +2,7 @@ use bls::PublicKeyBytes;
 use context_deserialize::ContextDeserialize;
 pub use eth2::Error;
 use eth2::types::beacon_response::EmptyMetadata;
-use eth2::types::builder_bid::SignedBuilderBid;
+use eth2::types::builder::SignedBuilderBid;
 use eth2::types::{
     ContentType, EthSpec, ExecutionBlockHash, ForkName, ForkVersionDecode, ForkVersionedResponse,
     SignedValidatorRegistrationData, Slot,
@@ -542,7 +542,7 @@ mod tests {
     use super::*;
     use bls::Signature;
     use eth2::types::MainnetEthSpec;
-    use eth2::types::builder_bid::{BuilderBid, BuilderBidFulu};
+    use eth2::types::builder::{BuilderBid, BuilderBidFulu};
     use eth2::types::test_utils::{SeedableRng, TestRandom, XorShiftRng};
     use mockito::{Matcher, Server, ServerGuard};
 

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -5,9 +5,9 @@ use ssz::{Decode, TryFromIter};
 use ssz_types::{FixedVector, VariableList, typenum::Unsigned};
 use strum::EnumString;
 use superstruct::superstruct;
-use types::beacon_block_body::KzgCommitments;
 use types::data::BlobsList;
 use types::execution::{ConsolidationRequests, DepositRequests, RequestType, WithdrawalRequests};
+use types::kzg_ext::KzgCommitments;
 use types::{Blob, KzgProof};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -15,7 +15,7 @@ use tokio::sync::{Mutex, RwLock, watch};
 use tokio_stream::wrappers::WatchStream;
 use tracing::{debug, error, info, warn};
 use types::ExecutionBlockHash;
-use types::non_zero_usize::new_non_zero_usize;
+use types::new_non_zero_usize;
 
 /// The number of payload IDs that will be stored for each `Engine`.
 ///

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -18,7 +18,7 @@ pub use engine_api::{http, http::HttpJsonRpc, http::deposit_methods};
 use engines::{Engine, EngineError};
 pub use engines::{EngineState, ForkchoiceState};
 use eth2::types::{BlobsBundle, FullPayloadContents};
-use eth2::types::{ForkVersionedResponse, builder_bid::SignedBuilderBid};
+use eth2::types::{ForkVersionedResponse, builder::SignedBuilderBid};
 use fixed_bytes::UintExtended;
 use fork_choice::ForkchoiceUpdateParameters;
 use logging::crit;
@@ -45,10 +45,10 @@ use tokio::{
 use tokio_stream::wrappers::WatchStream;
 use tracing::{Instrument, debug, debug_span, error, info, instrument, warn};
 use tree_hash::TreeHash;
-use types::beacon_block_body::KzgCommitments;
-use types::builder_bid::BuilderBid;
+use types::builder::BuilderBid;
 use types::execution::BlockProductionVersion;
-use types::non_zero_usize::new_non_zero_usize;
+use types::kzg_ext::KzgCommitments;
+use types::new_non_zero_usize;
 use types::{
     AbstractExecPayload, BlobsList, ExecutionPayloadDeneb, ExecutionRequests, KzgProofs,
     SignedBlindedBeaconBlock,

--- a/beacon_node/execution_layer/src/payload_cache.rs
+++ b/beacon_node/execution_layer/src/payload_cache.rs
@@ -3,7 +3,7 @@ use lru::LruCache;
 use parking_lot::Mutex;
 use std::num::NonZeroUsize;
 use tree_hash::TreeHash;
-use types::non_zero_usize::new_non_zero_usize;
+use types::new_non_zero_usize;
 use types::{EthSpec, Hash256};
 
 pub const DEFAULT_PAYLOAD_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(10);

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -29,7 +29,7 @@ use tokio_stream::StreamExt;
 use tracing::{debug, error, info, warn};
 use tree_hash::TreeHash;
 use types::ExecutionBlockHash;
-use types::builder_bid::{
+use types::builder::{
     BuilderBid, BuilderBidBellatrix, BuilderBidCapella, BuilderBidDeneb, BuilderBidElectra,
     BuilderBidFulu, SignedBuilderBid,
 };

--- a/beacon_node/http_api/src/block_rewards.rs
+++ b/beacon_node/http_api/src/block_rewards.rs
@@ -5,8 +5,8 @@ use state_processing::BlockReplayer;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tracing::{debug, warn};
-use types::beacon_block::BlindedBeaconBlock;
-use types::non_zero_usize::new_non_zero_usize;
+use types::block::BlindedBeaconBlock;
+use types::new_non_zero_usize;
 use warp_utils::reject::{beacon_state_error, custom_bad_request, unhandled_error};
 
 const STATE_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(2);

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -51,7 +51,7 @@ use types::{ChainSpec, EnrForkId, EthSpec};
 mod subnet_predicate;
 use crate::discovery::enr::{NEXT_FORK_DIGEST_ENR_KEY, PEERDAS_CUSTODY_GROUP_COUNT_ENR_KEY};
 pub use subnet_predicate::subnet_predicate;
-use types::non_zero_usize::new_non_zero_usize;
+use types::new_non_zero_usize;
 
 /// Local ENR storage filename.
 pub const ENR_FILENAME: &str = "enr.dat";

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use strum::IntoStaticStr;
 use superstruct::superstruct;
 use types::data::BlobIdentifier;
-use types::light_client_update::MAX_REQUEST_LIGHT_CLIENT_UPDATES;
+use types::light_client::consts::MAX_REQUEST_LIGHT_CLIENT_UPDATES;
 use types::{
     ChainSpec, ColumnIndex, DataColumnSidecar, DataColumnsByRootIdentifier, Epoch, EthSpec,
     ForkContext, Hash256, LightClientBootstrap, LightClientFinalityUpdate,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -40,7 +40,7 @@ use types::{
     DataColumnSubnetId, EthSpec, Hash256, IndexedAttestation, LightClientFinalityUpdate,
     LightClientOptimisticUpdate, ProposerSlashing, SignedAggregateAndProof, SignedBeaconBlock,
     SignedBlsToExecutionChange, SignedContributionAndProof, SignedVoluntaryExit, SingleAttestation,
-    Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId, beacon_block::BlockImportSource,
+    Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId, block::BlockImportSource,
 };
 
 use beacon_processor::work_reprocessing_queue::QueuedColumnReconstruction;

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -31,8 +31,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use store::KzgCommitment;
 use tracing::{debug, debug_span, error, info, instrument, warn};
-use types::beacon_block_body::format_kzg_commitments;
 use types::data::FixedBlobSidecarList;
+use types::kzg_ext::format_kzg_commitments;
 use types::{BlockImportSource, DataColumnSidecarList, Epoch, Hash256};
 
 /// Id associated to a batch processing request, either a sync batch or a parent lookup.

--- a/beacon_node/operation_pool/src/attestation.rs
+++ b/beacon_node/operation_pool/src/attestation.rs
@@ -8,8 +8,8 @@ use state_processing::common::{
 use std::collections::HashMap;
 use types::{
     Attestation, BeaconState, ChainSpec, EthSpec,
-    beacon_state::BeaconStateBase,
     consts::altair::{PARTICIPATION_FLAG_WEIGHTS, PROPOSER_WEIGHT, WEIGHT_DENOMINATOR},
+    state::BeaconStateBase,
 };
 
 pub const PROPOSER_REWARD_DENOMINATOR: u64 =

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -8,7 +8,7 @@ use std::num::NonZeroUsize;
 use strum::{Display, EnumString, VariantNames};
 use superstruct::superstruct;
 use types::EthSpec;
-use types::non_zero_usize::new_non_zero_usize;
+use types::new_non_zero_usize;
 use zstd::{Decoder, Encoder};
 
 #[cfg(all(feature = "redb", not(feature = "leveldb")))]

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -11,7 +11,7 @@ use std::ops::RangeInclusive;
 use std::str::FromStr;
 use std::sync::LazyLock;
 use superstruct::superstruct;
-use types::historical_summary::HistoricalSummary;
+use types::state::HistoricalSummary;
 use types::{BeaconState, ChainSpec, Epoch, EthSpec, Hash256, Slot, Validator};
 
 static EMPTY_PUBKEY: LazyLock<PublicKeyBytes> = LazyLock::new(PublicKeyBytes::empty);

--- a/consensus/state_processing/src/epoch_cache.rs
+++ b/consensus/state_processing/src/epoch_cache.rs
@@ -5,7 +5,7 @@ use crate::metrics;
 use fixed_bytes::FixedBytesExtended;
 use safe_arith::SafeArith;
 use tracing::instrument;
-use types::epoch_cache::{EpochCache, EpochCacheError, EpochCacheKey};
+use types::state::{EpochCache, EpochCacheError, EpochCacheKey};
 use types::{ActivationQueue, BeaconState, ChainSpec, EthSpec, ForkName, Hash256};
 
 /// Precursor to an `EpochCache`.

--- a/consensus/state_processing/src/per_epoch_processing/altair/inactivity_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/inactivity_updates.rs
@@ -1,8 +1,7 @@
 use crate::EpochProcessingError;
 use crate::per_epoch_processing::single_pass::{SinglePassConfig, process_epoch_single_pass};
-use types::beacon_state::BeaconState;
-use types::chain_spec::ChainSpec;
-use types::eth_spec::EthSpec;
+use types::core::{ChainSpec, EthSpec};
+use types::state::BeaconState;
 
 /// Slow version of `process_inactivity_updates` that runs a subset of single-pass processing.
 ///

--- a/consensus/state_processing/src/per_epoch_processing/altair/participation_flag_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/participation_flag_updates.rs
@@ -1,8 +1,8 @@
 use crate::EpochProcessingError;
 use milhouse::List;
 use types::attestation::ParticipationFlags;
-use types::beacon_state::BeaconState;
-use types::eth_spec::EthSpec;
+use types::core::EthSpec;
+use types::state::BeaconState;
 
 pub fn process_participation_flag_updates<E: EthSpec>(
     state: &mut BeaconState<E>,

--- a/consensus/state_processing/src/per_epoch_processing/altair/sync_committee_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/sync_committee_updates.rs
@@ -1,9 +1,8 @@
 use crate::EpochProcessingError;
 use safe_arith::SafeArith;
 use std::sync::Arc;
-use types::beacon_state::BeaconState;
-use types::chain_spec::ChainSpec;
-use types::eth_spec::EthSpec;
+use types::core::{ChainSpec, EthSpec};
+use types::state::BeaconState;
 
 pub fn process_sync_committee_updates<E: EthSpec>(
     state: &mut BeaconState<E>,

--- a/consensus/state_processing/src/per_epoch_processing/base/participation_record_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/base/participation_record_updates.rs
@@ -1,6 +1,6 @@
 use crate::EpochProcessingError;
-use types::beacon_state::BeaconState;
-use types::eth_spec::EthSpec;
+use types::core::EthSpec;
+use types::state::BeaconState;
 
 pub fn process_participation_record_updates<E: EthSpec>(
     state: &mut BeaconState<E>,

--- a/consensus/state_processing/src/per_epoch_processing/capella/historical_summaries_update.rs
+++ b/consensus/state_processing/src/per_epoch_processing/capella/historical_summaries_update.rs
@@ -1,6 +1,6 @@
 use crate::EpochProcessingError;
 use safe_arith::SafeArith;
-use types::historical_summary::HistoricalSummary;
+use types::state::HistoricalSummary;
 use types::{BeaconState, EthSpec};
 
 pub fn process_historical_summaries_update<E: EthSpec>(

--- a/consensus/state_processing/src/per_epoch_processing/effective_balance_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/effective_balance_updates.rs
@@ -1,8 +1,8 @@
 use super::errors::EpochProcessingError;
 use crate::per_epoch_processing::single_pass::{SinglePassConfig, process_epoch_single_pass};
 use safe_arith::SafeArith;
-use types::beacon_state::BeaconState;
-use types::chain_spec::ChainSpec;
+use types::core::ChainSpec;
+use types::state::BeaconState;
 use types::{BeaconStateError, EthSpec};
 
 /// This implementation is now only used in phase0. Later hard forks use single-pass.

--- a/consensus/state_processing/src/per_epoch_processing/historical_roots_update.rs
+++ b/consensus/state_processing/src/per_epoch_processing/historical_roots_update.rs
@@ -2,8 +2,8 @@ use super::errors::EpochProcessingError;
 use safe_arith::SafeArith;
 use tree_hash::TreeHash;
 use typenum::Unsigned;
-use types::beacon_state::BeaconState;
-use types::eth_spec::EthSpec;
+use types::core::EthSpec;
+use types::state::BeaconState;
 
 pub fn process_historical_roots_update<E: EthSpec>(
     state: &mut BeaconState<E>,

--- a/consensus/state_processing/src/per_epoch_processing/resets.rs
+++ b/consensus/state_processing/src/per_epoch_processing/resets.rs
@@ -2,8 +2,8 @@ use super::errors::EpochProcessingError;
 use milhouse::List;
 use safe_arith::SafeArith;
 use typenum::Unsigned;
-use types::beacon_state::BeaconState;
-use types::eth_spec::EthSpec;
+use types::core::EthSpec;
+use types::state::BeaconState;
 
 pub fn process_eth1_data_reset<E: EthSpec>(
     state: &mut BeaconState<E>,

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -49,60 +49,6 @@ pub use sync_committee::*;
 pub use validator::*;
 pub use withdrawal::*;
 
-// Temporary facade modules to maintain backwards compatibility for Lighthouse.
-pub mod eth_spec {
-    pub use crate::core::EthSpec;
-}
-
-pub mod chain_spec {
-    pub use crate::core::ChainSpec;
-}
-
-pub mod beacon_block {
-    pub use crate::block::{BlindedBeaconBlock, BlockImportSource};
-}
-
-pub mod beacon_block_body {
-    pub use crate::kzg_ext::{KzgCommitments, format_kzg_commitments};
-}
-
-pub mod beacon_state {
-    pub use crate::state::{
-        BeaconState, BeaconStateBase, CommitteeCache, compute_committee_index_in_epoch,
-        compute_committee_range_in_epoch, epoch_committee_count,
-    };
-}
-
 pub mod graffiti {
-    pub use crate::core::GraffitiString;
-}
-
-pub mod historical_summary {
-    pub use crate::state::HistoricalSummary;
-}
-
-pub mod epoch_cache {
-    pub use crate::state::{EpochCache, EpochCacheError, EpochCacheKey};
-}
-
-pub mod non_zero_usize {
-    pub use crate::core::new_non_zero_usize;
-}
-
-pub mod builder_bid {
-    pub use crate::builder::*;
-}
-
-pub mod light_client_update {
-    pub use crate::light_client::consts::{
-        CURRENT_SYNC_COMMITTEE_INDEX, CURRENT_SYNC_COMMITTEE_INDEX_ELECTRA, FINALIZED_ROOT_INDEX,
-        FINALIZED_ROOT_INDEX_ELECTRA, MAX_REQUEST_LIGHT_CLIENT_UPDATES, NEXT_SYNC_COMMITTEE_INDEX,
-        NEXT_SYNC_COMMITTEE_INDEX_ELECTRA,
-    };
-}
-
-pub mod sync_committee_contribution {
-    pub use crate::sync_committee::{
-        SyncCommitteeContributionError as Error, SyncContributionData,
-    };
+    pub use crate::core::{GRAFFITI_BYTES_LEN, Graffiti, GraffitiString};
 }

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -24,7 +24,7 @@ use std::str::FromStr;
 use std::string::ToString;
 use std::time::Duration;
 use tempfile::TempDir;
-use types::non_zero_usize::new_non_zero_usize;
+use types::new_non_zero_usize;
 use types::{Address, Checkpoint, Epoch, Hash256, MainnetEthSpec};
 
 const DEFAULT_EXECUTION_ENDPOINT: &str = "http://localhost:8551/";

--- a/slasher/src/config.rs
+++ b/slasher/src/config.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use strum::{Display, EnumString, VariantNames};
-use types::non_zero_usize::new_non_zero_usize;
+use types::new_non_zero_usize;
 use types::{Epoch, EthSpec, IndexedAttestation};
 
 pub const DEFAULT_CHUNK_SIZE: usize = 16;

--- a/testing/ef_tests/src/cases/merkle_proof_validity.rs
+++ b/testing/ef_tests/src/cases/merkle_proof_validity.rs
@@ -6,7 +6,7 @@ use tree_hash::Hash256;
 use typenum::Unsigned;
 use types::{
     BeaconBlockBody, BeaconBlockBodyCapella, BeaconBlockBodyDeneb, BeaconBlockBodyElectra,
-    BeaconBlockBodyFulu, BeaconBlockBodyGloas, BeaconState, FullPayload, light_client_update,
+    BeaconBlockBodyFulu, BeaconBlockBodyGloas, BeaconState, FullPayload, light_client,
 };
 
 #[derive(Debug, Clone, Deserialize)]
@@ -97,16 +97,16 @@ impl<E: EthSpec> Case for BeaconStateMerkleProofValidity<E> {
         state.update_tree_hash_cache().unwrap();
 
         let proof = match self.merkle_proof.leaf_index {
-            light_client_update::CURRENT_SYNC_COMMITTEE_INDEX_ELECTRA
-            | light_client_update::CURRENT_SYNC_COMMITTEE_INDEX => {
+            light_client::consts::CURRENT_SYNC_COMMITTEE_INDEX_ELECTRA
+            | light_client::consts::CURRENT_SYNC_COMMITTEE_INDEX => {
                 state.compute_current_sync_committee_proof()
             }
-            light_client_update::NEXT_SYNC_COMMITTEE_INDEX_ELECTRA
-            | light_client_update::NEXT_SYNC_COMMITTEE_INDEX => {
+            light_client::consts::NEXT_SYNC_COMMITTEE_INDEX_ELECTRA
+            | light_client::consts::NEXT_SYNC_COMMITTEE_INDEX => {
                 state.compute_next_sync_committee_proof()
             }
-            light_client_update::FINALIZED_ROOT_INDEX_ELECTRA
-            | light_client_update::FINALIZED_ROOT_INDEX => state.compute_finalized_root_proof(),
+            light_client::consts::FINALIZED_ROOT_INDEX_ELECTRA
+            | light_client::consts::FINALIZED_ROOT_INDEX => state.compute_finalized_root_proof(),
             _ => {
                 return Err(Error::FailedToParseTest(
                     "Could not retrieve merkle proof, invalid index".to_string(),

--- a/testing/ef_tests/src/type_name.rs
+++ b/testing/ef_tests/src/type_name.rs
@@ -1,5 +1,5 @@
 //! Mapping from types to canonical string identifiers used in testing.
-use types::historical_summary::HistoricalSummary;
+use types::state::HistoricalSummary;
 use types::*;
 
 pub trait TypeName {

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -239,7 +239,7 @@ macro_rules! ssz_static_test_no_run {
 #[cfg(feature = "fake_crypto")]
 mod ssz_static {
     use ef_tests::{Handler, SszStaticHandler, SszStaticTHCHandler, SszStaticWithSpecHandler};
-    use types::historical_summary::HistoricalSummary;
+    use types::state::HistoricalSummary;
     use types::{
         AttesterSlashingBase, AttesterSlashingElectra, ConsolidationRequest, DepositRequest,
         LightClientBootstrapAltair, PendingDeposit, PendingPartialWithdrawal, WithdrawalRequest, *,


### PR DESCRIPTION
## Proposed Changes

Removes the remaining facade re-exports from `consensus/types`. 
I have left `graffiti` as I think it has some utility so am leaning towards keeping it in the final API design.

## Additional Info

Previous PRs:
- #8643 
- #8665 
