### PR TITLE
Fix regression test for #8528

### DIFF
--- a/beacon_node/beacon_chain/tests/column_verification.rs
+++ b/beacon_node/beacon_chain/tests/column_verification.rs
@@ -170,7 +170,7 @@ async fn verify_header_signature_fork_block_bug() {
     // This keeps the head at the pre-fork state (Electra).
     harness.advance_slot();
     let rpc_block = harness
-        .build_rpc_block_from_blobs(block_root, signed_block.clone(), None)
+        .build_rpc_block_from_blobs(signed_block.clone(), None, false)
         .expect("Should build RPC block");
     let availability = harness
         .chain


### PR DESCRIPTION
## Issue Addressed

I accidentally broke `unstable` while merging some missed commits from `release-v8.0`. The merge was clean but semantically broken, and I didn't notice because I pushed without running CI :grimacing: 

## Proposed Changes

- Fix the regression test added for #8528, for compatibility with the recent `RpcBlock` changes. I'm passing `is_available = false` which seems correct for this test.
