### PR TITLE
fix second_payload head in execution engine test

### DIFF
--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -568,7 +568,7 @@ impl<Engine: GenericExecutionEngine> TestRig<Engine> {
          *
          * Indicate that the payload is the head of the chain, providing payload attributes.
          */
-        let head_block_hash = valid_payload.block_hash();
+        let head_block_hash = second_payload.block_hash();
         let finalized_block_hash = ExecutionBlockHash::zero();
         // To save sending proposer preparation data, just set the fee recipient
         // to the fee recipient configured for EE A.


### PR DESCRIPTION
## Summary
- Fix copy-paste bug in `test_rig.rs` where `valid_payload.block_hash()` was used instead of `second_payload.block_hash()` when setting head after validating the second payload
- The comment says "Indicate that the [second] payload is the head of the chain" but the code pointed back to the first payload
- Matches the correct pattern already used in the EE B section (lines 617, 670)

Supersedes #8410 (which targeted `stable` and is now closed).

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` clean (no new warnings)
- [ ] CI passes