### PR TITLE
fix: cache slot in check_block_relevancy to prevent TOCTOU

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1798,10 +1798,12 @@ pub fn check_block_relevancy<T: BeaconChainTypes>(
 ) -> Result<Hash256, BlockError> {
     let block = signed_block.message();
 
+    let present_slot = chain.slot()?;
+
     // Do not process blocks from the future.
-    if block.slot() > chain.slot()? {
+    if block.slot() > present_slot {
         return Err(BlockError::FutureSlot {
-            present_slot: chain.slot()?,
+            present_slot,
             block_slot: block.slot(),
         });
     }


### PR DESCRIPTION
## Why

`check_block_relevancy` called `chain.slot()?` twice — once for the comparison and once inside the `FutureSlot` error. Since `chain.slot()`https://github.com/sigp/lighthouse/blob/edba56b9a654cea555cb0db2e8d0712525686973/beacon_node/beacon_chain/src/block_verification.rs#L1247-L1249 reads the current time from the slot clock, the slot can advance between the two calls at a slot boundary. This causes `present_slot` in the error to be higher than `block_slot`, which is logically contradictory for a "future slot" error and can mislead logging and peer scoring.

Every other FutureSlot check in the codebase (gossip blocks, blobs, data columns, attestations, sync committees) already caches the slot in a local variable. This was the only place that didn't.

## What

Store `chain.slot()?` in a local variable and reuse it for both the comparison and the error construction, consistent with the rest of
the codebase.