### PR TITLE
Add `testing` feature in `consensus/types`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,7 +272,7 @@ tracing_samplers = { path = "common/tracing_samplers" }
 tree_hash = "0.12.0"
 tree_hash_derive = "0.12.0"
 typenum = "1"
-types = { path = "consensus/types" }
+types = { path = "consensus/types", features = ["testing"] }
 url = "2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 validator_client = { path = "validator_client" }

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -9,9 +9,16 @@ edition = { workspace = true }
 
 [features]
 default = ["sqlite", "legacy-arith"]
-# Allow saturating arithmetic on slots and epochs. Enabled by default, but deprecated.
 legacy-arith = []
 sqlite = ["dep:rusqlite"]
+
+testing = [
+    "dep:test_random_derive",
+    "dep:eth2_interop_keypairs",
+    "dep:rand_xorshift",
+    "dep:rayon",
+    "dep:smallvec",
+]
 arbitrary = [
     "dep:arbitrary",
     "bls/arbitrary",
@@ -31,7 +38,7 @@ bls = { workspace = true }
 compare_fields = { workspace = true }
 context_deserialize = { workspace = true }
 educe = { workspace = true }
-eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
+eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs", optional = true }
 ethereum_hashing = { workspace = true }
 ethereum_serde_utils = { workspace = true }
 ethereum_ssz = { workspace = true }
@@ -47,8 +54,8 @@ metastruct = "0.1.0"
 milhouse = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
-rand_xorshift = "0.4.0"
-rayon = { workspace = true }
+rand_xorshift = { version = "0.4.0", optional = true }
+rayon = { workspace = true, optional = true }
 regex = { workspace = true }
 rpds = { workspace = true }
 rusqlite = { workspace = true, optional = true }
@@ -56,12 +63,11 @@ safe_arith = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-smallvec = { workspace = true }
+smallvec = { workspace = true, optional = true }
 ssz_types = { workspace = true }
 superstruct = { workspace = true }
 swap_or_not_shuffle = { workspace = true }
-tempfile = { workspace = true }
-test_random_derive = { path = "../../common/test_random_derive" }
+test_random_derive = { path = "../../common/test_random_derive", optional = true }
 tracing = { workspace = true }
 tree_hash = { workspace = true }
 tree_hash_derive = { workspace = true }
@@ -72,6 +78,7 @@ beacon_chain = { workspace = true }
 criterion = { workspace = true }
 paste = { workspace = true }
 state_processing = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true }
 
 [lints.clippy]

--- a/consensus/types/src/attestation/aggregate_and_proof.rs
+++ b/consensus/types/src/attestation/aggregate_and_proof.rs
@@ -3,16 +3,18 @@ use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     attestation::{
         Attestation, AttestationBase, AttestationElectra, AttestationRef, SelectionProof,
     },
     core::{ChainSpec, Domain, EthSpec, Hash256, SignedRoot},
     fork::{Fork, ForkName},
-    test_utils::TestRandom,
 };
 
 #[superstruct(
@@ -26,11 +28,11 @@ use crate::{
             Deserialize,
             Encode,
             Decode,
-            TestRandom,
-            TreeHash,
+            TreeHash
         ),
         context_deserialize(ForkName),
         serde(bound = "E: EthSpec"),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),

--- a/consensus/types/src/attestation/attestation.rs
+++ b/consensus/types/src/attestation/attestation.rs
@@ -10,9 +10,12 @@ use serde::{Deserialize, Deserializer, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{BitList, BitVector};
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     attestation::{
         AttestationData, Checkpoint, IndexedAttestation, IndexedAttestationBase,
@@ -20,7 +23,6 @@ use crate::{
     },
     core::{ChainSpec, Domain, EthSpec, Hash256, SignedRoot, Slot, SlotData},
     fork::{Fork, ForkName},
-    test_utils::TestRandom,
 };
 
 #[derive(Debug, PartialEq, Clone)]
@@ -49,13 +51,13 @@ impl From<ssz_types::Error> for Error {
             Deserialize,
             Decode,
             Encode,
-            TestRandom,
             Educe,
             TreeHash,
         ),
         context_deserialize(ForkName),
         educe(PartialEq, Hash(bound(E: EthSpec))),
         serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),
@@ -605,7 +607,8 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for Vec<Attestation<E>> 
 */
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, Serialize, Deserialize, Decode, Encode, TestRandom, TreeHash, PartialEq)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, Serialize, Deserialize, Decode, Encode, TreeHash, PartialEq)]
 #[context_deserialize(ForkName)]
 pub struct SingleAttestation {
     #[serde(with = "serde_utils::quoted_u64")]

--- a/consensus/types/src/attestation/attestation_data.rs
+++ b/consensus/types/src/attestation/attestation_data.rs
@@ -1,33 +1,25 @@
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     attestation::Checkpoint,
     core::{Hash256, SignedRoot, Slot, SlotData},
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 /// The data upon which an attestation is based.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
 #[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    Hash,
-    Encode,
-    Decode,
-    TreeHash,
-    TestRandom,
-    Default,
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Encode, Decode, TreeHash, Default,
 )]
 #[context_deserialize(ForkName)]
 pub struct AttestationData {

--- a/consensus/types/src/attestation/checkpoint.rs
+++ b/consensus/types/src/attestation/checkpoint.rs
@@ -1,19 +1,22 @@
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{Epoch, Hash256},
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 /// Casper FFG checkpoint, used in attestations.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
 #[derive(
     Debug,
     Clone,
@@ -27,7 +30,6 @@ use crate::{
     Encode,
     Decode,
     TreeHash,
-    TestRandom,
 )]
 #[context_deserialize(ForkName)]
 pub struct Checkpoint {

--- a/consensus/types/src/attestation/indexed_attestation.rs
+++ b/consensus/types/src/attestation/indexed_attestation.rs
@@ -11,10 +11,13 @@ use ssz::Encode;
 use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{attestation::AttestationData, core::EthSpec, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{attestation::AttestationData, core::EthSpec, fork::ForkName};
 
 /// Details an attestation that can be slashable.
 ///
@@ -31,13 +34,13 @@ use crate::{attestation::AttestationData, core::EthSpec, fork::ForkName, test_ut
             Deserialize,
             Decode,
             Encode,
-            TestRandom,
             Educe,
             TreeHash,
         ),
         context_deserialize(ForkName),
         educe(PartialEq, Hash(bound(E: EthSpec))),
         serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),

--- a/consensus/types/src/attestation/indexed_payload_attestation.rs
+++ b/consensus/types/src/attestation/indexed_payload_attestation.rs
@@ -1,15 +1,19 @@
-use crate::test_utils::TestRandom;
-use crate::{EthSpec, ForkName, PayloadAttestationData};
 use bls::AggregateSignature;
 use context_deserialize::context_deserialize;
 use core::slice::Iter;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[derive(TestRandom, TreeHash, Debug, Clone, PartialEq, Encode, Decode, Serialize, Deserialize)]
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{EthSpec, attestation::PayloadAttestationData, fork::ForkName};
+
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(TreeHash, Debug, Clone, PartialEq, Encode, Decode, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(bound = "E: EthSpec", deny_unknown_fields)]
 #[cfg_attr(feature = "arbitrary", arbitrary(bound = "E: EthSpec"))]

--- a/consensus/types/src/attestation/participation_flags.rs
+++ b/consensus/types/src/attestation/participation_flags.rs
@@ -1,15 +1,16 @@
 use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, DecodeError, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash::{PackedEncoding, TreeHash, TreeHashType};
 
-use crate::{
-    core::{Hash256, consts::altair::NUM_FLAG_INDICES},
-    test_utils::TestRandom,
-};
+use crate::core::{Hash256, consts::altair::NUM_FLAG_INDICES};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Deserialize, Serialize, TestRandom)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Deserialize, Serialize)]
 #[serde(transparent)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ParticipationFlags {

--- a/consensus/types/src/attestation/payload_attestation.rs
+++ b/consensus/types/src/attestation/payload_attestation.rs
@@ -1,16 +1,19 @@
-use crate::attestation::payload_attestation_data::PayloadAttestationData;
-use crate::test_utils::TestRandom;
-use crate::{EthSpec, ForkName};
 use bls::AggregateSignature;
 use context_deserialize::context_deserialize;
 use educe::Educe;
 use serde::{Deserialize, Serialize};
 use ssz::BitVector;
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[derive(TestRandom, TreeHash, Debug, Clone, Encode, Decode, Serialize, Deserialize, Educe)]
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{EthSpec, attestation::PayloadAttestationData, fork::ForkName};
+
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(TreeHash, Debug, Clone, Encode, Decode, Serialize, Deserialize, Educe)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(bound = "E: EthSpec", deny_unknown_fields)]
 #[cfg_attr(feature = "arbitrary", arbitrary(bound = "E: EthSpec"))]

