### PR TITLE
Fast path for `/eth/v1/beacon/blocks/head/root`

### DIFF
--- a/beacon_node/beacon_chain/src/early_attester_cache.rs
+++ b/beacon_node/beacon_chain/src/early_attester_cache.rs
@@ -254,4 +254,9 @@ impl<E: EthSpec> EarlyAttesterCache<E> {
             .filter(|item| item.beacon_block_root == block_root)
             .map(|item| item.proto_block.clone())
     }
+
+    /// Fetch the slot and block root of the current head block.
+    pub fn get_head_block_root(&self) -> Option<Hash256> {
+        self.item.read().as_ref().map(|item| item.beacon_block_root)
+    }
 }

--- a/beacon_node/beacon_chain/src/early_attester_cache.rs
+++ b/beacon_node/beacon_chain/src/early_attester_cache.rs
@@ -256,7 +256,10 @@ impl<E: EthSpec> EarlyAttesterCache<E> {
     }
 
     /// Fetch the slot and block root of the current head block.
-    pub fn get_head_block_root(&self) -> Option<Hash256> {
-        self.item.read().as_ref().map(|item| item.beacon_block_root)
+    pub fn get_head_block_root(&self) -> Option<(Slot, Hash256)> {
+        self.item
+            .read()
+            .as_ref()
+            .map(|item| (item.block.slot(), item.beacon_block_root))
     }
 }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1190,7 +1190,25 @@ pub fn serve<T: BeaconChainTypes>(
                     Priority::P1
                 };
                 task_spawner.blocking_json_task(priority, move || {
-                    let (block_root, execution_optimistic, finalized) = block_id.root(&chain)?;
+                    // Fast-path for the head block root. We read from the early attester cache
+                    // so that we can produce sync committee messages for the new head prior
+                    // to it being fully imported (written to the DB/etc).
+                    //
+                    // See: https://github.com/sigp/lighthouse/issues/8667
+                    let (block_root, execution_optimistic, finalized) =
+                        if let BlockId(eth2::types::BlockId::Head) = block_id
+                            && let Some(head_block_root) =
+                                chain.early_attester_cache.get_head_block_root()
+                        {
+                            // We know execution is NOT optimistic if the block is from the early
+                            // attester cache because only properly validated blocks are added.
+                            // Similarly we know it is NOT finalized.
+                            let execution_optimistic = false;
+                            let finalized = false;
+                            (head_block_root, execution_optimistic, finalized)
+                        } else {
+                            block_id.root(&chain)?
+                        };
                     Ok(
                         api_types::GenericResponse::from(api_types::RootData::from(block_root))
                             .add_execution_optimistic_finalized(execution_optimistic, finalized),

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1192,13 +1192,16 @@ pub fn serve<T: BeaconChainTypes>(
                 task_spawner.blocking_json_task(priority, move || {
                     // Fast-path for the head block root. We read from the early attester cache
                     // so that we can produce sync committee messages for the new head prior
-                    // to it being fully imported (written to the DB/etc).
+                    // to it being fully imported (written to the DB/etc). We also check that the
+                    // cache is not stale or out of date by comparing against the cached head
+                    // prior to using it.
                     //
                     // See: https://github.com/sigp/lighthouse/issues/8667
                     let (block_root, execution_optimistic, finalized) =
                         if let BlockId(eth2::types::BlockId::Head) = block_id
-                            && let Some(head_block_root) =
+                            && let Some((head_block_slot, head_block_root)) =
                                 chain.early_attester_cache.get_head_block_root()
+                            && head_block_slot >= chain.canonical_head.cached_head().head_slot()
                         {
                             // We know execution is NOT optimistic if the block is from the early
                             // attester cache because only properly validated blocks are added.


### PR DESCRIPTION
## Issue Addressed

Closes:

- https://github.com/sigp/lighthouse/issues/8667

## Proposed Changes

Use the `early_attester_cache` to serve the head block root (if present). This should be faster than waiting for the head to finish importing.

## Additional Info

As a precaution, we check that the `early_attester_cache`'s head is at least as recent as the `cached_head`. The `cached_head` lock is only taken lazily (in the `&&`), and using `>=` rather than `>` ensures we don't bounce the `cached_head` lock in the case where the `early_attester_cache` and `cached_head` are from identical slots.
