### PR TITLE
Bump bytes to 1.11.1 to fix RUSTSEC-2026-0007

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,9 +1608,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -3098,7 +3098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4729,7 +4729,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6291,7 +6291,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7199,7 +7199,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7716,7 +7716,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8781,7 +8781,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10132,7 +10132,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ bincode = "1"
 bitvec = "1"
 bls = { path = "crypto/bls" }
 byteorder = "1"
-bytes = "1"
+bytes = "1.11.1"
 # Turn off c-kzg's default features which include `blst/portable`. We can turn on blst's portable
 # feature ourselves when desired.
 c-kzg = { version = "2.1", default-features = false }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4889,7 +4889,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let proposal_epoch = proposal_slot.epoch(T::EthSpec::slots_per_epoch());
         if head_state.current_epoch() == proposal_epoch {
             return get_expected_withdrawals(&unadvanced_state, &self.spec)
-                .map(|(withdrawals, _)| withdrawals)
+                .map(Into::into)
                 .map_err(Error::PrepareProposerFailed);
         }
 
@@ -4907,7 +4907,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             &self.spec,
         )?;
         get_expected_withdrawals(&advanced_state, &self.spec)
-            .map(|(withdrawals, _)| withdrawals)
+            .map(Into::into)
             .map_err(Error::PrepareProposerFailed)
     }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1296,6 +1296,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         Ok(self.store.get_blinded_block(block_root)?)
     }
 
+    pub fn get_payload_envelope(
+        &self,
+        block_root: &Hash256,
+    ) -> Result<Option<SignedExecutionPayloadEnvelope<T::EthSpec>>, Error> {
+        Ok(self.store.get_payload_envelope(block_root)?)
+    }
+
     /// Return the status of a block as it progresses through the various caches of the beacon
     /// chain. Used by sync to learn the status of a block and prevent repeated downloads /
     /// processing attempts.

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -371,7 +371,7 @@ pub fn get_execution_payload<T: BeaconChainTypes>(
     let latest_execution_payload_header_block_hash = latest_execution_payload_header.block_hash();
     let latest_execution_payload_header_gas_limit = latest_execution_payload_header.gas_limit();
     let withdrawals = if state.fork_name_unchecked().capella_enabled() {
-        Some(get_expected_withdrawals(state, spec)?.0.into())
+        Some(Withdrawals::<T::EthSpec>::from(get_expected_withdrawals(state, spec)?).into())
     } else {
         None
     };

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -773,6 +773,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
                     StoreOp::DeleteBlock(block_root),
                     StoreOp::DeleteExecutionPayload(block_root),
                     StoreOp::DeleteBlobs(block_root),
+                    StoreOp::DeletePayloadEnvelope(block_root),
                     StoreOp::DeleteSyncCommitteeBranch(block_root),
                 ]
             })

--- a/beacon_node/beacon_chain/tests/schema_stability.rs
+++ b/beacon_node/beacon_chain/tests/schema_stability.rs
@@ -106,8 +106,8 @@ fn check_db_columns() {
     let current_columns: Vec<&'static str> = DBColumn::iter().map(|c| c.as_str()).collect();
     let expected_columns = vec![
         "bma", "blk", "blb", "bdc", "bdi", "ste", "hsd", "hsn", "bsn", "bsd", "bss", "bs3", "bcs",
-        "bst", "exp", "bch", "opo", "etc", "frk", "pkc", "brp", "bsx", "bsr", "bbx", "bbr", "bhr",
-        "brm", "dht", "cus", "otb", "bhs", "olc", "lcu", "scb", "scm", "dmy",
+        "bst", "exp", "pay", "bch", "opo", "etc", "frk", "pkc", "brp", "bsx", "bsr", "bbx", "bbr",
+        "bhr", "brm", "dht", "cus", "otb", "bhs", "olc", "lcu", "scb", "scm", "dmy",
     ];
     assert_eq!(expected_columns, current_columns);
 }