--- a/consensus/types/src/attestation/payload_attestation_data.rs
+++ b/consensus/types/src/attestation/payload_attestation_data.rs
@@ -1,14 +1,16 @@
-use crate::test_utils::TestRandom;
-use crate::{ForkName, Hash256, SignedRoot, Slot};
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[derive(
-    TestRandom, TreeHash, Debug, Clone, PartialEq, Eq, Encode, Decode, Serialize, Deserialize, Hash,
-)]
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{Hash256, SignedRoot, Slot, fork::ForkName};
+
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(TreeHash, Debug, Clone, PartialEq, Eq, Encode, Decode, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[context_deserialize(ForkName)]
 pub struct PayloadAttestationData {

--- a/consensus/types/src/attestation/payload_attestation_message.rs
+++ b/consensus/types/src/attestation/payload_attestation_message.rs
@@ -1,14 +1,17 @@
-use crate::ForkName;
-use crate::attestation::payload_attestation_data::PayloadAttestationData;
-use crate::test_utils::TestRandom;
 use bls::Signature;
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[derive(TestRandom, TreeHash, Debug, Clone, PartialEq, Encode, Decode, Serialize, Deserialize)]
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{ForkName, attestation::PayloadAttestationData};
+
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(TreeHash, Debug, Clone, PartialEq, Encode, Decode, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[context_deserialize(ForkName)]
 pub struct PayloadAttestationMessage {

--- a/consensus/types/src/attestation/pending_attestation.rs
+++ b/consensus/types/src/attestation/pending_attestation.rs
@@ -2,10 +2,13 @@ use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::BitList;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{attestation::AttestationData, core::EthSpec, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{attestation::AttestationData, core::EthSpec, fork::ForkName};
 
 /// An attestation that has been included in the state but not yet fully processed.
 ///
@@ -15,7 +18,8 @@ use crate::{attestation::AttestationData, core::EthSpec, fork::ForkName, test_ut
     derive(arbitrary::Arbitrary),
     arbitrary(bound = "E: EthSpec")
 )]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct PendingAttestation<E: EthSpec> {
     pub aggregation_bits: BitList<E::MaxValidatorsPerCommittee>,

--- a/consensus/types/src/attestation/signed_aggregate_and_proof.rs
+++ b/consensus/types/src/attestation/signed_aggregate_and_proof.rs
@@ -3,9 +3,12 @@ use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     attestation::{
         AggregateAndProof, AggregateAndProofBase, AggregateAndProofElectra, AggregateAndProofRef,
@@ -13,7 +16,6 @@ use crate::{
     },
     core::{ChainSpec, Domain, EthSpec, Hash256, SignedRoot},
     fork::{Fork, ForkName},
-    test_utils::TestRandom,
 };
 
 /// A Validators signed aggregate proof to publish on the `beacon_aggregate_and_proof`
@@ -31,11 +33,11 @@ use crate::{
             Deserialize,
             Encode,
             Decode,
-            TestRandom,
             TreeHash,
         ),
         context_deserialize(ForkName),
         serde(bound = "E: EthSpec"),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),

--- a/consensus/types/src/block/beacon_block.rs
+++ b/consensus/types/src/block/beacon_block.rs
@@ -9,11 +9,14 @@ use ssz::{Decode, DecodeError};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{BitList, BitVector, FixedVector, VariableList};
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 use typenum::Unsigned;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     SignedExecutionPayloadBid,
     attestation::{AttestationBase, AttestationData, IndexedAttestationBase},
@@ -34,7 +37,6 @@ use crate::{
     slashing::{AttesterSlashingBase, ProposerSlashing},
     state::BeaconStateError,
     sync_committee::SyncAggregate,
-    test_utils::TestRandom,
 };
 
 /// A block of the `BeaconChain`.
@@ -49,10 +51,10 @@ use crate::{
             Encode,
             Decode,
             TreeHash,
-            TestRandom,
             Educe,
         ),
         educe(PartialEq, Hash(bound(E: EthSpec, Payload: AbstractExecPayload<E>))),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         serde(
             bound = "E: EthSpec, Payload: AbstractExecPayload<E>",
             deny_unknown_fields

--- a/consensus/types/src/block/beacon_block_body.rs
+++ b/consensus/types/src/block/beacon_block_body.rs
@@ -9,10 +9,13 @@ use serde::{Deserialize, Deserializer, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{FixedVector, VariableList};
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash::{BYTES_PER_CHUNK, TreeHash};
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     SignedExecutionPayloadBid,
     attestation::{
@@ -37,7 +40,6 @@ use crate::{
     },
     state::BeaconStateError,
     sync_committee::SyncAggregate,
-    test_utils::TestRandom,
 };
 
 /// The number of leaves (including padding) on the `BeaconBlockBody` Merkle tree.
@@ -64,10 +66,10 @@ pub const BLOB_KZG_COMMITMENTS_INDEX: usize = 11;
             Encode,
             Decode,
             TreeHash,
-            TestRandom,
             Educe,
         ),
         educe(PartialEq, Hash(bound(E: EthSpec, Payload: AbstractExecPayload<E>))),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         serde(
             bound = "E: EthSpec, Payload: AbstractExecPayload<E>",
             deny_unknown_fields

--- a/consensus/types/src/block/beacon_block_header.rs
+++ b/consensus/types/src/block/beacon_block_header.rs
@@ -2,24 +2,25 @@ use bls::SecretKey;
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     block::SignedBeaconBlockHeader,
     core::{ChainSpec, Domain, EthSpec, Hash256, SignedRoot, Slot},
     fork::{Fork, ForkName},
-    test_utils::TestRandom,
 };
 
 /// A header of a `BeaconBlock`.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct BeaconBlockHeader {
     pub slot: Slot,

--- a/consensus/types/src/block/signed_beacon_block.rs
+++ b/consensus/types/src/block/signed_beacon_block.rs
@@ -8,11 +8,14 @@ use serde::{Deserialize, Deserializer, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::FixedVector;
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tracing::instrument;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     block::{
         BLOB_KZG_COMMITMENTS_INDEX, BeaconBlock, BeaconBlockAltair, BeaconBlockBase,
@@ -32,7 +35,6 @@ use crate::{
     fork::{Fork, ForkName, ForkVersionDecode, InconsistentFork, map_fork_name},
     kzg_ext::format_kzg_commitments,
     state::BeaconStateError,
-    test_utils::TestRandom,
 };
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -76,8 +78,8 @@ impl From<SignedBeaconBlockHash> for Hash256 {
             Decode,
             TreeHash,
             Educe,
-            TestRandom
         ),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         educe(PartialEq, Hash(bound(E: EthSpec))),
         serde(bound = "E: EthSpec, Payload: AbstractExecPayload<E>"),
         cfg_attr(

--- a/consensus/types/src/block/signed_beacon_block_header.rs
+++ b/consensus/types/src/block/signed_beacon_block_header.rs
@@ -2,23 +2,24 @@ use bls::{PublicKey, Signature};
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     block::BeaconBlockHeader,
     core::{ChainSpec, Domain, EthSpec, Hash256, SignedRoot},
     fork::{Fork, ForkName},
-    test_utils::TestRandom,
 };
 
 /// A signed header of a `BeaconBlock`.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct SignedBeaconBlockHeader {
     pub message: BeaconBlockHeader,

--- a/consensus/types/src/builder/builder.rs
+++ b/consensus/types/src/builder/builder.rs
@@ -1,17 +1,18 @@
+#[cfg(feature = "testing")]
 use crate::test_utils::TestRandom;
 use crate::{Address, Epoch};
 use bls::PublicKeyBytes;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
 pub type BuilderIndex = u64;
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct Builder {
     pub pubkey: PublicKeyBytes,
     #[serde(with = "serde_utils::quoted_u8")]

--- a/consensus/types/src/builder/builder_bid.rs
+++ b/consensus/types/src/builder/builder_bid.rs
@@ -5,9 +5,12 @@ use serde::{Deserialize, Deserializer, Serialize};
 use ssz::Decode;
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{ChainSpec, EthSpec, SignedRoot, Uint256},
     execution::{
@@ -17,7 +20,6 @@ use crate::{
     },
     fork::{ForkName, ForkVersionDecode},
     kzg_ext::KzgCommitments,
-    test_utils::TestRandom,
 };
 
 #[superstruct(
@@ -32,9 +34,9 @@ use crate::{
             TreeHash,
             Decode,
             Clone,
-            TestRandom
         ),
-        serde(bound = "E: EthSpec", deny_unknown_fields)
+        serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom))
     ),
     map_ref_into(ExecutionPayloadHeaderRef),
     map_ref_mut_into(ExecutionPayloadHeaderRefMut)

--- a/consensus/types/src/builder/builder_pending_payment.rs
+++ b/consensus/types/src/builder/builder_pending_payment.rs
@@ -1,24 +1,16 @@
+#[cfg(feature = "testing")]
 use crate::test_utils::TestRandom;
 use crate::{BuilderPendingWithdrawal, ForkName};
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg_attr(feature = "testing", derive(TestRandom))]
 #[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    Clone,
-    Default,
-    Serialize,
-    Deserialize,
-    Encode,
-    Decode,
-    TreeHash,
-    TestRandom,
+    Debug, Default, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash,
 )]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[context_deserialize(ForkName)]

--- a/consensus/types/src/builder/builder_pending_withdrawal.rs
+++ b/consensus/types/src/builder/builder_pending_withdrawal.rs
@@ -1,24 +1,16 @@
+#[cfg(feature = "testing")]
 use crate::test_utils::TestRandom;
 use crate::{Address, ForkName};
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg_attr(feature = "testing", derive(TestRandom))]
 #[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    Clone,
-    Default,
-    Serialize,
-    Deserialize,
-    Encode,
-    Decode,
-    TreeHash,
-    TestRandom,
+    Debug, PartialEq, Eq, Hash, Clone, Default, Serialize, Deserialize, Encode, Decode, TreeHash,
 )]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[context_deserialize(ForkName)]

