### PR TITLE
fix: set slot_number to latest_block_header.slot in Gloas upgrade

### DIFF
--- a/consensus/state_processing/src/upgrade/gloas.rs
+++ b/consensus/state_processing/src/upgrade/gloas.rs
@@ -64,7 +64,9 @@ pub fn upgrade_state_to_gloas<E: EthSpec>(
         current_sync_committee: pre.current_sync_committee.clone(),
         next_sync_committee: pre.next_sync_committee.clone(),
         // Execution - upgrade header from Fulu to Gloas
-        latest_execution_payload_header: pre.latest_execution_payload_header.upgrade_to_gloas(),
+        latest_execution_payload_header: pre
+            .latest_execution_payload_header
+            .upgrade_to_gloas(pre.latest_block_header.slot.into()),
         // Capella
         next_withdrawal_index: pre.next_withdrawal_index,
         next_withdrawal_validator_index: pre.next_withdrawal_validator_index,

--- a/consensus/types/src/execution/execution_payload_header.rs
+++ b/consensus/types/src/execution/execution_payload_header.rs
@@ -275,7 +275,7 @@ impl<E: EthSpec> ExecutionPayloadHeaderElectra<E> {
 }
 
 impl<E: EthSpec> ExecutionPayloadHeaderFulu<E> {
-    pub fn upgrade_to_gloas(&self) -> ExecutionPayloadHeaderGloas<E> {
+    pub fn upgrade_to_gloas(&self, slot_number: u64) -> ExecutionPayloadHeaderGloas<E> {
         ExecutionPayloadHeaderGloas {
             parent_hash: self.parent_hash,
             fee_recipient: self.fee_recipient,
@@ -295,7 +295,7 @@ impl<E: EthSpec> ExecutionPayloadHeaderFulu<E> {
             blob_gas_used: self.blob_gas_used,
             excess_blob_gas: self.excess_blob_gas,
             block_access_list_root: Hash256::zero(),
-            slot_number: 0,
+            slot_number,
         }
     }
 }


### PR DESCRIPTION
## Summary

- During the Fulu→Gloas state upgrade, `upgrade_to_gloas()` on `ExecutionPayloadHeaderFulu` hardcoded `slot_number: 0` in the new Gloas header
- This causes beacon state root divergence between Lighthouse and Lodestar at the Gloas fork boundary (slot 8 with minimal preset)
- Fix: pass `pre.latest_block_header.slot` to `upgrade_to_gloas()` so the upgraded header carries forward the correct slot number

## Test plan

- [x] Built with `FEATURES="spec-minimal"` — compiles cleanly
- [x] Tested locally with Kurtosis (LH supernode + Geth, 2x LS + NM): all 3 nodes in consensus through 7+ epochs, epoch 4 finalized, same head root throughout
- [x] Confirmed this resolves the LS + NM beacon state root divergence at the Gloas fork boundary (previously failed every time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)