### PR TITLE
Fix Gloas EF test failures and add test exclusions

### DIFF
--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -387,6 +387,30 @@ pub fn process_proposer_slashings<E: EthSpec>(
             verify_proposer_slashing(proposer_slashing, state, verify_signatures, spec)
                 .map_err(|e| e.into_with_index(i))?;
 
+            // [New in Gloas:EIP7732]
+            // Remove the BuilderPendingPayment corresponding to this proposal
+            // if it is still in the 2-epoch window.
+            let slot = proposer_slashing.signed_header_1.message.slot;
+            let proposal_epoch = slot.epoch(E::slots_per_epoch());
+            let current_epoch = state.current_epoch();
+            let slot_in_epoch = slot.as_u64() % E::slots_per_epoch();
+
+            let payment_index = if proposal_epoch == current_epoch {
+                Some(E::slots_per_epoch() + slot_in_epoch)
+            } else if proposal_epoch == current_epoch.saturating_sub(1u64) {
+                Some(slot_in_epoch)
+            } else {
+                None
+            };
+
+            if let Some(index) = payment_index {
+                if let Ok(builder_pending_payments) = state.builder_pending_payments_mut() {
+                    if let Some(payment) = builder_pending_payments.get_mut(index as usize) {
+                        *payment = BuilderPendingPayment::default();
+                    }
+                }
+            }
+
             slash_validator(
                 state,
                 proposer_slashing.signed_header_1.message.proposer_index as usize,

--- a/consensus/state_processing/src/per_block_processing/signature_sets.rs
+++ b/consensus/state_processing/src/per_block_processing/signature_sets.rs
@@ -318,9 +318,11 @@ where
         );
     }
 
-    let domain = spec.compute_domain(
+    let epoch = indexed_payload_attestation.data.slot.epoch(E::slots_per_epoch());
+    let domain = spec.get_domain(
+        epoch,
         Domain::PTCAttester,
-        spec.genesis_fork_version,
+        &state.fork(),
         state.genesis_validators_root(),
     );
 

--- a/consensus/state_processing/src/per_block_processing/signature_sets.rs
+++ b/consensus/state_processing/src/per_block_processing/signature_sets.rs
@@ -318,7 +318,10 @@ where
         );
     }
 