--- a/consensus/types/src/consolidation/consolidation_request.rs
+++ b/consensus/types/src/consolidation/consolidation_request.rs
@@ -3,19 +3,20 @@ use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{Address, SignedRoot},
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct ConsolidationRequest {
     pub source_address: Address,

--- a/consensus/types/src/consolidation/pending_consolidation.rs
+++ b/consensus/types/src/consolidation/pending_consolidation.rs
@@ -1,15 +1,17 @@
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{fork::ForkName, test_utils::TestRandom};
+use crate::fork::ForkName;
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct PendingConsolidation {
     #[serde(with = "serde_utils::quoted_u64")]

--- a/consensus/types/src/core/enr_fork_id.rs
+++ b/consensus/types/src/core/enr_fork_id.rs
@@ -1,18 +1,20 @@
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{core::Epoch, test_utils::TestRandom};
+use crate::core::Epoch;
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 
 /// Specifies a fork which allows nodes to identify each other on the network. This fork is used in
 /// a nodes local ENR.
 ///
 /// Spec v0.11
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, Clone, PartialEq, Default, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct EnrForkId {
     /// Fork digest of the current fork computed from [`ChainSpec::compute_fork_digest`].
     #[serde(with = "serde_utils::bytes_4_hex")]

--- a/consensus/types/src/core/execution_block_hash.rs
+++ b/consensus/types/src/core/execution_block_hash.rs
@@ -1,11 +1,14 @@
 use std::fmt;
 
 use fixed_bytes::FixedBytesExtended;
+#[cfg(feature = "testing")]
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, DecodeError, Encode};
 
-use crate::{core::Hash256, test_utils::TestRandom};
+use crate::core::Hash256;
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Default, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, Hash)]
@@ -86,6 +89,7 @@ impl tree_hash::TreeHash for ExecutionBlockHash {
     }
 }
 
