### PR TITLE
Remove unused anvil references

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -92,10 +92,6 @@ jobs:
           bins: cargo-nextest
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install Foundry (anvil)
-      uses: foundry-rs/foundry-toolchain@v1
-      with:
-        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run tests in release
       run: make test-release
     - name: Show cache stats
@@ -213,10 +209,6 @@ jobs:
       with:
           channel: stable
           bins: cargo-nextest
-    - name: Install Foundry (anvil)
-      uses: foundry-rs/foundry-toolchain@v1
-      with:
-        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run tests in debug
       run: make test-debug
   state-transition-vectors-ubuntu:

--- a/book/src/contributing_setup.md
+++ b/book/src/contributing_setup.md
@@ -10,9 +10,6 @@ base dependencies.
 
 The additional requirements for developers are:
 
-- [`anvil`](https://github.com/foundry-rs/foundry/tree/master/crates/anvil). This is used to
-  simulate the execution chain during tests. You'll get failures during tests if you
-  don't have `anvil` available on your `PATH`.
 - [`cmake`](https://cmake.org/cmake/help/latest/command/install.html). Used by
   some dependencies. See [`Installation Guide`](./installation.md) for more info.
 - [`java 17 runtime`](https://openjdk.java.net/projects/jdk/). 17 is the minimum,


### PR DESCRIPTION
## Issue Addressed

AFAICT `anvil` is not used anywhere in the codebase. Lighthouse has its own `MockExecutionLayer` for testing. This PR remove `anvil` installations and references in developer documentation.