### PR TITLE
Remove libp2p multiaddress 

### DIFF
--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -73,9 +73,6 @@ pub struct Config {
     /// List of nodes to initially connect to, on Multiaddr format.
     pub boot_nodes_multiaddr: Vec<Multiaddr>,
 
-    /// List of libp2p nodes to initially connect to.
-    pub libp2p_nodes: Vec<Multiaddr>,
-
     /// List of trusted libp2p nodes which are not scored and marked as explicit.
     pub trusted_peers: Vec<PeerIdSerialized>,
 
@@ -343,7 +340,6 @@ impl Default for Config {
             discv5_config,
             boot_nodes_enr: vec![],
             boot_nodes_multiaddr: vec![],
-            libp2p_nodes: vec![],
             trusted_peers: vec![],
             disable_peer_scoring: false,
             client_version: lighthouse_version::version_with_platform(),

--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -73,6 +73,9 @@ pub struct Config {
     /// List of nodes to initially connect to, on Multiaddr format.
     pub boot_nodes_multiaddr: Vec<Multiaddr>,
 
+    /// List of libp2p nodes to initially connect to.
+    pub libp2p_nodes: Vec<Multiaddr>,
+
     /// List of trusted libp2p nodes which are not scored and marked as explicit.
     pub trusted_peers: Vec<PeerIdSerialized>,
 
@@ -340,6 +343,7 @@ impl Default for Config {
             discv5_config,
             boot_nodes_enr: vec![],
             boot_nodes_multiaddr: vec![],
+            libp2p_nodes: vec![],
             trusted_peers: vec![],
             disable_peer_scoring: false,
             client_version: lighthouse_version::version_with_platform(),

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -264,47 +264,62 @@ impl<E: EthSpec> Discovery<E> {
             info!("Contacting Multiaddr boot-nodes for their ENR");
         }
 
-        // get futures for requesting the Enrs associated to these multiaddr and wait for their
+        // get futures for requesting the ENRs associated to these multiaddr and wait for their
         // completion
-        let mut fut_coll = config
+        let discv5_eligible_addrs = config
             .boot_nodes_multiaddr
             .iter()
-            .map(|addr| addr.to_string())
-            // request the ENR for this multiaddr and keep the original for logging
-            .map(|addr| {
-                futures::future::join(
-                    discv5.request_enr(addr.clone()),
-                    futures::future::ready(addr),
-                )
-            })
-            .collect::<FuturesUnordered<_>>();
+            // Filter out multiaddrs without UDP or P2P protocols required for discv5 ENR requests
+            .filter(|addr| {
+                addr.iter().any(|proto| matches!(proto, Protocol::Udp(_)))
+                    && addr.iter().any(|proto| matches!(proto, Protocol::P2p(_)))
+            });
 
-        while let Some((result, original_addr)) = fut_coll.next().await {
-            match result {
-                Ok(enr) => {
-                    debug!(
-                        node_id = %enr.node_id(),
-                        peer_id = %enr.peer_id(),
-                        ip4 = ?enr.ip4(),
-                        udp4 = ?enr.udp4(),
-                        tcp4 = ?enr.tcp4(),
-                        quic4 = ?enr.quic4(),
-                        "Adding node to routing table"
-                    );
-                    let _ = discv5.add_enr(enr).map_err(|e| {
-                        error!(
-                            addr = original_addr.to_string(),
-                            error = e.to_string(),
-                            "Could not add peer to the local routing table"
-                        )
-                    });
-                }
-                Err(e) => {
-                    error!(
-                        multiaddr = original_addr.to_string(),
-                        error = e.to_string(),
-                        "Error getting mapping to ENR"
+        if config.disable_discovery {
+            if discv5_eligible_addrs.count() > 0 {
+                warn!(
+                    "Boot node multiaddrs requiring discv5 ENR lookup will be ignored because discovery is disabled"
+                );
+            }
+        } else {
+            let mut fut_coll = discv5_eligible_addrs
+                .map(|addr| addr.to_string())
+                // request the ENR for this multiaddr and keep the original for logging
+                .map(|addr| {
+                    futures::future::join(
+                        discv5.request_enr(addr.clone()),
+                        futures::future::ready(addr),
                     )
+                })
+                .collect::<FuturesUnordered<_>>();
+
+            while let Some((result, original_addr)) = fut_coll.next().await {
+                match result {
+                    Ok(enr) => {
+                        debug!(
+                            node_id = %enr.node_id(),
+                            peer_id = %enr.peer_id(),
+                            ip4 = ?enr.ip4(),
+                            udp4 = ?enr.udp4(),
+                            tcp4 = ?enr.tcp4(),
+                            quic4 = ?enr.quic4(),
+                            "Adding node to routing table"
+                        );
+                        let _ = discv5.add_enr(enr).map_err(|e| {
+                            error!(
+                                addr = original_addr.to_string(),
+                                error = e.to_string(),
+                                "Could not add peer to the local routing table"
+                            )
+                        });
+                    }
+                    Err(e) => {
+                        error!(
+                            multiaddr = original_addr.to_string(),
+                            error = e.to_string(),
+                            "Error getting mapping to ENR"
+                        )
+                    }
                 }
             }
         }

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -573,11 +573,6 @@ impl<E: EthSpec> Network<E> {
             };
         };
 
-        // attempt to connect to user-input libp2p nodes
-        for multiaddr in &config.libp2p_nodes {
-            dial(multiaddr.clone());
-        }
-
         // attempt to connect to any specified boot-nodes
         let mut boot_nodes = config.boot_nodes_enr.clone();
         boot_nodes.dedup();

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -573,6 +573,12 @@ impl<E: EthSpec> Network<E> {
             };
         };
 
+        // attempt to connect to user-input libp2p nodes
+        // DEPRECATED: can be removed in v8.2.0./v9.0.0
+        for multiaddr in &config.libp2p_nodes {
+            dial(multiaddr.clone());
+        }
+
         // attempt to connect to any specified boot-nodes
         let mut boot_nodes = config.boot_nodes_enr.clone();
         boot_nodes.dedup();

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -364,7 +364,7 @@ pub fn cli_app() -> Command {
                 .long("libp2p-addresses")
                 .value_name("MULTIADDR")
                 .help("One or more comma-delimited multiaddrs to manually connect to a libp2p peer \
-                       without an ENR. DEPRECATED. The --libp2p-nodes flag is deprecated and replaced by --boot-nodes")
+                       without an ENR. DEPRECATED. The --libp2p-addresses flag is deprecated and replaced by --boot-nodes")
                 .action(ArgAction::Set)
                 .display_order(0)
         )

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -359,15 +359,6 @@ pub fn cli_app() -> Command {
                 This disables this feature, fixing the ENR's IP/PORT to those specified on boot.")
                 .display_order(0)
         )
-        .arg(
-            Arg::new("libp2p-addresses")
-                .long("libp2p-addresses")
-                .value_name("MULTIADDR")
-                .help("One or more comma-delimited multiaddrs to manually connect to a libp2p peer \
-                       without an ENR.")
-                .action(ArgAction::Set)
-                .display_order(0)
-        )
         // NOTE: This is hide because it is primarily a developer feature for testnets and
         // debugging. We remove it from the list to avoid clutter.
         .arg(

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -359,6 +359,15 @@ pub fn cli_app() -> Command {
                 This disables this feature, fixing the ENR's IP/PORT to those specified on boot.")
                 .display_order(0)
         )
+        .arg(
+            Arg::new("libp2p-addresses")
+                .long("libp2p-addresses")
+                .value_name("MULTIADDR")
+                .help("One or more comma-delimited multiaddrs to manually connect to a libp2p peer \
+                       without an ENR. DEPRECATED. The --libp2p-nodes flag is deprecated and replaced by --boot-nodes")
+                .action(ArgAction::Set)
+                .display_order(0)
+        )
         // NOTE: This is hide because it is primarily a developer feature for testnets and
         // debugging. We remove it from the list to avoid clutter.
         .arg(

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1206,7 +1206,7 @@ pub fn set_network_config(
 
     // DEPRECATED: can be removed in v8.2.0./v9.0.0
     if let Some(libp2p_addresses_str) = cli_args.get_one::<String>("libp2p-addresses") {
-        warn!("The --libp2p-nodes flag is deprecated and replaced by --boot-nodes");
+        warn!("The --libp2p-addresses flag is deprecated and replaced by --boot-nodes");
         config.libp2p_nodes = libp2p_addresses_str
             .split(',')
             .map(|multiaddr| {

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -15,7 +15,7 @@ use directory::{DEFAULT_BEACON_NODE_DIR, DEFAULT_NETWORK_DIR, DEFAULT_ROOT_DIR};
 use environment::RuntimeContext;
 use execution_layer::DEFAULT_JWT_FILE;
 use http_api::TlsConfig;
-use lighthouse_network::{Enr, Multiaddr, NetworkConfig, PeerIdSerialized, multiaddr::Protocol};
+use lighthouse_network::{Enr, Multiaddr, NetworkConfig, PeerIdSerialized};
 use network_utils::listen_addr::ListenAddress;
 use sensitive_url::SensitiveUrl;
 use std::collections::HashSet;
@@ -28,7 +28,7 @@ use std::num::NonZeroU16;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 use types::graffiti::GraffitiString;
 use types::{Checkpoint, Epoch, EthSpec, Hash256};
 
@@ -1196,29 +1196,12 @@ pub fn set_network_config(
                     let multi: Multiaddr = addr
                         .parse()
                         .map_err(|_| format!("Not valid as ENR nor Multiaddr: {}", addr))?;
-                    if !multi.iter().any(|proto| matches!(proto, Protocol::Udp(_))) {
-                        error!(multiaddr = multi.to_string(), "Missing UDP in Multiaddr");
-                    }
-                    if !multi.iter().any(|proto| matches!(proto, Protocol::P2p(_))) {
-                        error!(multiaddr = multi.to_string(), "Missing P2P in Multiaddr");
-                    }
                     multiaddrs.push(multi);
                 }
             }
         }
         config.boot_nodes_enr = enrs;
         config.boot_nodes_multiaddr = multiaddrs;
-    }
-
-    if let Some(libp2p_addresses_str) = cli_args.get_one::<String>("libp2p-addresses") {
-        config.libp2p_nodes = libp2p_addresses_str
-            .split(',')
-            .map(|multiaddr| {
-                multiaddr
-                    .parse()
-                    .map_err(|_| format!("Invalid Multiaddr: {}", multiaddr))
-            })
-            .collect::<Result<Vec<Multiaddr>, _>>()?;
     }
 
     if parse_flag(cli_args, "disable-peer-scoring") {

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1204,6 +1204,19 @@ pub fn set_network_config(
         config.boot_nodes_multiaddr = multiaddrs;
     }
 
+    // DEPRECATED: can be removed in v8.2.0./v9.0.0
+    if let Some(libp2p_addresses_str) = cli_args.get_one::<String>("libp2p-addresses") {
+        warn!("The --libp2p-nodes flag is deprecated and replaced by --boot-nodes");
+        config.libp2p_nodes = libp2p_addresses_str
+            .split(',')
+            .map(|multiaddr| {
+                multiaddr
+                    .parse()
+                    .map_err(|_| format!("Invalid Multiaddr: {}", multiaddr))
+            })
+            .collect::<Result<Vec<Multiaddr>, _>>()?;
+    }
+
     if parse_flag(cli_args, "disable-peer-scoring") {
         config.disable_peer_scoring = true;
     }

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -223,6 +223,10 @@ Options:
           store the block SSZ as a file at this path. This feature is only
           recommended for developers. This directory is not pruned, users should
           be careful to avoid filling up their disks.
+      --libp2p-addresses <MULTIADDR>
+          One or more comma-delimited multiaddrs to manually connect to a libp2p
+          peer without an ENR. DEPRECATED. The --libp2p-nodes flag is deprecated
+          and replaced by --boot-nodes
       --listen-address [<ADDRESS>...]
           The address lighthouse will listen for UDP and TCP connections. To
           listen over IPv4 and IPv6 set this flag twice with the different

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -223,9 +223,6 @@ Options:
           store the block SSZ as a file at this path. This feature is only
           recommended for developers. This directory is not pruned, users should
           be careful to avoid filling up their disks.
-      --libp2p-addresses <MULTIADDR>
-          One or more comma-delimited multiaddrs to manually connect to a libp2p
-          peer without an ENR.
       --listen-address [<ADDRESS>...]
           The address lighthouse will listen for UDP and TCP connections. To
           listen over IPv4 and IPv6 set this flag twice with the different

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -225,7 +225,7 @@ Options:
           be careful to avoid filling up their disks.
       --libp2p-addresses <MULTIADDR>
           One or more comma-delimited multiaddrs to manually connect to a libp2p
-          peer without an ENR. DEPRECATED. The --libp2p-nodes flag is deprecated
+          peer without an ENR. DEPRECATED. The --libp2p-addresses flag is deprecated
           and replaced by --boot-nodes
       --listen-address [<ADDRESS>...]
           The address lighthouse will listen for UDP and TCP connections. To

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -225,8 +225,8 @@ Options:
           be careful to avoid filling up their disks.
       --libp2p-addresses <MULTIADDR>
           One or more comma-delimited multiaddrs to manually connect to a libp2p
-          peer without an ENR. DEPRECATED. The --libp2p-addresses flag is deprecated
-          and replaced by --boot-nodes
+          peer without an ENR. DEPRECATED. The --libp2p-addresses flag is
+          deprecated and replaced by --boot-nodes
       --listen-address [<ADDRESS>...]
           The address lighthouse will listen for UDP and TCP connections. To
           listen over IPv4 and IPv6 set this flag twice with the different


### PR DESCRIPTION
After a user reported on Discord reported having problems starting Lighthouse with discovery disabled and providing `--boot-nodes`
I noticed that when a bootnode is provided as ENR lighthouse connects to it directly using libp2p, when a bootnode is a multiaddress it needs to be a UDP multiaddress so that Lighthouse uses Discovery to fetch that node's ENR.
But then later when bootstrapping libp2p, Lighthouse tries to dial those multiaddresses directly from libp2p if they are TCP, thing is, they won't be, as that was not allowed when the config was parsed.
Lighthouse also supports `libp2p-nodes` config flag that dials the addresses provided in the same way as when providing a valid `ENR`.

This PR basically removes the `--libp2p-nodes` flag and uniforms on `boot-nodes` flag allowing users to pass TCP multiaddresses with the `--boot-nodes` flag