+#[cfg(feature = "testing")]
 impl TestRandom for ExecutionBlockHash {
     fn random_for_test(rng: &mut impl RngCore) -> Self {
         Self(Hash256::random_for_test(rng))

--- a/consensus/types/src/core/graffiti.rs
+++ b/consensus/types/src/core/graffiti.rs
@@ -1,12 +1,16 @@
 use std::{fmt, str::FromStr};
 
+#[cfg(feature = "testing")]
 use rand::RngCore;
 use regex::bytes::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
 use ssz::{Decode, DecodeError, Encode};
 use tree_hash::{PackedEncoding, TreeHash};
 
-use crate::{core::Hash256, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::core::Hash256;
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 
 pub const GRAFFITI_BYTES_LEN: usize = 32;
 
@@ -181,6 +185,7 @@ impl TreeHash for Graffiti {
     }
 }
 
+#[cfg(feature = "testing")]
 impl TestRandom for Graffiti {
     fn random_for_test(rng: &mut impl RngCore) -> Self {
         Self::from(Hash256::random_for_test(rng).0)

--- a/consensus/types/src/core/signing_data.rs
+++ b/consensus/types/src/core/signing_data.rs
@@ -1,14 +1,18 @@
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
-use crate::{core::Hash256, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{core::Hash256, fork::ForkName};
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct SigningData {
     pub object_root: Hash256,

--- a/consensus/types/src/core/slot_epoch.rs
+++ b/consensus/types/src/core/slot_epoch.rs
@@ -12,15 +12,15 @@
 
 use std::{fmt, hash::Hash};
 
+#[cfg(feature = "testing")]
 use rand::RngCore;
 use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, DecodeError, Encode};
 
-use crate::{
-    core::{ChainSpec, SignedRoot},
-    test_utils::TestRandom,
-};
+use crate::core::{ChainSpec, SignedRoot};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 
 #[cfg(feature = "legacy-arith")]
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, Sub, SubAssign};

--- a/consensus/types/src/core/slot_epoch_macros.rs
+++ b/consensus/types/src/core/slot_epoch_macros.rs
@@ -294,6 +294,7 @@ macro_rules! impl_ssz {
 
         impl SignedRoot for $type {}
 
+        #[cfg(feature = "testing")]
         impl TestRandom for $type {
             fn random_for_test(rng: &mut impl RngCore) -> Self {
                 $type::from(u64::random_for_test(rng))

--- a/consensus/types/src/data/blob_sidecar.rs
+++ b/consensus/types/src/data/blob_sidecar.rs
@@ -11,10 +11,13 @@ use serde::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
 use ssz_types::{FixedVector, RuntimeFixedVector, RuntimeVariableList, VariableList};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     block::{
         BLOB_KZG_COMMITMENTS_INDEX, BeaconBlockHeader, SignedBeaconBlock, SignedBeaconBlockHeader,
@@ -25,7 +28,6 @@ use crate::{
     fork::ForkName,
     kzg_ext::KzgProofs,
     state::BeaconStateError,
-    test_utils::TestRandom,
 };
 
 /// Container of the data that identifies an individual blob.
@@ -55,7 +57,8 @@ impl Ord for BlobIdentifier {
     derive(arbitrary::Arbitrary),
     arbitrary(bound = "E: EthSpec")
 )]
-#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom, Educe)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Educe)]
 #[context_deserialize(ForkName)]
 #[serde(bound = "E: EthSpec")]
 #[educe(PartialEq, Eq, Hash(bound(E: EthSpec)))]

--- a/consensus/types/src/data/data_column_sidecar.rs
+++ b/consensus/types/src/data/data_column_sidecar.rs
@@ -11,17 +11,19 @@ use ssz::Encode;
 use ssz_derive::{Decode, Encode};
 use ssz_types::Error as SszError;
 use ssz_types::{FixedVector, VariableList};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     block::{BLOB_KZG_COMMITMENTS_INDEX, BeaconBlockHeader, SignedBeaconBlockHeader},
     core::{Epoch, EthSpec, Hash256, Slot},
     fork::ForkName,
     kzg_ext::{KzgCommitments, KzgError},
     state::BeaconStateError,
-    test_utils::TestRandom,
 };
 
 pub type ColumnIndex = u64;
@@ -43,7 +45,8 @@ pub type DataColumnSidecarList<E> = Vec<Arc<DataColumnSidecar<E>>>;
     derive(arbitrary::Arbitrary),
     arbitrary(bound = "E: EthSpec")
 )]
-#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom, Educe)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Educe)]
 #[serde(bound = "E: EthSpec")]
 #[educe(PartialEq, Eq, Hash(bound(E: EthSpec)))]
 #[context_deserialize(ForkName)]

--- a/consensus/types/src/deposit/deposit.rs
+++ b/consensus/types/src/deposit/deposit.rs
@@ -2,11 +2,14 @@ use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::FixedVector;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 use typenum::U33;
 
-use crate::{core::Hash256, deposit::DepositData, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{core::Hash256, deposit::DepositData, fork::ForkName};
 
 pub const DEPOSIT_TREE_DEPTH: usize = 32;
 
@@ -14,9 +17,8 @@ pub const DEPOSIT_TREE_DEPTH: usize = 32;
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct Deposit {
     pub proof: FixedVector<Hash256, U33>,

--- a/consensus/types/src/deposit/deposit_data.rs
+++ b/consensus/types/src/deposit/deposit_data.rs
@@ -2,23 +2,24 @@ use bls::{PublicKeyBytes, SecretKey, SignatureBytes};
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{ChainSpec, Hash256, SignedRoot},
     deposit::DepositMessage,
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 /// The data supplied by the user to the deposit contract.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct DepositData {
     pub pubkey: PublicKeyBytes,

--- a/consensus/types/src/deposit/deposit_message.rs
+++ b/consensus/types/src/deposit/deposit_message.rs
@@ -2,20 +2,23 @@ use bls::PublicKeyBytes;
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{Hash256, SignedRoot},
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 /// The data supplied by the user to the deposit contract.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct DepositMessage {
     pub pubkey: PublicKeyBytes,

--- a/consensus/types/src/deposit/deposit_request.rs
+++ b/consensus/types/src/deposit/deposit_request.rs
@@ -3,15 +3,17 @@ use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{core::Hash256, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{core::Hash256, fork::ForkName};
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct DepositRequest {
     pub pubkey: PublicKeyBytes,

--- a/consensus/types/src/deposit/deposit_tree_snapshot.rs
+++ b/consensus/types/src/deposit/deposit_tree_snapshot.rs
@@ -3,11 +3,15 @@ use fixed_bytes::FixedBytesExtended;
 use int_to_bytes::int_to_bytes32;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 
-use crate::{core::Hash256, deposit::DEPOSIT_TREE_DEPTH, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{core::Hash256, deposit::DEPOSIT_TREE_DEPTH};
 
-#[derive(Encode, Decode, Deserialize, Serialize, Clone, Debug, PartialEq, TestRandom)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Encode, Decode, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct FinalizedExecutionBlock {
     pub deposit_root: Hash256,
     pub deposit_count: u64,
@@ -26,7 +30,8 @@ impl From<&DepositTreeSnapshot> for FinalizedExecutionBlock {
     }
 }
 
-#[derive(Encode, Decode, Deserialize, Serialize, Clone, Debug, PartialEq, TestRandom)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Encode, Decode, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct DepositTreeSnapshot {
     pub finalized: Vec<Hash256>,
     pub deposit_root: Hash256,

--- a/consensus/types/src/deposit/pending_deposit.rs
+++ b/consensus/types/src/deposit/pending_deposit.rs
@@ -2,19 +2,20 @@ use bls::{PublicKeyBytes, SignatureBytes};
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{Hash256, Slot},
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct PendingDeposit {
     pub pubkey: PublicKeyBytes,

--- a/consensus/types/src/execution/bls_to_execution_change.rs
+++ b/consensus/types/src/execution/bls_to_execution_change.rs
@@ -2,20 +2,21 @@ use bls::{PublicKeyBytes, SecretKey};
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{Address, ChainSpec, Domain, Hash256, SignedRoot},
     execution::SignedBlsToExecutionChange,
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct BlsToExecutionChange {
     #[serde(with = "serde_utils::quoted_u64")]

--- a/consensus/types/src/execution/eth1_data.rs
+++ b/consensus/types/src/execution/eth1_data.rs
@@ -1,28 +1,21 @@
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{core::Hash256, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{core::Hash256, fork::ForkName};
 
 /// Contains data obtained from the Eth1 chain.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
 #[derive(
-    Debug,
-    PartialEq,
-    Clone,
-    Default,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    Encode,
-    Decode,
-    TreeHash,
-    TestRandom,
+    Debug, PartialEq, Eq, Hash, Clone, Default, Serialize, Deserialize, Encode, Decode, TreeHash,
 )]
 #[context_deserialize(ForkName)]
 pub struct Eth1Data {

--- a/consensus/types/src/execution/execution_payload.rs
+++ b/consensus/types/src/execution/execution_payload.rs
@@ -6,14 +6,16 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{FixedVector, VariableList};
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{Address, EthSpec, ExecutionBlockHash, Hash256},
     fork::{ForkName, ForkVersionDecode},
     state::BeaconStateError,
-    test_utils::TestRandom,
     withdrawal::Withdrawals,
 };
 
@@ -35,12 +37,12 @@ pub type Transactions<E> = VariableList<
             Encode,
             Decode,
             TreeHash,
-            TestRandom,
             Educe,
         ),
         context_deserialize(ForkName),
         educe(PartialEq, Hash(bound(E: EthSpec))),
         serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),

--- a/consensus/types/src/execution/execution_payload_bid.rs
+++ b/consensus/types/src/execution/execution_payload_bid.rs
@@ -1,15 +1,16 @@
+#[cfg(feature = "testing")]
 use crate::test_utils::TestRandom;
 use crate::{Address, ExecutionBlockHash, ForkName, Hash256, SignedRoot, Slot};
 use context_deserialize::context_deserialize;
 use educe::Educe;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[derive(
-    Default, Debug, Clone, Serialize, Encode, Decode, Deserialize, TreeHash, Educe, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Default, Debug, Clone, Serialize, Encode, Decode, Deserialize, TreeHash, Educe)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[educe(PartialEq, Hash)]
 #[context_deserialize(ForkName)]

--- a/consensus/types/src/execution/execution_payload_envelope.rs
+++ b/consensus/types/src/execution/execution_payload_envelope.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "testing")]
 use crate::test_utils::TestRandom;
 use crate::{
     EthSpec, ExecutionPayloadGloas, ExecutionRequests, ForkName, Hash256, KzgCommitments,
@@ -7,10 +8,12 @@ use context_deserialize::context_deserialize;
 use educe::Educe;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, Clone, Serialize, Encode, Decode, Deserialize, TestRandom, TreeHash, Educe)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, Serialize, Encode, Decode, Deserialize, TreeHash, Educe)]
 #[educe(PartialEq, Hash(bound(E: EthSpec)))]
 #[context_deserialize(ForkName)]
 #[serde(bound = "E: EthSpec")]

--- a/consensus/types/src/execution/execution_payload_header.rs
+++ b/consensus/types/src/execution/execution_payload_header.rs
@@ -6,10 +6,13 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{FixedVector, VariableList};
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{Address, EthSpec, ExecutionBlockHash, Hash256, Uint256},
     execution::{
@@ -19,7 +22,6 @@ use crate::{
     fork::ForkName,
     map_execution_payload_ref_into_execution_payload_header,
     state::BeaconStateError,
-    test_utils::TestRandom,
 };
 
 #[superstruct(
@@ -34,10 +36,10 @@ use crate::{
             Encode,
             Decode,
             TreeHash,
-            TestRandom,
             Educe,
         ),
         educe(PartialEq, Hash(bound(E: EthSpec))),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         serde(bound = "E: EthSpec", deny_unknown_fields),
         cfg_attr(
             feature = "arbitrary",

--- a/consensus/types/src/execution/execution_requests.rs
+++ b/consensus/types/src/execution/execution_requests.rs
@@ -6,15 +6,17 @@ use serde::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     consolidation::ConsolidationRequest,
     core::{EthSpec, Hash256},
     deposit::DepositRequest,
     fork::ForkName,
-    test_utils::TestRandom,
     withdrawal::WithdrawalRequest,
 };
 
@@ -30,9 +32,8 @@ pub type ConsolidationRequests<E> =
     derive(arbitrary::Arbitrary),
     arbitrary(bound = "E: EthSpec")
 )]
-#[derive(
-    Debug, Educe, Default, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Educe, Default, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[serde(bound = "E: EthSpec")]
 #[educe(PartialEq, Eq, Hash(bound(E: EthSpec)))]
 #[context_deserialize(ForkName)]

--- a/consensus/types/src/execution/payload.rs
+++ b/consensus/types/src/execution/payload.rs
@@ -6,9 +6,13 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
 use std::{borrow::Cow, fmt::Debug, hash::Hash};
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
+
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 
 use crate::{
     core::{Address, EthSpec, ExecutionBlockHash, Hash256},
@@ -22,7 +26,6 @@ use crate::{
     fork::ForkName,
     map_execution_payload_into_blinded_payload, map_execution_payload_into_full_payload,
     state::BeaconStateError,
-    test_utils::TestRandom,
 };
 
 #[derive(Debug, PartialEq)]
@@ -63,7 +66,7 @@ pub trait ExecPayload<E: EthSpec>: Debug + Clone + PartialEq + Hash + TreeHash +
 }
 
 /// `ExecPayload` functionality the requires ownership.
-#[cfg(feature = "arbitrary")]
+#[cfg(all(feature = "arbitrary", feature = "testing"))]
 pub trait OwnedExecPayload<E: EthSpec>:
     ExecPayload<E>
     + Default
@@ -76,7 +79,7 @@ pub trait OwnedExecPayload<E: EthSpec>:
     + 'static
 {
 }
-#[cfg(feature = "arbitrary")]
+#[cfg(all(feature = "arbitrary", feature = "testing"))]
 impl<E: EthSpec, P> OwnedExecPayload<E> for P where
     P: ExecPayload<E>
         + Default
@@ -91,12 +94,37 @@ impl<E: EthSpec, P> OwnedExecPayload<E> for P where
 }
 
 /// `ExecPayload` functionality the requires ownership.
-#[cfg(not(feature = "arbitrary"))]
+#[cfg(all(feature = "arbitrary", not(feature = "testing")))]
+pub trait OwnedExecPayload<E: EthSpec>:
+    ExecPayload<E>
+    + Default
+    + Serialize
+    + DeserializeOwned
+    + Encode
+    + Decode
+    + for<'a> arbitrary::Arbitrary<'a>
+    + 'static
+{
+}
+#[cfg(all(feature = "arbitrary", not(feature = "testing")))]
+impl<E: EthSpec, P> OwnedExecPayload<E> for P where
+    P: ExecPayload<E>
+        + Default
+        + Serialize
+        + DeserializeOwned
+        + Encode
+        + Decode
+        + for<'a> arbitrary::Arbitrary<'a>
+        + 'static
+{
+}
+
+#[cfg(all(not(feature = "arbitrary"), feature = "testing"))]
 pub trait OwnedExecPayload<E: EthSpec>:
     ExecPayload<E> + Default + Serialize + DeserializeOwned + Encode + Decode + TestRandom + 'static
 {
 }
-#[cfg(not(feature = "arbitrary"))]
+#[cfg(all(not(feature = "arbitrary"), feature = "testing"))]
 impl<E: EthSpec, P> OwnedExecPayload<E> for P where
     P: ExecPayload<E>
         + Default
@@ -106,6 +134,17 @@ impl<E: EthSpec, P> OwnedExecPayload<E> for P where
         + Decode
         + TestRandom
         + 'static
+{
+}
+
+#[cfg(all(not(feature = "arbitrary"), not(feature = "testing")))]
+pub trait OwnedExecPayload<E: EthSpec>:
+    ExecPayload<E> + Default + Serialize + DeserializeOwned + Encode + Decode + 'static
+{
+}
+#[cfg(all(not(feature = "arbitrary"), not(feature = "testing")))]
+impl<E: EthSpec, P> OwnedExecPayload<E> for P where
+    P: ExecPayload<E> + Default + Serialize + DeserializeOwned + Encode + Decode + 'static
 {
 }
 
@@ -159,19 +198,10 @@ pub trait AbstractExecPayload<E: EthSpec>:
 #[superstruct(
     variants(Bellatrix, Capella, Deneb, Electra, Fulu),
     variant_attributes(
-        derive(
-            Debug,
-            Clone,
-            Serialize,
-            Deserialize,
-            Encode,
-            Decode,
-            TestRandom,
-            TreeHash,
-            Educe,
-        ),
+        derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Educe,),
         educe(PartialEq, Hash(bound(E: EthSpec))),
         serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),
@@ -526,19 +556,10 @@ impl<E: EthSpec> TryFrom<ExecutionPayloadHeader<E>> for FullPayload<E> {
 #[superstruct(
     variants(Bellatrix, Capella, Deneb, Electra, Fulu),
     variant_attributes(
-        derive(
-            Debug,
-            Clone,
-            Serialize,
-            Deserialize,
-            Encode,
-            Decode,
-            TestRandom,
-            TreeHash,
-            Educe,
-        ),
+        derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Educe,),
         educe(PartialEq, Hash(bound(E: EthSpec))),
         serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),

--- a/consensus/types/src/execution/signed_bls_to_execution_change.rs
+++ b/consensus/types/src/execution/signed_bls_to_execution_change.rs
@@ -2,15 +2,17 @@ use bls::Signature;
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{execution::BlsToExecutionChange, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{execution::BlsToExecutionChange, fork::ForkName};
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct SignedBlsToExecutionChange {
     pub message: BlsToExecutionChange,

--- a/consensus/types/src/execution/signed_execution_payload_bid.rs
+++ b/consensus/types/src/execution/signed_execution_payload_bid.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "testing")]
 use crate::test_utils::TestRandom;
 use crate::{ExecutionPayloadBid, ForkName};
 use bls::Signature;
@@ -5,10 +6,12 @@ use context_deserialize::context_deserialize;
 use educe::Educe;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[derive(TestRandom, TreeHash, Debug, Clone, Encode, Decode, Serialize, Deserialize, Educe)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(TreeHash, Debug, Clone, Encode, Decode, Serialize, Deserialize, Educe)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[educe(PartialEq, Hash)]
 #[context_deserialize(ForkName)]

--- a/consensus/types/src/execution/signed_execution_payload_envelope.rs
+++ b/consensus/types/src/execution/signed_execution_payload_envelope.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "testing")]
 use crate::test_utils::TestRandom;
 use crate::{
     ChainSpec, Domain, Epoch, EthSpec, ExecutionBlockHash, ExecutionPayloadEnvelope, Fork, Hash256,
@@ -7,10 +8,12 @@ use bls::{PublicKey, Signature};
 use educe::Educe;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, Clone, Serialize, Encode, Decode, Deserialize, TestRandom, TreeHash, Educe)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, Serialize, Encode, Decode, Deserialize, TreeHash, Educe)]
 #[educe(PartialEq, Hash(bound(E: EthSpec)))]
 #[serde(bound = "E: EthSpec")]
 pub struct SignedExecutionPayloadEnvelope<E: EthSpec> {

--- a/consensus/types/src/exit/signed_voluntary_exit.rs
+++ b/consensus/types/src/exit/signed_voluntary_exit.rs
@@ -2,18 +2,20 @@ use bls::Signature;
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{exit::VoluntaryExit, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{exit::VoluntaryExit, fork::ForkName};
 
 /// An exit voluntarily submitted a validator who wishes to withdraw.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct SignedVoluntaryExit {
     pub message: VoluntaryExit,

--- a/consensus/types/src/exit/voluntary_exit.rs
+++ b/consensus/types/src/exit/voluntary_exit.rs
@@ -2,23 +2,24 @@ use bls::SecretKey;
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{ChainSpec, Domain, Epoch, Hash256, SignedRoot},
     exit::SignedVoluntaryExit,
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 /// An exit voluntarily submitted a validator who wishes to withdraw.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct VoluntaryExit {
     /// Earliest epoch when voluntary exit can be processed.

--- a/consensus/types/src/fork/fork.rs
+++ b/consensus/types/src/fork/fork.rs
@@ -1,27 +1,21 @@
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{core::Epoch, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{core::Epoch, fork::ForkName};
 
 /// Specifies a fork of the `BeaconChain`, to prevent replay attacks.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Default,
-    Serialize,
-    Deserialize,
-    Encode,
-    Decode,
-    TreeHash,
-    TestRandom,
+    Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize, Encode, Decode, TreeHash,
 )]
 #[context_deserialize(ForkName)]
 pub struct Fork {

--- a/consensus/types/src/fork/fork_data.rs
+++ b/consensus/types/src/fork/fork_data.rs
@@ -1,22 +1,23 @@
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{Hash256, SignedRoot},
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 /// Specifies a fork of the `BeaconChain`, to prevent replay attacks.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, Clone, PartialEq, Default, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct ForkData {
     #[serde(with = "serde_utils::bytes_4_hex")]

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -9,6 +9,7 @@
     )
 )]
 