-    let epoch = indexed_payload_attestation.data.slot.epoch(E::slots_per_epoch());
+    let epoch = indexed_payload_attestation
+        .data
+        .slot
+        .epoch(E::slots_per_epoch());
     let domain = spec.get_domain(
         epoch,
         Domain::PTCAttester,

--- a/consensus/state_processing/src/upgrade/gloas.rs
+++ b/consensus/state_processing/src/upgrade/gloas.rs
@@ -1,6 +1,7 @@
 use milhouse::{List, Vector};
 use ssz_types::BitVector;
 use std::mem;
+use typenum::Unsigned;
 use types::{
     BeaconState, BeaconStateError as Error, BeaconStateGloas, BuilderPendingPayment, ChainSpec,
     EthSpec, ExecutionPayloadBid, Fork,
@@ -91,7 +92,12 @@ pub fn upgrade_state_to_gloas<E: EthSpec>(
         // Gloas
         builders: List::default(),
         next_withdrawal_builder_index: 0,
-        execution_payload_availability: BitVector::default(), // All bits set to false initially
+        // All bits set to true per spec:
+        // execution_payload_availability = [0b1 for _ in range(SLOTS_PER_HISTORICAL_ROOT)]
+        execution_payload_availability: BitVector::from_bytes(
+            vec![0xFFu8; E::SlotsPerHistoricalRoot::to_usize() / 8].into(),
+        )
+        .expect("SlotsPerHistoricalRoot is always divisible by 8"),
         builder_pending_payments: Vector::new(vec![
             BuilderPendingPayment::default();
             E::builder_pending_payments_limit()

--- a/consensus/types/src/core/chain_spec.rs
+++ b/consensus/types/src/core/chain_spec.rs
@@ -1248,7 +1248,7 @@ impl ChainSpec {
             fulu_fork_version: [0x06, 0x00, 0x00, 0x01],
             fulu_fork_epoch: None,
             // Gloas
-            gloas_fork_version: [0x07, 0x00, 0x00, 0x00],
+            gloas_fork_version: [0x07, 0x00, 0x00, 0x01],
             gloas_fork_epoch: None,
             // Other
             network_id: 2, // lighthouse testnet network id

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -47,6 +47,19 @@ excluded_paths = [
     "bls12-381-tests/hash_to_G2",
     "tests/.*/eip7732",
     "tests/.*/eip7805",
+    # TODO(EIP-7732): Gloas execution_payload_bid tests require process_execution_payload_bid
+    # which is not yet implemented.
+    "tests/.*/gloas/operations/execution_payload_bid/.*",
+    # TODO(EIP-7732): Gloas deposit_request tests require builder deposit functionality
+    # (apply_deposit_for_builder, add_builder_to_registry) which is not yet implemented.
+    "tests/.*/gloas/operations/deposit_request/.*",
+    # TODO(EIP-7732): Gloas sanity, transition, random, finality, and fork_choice tests require
+    # full block processing which is not yet complete.
+    "tests/.*/gloas/sanity/.*",
+    "tests/.*/gloas/transition/.*",
+    "tests/.*/gloas/random/.*",
+    "tests/.*/gloas/finality/.*",
+    "tests/.*/gloas/fork_choice/.*",
     # Ignore MatrixEntry SSZ tests for now.
     "tests/.*/fulu/ssz_static/MatrixEntry/.*",
     # EIP-7916 is still in draft and hasn't been implemented yet https://eips.ethereum.org/EIPS/eip-7916
@@ -59,8 +72,6 @@ excluded_paths = [
     # Ignore full epoch tests for now (just test the sub-transitions).
     "tests/.*/.*/epoch_processing/.*/pre_epoch.ssz_snappy",
     "tests/.*/.*/epoch_processing/.*/post_epoch.ssz_snappy",
-    # Ignore gloas tests for now
-    "tests/.*/gloas/.*",
     # Ignore KZG tests that target internal kzg library functions
     "tests/.*/compute_verify_cell_kzg_proof_batch_challenge/.*",
     "tests/.*/compute_challenge/.*",

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -503,7 +503,10 @@ impl<E: EthSpec> Operation<E> for DepositRequest {
     }
 
     fn is_enabled_for_fork(fork_name: ForkName) -> bool {
-        fork_name.electra_enabled()
+        // TODO(EIP-7732): Gloas deposit_request tests require builder deposit functionality
+        // (apply_deposit_for_builder, add_builder_to_registry) which is not yet implemented.
+        // https://github.com/sigp/lighthouse/issues/XXXX
+        fork_name.electra_enabled() && fork_name != ForkName::Gloas
     }
 
     fn decode(path: &Path, _fork_name: ForkName, _spec: &ChainSpec) -> Result<Self, Error> {

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -652,6 +652,11 @@ impl<E: EthSpec + TypeName> Handler for FinalityHandler<E> {
     fn handler_name(&self) -> String {
         "finality".into()
     }
+
+    fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
+        // TODO(EIP-7732): Gloas finality tests require full block processing which is not yet complete
+        fork_name != ForkName::Gloas
+    }
 }
 
 pub struct ForkChoiceHandler<E> {
@@ -696,6 +701,12 @@ impl<E: EthSpec + TypeName> Handler for ForkChoiceHandler<E> {
 
         // Tests are no longer generated for the base/phase0 specification.
         if fork_name == ForkName::Base {
+            return false;
+        }
+
+        // TODO(EIP-7732): Gloas fork choice not yet implemented
+        // https://github.com/sigp/lighthouse/issues/XXXX
+        if fork_name == ForkName::Gloas {
             return false;
         }
 

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -491,10 +491,11 @@ impl<E: EthSpec + TypeName> Handler for SanityBlocksHandler<E> {
         "blocks".into()
     }
 
-    fn is_enabled_for_fork(&self, _fork_name: ForkName) -> bool {
+    fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
         // NOTE: v1.1.0-beta.4 doesn't mark the historical blocks test as requiring real crypto, so
         // only run these tests with real crypto for now.
-        cfg!(not(feature = "fake_crypto"))
+        // TODO(EIP-7732): Gloas sanity tests require full block processing which is not yet complete
+        fork_name != ForkName::Gloas && cfg!(not(feature = "fake_crypto"))
     }
 }
 
@@ -519,7 +520,9 @@ impl<E: EthSpec + TypeName> Handler for SanitySlotsHandler<E> {
 
     fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
         // Some sanity tests compute sync committees, which requires real crypto.
-        fork_name == ForkName::Base || cfg!(not(feature = "fake_crypto"))
+        // TODO(EIP-7732): Gloas sanity tests require full block processing which is not yet complete
+        fork_name != ForkName::Gloas
+            && (fork_name == ForkName::Base || cfg!(not(feature = "fake_crypto")))
     }
 }
 
@@ -540,6 +543,11 @@ impl<E: EthSpec + TypeName> Handler for RandomHandler<E> {
 
     fn handler_name(&self) -> String {
         "random".into()
+    }
+
+    fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
+        // TODO(EIP-7732): Gloas random tests require full block processing which is not yet complete
+        fork_name != ForkName::Gloas
     }
 }
 
@@ -630,6 +638,11 @@ impl<E: EthSpec + TypeName> Handler for TransitionHandler<E> {
 
     fn handler_name(&self) -> String {
         "core".into()
+    }
+
+    fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
+        // TODO(EIP-7732): Gloas transition tests require full block processing which is not yet complete
+        fork_name != ForkName::Gloas
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix `execution_payload_availability` initialization in fork upgrade to use all ones (0xFF bytes) instead of zeros per spec
- Fix `gloas_fork_version` in minimal spec from `[0x07, 0x00, 0x00, 0x00]` to `[0x07, 0x00, 0x00, 0x01]`
- Fix payload attestation signature domain calculation to use `get_domain` instead of `compute_domain`
- Add builder pending payment clearing on proposer slashing per EIP-7732 spec
- Add test exclusions for unimplemented Gloas functionality with TODO comments

## Test plan

- [x] `fork_upgrade` EF tests now pass
- [x] Excluded tests compile and skip correctly
- [x] Run `make test-ef` to verify all accessible tests pass
