### PR TITLE
fix: Update Cargo.toml adding license Apache-2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,8 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 version = "8.1.0"
+license = "Apache-2.0"
+readme = "README.md"
 
 [workspace.dependencies]
 account_utils = { path = "common/account_utils" }


### PR DESCRIPTION
## Proposed Changes

This PR adds the license field to `Cargo.toml`, specifying **Apache-2.0**, consistent with the existing `LICENSE` file.

This makes the licensing explicit at the crate level and helps other projects reuse Lighthouse crates without needing additional clarification about their license.

## Additional Information

Is there a plan to publish Lighthouse, or some of its sub-crates, to crates.io in the future?