+#[cfg(feature = "testing")]
 #[macro_use]
 pub mod test_utils;
 

--- a/consensus/types/src/light_client/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client/light_client_bootstrap.rs
@@ -7,9 +7,12 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use ssz_types::FixedVector;
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     block::SignedBlindedBeaconBlock,
     core::{ChainSpec, EthSpec, Hash256, Slot},
@@ -21,7 +24,6 @@ use crate::{
     },
     state::BeaconState,
     sync_committee::SyncCommittee,
-    test_utils::TestRandom,
 };
 
 /// A LightClientBootstrap is the initializer we send over to light_client nodes
@@ -29,19 +31,10 @@ use crate::{
 #[superstruct(
     variants(Altair, Capella, Deneb, Electra, Fulu),
     variant_attributes(
-        derive(
-            Debug,
-            Clone,
-            Serialize,
-            Deserialize,
-            Educe,
-            Decode,
-            Encode,
-            TestRandom,
-            TreeHash,
-        ),
+        derive(Debug, Clone, Serialize, Deserialize, Educe, Decode, Encode, TreeHash,),
         educe(PartialEq),
         serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),

--- a/consensus/types/src/light_client/light_client_finality_update.rs
+++ b/consensus/types/src/light_client/light_client_finality_update.rs
@@ -6,9 +6,12 @@ use ssz_derive::Decode;
 use ssz_derive::Encode;
 use ssz_types::FixedVector;
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     block::SignedBlindedBeaconBlock,
     core::{ChainSpec, EthSpec, Hash256, Slot},
@@ -19,25 +22,15 @@ use crate::{
         LightClientHeaderElectra, LightClientHeaderFulu,
     },
     sync_committee::SyncAggregate,
-    test_utils::TestRandom,
 };
 
 #[superstruct(
     variants(Altair, Capella, Deneb, Electra, Fulu),
     variant_attributes(
-        derive(
-            Debug,
-            Clone,
-            Serialize,
-            Deserialize,
-            Educe,
-            Decode,
-            Encode,
-            TestRandom,
-            TreeHash,
-        ),
+        derive(Debug, Clone, Serialize, Deserialize, Educe, Decode, Encode, TreeHash,),
         educe(PartialEq),
         serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),

