### PR TITLE
Disable `sqlite` by default

### DIFF
--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
 edition = { workspace = true }
 
 [features]
-default = ["sqlite", "legacy-arith"]
+default = ["legacy-arith"]
 # Allow saturating arithmetic on slots and epochs. Enabled by default, but deprecated.
 legacy-arith = []
 sqlite = ["dep:rusqlite"]

--- a/validator_client/slashing_protection/Cargo.toml
+++ b/validator_client/slashing_protection/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }
-types = { workspace = true }
+types = { workspace = true, features = ["sqlite"] }
 
 [dev-dependencies]
 rayon = { workspace = true }


### PR DESCRIPTION
## Issue Addressed

Compiling types with the `sqlite` feature more than doubles the total compile time. Most downstream users don't need `sqlite` compatibility for `Slot` and `Epoch` types.

## Proposed Changes

Disable the `sqlite` feature by default.