--- a/beacon_node/http_api/src/builder_states.rs
+++ b/beacon_node/http_api/src/builder_states.rs
@@ -32,7 +32,7 @@ pub fn get_next_withdrawals<T: BeaconChainTypes>(
     }
 
     match get_expected_withdrawals(&state, &chain.spec) {
-        Ok((withdrawals, _)) => Ok(withdrawals),
+        Ok(expected_withdrawals) => Ok(expected_withdrawals.into()),
         Err(e) => Err(warp_utils::reject::custom_server_error(format!(
             "failed to get expected withdrawal: {:?}",
             e

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -634,7 +634,7 @@ pub async fn proposer_boost_re_org_test(
     assert_eq!(state_b.slot(), slot_b);
     let pre_advance_withdrawals = get_expected_withdrawals(&state_b, &harness.chain.spec)
         .unwrap()
-        .0
+        .withdrawals()
         .to_vec();
     complete_state_advance(&mut state_b, None, slot_c, &harness.chain.spec).unwrap();
 
@@ -724,7 +724,7 @@ pub async fn proposer_boost_re_org_test(
         get_expected_withdrawals(&state_b, &harness.chain.spec)
     }
     .unwrap()
-    .0
+    .withdrawals()
     .to_vec();
     let payload_attribs_withdrawals = payload_attribs.withdrawals().unwrap();
     assert_eq!(expected_withdrawals, *payload_attribs_withdrawals);

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -6660,7 +6660,8 @@ impl ApiTester {
         }
         let expected_withdrawals = get_expected_withdrawals(&state, &self.chain.spec)
             .unwrap()
-            .0;
+            .withdrawals()
+            .to_vec();
 
         // fetch expected withdrawals from the client
         let result = self.client.get_expected_withdrawals(&state_id).await;
@@ -6668,7 +6669,7 @@ impl ApiTester {
             Ok(withdrawal_response) => {
                 assert_eq!(withdrawal_response.execution_optimistic, Some(false));
                 assert_eq!(withdrawal_response.finalized, Some(false));
-                assert_eq!(withdrawal_response.data, expected_withdrawals.to_vec());
+                assert_eq!(withdrawal_response.data, expected_withdrawals);
             }
             Err(_) => {
                 panic!("query failed incorrectly");

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -745,6 +745,32 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             .map_err(|e| e.into())
     }
 
+    pub fn get_payload_envelope(
+        &self,
+        block_root: &Hash256,
+    ) -> Result<Option<SignedExecutionPayloadEnvelope<E>>, Error> {
+        let key = block_root.as_slice();
+
+        match self
+            .hot_db
+            .get_bytes(SignedExecutionPayloadEnvelope::<E>::db_column(), key)?
+        {
+            Some(bytes) => {
+                let envelope = SignedExecutionPayloadEnvelope::from_ssz_bytes(&bytes)?;
+                Ok(Some(envelope))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Check if the payload envelope for a block exists on disk.
+    pub fn payload_envelope_exists(&self, block_root: &Hash256) -> Result<bool, Error> {
+        self.hot_db.key_exists(
+            SignedExecutionPayloadEnvelope::<E>::db_column(),
+            block_root.as_slice(),
+        )
+    }
+
     /// Load the execution payload for a block from disk.
     /// This method deserializes with the proper fork.
     pub fn get_execution_payload(
@@ -1027,6 +1053,33 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         }
     }
 
+    // TODO(gloas) we should store the execution payload separately like we do for blocks.
+    /// Prepare a signed execution payload envelope for storage in the database.
+    pub fn payload_envelope_as_kv_store_ops(
+        &self,
+        key: &Hash256,
+        payload: &SignedExecutionPayloadEnvelope<E>,
+        ops: &mut Vec<KeyValueStoreOp>,
+    ) {
+        ops.push(KeyValueStoreOp::PutKeyValue(
+            SignedExecutionPayloadEnvelope::<E>::db_column(),
+            key.as_slice().into(),
+            payload.as_ssz_bytes(),
+        ));
+    }
+
+    pub fn put_payload_envelope(
+        &self,
+        block_root: &Hash256,
+        payload_envelope: SignedExecutionPayloadEnvelope<E>,
+    ) -> Result<(), Error> {
+        self.hot_db.put_bytes(
+            SignedExecutionPayloadEnvelope::<E>::db_column(),
+            block_root.as_slice(),
+            &payload_envelope.as_ssz_bytes(),
+        )
+    }
+
     /// Store a state in the store.
     pub fn put_state(&self, state_root: &Hash256, state: &BeaconState<E>) -> Result<(), Error> {
         let mut ops: Vec<KeyValueStoreOp> = Vec::new();
@@ -1283,6 +1336,14 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     );
                 }
 
+                StoreOp::PutPayloadEnvelope(block_root, payload_envelope) => {
+                    self.payload_envelope_as_kv_store_ops(
+                        &block_root,
+                        &payload_envelope,
+                        &mut key_value_batch,
+                    );
+                }
+
                 StoreOp::PutStateSummary(state_root, summary) => {
                     key_value_batch.push(summary.as_kv_store_op(state_root));
                 }
@@ -1307,6 +1368,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         key_value_batch
                             .push(KeyValueStoreOp::DeleteKey(DBColumn::BeaconDataColumn, key));
                     }
+                }
+
+                StoreOp::DeletePayloadEnvelope(block_root) => {
+                    key_value_batch.push(KeyValueStoreOp::DeleteKey(
+                        SignedExecutionPayloadEnvelope::<E>::db_column(),
+                        block_root.as_slice().to_vec(),
+                    ))
                 }
 
                 StoreOp::DeleteState(state_root, slot) => {
@@ -1528,6 +1596,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
                     StoreOp::PutDataColumns(_, _) => (),
 
+                    StoreOp::PutPayloadEnvelope(_, _) => (),
+
                     StoreOp::PutState(_, _) => (),
 
                     StoreOp::PutStateSummary(_, _) => (),
@@ -1535,6 +1605,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     StoreOp::DeleteBlock(block_root) => {
                         guard.delete_block(&block_root);
                     }
+
+                    StoreOp::DeletePayloadEnvelope(_) => (),
 
                     StoreOp::DeleteState(_, _) => (),
 

--- a/beacon_node/store/src/impls.rs
+++ b/beacon_node/store/src/impls.rs
@@ -1,1 +1,2 @@
 pub mod execution_payload;
+mod signed_execution_payload_envelope;

--- a/beacon_node/store/src/impls/signed_execution_payload_envelope.rs
+++ b/beacon_node/store/src/impls/signed_execution_payload_envelope.rs
@@ -1,0 +1,18 @@
+use ssz::{Decode, Encode};
+use types::{EthSpec, SignedExecutionPayloadEnvelope};
+
+use crate::{DBColumn, Error, StoreItem};
+
+impl<E: EthSpec> StoreItem for SignedExecutionPayloadEnvelope<E> {
+    fn db_column() -> DBColumn {
+        DBColumn::PayloadEnvelope
+    }
+
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
+    }
+
+    fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(Self::from_ssz_bytes(bytes)?)
+    }
+}

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -234,12 +234,14 @@ pub enum StoreOp<'a, E: EthSpec> {
     PutState(Hash256, &'a BeaconState<E>),
     PutBlobs(Hash256, BlobSidecarList<E>),
     PutDataColumns(Hash256, DataColumnSidecarList<E>),
+    PutPayloadEnvelope(Hash256, Arc<SignedExecutionPayloadEnvelope<E>>),
     PutStateSummary(Hash256, HotStateSummary),
     DeleteBlock(Hash256),
     DeleteBlobs(Hash256),
     DeleteDataColumns(Hash256, Vec<ColumnIndex>, ForkName),
     DeleteState(Hash256, Option<Slot>),
     DeleteExecutionPayload(Hash256),
+    DeletePayloadEnvelope(Hash256),
     DeleteSyncCommitteeBranch(Hash256),
     KeyValueOp(KeyValueStoreOp),
 }
@@ -310,6 +312,9 @@ pub enum DBColumn {
     /// Execution payloads for blocks more recent than the finalized checkpoint.
     #[strum(serialize = "exp")]
     ExecPayload,
+    /// Post-gloas execution payload envelopes.
+    #[strum(serialize = "pay")]
+    PayloadEnvelope,
     /// For persisting in-memory state to the database.
     #[strum(serialize = "bch")]
     BeaconChain,
@@ -421,7 +426,8 @@ impl DBColumn {
             | Self::BeaconRestorePoint
             | Self::DhtEnrs
             | Self::CustodyContext
-            | Self::OptimisticTransitionBlock => 32,
+            | Self::OptimisticTransitionBlock
+            | Self::PayloadEnvelope => 32,
             Self::BeaconBlockRoots
             | Self::BeaconDataColumnCustodyInfo
             | Self::BeaconBlockRootsChunked

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -1,7 +1,7 @@
 use crate::consensus_context::ConsensusContext;
 use errors::{BlockOperationError, BlockProcessingError, HeaderInvalid};
 use rayon::prelude::*;
-use safe_arith::{ArithError, SafeArith, SafeArithIter};
+use safe_arith::{ArithError, SafeArith};
 use signature_sets::{block_proposal_signature_set, get_pubkey_from_state, randao_signature_set};
 use std::borrow::Cow;
 use tree_hash::TreeHash;
@@ -24,9 +24,11 @@ pub use verify_deposit::{
     get_existing_validator_index, is_valid_deposit_signature, verify_deposit_merkle_proof,
 };
 pub use verify_exit::verify_exit;
+pub use withdrawals::get_expected_withdrawals;
 
 pub mod altair;
 pub mod block_signature_verifier;
+pub mod builder;
 pub mod deneb;
 pub mod errors;
 mod is_valid_indexed_attestation;
@@ -39,8 +41,8 @@ mod verify_bls_to_execution_change;
 mod verify_deposit;
 mod verify_exit;
 mod verify_proposer_slashing;
+pub mod withdrawals;
 
-use crate::common::decrease_balance;
 use crate::common::update_progressive_balances_cache::{
     initialize_progressive_balances_cache, update_progressive_balances_metrics,
 };
@@ -172,13 +174,20 @@ pub fn per_block_processing<E: EthSpec, Payload: AbstractExecPayload<E>>(
     // previous block.
     if is_execution_enabled(state, block.body()) {
         let body = block.body();
-        // TODO(EIP-7732): build out process_withdrawals variant for gloas
-        process_withdrawals::<E, Payload>(state, body.execution_payload()?, spec)?;
-        process_execution_payload::<E, Payload>(state, body, spec)?;
+        if state.fork_name_unchecked().gloas_enabled() {
+            withdrawals::gloas::process_withdrawals::<E>(state, spec)?;
+            // TODO(EIP-7732): process execution payload bid
+        } else {
+            if state.fork_name_unchecked().capella_enabled() {
+                withdrawals::capella_electra::process_withdrawals::<E, Payload>(
+                    state,
+                    body.execution_payload()?,
+                    spec,
+                )?;
+            }
+            process_execution_payload::<E, Payload>(state, body, spec)?;
+        }
     }
-
-    // TODO(EIP-7732): build out process_execution_bid
-    // process_execution_bid(state, block, verify_signatures, spec)?;
 
     process_randao(state, block, verify_randao, ctxt, spec)?;
     process_eth1_data(state, block.body().eth1_data())?;
@@ -512,191 +521,4 @@ pub fn compute_timestamp_at_slot<E: EthSpec>(
     slots_since_genesis
         .safe_mul(spec.get_slot_duration().as_secs())
         .and_then(|since_genesis| state.genesis_time().safe_add(since_genesis))
-}
-
-/// Compute the next batch of withdrawals which should be included in a block.
-///
-/// https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-get_expected_withdrawals
-pub fn get_expected_withdrawals<E: EthSpec>(
-    state: &BeaconState<E>,
-    spec: &ChainSpec,
-) -> Result<(Withdrawals<E>, Option<usize>), BlockProcessingError> {
-    let epoch = state.current_epoch();
-    let mut withdrawal_index = state.next_withdrawal_index()?;
-    let mut validator_index = state.next_withdrawal_validator_index()?;
-    let mut withdrawals = Vec::<Withdrawal>::with_capacity(E::max_withdrawals_per_payload());
-    let fork_name = state.fork_name_unchecked();
-
-    // [New in Electra:EIP7251]
-    // Consume pending partial withdrawals
-    let processed_partial_withdrawals_count =
-        if let Ok(pending_partial_withdrawals) = state.pending_partial_withdrawals() {
-            let mut processed_partial_withdrawals_count = 0;
-            for withdrawal in pending_partial_withdrawals {
-                if withdrawal.withdrawable_epoch > epoch
-                    || withdrawals.len() == spec.max_pending_partials_per_withdrawals_sweep as usize
-                {
-                    break;
-                }
-
-                let validator = state.get_validator(withdrawal.validator_index as usize)?;
-
-                let has_sufficient_effective_balance =
-                    validator.effective_balance >= spec.min_activation_balance;
-                let total_withdrawn = withdrawals
-                    .iter()
-                    .filter_map(|w| {
-                        (w.validator_index == withdrawal.validator_index).then_some(w.amount)
-                    })
-                    .safe_sum()?;
-                let balance = state
-                    .get_balance(withdrawal.validator_index as usize)?
-                    .safe_sub(total_withdrawn)?;
-                let has_excess_balance = balance > spec.min_activation_balance;
-
-                if validator.exit_epoch == spec.far_future_epoch
-                    && has_sufficient_effective_balance
-                    && has_excess_balance
-                {
-                    let withdrawable_balance = std::cmp::min(
-                        balance.safe_sub(spec.min_activation_balance)?,
-                        withdrawal.amount,
-                    );
-                    withdrawals.push(Withdrawal {
-                        index: withdrawal_index,
-                        validator_index: withdrawal.validator_index,
-                        address: validator
-                            .get_execution_withdrawal_address(spec)
-                            .ok_or(BeaconStateError::NonExecutionAddressWithdrawalCredential)?,
-                        amount: withdrawable_balance,
-                    });
-                    withdrawal_index.safe_add_assign(1)?;
-                }
-                processed_partial_withdrawals_count.safe_add_assign(1)?;
-            }
-            Some(processed_partial_withdrawals_count)
-        } else {
-            None
-        };
-
-    let bound = std::cmp::min(
-        state.validators().len() as u64,
-        spec.max_validators_per_withdrawals_sweep,
-    );
-    for _ in 0..bound {
-        let validator = state.get_validator(validator_index as usize)?;
-        let partially_withdrawn_balance = withdrawals
-            .iter()
-            .filter_map(|withdrawal| {
-                (withdrawal.validator_index == validator_index).then_some(withdrawal.amount)
-            })
-            .safe_sum()?;
-        let balance = state
-            .balances()
-            .get(validator_index as usize)
-            .ok_or(BeaconStateError::BalancesOutOfBounds(
-                validator_index as usize,
-            ))?
-            .safe_sub(partially_withdrawn_balance)?;
-        if validator.is_fully_withdrawable_validator(balance, epoch, spec, fork_name) {
-            withdrawals.push(Withdrawal {
-                index: withdrawal_index,
-                validator_index,
-                address: validator
-                    .get_execution_withdrawal_address(spec)
-                    .ok_or(BlockProcessingError::WithdrawalCredentialsInvalid)?,
-                amount: balance,
-            });
-            withdrawal_index.safe_add_assign(1)?;
-        } else if validator.is_partially_withdrawable_validator(balance, spec, fork_name) {
-            withdrawals.push(Withdrawal {
-                index: withdrawal_index,
-                validator_index,
-                address: validator
-                    .get_execution_withdrawal_address(spec)
-                    .ok_or(BlockProcessingError::WithdrawalCredentialsInvalid)?,
-                amount: balance.safe_sub(validator.get_max_effective_balance(spec, fork_name))?,
-            });
-            withdrawal_index.safe_add_assign(1)?;
-        }
-        if withdrawals.len() == E::max_withdrawals_per_payload() {
-            break;
-        }
-        validator_index = validator_index
-            .safe_add(1)?
-            .safe_rem(state.validators().len() as u64)?;
-    }
-
-    Ok((
-        withdrawals
-            .try_into()
-            .map_err(BlockProcessingError::SszTypesError)?,
-        processed_partial_withdrawals_count,
-    ))
-}
-
-/// Apply withdrawals to the state.
-/// TODO(EIP-7732): abstract this out and create gloas variant
-pub fn process_withdrawals<E: EthSpec, Payload: AbstractExecPayload<E>>(
-    state: &mut BeaconState<E>,
-    payload: Payload::Ref<'_>,
-    spec: &ChainSpec,
-) -> Result<(), BlockProcessingError> {
-    if state.fork_name_unchecked().capella_enabled() {
-        let (expected_withdrawals, processed_partial_withdrawals_count) =
-            get_expected_withdrawals(state, spec)?;
-        let expected_root = expected_withdrawals.tree_hash_root();
-        let withdrawals_root = payload.withdrawals_root()?;
-
-        if expected_root != withdrawals_root {
-            return Err(BlockProcessingError::WithdrawalsRootMismatch {
-                expected: expected_root,
-                found: withdrawals_root,
-            });
-        }
-
-        for withdrawal in expected_withdrawals.iter() {
-            decrease_balance(
-                state,
-                withdrawal.validator_index as usize,
-                withdrawal.amount,
-            )?;
-        }
-
-        // Update pending partial withdrawals [New in Electra:EIP7251]
-        if let Some(processed_partial_withdrawals_count) = processed_partial_withdrawals_count {
-            state
-                .pending_partial_withdrawals_mut()?
-                .pop_front(processed_partial_withdrawals_count)?;
-        }
-
-        // Update the next withdrawal index if this block contained withdrawals
-        if let Some(latest_withdrawal) = expected_withdrawals.last() {
-            *state.next_withdrawal_index_mut()? = latest_withdrawal.index.safe_add(1)?;
-
-            // Update the next validator index to start the next withdrawal sweep
-            if expected_withdrawals.len() == E::max_withdrawals_per_payload() {
-                // Next sweep starts after the latest withdrawal's validator index
-                let next_validator_index = latest_withdrawal
-                    .validator_index
-                    .safe_add(1)?
-                    .safe_rem(state.validators().len() as u64)?;
-                *state.next_withdrawal_validator_index_mut()? = next_validator_index;
-            }
-        }
-
-        // Advance sweep by the max length of the sweep if there was not a full set of withdrawals
-        if expected_withdrawals.len() != E::max_withdrawals_per_payload() {
-            let next_validator_index = state
-                .next_withdrawal_validator_index()?
-                .safe_add(spec.max_validators_per_withdrawals_sweep)?
-                .safe_rem(state.validators().len() as u64)?;
-            *state.next_withdrawal_validator_index_mut()? = next_validator_index;
-        }
-
-        Ok(())
-    } else {
-        // these shouldn't even be encountered but they're here for completeness
-        Ok(())
-    }
 }

--- a/consensus/state_processing/src/per_block_processing/builder.rs
+++ b/consensus/state_processing/src/per_block_processing/builder.rs
@@ -1,0 +1,13 @@
+use types::{builder::BuilderIndex, consts::gloas::BUILDER_INDEX_FLAG};
+
+pub fn is_builder_index(validator_index: u64) -> bool {
+    validator_index & BUILDER_INDEX_FLAG != 0
+}
+
+pub fn convert_builder_index_to_validator_index(builder_index: BuilderIndex) -> u64 {
+    builder_index | BUILDER_INDEX_FLAG
+}
+
+pub fn convert_validator_index_to_builder_index(validator_index: u64) -> BuilderIndex {
+    validator_index & !BUILDER_INDEX_FLAG
+}

--- a/consensus/state_processing/src/per_block_processing/errors.rs
+++ b/consensus/state_processing/src/per_block_processing/errors.rs
@@ -90,6 +90,14 @@ pub enum BlockProcessingError {
         found: Hash256,
     },
     WithdrawalCredentialsInvalid,
+    /// This should be unreachable unless there's a logical flaw in the spec for withdrawals.
+    WithdrawalsLimitExceeded {
+        limit: usize,
+        prior_withdrawals: usize,
+    },
+    /// Unreachable unless there's a logic error in LH.
+    IncorrectExpectedWithdrawalsVariant,
+    MissingLastWithdrawal,
     PendingAttestationInElectra,
 }
 

--- a/consensus/state_processing/src/per_block_processing/withdrawals.rs
+++ b/consensus/state_processing/src/per_block_processing/withdrawals.rs
@@ -1,0 +1,543 @@
+use crate::common::decrease_balance;
+use crate::per_block_processing::builder::{
+    convert_builder_index_to_validator_index, convert_validator_index_to_builder_index,
+    is_builder_index,
+};
+use crate::per_block_processing::errors::BlockProcessingError;
+use milhouse::List;
+use safe_arith::{SafeArith, SafeArithIter};
+use tree_hash::TreeHash;
+use types::{
+    AbstractExecPayload, BeaconState, BeaconStateError, ChainSpec, EthSpec, ExecPayload,
+    ExpectedWithdrawals, ExpectedWithdrawalsCapella, ExpectedWithdrawalsElectra,
+    ExpectedWithdrawalsGloas, Validator, Withdrawal, Withdrawals,
+};
+
+/// Compute the next batch of withdrawals which should be included in a block.
+///
+/// https://ethereum.github.io/consensus-specs/specs/gloas/beacon-chain/#modified-get_expected_withdrawals
+#[allow(clippy::type_complexity)]
+pub fn get_expected_withdrawals<E: EthSpec>(
+    state: &BeaconState<E>,
+    spec: &ChainSpec,
+) -> Result<ExpectedWithdrawals<E>, BlockProcessingError> {
+    let mut withdrawal_index = state.next_withdrawal_index()?;
+    let mut withdrawals = Vec::<Withdrawal>::with_capacity(E::max_withdrawals_per_payload());
+
+    // [New in Gloas:EIP7732]
+    // Get builder withdrawals
+    let processed_builder_withdrawals_count =
+        get_builder_withdrawals(state, &mut withdrawal_index, &mut withdrawals)?;
+
+    // [New in Electra:EIP7251]
+    // Get partial withdrawals.
+    let processed_partial_withdrawals_count =
+        get_pending_partial_withdrawals(state, &mut withdrawal_index, &mut withdrawals, spec)?;
+
+    // [New in Gloas:EIP7732]
+    // Get builders sweep withdrawals
+    let processed_builders_sweep_count =
+        get_builders_sweep_withdrawals(state, &mut withdrawal_index, &mut withdrawals)?;
+
+    // Get validators sweep withdrawals
+    let processed_sweep_withdrawals_count =
+        get_validators_sweep_withdrawals(state, &mut withdrawal_index, &mut withdrawals, spec)?;
+
+    let withdrawals = withdrawals
+        .try_into()
+        .map_err(BlockProcessingError::SszTypesError)?;
+
+    let fork_name = state.fork_name_unchecked();
+    if fork_name.gloas_enabled() {
+        Ok(ExpectedWithdrawals::Gloas(ExpectedWithdrawalsGloas {
+            withdrawals,
+            processed_builder_withdrawals_count: processed_builder_withdrawals_count
+                .ok_or(BlockProcessingError::IncorrectExpectedWithdrawalsVariant)?,
+            processed_partial_withdrawals_count: processed_partial_withdrawals_count
+                .ok_or(BlockProcessingError::IncorrectExpectedWithdrawalsVariant)?,
+            processed_builders_sweep_count: processed_builders_sweep_count
+                .ok_or(BlockProcessingError::IncorrectExpectedWithdrawalsVariant)?,
+            processed_sweep_withdrawals_count,
+        }))
+    } else if fork_name.electra_enabled() {
+        Ok(ExpectedWithdrawals::Electra(ExpectedWithdrawalsElectra {
+            withdrawals,
+            processed_partial_withdrawals_count: processed_partial_withdrawals_count
+                .ok_or(BlockProcessingError::IncorrectExpectedWithdrawalsVariant)?,
+            processed_sweep_withdrawals_count,
+        }))
+    } else {
+        Ok(ExpectedWithdrawals::Capella(ExpectedWithdrawalsCapella {
+            withdrawals,
+            processed_sweep_withdrawals_count,
+        }))
+    }
+}
+
+pub fn get_builder_withdrawals<E: EthSpec>(
+    state: &BeaconState<E>,
+    withdrawal_index: &mut u64,
+    withdrawals: &mut Vec<Withdrawal>,
+) -> Result<Option<u64>, BlockProcessingError> {
+    let Ok(builder_pending_withdrawals) = state.builder_pending_withdrawals() else {
+        // Pre-Gloas, nothing to do.
+        return Ok(None);
+    };
+
+    // TODO(gloas): this has already changed on `master`, we need to update at next spec release
+    let withdrawals_limit = E::max_withdrawals_per_payload();
+
+    // TODO(gloas): this assert is from `master`, remove this comment once it is part of the tested
+    // spec version.
+    block_verify!(
+        withdrawals.len() <= withdrawals_limit,
+        BlockProcessingError::WithdrawalsLimitExceeded {
+            limit: withdrawals_limit,
+            prior_withdrawals: withdrawals.len()
+        }
+    );
+
+    let mut processed_count = 0;
+    for withdrawal in builder_pending_withdrawals {
+        let has_reached_limit = withdrawals.len() == withdrawals_limit;
+
+        if has_reached_limit {
+            break;
+        }
+
+        let builder_index = withdrawal.builder_index;
+
+        withdrawals.push(Withdrawal {
+            index: *withdrawal_index,
+            validator_index: convert_builder_index_to_validator_index(builder_index),
+            address: withdrawal.fee_recipient,
+            amount: withdrawal.amount,
+        });
+        withdrawal_index.safe_add_assign(1)?;
+        processed_count.safe_add_assign(1)?;
+    }
+    Ok(Some(processed_count))
+}
+
+pub fn get_pending_partial_withdrawals<E: EthSpec>(
+    state: &BeaconState<E>,
+    withdrawal_index: &mut u64,
+    withdrawals: &mut Vec<Withdrawal>,
+    spec: &ChainSpec,
+) -> Result<Option<u64>, BlockProcessingError> {
+    let Ok(pending_partial_withdrawals) = state.pending_partial_withdrawals() else {
+        // Pre-Electra nothing to do.
+        return Ok(None);
+    };
+    let epoch = state.current_epoch();
+
+    let withdrawals_limit = std::cmp::min(
+        withdrawals
+            .len()
+            .safe_add(spec.max_pending_partials_per_withdrawals_sweep as usize)?,
+        E::max_withdrawals_per_payload().safe_sub(1)?,
+    );
+
+    // TODO(gloas): this assert is from `master`, remove this comment once it is part of the tested
+    // spec version.
+    block_verify!(
+        withdrawals.len() <= withdrawals_limit,
+        BlockProcessingError::WithdrawalsLimitExceeded {
+            limit: withdrawals_limit,
+            prior_withdrawals: withdrawals.len()
+        }
+    );
+
+    let mut processed_count = 0;
+    for withdrawal in pending_partial_withdrawals {
+        let is_withdrawable = withdrawal.withdrawable_epoch <= epoch;
+        let has_reached_limit = withdrawals.len() >= withdrawals_limit;
+
+        if !is_withdrawable || has_reached_limit {
+            break;
+        }
+
+        let validator_index = withdrawal.validator_index;
+        let validator = state.get_validator(validator_index as usize)?;
+        let balance = get_balance_after_withdrawals(state, validator_index, withdrawals)?;
+
+        if is_eligible_for_partial_withdrawals(validator, balance, spec) {
+            let withdrawal_amount = std::cmp::min(
+                balance.safe_sub(spec.min_activation_balance)?,
+                withdrawal.amount,
+            );
+            withdrawals.push(Withdrawal {
+                index: *withdrawal_index,
+                validator_index,
+                address: validator
+                    .get_execution_withdrawal_address(spec)
+                    .ok_or(BeaconStateError::NonExecutionAddressWithdrawalCredential)?,
+                amount: withdrawal_amount,
+            });
+            withdrawal_index.safe_add_assign(1)?;
+        }
+        processed_count.safe_add_assign(1)?;
+    }
+
+    Ok(Some(processed_count))
+}
+
+/// Get withdrawals from the builders sweep.
+///
+/// This function iterates through builders starting from `next_withdrawal_builder_index`
+/// and adds withdrawals for builders whose withdrawable_epoch has been reached and have balance.
+///
+/// https://ethereum.github.io/consensus-specs/specs/gloas/beacon-chain/#new-get_builders_sweep_withdrawals
+pub fn get_builders_sweep_withdrawals<E: EthSpec>(
+    state: &BeaconState<E>,
+    withdrawal_index: &mut u64,
+    withdrawals: &mut Vec<Withdrawal>,
+) -> Result<Option<u64>, BlockProcessingError> {
+    let Ok(builders) = state.builders() else {
+        // Pre-Gloas, nothing to do.
+        return Ok(None);
+    };
+
+    if builders.is_empty() {
+        return Ok(Some(0));
+    }
+
+    let epoch = state.current_epoch();
+    let builders_limit = std::cmp::min(builders.len(), E::max_builders_per_withdrawals_sweep());
+
+    // TODO(gloas): this has already changed on `master`, we should update at the next spec release
+    let withdrawals_limit = E::max_withdrawals_per_payload();
+
+    // TODO(gloas): this assert is from `master`, remove this comment once it is part of the tested
+    // spec version.
+    block_verify!(
+        withdrawals.len() <= withdrawals_limit,
+        BlockProcessingError::WithdrawalsLimitExceeded {
+            limit: withdrawals_limit,
+            prior_withdrawals: withdrawals.len()
+        }
+    );
+
+    let mut processed_count: u64 = 0;
+    let mut builder_index = state.next_withdrawal_builder_index()?;
+
+    for _ in 0..builders_limit {
+        if withdrawals.len() >= withdrawals_limit {
+            break;
+        }
+
+        let builder = builders
+            .get(builder_index as usize)
+            .ok_or(BeaconStateError::UnknownBuilder(builder_index))?;
+
+        if builder.withdrawable_epoch <= epoch && builder.balance > 0 {
+            withdrawals.push(Withdrawal {
+                index: *withdrawal_index,
+                validator_index: convert_builder_index_to_validator_index(builder_index),
+                address: builder.execution_address,
+                amount: builder.balance,
+            });
+            withdrawal_index.safe_add_assign(1)?;
+        }
+
+        builder_index = builder_index.safe_add(1)?.safe_rem(builders.len() as u64)?;
+        processed_count.safe_add_assign(1)?;
+    }
+
+    Ok(Some(processed_count))
+}
+
+/// Get withdrawals from the validator sweep.
+///
+/// This function iterates through validators starting from `next_withdrawal_validator_index`
+/// and adds full or partial withdrawals for eligible validators.
+///
+/// https://ethereum.github.io/consensus-specs/specs/capella/beacon-chain/#new-get_validators_sweep_withdrawals
+pub fn get_validators_sweep_withdrawals<E: EthSpec>(
+    state: &BeaconState<E>,
+    withdrawal_index: &mut u64,
+    withdrawals: &mut Vec<Withdrawal>,
+    spec: &ChainSpec,
+) -> Result<u64, BlockProcessingError> {
+    let epoch = state.current_epoch();
+    let fork_name = state.fork_name_unchecked();
+    let mut validator_index = state.next_withdrawal_validator_index()?;
+    let validators_limit = std::cmp::min(
+        state.validators().len() as u64,
+        spec.max_validators_per_withdrawals_sweep,
+    );
+    let withdrawals_limit = E::max_withdrawals_per_payload();
+
+    // There must be at least one space reserved for validator sweep withdrawals
+    block_verify!(
+        withdrawals.len() < withdrawals_limit,
+        BlockProcessingError::WithdrawalsLimitExceeded {
+            limit: withdrawals_limit,
+            prior_withdrawals: withdrawals.len()
+        }
+    );
+
+    let mut processed_count: u64 = 0;
+
+    for _ in 0..validators_limit {
+        if withdrawals.len() >= withdrawals_limit {
+            break;
+        }
+
+        let validator = state.get_validator(validator_index as usize)?;
+        let balance = get_balance_after_withdrawals(state, validator_index, withdrawals)?;
+
+        if validator.is_fully_withdrawable_validator(balance, epoch, spec, fork_name) {
+            withdrawals.push(Withdrawal {
+                index: *withdrawal_index,
+                validator_index,
+                address: validator
+                    .get_execution_withdrawal_address(spec)
+                    .ok_or(BlockProcessingError::WithdrawalCredentialsInvalid)?,
+                amount: balance,
+            });
+            withdrawal_index.safe_add_assign(1)?;
+        } else if validator.is_partially_withdrawable_validator(balance, spec, fork_name) {
+            withdrawals.push(Withdrawal {
+                index: *withdrawal_index,
+                validator_index,
+                address: validator
+                    .get_execution_withdrawal_address(spec)
+                    .ok_or(BlockProcessingError::WithdrawalCredentialsInvalid)?,
+                amount: balance.safe_sub(validator.get_max_effective_balance(spec, fork_name))?,
+            });
+            withdrawal_index.safe_add_assign(1)?;
+        }
+
+        validator_index = validator_index
+            .safe_add(1)?
+            .safe_rem(state.validators().len() as u64)?;
+        processed_count.safe_add_assign(1)?;
+    }
+
+    Ok(processed_count)
+}
+
+pub fn get_balance_after_withdrawals<E: EthSpec>(
+    state: &BeaconState<E>,
+    validator_index: u64,
+    withdrawals: &[Withdrawal],
+) -> Result<u64, BeaconStateError> {
+    let withdrawn = withdrawals
+        .iter()
+        .filter(|withdrawal| withdrawal.validator_index == validator_index)
+        .map(|withdrawal| withdrawal.amount)
+        .safe_sum()?;
+    state
+        .get_balance(validator_index as usize)?
+        .safe_sub(withdrawn)
+        .map_err(Into::into)
+}
+
+fn is_eligible_for_partial_withdrawals(
+    validator: &Validator,
+    balance: u64,
+    spec: &ChainSpec,
+) -> bool {
+    let has_sufficient_effective_balance =
+        validator.effective_balance >= spec.min_activation_balance;
+    let has_excess_balance = balance > spec.min_activation_balance;
+    validator.exit_epoch == spec.far_future_epoch
+        && has_sufficient_effective_balance
+        && has_excess_balance
+}
+
+fn update_next_withdrawal_index<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    withdrawals: &Withdrawals<E>,
+) -> Result<(), BlockProcessingError> {
+    // Update the next withdrawal index if this block contained withdrawals
+    if let Some(latest_withdrawal) = withdrawals.last() {
+        *state.next_withdrawal_index_mut()? = latest_withdrawal.index.safe_add(1)?;
+    }
+    Ok(())
+}
+
+fn update_payload_expected_withdrawals<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    withdrawals: &Withdrawals<E>,
+) -> Result<(), BlockProcessingError> {
+    *state.payload_expected_withdrawals_mut()? = List::new(withdrawals.to_vec())?;
+    Ok(())
+}
+
+fn update_builder_pending_withdrawals<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    processed_builder_withdrawals_count: u64,
+) -> Result<(), BlockProcessingError> {
+    state
+        .builder_pending_withdrawals_mut()?
+        .pop_front(processed_builder_withdrawals_count as usize)?;
+    Ok(())
+}
+
+fn update_pending_partial_withdrawals<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    processed_partial_withdrawals_count: u64,
+) -> Result<(), BlockProcessingError> {
+    state
+        .pending_partial_withdrawals_mut()?
+        .pop_front(processed_partial_withdrawals_count as usize)?;
+    Ok(())
+}
+
+fn update_next_withdrawal_builder_index<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    processed_builders_sweep_count: u64,
+) -> Result<(), BlockProcessingError> {
+    if !state.builders()?.is_empty() {
+        // Update the next builder index to start the next withdrawal sweep
+        let next_index = state
+            .next_withdrawal_builder_index()?
+            .safe_add(processed_builders_sweep_count)?;
+        let next_builder_index = next_index.safe_rem(state.builders()?.len() as u64)?;
+        *state.next_withdrawal_builder_index_mut()? = next_builder_index;
+    }
+    Ok(())
+}
+
+fn update_next_withdrawal_validator_index<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    withdrawals: &Withdrawals<E>,
+    spec: &ChainSpec,
+) -> Result<(), BlockProcessingError> {
+    // Update the next validator index to start the next withdrawal sweep
+    if withdrawals.len() == E::max_withdrawals_per_payload() {
+        // Next sweep starts after the latest withdrawal's validator index
+        let latest_withdrawal = withdrawals
+            .last()
+            .ok_or(BlockProcessingError::MissingLastWithdrawal)?;
+        let next_validator_index = latest_withdrawal
+            .validator_index
+            .safe_add(1)?
+            .safe_rem(state.validators().len() as u64)?;
+        *state.next_withdrawal_validator_index_mut()? = next_validator_index;
+    } else {
+        // Advance sweep by the max length of the sweep if there was not a full set of withdrawals
+        let next_validator_index = state
+            .next_withdrawal_validator_index()?
+            .safe_add(spec.max_validators_per_withdrawals_sweep)?
+            .safe_rem(state.validators().len() as u64)?;
+        *state.next_withdrawal_validator_index_mut()? = next_validator_index;
+    }
+    Ok(())
+}
+
+pub fn apply_withdrawals<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    withdrawals: &Withdrawals<E>,
+) -> Result<(), BlockProcessingError> {
+    for withdrawal in withdrawals {
+        if state.fork_name_unchecked().gloas_enabled()
+            && is_builder_index(withdrawal.validator_index)
+        {
+            let builder_index =
+                convert_validator_index_to_builder_index(withdrawal.validator_index);
+            let builder = state
+                .builders_mut()?
+                .get_mut(builder_index as usize)
+                .ok_or(BeaconStateError::UnknownBuilder(builder_index))?;
+            builder.balance = builder.balance.saturating_sub(withdrawal.amount);
+        } else {
+            decrease_balance(
+                state,
+                withdrawal.validator_index as usize,
+                withdrawal.amount,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+pub mod capella_electra {
+    use super::*;
+
+    /// Apply withdrawals to the state.
+    pub fn process_withdrawals<E: EthSpec, Payload: AbstractExecPayload<E>>(
+        state: &mut BeaconState<E>,
+        payload: Payload::Ref<'_>,
+        spec: &ChainSpec,
+    ) -> Result<(), BlockProcessingError> {
+        let expected_withdrawals = get_expected_withdrawals(state, spec)?;
+
+        let expected_root = expected_withdrawals.withdrawals().tree_hash_root();
+        let withdrawals_root = payload.withdrawals_root()?;
+        if expected_root != withdrawals_root {
+            return Err(BlockProcessingError::WithdrawalsRootMismatch {
+                expected: expected_root,
+                found: withdrawals_root,
+            });
+        }
+
+        // Apply expected withdrawals.
+        apply_withdrawals(state, expected_withdrawals.withdrawals())?;
+
+        // [Common] Update withdrawals fields in the state
+        update_next_withdrawal_index(state, expected_withdrawals.withdrawals())?;
+
+        // [New in Electra:EIP7251]
+        if let Ok(processed_partial_withdrawals_count) =
+            expected_withdrawals.processed_partial_withdrawals_count()
+        {
+            update_pending_partial_withdrawals(state, processed_partial_withdrawals_count)?;
+        }
+
+        // [Common from Capella]
+        update_next_withdrawal_validator_index(state, expected_withdrawals.withdrawals(), spec)?;
+
+        Ok(())
+    }
+}
+
+pub mod gloas {
+    use super::*;
+
+    /// Apply withdrawals to the state.
+    pub fn process_withdrawals<E: EthSpec>(
+        state: &mut BeaconState<E>,
+        spec: &ChainSpec,
+    ) -> Result<(), BlockProcessingError> {
+        if !state.is_parent_block_full() {
+            return Ok(());
+        }
+
+        let ExpectedWithdrawals::Gloas(ExpectedWithdrawalsGloas {
+            withdrawals,
+            processed_builder_withdrawals_count,
+            processed_partial_withdrawals_count,
+            processed_builders_sweep_count,
+            processed_sweep_withdrawals_count: _,
+        }) = get_expected_withdrawals(state, spec)?
+        else {
+            return Err(BlockProcessingError::IncorrectExpectedWithdrawalsVariant);
+        };
+
+        // Apply expected withdrawals.
+        apply_withdrawals(state, &withdrawals)?;
+
+        // [Common] Update withdrawals fields in the state
+        update_next_withdrawal_index(state, &withdrawals)?;
+
+        // [New in Gloas:EIP7732]
+        update_payload_expected_withdrawals(state, &withdrawals)?;
+
+        // [New in Gloas:EIP7732]
+        update_builder_pending_withdrawals(state, processed_builder_withdrawals_count)?;
+
+        // [Common from Electra]
+        update_pending_partial_withdrawals(state, processed_partial_withdrawals_count)?;
+
+        // [New in Gloas:EIP7732]
+        update_next_withdrawal_builder_index(state, processed_builders_sweep_count)?;
+
+        // [Common from Capella]
+        update_next_withdrawal_validator_index(state, &withdrawals, spec)?;
+
+        Ok(())
+    }
+}

--- a/consensus/types/src/state/beacon_state.rs
+++ b/consensus/types/src/state/beacon_state.rs
@@ -23,13 +23,13 @@ use tree_hash_derive::TreeHash;
 use typenum::Unsigned;
 
 use crate::{
-    Builder, BuilderIndex, BuilderPendingPayment, BuilderPendingWithdrawal, ExecutionBlockHash,
-    ExecutionPayloadBid, Withdrawal,
+    ExecutionBlockHash, ExecutionPayloadBid, Withdrawal,
     attestation::{
         AttestationData, AttestationDuty, BeaconCommittee, Checkpoint, CommitteeIndex, PTC,
         ParticipationFlags, PendingAttestation,
     },
     block::{BeaconBlock, BeaconBlockHeader, SignedBeaconBlockHash},
+    builder::{Builder, BuilderIndex, BuilderPendingPayment, BuilderPendingWithdrawal},
     consolidation::PendingConsolidation,
     core::{ChainSpec, Domain, Epoch, EthSpec, Hash256, RelativeEpoch, RelativeEpochError, Slot},
     deposit::PendingDeposit,
@@ -68,6 +68,7 @@ pub enum BeaconStateError {
     EpochOutOfBounds,
     SlotOutOfBounds,
     UnknownValidator(usize),
+    UnknownBuilder(BuilderIndex),
     UnableToDetermineProducer,
     InvalidBitfield,
     EmptyCommittee,

--- a/consensus/types/src/withdrawal/expected_withdrawals.rs
+++ b/consensus/types/src/withdrawal/expected_withdrawals.rs
@@ -1,0 +1,29 @@
+use crate::{EthSpec, Withdrawals};
+use superstruct::superstruct;
+
+#[superstruct(
+    variants(Capella, Electra, Gloas),
+    variant_attributes(derive(Debug, PartialEq, Clone))
+)]
+#[derive(Debug, PartialEq, Clone)]
+pub struct ExpectedWithdrawals<E: EthSpec> {
+    pub withdrawals: Withdrawals<E>,
+    #[superstruct(only(Gloas), partial_getter(copy))]
+    pub processed_builder_withdrawals_count: u64,
+    #[superstruct(only(Electra, Gloas), partial_getter(copy))]
+    pub processed_partial_withdrawals_count: u64,
+    #[superstruct(only(Gloas), partial_getter(copy))]
+    pub processed_builders_sweep_count: u64,
+    #[superstruct(getter(copy))]
+    pub processed_sweep_withdrawals_count: u64,
+}
+
+impl<E: EthSpec> From<ExpectedWithdrawals<E>> for Withdrawals<E> {
+    fn from(expected_withdrawals: ExpectedWithdrawals<E>) -> Withdrawals<E> {
+        match expected_withdrawals {
+            ExpectedWithdrawals::Capella(ew) => ew.withdrawals,
+            ExpectedWithdrawals::Electra(ew) => ew.withdrawals,
+            ExpectedWithdrawals::Gloas(ew) => ew.withdrawals,
+        }
+    }
+}

--- a/consensus/types/src/withdrawal/mod.rs
+++ b/consensus/types/src/withdrawal/mod.rs
@@ -1,8 +1,13 @@
+mod expected_withdrawals;
 mod pending_partial_withdrawal;
 mod withdrawal;
 mod withdrawal_credentials;
 mod withdrawal_request;
 
+pub use expected_withdrawals::{
+    ExpectedWithdrawals, ExpectedWithdrawalsCapella, ExpectedWithdrawalsElectra,
+    ExpectedWithdrawalsGloas,
+};
 pub use pending_partial_withdrawal::PendingPartialWithdrawal;
 pub use withdrawal::{Withdrawal, Withdrawals};
 pub use withdrawal_credentials::WithdrawalCredentials;

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -19,7 +19,7 @@ use state_processing::{
             altair_deneb, base, process_attester_slashings, process_bls_to_execution_changes,
             process_deposits, process_exits, process_proposer_slashings,
         },
-        process_sync_aggregate, process_withdrawals,
+        process_sync_aggregate, withdrawals,
     },
 };
 use std::fmt::Debug;
@@ -45,7 +45,7 @@ struct ExecutionMetadata {
 /// Newtype for testing withdrawals.
 #[derive(Debug, Clone, Deserialize)]
 pub struct WithdrawalsPayload<E: EthSpec> {
-    payload: FullPayload<E>,
+    payload: ExecutionPayload<E>,
 }
 
 #[derive(Debug, Clone)]
@@ -408,9 +408,7 @@ impl<E: EthSpec> Operation<E> for WithdrawalsPayload<E> {
         ssz_decode_file_with(path, |bytes| {
             ExecutionPayload::from_ssz_bytes_by_fork(bytes, fork_name)
         })
-        .map(|payload| WithdrawalsPayload {
-            payload: payload.into(),
-        })
+        .map(|payload| WithdrawalsPayload { payload })
     }
 
     fn apply_to(
@@ -419,8 +417,16 @@ impl<E: EthSpec> Operation<E> for WithdrawalsPayload<E> {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        // TODO(EIP-7732): implement separate gloas and non-gloas variants of process_withdrawals
-        process_withdrawals::<_, FullPayload<_>>(state, self.payload.to_ref(), spec)
+        if state.fork_name_unchecked().gloas_enabled() {
+            withdrawals::gloas::process_withdrawals(state, spec)
+        } else {
+            let full_payload = FullPayload::from(self.payload.clone());
+            withdrawals::capella_electra::process_withdrawals::<_, FullPayload<_>>(
+                state,
+                full_payload.to_ref(),
+                spec,
+            )
+        }
     }
 }
 

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -1117,6 +1117,17 @@ impl<E: EthSpec + TypeName, O: Operation<E>> Handler for OperationsHandler<E, O>
     fn handler_name(&self) -> String {
         O::handler_name()
     }
+
+    fn disabled_forks(&self) -> Vec<ForkName> {
+        // TODO(gloas): Can be removed once we enable Gloas on all tests
+        vec![]
+    }
+
+    fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
+        // TODO(gloas): So far only withdrawals tests are enabled for Gloas.
+        Self::Case::is_enabled_for_fork(fork_name)
+            && (!fork_name.gloas_enabled() || self.handler_name() == "withdrawals")
+    }
 }
 
 #[derive(Educe)]


### PR DESCRIPTION
## Description

Fixes integer overflow vulnerability in `BytesMut::reserve` (RUSTSEC-2026-0007) by bumping `bytes` from 1.11.0 to 1.11.1.

## Additional Info

Advisory: https://github.com/advisories/GHSA-434x-w66g-qw3r