--- a/consensus/types/src/light_client/light_client_header.rs
+++ b/consensus/types/src/light_client/light_client_header.rs
@@ -7,9 +7,12 @@ use ssz::Decode;
 use ssz_derive::{Decode, Encode};
 use ssz_types::FixedVector;
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     block::{BeaconBlockBody, BeaconBlockHeader, SignedBlindedBeaconBlock},
     core::{ChainSpec, EthSpec, Hash256},
@@ -19,25 +22,15 @@ use crate::{
     },
     fork::ForkName,
     light_client::{ExecutionPayloadProofLen, LightClientError, consts::EXECUTION_PAYLOAD_INDEX},
-    test_utils::TestRandom,
 };
 
 #[superstruct(
     variants(Altair, Capella, Deneb, Electra, Fulu,),
     variant_attributes(
-        derive(
-            Debug,
-            Clone,
-            Serialize,
-            Deserialize,
-            Educe,
-            Decode,
-            Encode,
-            TestRandom,
-            TreeHash,
-        ),
+        derive(Debug, Clone, Serialize, Deserialize, Educe, Decode, Encode, TreeHash,),
         educe(PartialEq),
         serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),

--- a/consensus/types/src/light_client/light_client_optimistic_update.rs
+++ b/consensus/types/src/light_client/light_client_optimistic_update.rs
@@ -4,10 +4,13 @@ use serde::{Deserialize, Deserializer, Serialize};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash::Hash256;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     block::SignedBlindedBeaconBlock,
     core::{ChainSpec, EthSpec, Slot},
@@ -17,7 +20,6 @@ use crate::{
         LightClientHeaderDeneb, LightClientHeaderElectra, LightClientHeaderFulu,
     },
     sync_committee::SyncAggregate,
-    test_utils::TestRandom,
 };
 
 /// A LightClientOptimisticUpdate is the update we send on each slot,
@@ -25,19 +27,10 @@ use crate::{
 #[superstruct(
     variants(Altair, Capella, Deneb, Electra, Fulu),
     variant_attributes(
-        derive(
-            Debug,
-            Clone,
-            Serialize,
-            Deserialize,
-            Educe,
-            Decode,
-            Encode,
-            TestRandom,
-            TreeHash,
-        ),
+        derive(Debug, Clone, Serialize, Deserialize, Educe, Decode, Encode, TreeHash,),
         educe(PartialEq),
         serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),

--- a/consensus/types/src/light_client/light_client_update.rs
+++ b/consensus/types/src/light_client/light_client_update.rs
@@ -10,10 +10,13 @@ use ssz_derive::Decode;
 use ssz_derive::Encode;
 use ssz_types::FixedVector;
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 use typenum::{U4, U5, U6, U7};
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     block::SignedBlindedBeaconBlock,
     core::{ChainSpec, Epoch, EthSpec, Hash256, Slot},
@@ -23,7 +26,6 @@ use crate::{
         LightClientHeaderDeneb, LightClientHeaderElectra, LightClientHeaderFulu,
     },
     sync_committee::{SyncAggregate, SyncCommittee},
-    test_utils::TestRandom,
 };
 
 pub type FinalizedRootProofLen = U6;
@@ -47,19 +49,10 @@ type NextSyncCommitteeBranchElectra = FixedVector<Hash256, NextSyncCommitteeProo
 #[superstruct(
     variants(Altair, Capella, Deneb, Electra, Fulu),
     variant_attributes(
-        derive(
-            Debug,
-            Clone,
-            Serialize,
-            Deserialize,
-            Educe,
-            Decode,
-            Encode,
-            TestRandom,
-            TreeHash,
-        ),
+        derive(Debug, Clone, Serialize, Deserialize, Educe, Decode, Encode, TreeHash,),
         educe(PartialEq),
         serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),

--- a/consensus/types/src/slashing/attester_slashing.rs
+++ b/consensus/types/src/slashing/attester_slashing.rs
@@ -1,36 +1,30 @@
 use context_deserialize::{ContextDeserialize, context_deserialize};
 use educe::Educe;
+#[cfg(feature = "testing")]
 use rand::{Rng, RngCore};
 use serde::{Deserialize, Deserializer, Serialize};
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     attestation::{IndexedAttestationBase, IndexedAttestationElectra, IndexedAttestationRef},
     core::EthSpec,
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 #[superstruct(
     variants(Base, Electra),
     variant_attributes(
-        derive(
-            Educe,
-            Debug,
-            Clone,
-            Serialize,
-            Deserialize,
-            Encode,
-            Decode,
-            TreeHash,
-            TestRandom,
-        ),
+        derive(Educe, Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash,),
         context_deserialize(ForkName),
         educe(PartialEq, Eq, Hash(bound(E: EthSpec))),
         serde(bound = "E: EthSpec"),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),
@@ -171,6 +165,7 @@ impl<E: EthSpec> AttesterSlashing<E> {
     }
 }
 
