### PR TITLE
Support pinning nightly ef test runs

### DIFF
--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,6 +1,6 @@
 # To download/extract nightly tests, run:
 # CONSENSUS_SPECS_TEST_VERSION=nightly make
-CONSENSUS_SPECS_TEST_VERSION ?= nightly-21575883288
+CONSENSUS_SPECS_TEST_VERSION ?= v1.7.0-alpha.1
 REPO_NAME := consensus-spec-tests
 OUTPUT_DIR := ./$(REPO_NAME)
 

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,6 +1,6 @@
 # To download/extract nightly tests, run:
 # CONSENSUS_SPECS_TEST_VERSION=nightly make
-CONSENSUS_SPECS_TEST_VERSION ?= v1.7.0-alpha.1
+CONSENSUS_SPECS_TEST_VERSION ?= nightly-21575883288
 REPO_NAME := consensus-spec-tests
 OUTPUT_DIR := ./$(REPO_NAME)
 

--- a/testing/ef_tests/download_test_vectors.sh
+++ b/testing/ef_tests/download_test_vectors.sh
@@ -35,7 +35,7 @@ if [[ "$version" == "nightly" || "$version" =~ ^nightly-[0-9]+$ ]]; then
 	fi
 
 	echo "Downloading nightly test vectors for run: ${run_id}"
-	curl --fail -v -H "${auth_header}" "${api}/repos/${repo}/actions/runs/${run_id}/artifacts" | cat |
+	curl --fail -H "${auth_header}" "${api}/repos/${repo}/actions/runs/${run_id}/artifacts" |
 		jq -c '.artifacts[] | {name, url: .archive_download_url}' |
 		while read -r artifact; do
 			name=$(echo "${artifact}" | jq -r .name)
@@ -46,7 +46,7 @@ if [[ "$version" == "nightly" || "$version" =~ ^nightly-[0-9]+$ ]]; then
 			fi
 
 			echo "Downloading artifact: ${name}"
-			curl --fail --progress-bar --location --show-error --retry 3 --retry-all-errors --fail \
+			curl --progress-bar --location --show-error --retry 3 --retry-all-errors --fail \
 				-H "${auth_header}" -H "Accept: application/vnd.github+json" \
 				--output "${name}.zip" "${url}" || {
 				echo "Failed to download ${name}"
@@ -60,7 +60,7 @@ else
 	for test in "${TESTS[@]}"; do
 		if [[ ! -e "${test}.tar.gz" ]]; then
 			echo "Downloading: ${version}/${test}.tar.gz"
-			curl --fail --progress-bar --location --remote-name --show-error --retry 3 --retry-all-errors --fail \
+			curl --progress-bar --location --remote-name --show-error --retry 3 --retry-all-errors --fail \
 				"https://github.com/ethereum/consensus-specs/releases/download/${version}/${test}.tar.gz" \
 				|| {
 					echo "Curl failed. Aborting"

--- a/testing/ef_tests/download_test_vectors.sh
+++ b/testing/ef_tests/download_test_vectors.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 TESTS=("general" "minimal" "mainnet")
 
 version=${1}
-if [[ "$version" == "nightly" ]]; then
+if [[ "$version" == "nightly" || "$version" =~ ^nightly-[0-9]+$ ]]; then
 	if [[ -z "${GITHUB_TOKEN:-}" ]]; then
 		echo "Error GITHUB_TOKEN is not set"
 		exit 1
@@ -21,9 +21,13 @@ if [[ "$version" == "nightly" ]]; then
 	api="https://api.github.com"
 	auth_header="Authorization: token ${GITHUB_TOKEN}"
 
-	run_id=$(curl -s -H "${auth_header}" \
-		"${api}/repos/${repo}/actions/workflows/generate_vectors.yml/runs?branch=dev&status=success&per_page=1" |
-		jq -r '.workflow_runs[0].id')
+	if [[ "$version" == "nightly" ]]; then
+		run_id=$(curl --fail -s -H "${auth_header}" \
+			"${api}/repos/${repo}/actions/workflows/generate_vectors.yml/runs?branch=master&status=success&per_page=1" |
+			jq -r '.workflow_runs[0].id')
+	else
+		run_id="${version#nightly-}"
+	fi
 
 	if [[ "${run_id}" == "null" || -z "${run_id}" ]]; then
 		echo "No successful nightly workflow run found"
@@ -31,7 +35,7 @@ if [[ "$version" == "nightly" ]]; then
 	fi
 
 	echo "Downloading nightly test vectors for run: ${run_id}"
-	curl -s -H "${auth_header}" "${api}/repos/${repo}/actions/runs/${run_id}/artifacts" |
+	curl --fail -v -H "${auth_header}" "${api}/repos/${repo}/actions/runs/${run_id}/artifacts" | cat |
 		jq -c '.artifacts[] | {name, url: .archive_download_url}' |
 		while read -r artifact; do
 			name=$(echo "${artifact}" | jq -r .name)
@@ -42,7 +46,7 @@ if [[ "$version" == "nightly" ]]; then
 			fi
 
 			echo "Downloading artifact: ${name}"
-			curl --progress-bar --location --show-error --retry 3 --retry-all-errors --fail \
+			curl --fail --progress-bar --location --show-error --retry 3 --retry-all-errors --fail \
 				-H "${auth_header}" -H "Accept: application/vnd.github+json" \
 				--output "${name}.zip" "${url}" || {
 				echo "Failed to download ${name}"
@@ -56,7 +60,7 @@ else
 	for test in "${TESTS[@]}"; do
 		if [[ ! -e "${test}.tar.gz" ]]; then
 			echo "Downloading: ${version}/${test}.tar.gz"
-			curl --progress-bar --location --remote-name --show-error --retry 3 --retry-all-errors --fail \
+			curl --fail --progress-bar --location --remote-name --show-error --retry 3 --retry-all-errors --fail \
 				"https://github.com/ethereum/consensus-specs/releases/download/${version}/${test}.tar.gz" \
 				|| {
 					echo "Curl failed. Aborting"

--- a/testing/ef_tests/download_test_vectors.sh
+++ b/testing/ef_tests/download_test_vectors.sh
@@ -23,7 +23,7 @@ if [[ "$version" == "nightly" || "$version" =~ ^nightly-[0-9]+$ ]]; then
 
 	if [[ "$version" == "nightly" ]]; then
 		run_id=$(curl --fail -s -H "${auth_header}" \
-			"${api}/repos/${repo}/actions/workflows/generate_vectors.yml/runs?branch=master&status=success&per_page=1" |
+			"${api}/repos/${repo}/actions/workflows/nightly-reftests.yml/runs?branch=master&status=success&per_page=1" |
 			jq -r '.workflow_runs[0].id')
 	else
 		run_id="${version#nightly-}"


### PR DESCRIPTION
## Description

Adds support for pinning a specific nightly ef test run by using `nightly-<run_id>` format (e.g., `CONSENSUS_SPECS_TEST_VERSION=nightly-21575883288`). This allows CI and local testing to reproduce results from a specific consensus-specs workflow run rather than always fetching the latest.

Also fixes the workflow branch from `dev` to `master` and adds `--fail` flags to curl commands for better error handling.

## Additional Info

Usage:
- `CONSENSUS_SPECS_TEST_VERSION=nightly make` - fetches latest nightly
- `CONSENSUS_SPECS_TEST_VERSION=nightly-21575883288 make` - fetches specific run