+#[cfg(feature = "testing")]
 impl<E: EthSpec> TestRandom for AttesterSlashing<E> {
     fn random_for_test(rng: &mut impl RngCore) -> Self {
         if rng.random_bool(0.5) {

--- a/consensus/types/src/slashing/proposer_slashing.rs
+++ b/consensus/types/src/slashing/proposer_slashing.rs
@@ -1,18 +1,20 @@
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{block::SignedBeaconBlockHeader, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{block::SignedBeaconBlockHeader, fork::ForkName};
 
 /// Two conflicting proposals from the same proposer (validator).
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct ProposerSlashing {
     pub signed_header_1: SignedBeaconBlockHeader,

--- a/consensus/types/src/state/beacon_state.rs
+++ b/consensus/types/src/state/beacon_state.rs
@@ -16,12 +16,15 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{BitVector, FixedVector};
 use superstruct::superstruct;
 use swap_or_not_shuffle::compute_shuffled_index;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tracing::instrument;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 use typenum::Unsigned;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     Builder, BuilderIndex, BuilderPendingPayment, BuilderPendingWithdrawal, ExecutionBlockHash,
     ExecutionPayloadBid, Withdrawal,
@@ -49,7 +52,6 @@ use crate::{
         get_active_validator_indices,
     },
     sync_committee::{SyncCommittee, SyncDuty},
-    test_utils::TestRandom,
     validator::Validator,
     withdrawal::PendingPartialWithdrawal,
 };
@@ -263,10 +265,10 @@ impl From<BeaconStateHash> for Hash256 {
             Encode,
             Decode,
             TreeHash,
-            TestRandom,
             CompareFields,
         ),
         serde(bound = "E: EthSpec", deny_unknown_fields),
+        cfg_attr(feature = "testing", derive(TestRandom)),
         cfg_attr(
             feature = "arbitrary",
             derive(arbitrary::Arbitrary),
@@ -429,21 +431,21 @@ where
     // History
     #[metastruct(exclude_from(tree_lists))]
     pub latest_block_header: BeaconBlockHeader,
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[compare_fields(as_iter)]
     pub block_roots: Vector<Hash256, E::SlotsPerHistoricalRoot>,
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[compare_fields(as_iter)]
     pub state_roots: Vector<Hash256, E::SlotsPerHistoricalRoot>,
     // Frozen in Capella, replaced by historical_summaries
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[compare_fields(as_iter)]
     pub historical_roots: List<Hash256, E::HistoricalRootsLimit>,
 
     // Ethereum 1.0 chain data
     #[metastruct(exclude_from(tree_lists))]
     pub eth1_data: Eth1Data,
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     pub eth1_data_votes: List<Eth1Data, E::SlotsPerEth1VotingPeriod>,
     #[superstruct(getter(copy))]
     #[metastruct(exclude_from(tree_lists))]
@@ -452,42 +454,42 @@ where
 
     // Registry
     #[compare_fields(as_iter)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     pub validators: List<Validator, E::ValidatorRegistryLimit>,
     #[serde(with = "ssz_types::serde_utils::quoted_u64_var_list")]
     #[compare_fields(as_iter)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     pub balances: List<u64, E::ValidatorRegistryLimit>,
 
     // Randomness
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     pub randao_mixes: Vector<Hash256, E::EpochsPerHistoricalVector>,
 
     // Slashings
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[serde(with = "ssz_types::serde_utils::quoted_u64_fixed_vec")]
     pub slashings: Vector<u64, E::EpochsPerSlashingsVector>,
 
     // Attestations (genesis fork only)
     #[superstruct(only(Base))]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     pub previous_epoch_attestations: List<PendingAttestation<E>, E::MaxPendingAttestations>,
     #[superstruct(only(Base))]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     pub current_epoch_attestations: List<PendingAttestation<E>, E::MaxPendingAttestations>,
 
     // Participation (Altair and later)
     #[compare_fields(as_iter)]
     #[superstruct(only(Altair, Bellatrix, Capella, Deneb, Electra, Fulu, Gloas))]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[compare_fields(as_iter)]
     pub previous_epoch_participation: List<ParticipationFlags, E::ValidatorRegistryLimit>,
     #[superstruct(only(Altair, Bellatrix, Capella, Deneb, Electra, Fulu, Gloas))]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     pub current_epoch_participation: List<ParticipationFlags, E::ValidatorRegistryLimit>,
 
     // Finality
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[metastruct(exclude_from(tree_lists))]
     pub justification_bits: BitVector<E::JustificationBitsLength>,
     #[superstruct(getter(copy))]
@@ -503,7 +505,7 @@ where
     // Inactivity
     #[serde(with = "ssz_types::serde_utils::quoted_u64_var_list")]
     #[superstruct(only(Altair, Bellatrix, Capella, Deneb, Electra, Fulu, Gloas))]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     pub inactivity_scores: List<u64, E::ValidatorRegistryLimit>,
 
     // Light-client sync committees
@@ -558,7 +560,7 @@ where
     pub next_withdrawal_validator_index: u64,
     // Deep history valid from Capella onwards.
     #[superstruct(only(Capella, Deneb, Electra, Fulu, Gloas))]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     pub historical_summaries: List<HistoricalSummary, E::HistoricalRootsLimit>,
 
     // Electra
@@ -585,28 +587,28 @@ where
     #[metastruct(exclude_from(tree_lists))]
     pub earliest_consolidation_epoch: Epoch,
     #[compare_fields(as_iter)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[superstruct(only(Electra, Fulu, Gloas))]
     pub pending_deposits: List<PendingDeposit, E::PendingDepositsLimit>,
     #[compare_fields(as_iter)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[superstruct(only(Electra, Fulu, Gloas))]
     pub pending_partial_withdrawals:
         List<PendingPartialWithdrawal, E::PendingPartialWithdrawalsLimit>,
     #[compare_fields(as_iter)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[superstruct(only(Electra, Fulu, Gloas))]
     pub pending_consolidations: List<PendingConsolidation, E::PendingConsolidationsLimit>,
 
     // Fulu
     #[compare_fields(as_iter)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[superstruct(only(Fulu, Gloas))]
     #[serde(with = "ssz_types::serde_utils::quoted_u64_fixed_vec")]
     pub proposer_lookahead: Vector<u64, E::ProposerLookaheadSlots>,
     // Gloas
     #[compare_fields(as_iter)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[superstruct(only(Gloas))]
     pub builders: List<Builder, E::BuilderRegistryLimit>,
 
@@ -615,29 +617,29 @@ where
     #[superstruct(only(Gloas), partial_getter(copy))]
     pub next_withdrawal_builder_index: BuilderIndex,
 
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[superstruct(only(Gloas))]
     #[metastruct(exclude_from(tree_lists))]
     pub execution_payload_availability: BitVector<E::SlotsPerHistoricalRoot>,
 
     #[compare_fields(as_iter)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[superstruct(only(Gloas))]
     pub builder_pending_payments: Vector<BuilderPendingPayment, E::BuilderPendingPaymentsLimit>,
 
     #[compare_fields(as_iter)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[superstruct(only(Gloas))]
     pub builder_pending_withdrawals:
         List<BuilderPendingWithdrawal, E::BuilderPendingWithdrawalsLimit>,
 
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[superstruct(only(Gloas))]
     #[metastruct(exclude_from(tree_lists))]
     pub latest_block_hash: ExecutionBlockHash,
 
     #[compare_fields(as_iter)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[superstruct(only(Gloas))]
     pub payload_expected_withdrawals: List<Withdrawal, E::MaxWithdrawalsPerPayload>,
 
@@ -645,44 +647,44 @@ where
     #[serde(skip_serializing, skip_deserializing)]
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[metastruct(exclude)]
     pub total_active_balance: Option<(Epoch, u64)>,
     #[serde(skip_serializing, skip_deserializing)]
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[metastruct(exclude)]
     pub committee_caches: [Arc<CommitteeCache>; CACHED_EPOCHS],
     #[serde(skip_serializing, skip_deserializing)]
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[metastruct(exclude)]
     pub progressive_balances_cache: ProgressiveBalancesCache,
     #[serde(skip_serializing, skip_deserializing)]
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[metastruct(exclude)]
     pub pubkey_cache: PubkeyCache,
     #[serde(skip_serializing, skip_deserializing)]
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[metastruct(exclude)]
     pub exit_cache: ExitCache,
     #[serde(skip_serializing, skip_deserializing)]
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[metastruct(exclude)]
     pub slashings_cache: SlashingsCache,
     /// Epoch cache of values that are useful for block processing that are static over an epoch.
     #[serde(skip_serializing, skip_deserializing)]
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     #[metastruct(exclude)]
     pub epoch_cache: EpochCache,
 }

--- a/consensus/types/src/state/historical_batch.rs
+++ b/consensus/types/src/state/historical_batch.rs
@@ -2,13 +2,15 @@ use context_deserialize::context_deserialize;
 use milhouse::Vector;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{EthSpec, Hash256},
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 /// Historical block and state roots.
@@ -19,12 +21,13 @@ use crate::{
     derive(arbitrary::Arbitrary),
     arbitrary(bound = "E: EthSpec")
 )]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct HistoricalBatch<E: EthSpec> {
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     pub block_roots: Vector<Hash256, E::SlotsPerHistoricalRoot>,
-    #[test_random(default)]
+    #[cfg_attr(feature = "testing", test_random(default))]
     pub state_roots: Vector<Hash256, E::SlotsPerHistoricalRoot>,
 }
 

--- a/consensus/types/src/state/historical_summary.rs
+++ b/consensus/types/src/state/historical_summary.rs
@@ -2,15 +2,17 @@ use compare_fields::CompareFields;
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{EthSpec, Hash256},
     fork::ForkName,
     state::BeaconState,
-    test_utils::TestRandom,
 };
 
 /// `HistoricalSummary` matches the components of the phase0 `HistoricalBatch`
@@ -19,6 +21,7 @@ use crate::{
 ///
 /// https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#historicalsummary
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
 #[derive(
     Debug,
     PartialEq,
@@ -28,7 +31,6 @@ use crate::{
     Encode,
     Decode,
     TreeHash,
-    TestRandom,
     CompareFields,
     Clone,
     Copy,

--- a/consensus/types/src/sync_committee/contribution_and_proof.rs
+++ b/consensus/types/src/sync_committee/contribution_and_proof.rs
@@ -2,14 +2,16 @@ use bls::{SecretKey, Signature};
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{ChainSpec, EthSpec, Hash256, SignedRoot},
     fork::{Fork, ForkName},
     sync_committee::{SyncCommitteeContribution, SyncSelectionProof},
-    test_utils::TestRandom,
 };
 
 /// A Validators aggregate sync committee contribution and selection proof.
@@ -18,7 +20,8 @@ use crate::{
     derive(arbitrary::Arbitrary),
     arbitrary(bound = "E: EthSpec")
 )]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[serde(bound = "E: EthSpec")]
 #[context_deserialize(ForkName)]
 pub struct ContributionAndProof<E: EthSpec> {

--- a/consensus/types/src/sync_committee/signed_contribution_and_proof.rs
+++ b/consensus/types/src/sync_committee/signed_contribution_and_proof.rs
@@ -2,14 +2,16 @@ use bls::{SecretKey, Signature};
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{ChainSpec, Domain, EthSpec, Hash256, SignedRoot},
     fork::{Fork, ForkName},
     sync_committee::{ContributionAndProof, SyncCommitteeContribution, SyncSelectionProof},
-    test_utils::TestRandom,
 };
 
 /// A Validators signed contribution proof to publish on the `sync_committee_contribution_and_proof`
@@ -19,7 +21,8 @@ use crate::{
     derive(arbitrary::Arbitrary),
     arbitrary(bound = "E: EthSpec")
 )]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[serde(bound = "E: EthSpec")]
 #[context_deserialize(ForkName)]
 pub struct SignedContributionAndProof<E: EthSpec> {

--- a/consensus/types/src/sync_committee/sync_aggregate.rs
+++ b/consensus/types/src/sync_committee/sync_aggregate.rs
@@ -5,14 +5,16 @@ use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::BitVector;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{EthSpec, consts::altair::SYNC_COMMITTEE_SUBNET_COUNT},
     fork::ForkName,
     sync_committee::SyncCommitteeContribution,
-    test_utils::TestRandom,
 };
 
 #[derive(Debug, PartialEq)]
@@ -32,7 +34,8 @@ impl From<ArithError> for Error {
     derive(arbitrary::Arbitrary),
     arbitrary(bound = "E: EthSpec")
 )]
-#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom, Educe)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, Educe)]
 #[educe(PartialEq, Hash(bound(E: EthSpec)))]
 #[serde(bound = "E: EthSpec")]
 #[context_deserialize(ForkName)]

--- a/consensus/types/src/sync_committee/sync_aggregator_selection_data.rs
+++ b/consensus/types/src/sync_committee/sync_aggregator_selection_data.rs
@@ -1,19 +1,20 @@
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{SignedRoot, Slot},
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, Hash, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Hash, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct SyncAggregatorSelectionData {
     pub slot: Slot,

--- a/consensus/types/src/sync_committee/sync_committee.rs
+++ b/consensus/types/src/sync_committee/sync_committee.rs
@@ -6,10 +6,13 @@ use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::FixedVector;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{core::EthSpec, fork::ForkName, sync_committee::SyncSubnetId, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{core::EthSpec, fork::ForkName, sync_committee::SyncSubnetId};
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -32,7 +35,8 @@ impl From<ArithError> for Error {
     derive(arbitrary::Arbitrary),
     arbitrary(bound = "E: EthSpec")
 )]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[serde(bound = "E: EthSpec")]
 #[context_deserialize(ForkName)]
 pub struct SyncCommittee<E: EthSpec> {

--- a/consensus/types/src/sync_committee/sync_committee_contribution.rs
+++ b/consensus/types/src/sync_committee/sync_committee_contribution.rs
@@ -3,14 +3,16 @@ use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::BitVector;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{EthSpec, Hash256, SignedRoot, Slot, SlotData},
     fork::ForkName,
     sync_committee::SyncCommitteeMessage,
-    test_utils::TestRandom,
 };
 
 #[derive(Debug, PartialEq)]
@@ -26,7 +28,8 @@ pub enum Error {
     derive(arbitrary::Arbitrary),
     arbitrary(bound = "E: EthSpec")
 )]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[serde(bound = "E: EthSpec")]
 #[context_deserialize(ForkName)]
 pub struct SyncCommitteeContribution<E: EthSpec> {
@@ -79,7 +82,8 @@ impl<E: EthSpec> SyncCommitteeContribution<E> {
 impl SignedRoot for Hash256 {}
 
 /// This is not in the spec, but useful for determining uniqueness of sync committee contributions
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct SyncContributionData {
     pub slot: Slot,
     pub beacon_block_root: Hash256,

--- a/consensus/types/src/sync_committee/sync_committee_message.rs
+++ b/consensus/types/src/sync_committee/sync_committee_message.rs
@@ -2,18 +2,21 @@ use bls::{SecretKey, Signature};
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{ChainSpec, Domain, EthSpec, Hash256, SignedRoot, Slot, SlotData},
     fork::{Fork, ForkName},
-    test_utils::TestRandom,
 };
 
 /// The data upon which a `SyncCommitteeContribution` is based.
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct SyncCommitteeMessage {
     pub slot: Slot,

--- a/consensus/types/src/validator/validator.rs
+++ b/consensus/types/src/validator/validator.rs
@@ -3,24 +3,25 @@ use context_deserialize::context_deserialize;
 use fixed_bytes::FixedBytesExtended;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     attestation::Checkpoint,
     core::{Address, ChainSpec, Epoch, EthSpec, Hash256},
     fork::ForkName,
     state::BeaconState,
-    test_utils::TestRandom,
 };
 
 /// Information about a `BeaconChain` validator.
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct Validator {
     pub pubkey: PublicKeyBytes,

--- a/consensus/types/src/withdrawal/pending_partial_withdrawal.rs
+++ b/consensus/types/src/withdrawal/pending_partial_withdrawal.rs
@@ -1,15 +1,17 @@
 use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{core::Epoch, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{core::Epoch, fork::ForkName};
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct PendingPartialWithdrawal {
     #[serde(with = "serde_utils::quoted_u64")]

--- a/consensus/types/src/withdrawal/withdrawal.rs
+++ b/consensus/types/src/withdrawal/withdrawal.rs
@@ -2,19 +2,20 @@ use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
 use crate::{
     core::{Address, EthSpec},
     fork::ForkName,
-    test_utils::TestRandom,
 };
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct Withdrawal {
     #[serde(with = "serde_utils::quoted_u64")]

--- a/consensus/types/src/withdrawal/withdrawal_request.rs
+++ b/consensus/types/src/withdrawal/withdrawal_request.rs
@@ -3,15 +3,17 @@ use context_deserialize::context_deserialize;
 use serde::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
+#[cfg(feature = "testing")]
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-use crate::{core::Address, fork::ForkName, test_utils::TestRandom};
+#[cfg(feature = "testing")]
+use crate::test_utils::TestRandom;
+use crate::{core::Address, fork::ForkName};
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[cfg_attr(feature = "testing", derive(TestRandom))]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash)]
 #[context_deserialize(ForkName)]
 pub struct WithdrawalRequest {
     #[serde(with = "serde_utils::address_hex")]


### PR DESCRIPTION
## Issue Addressed

#8652

## Proposed Changes

Feature gate all testing utility code: `test_utils`, `TestRandom`, etc

## Additional Info
I will be posting a new PR soon which removes `TestRandom` entirely as its function might be made redundant by `arbitrary`.
