### PR TITLE
Implement inactivity scores ef tests unstable

### DIFF
--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -76,8 +76,6 @@ excluded_paths = [
     # Ignore full epoch tests for now (just test the sub-transitions).
     "tests/.*/.*/epoch_processing/.*/pre_epoch.ssz_snappy",
     "tests/.*/.*/epoch_processing/.*/post_epoch.ssz_snappy",
-    # Ignore inactivity_scores tests for now (should implement soon).
-    "tests/.*/.*/rewards/inactivity_scores/.*",
     # Ignore KZG tests that target internal kzg library functions
     "tests/.*/compute_verify_cell_kzg_proof_batch_challenge/.*",
     "tests/.*/compute_challenge/.*",

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -86,9 +86,7 @@ pub trait Handler {
                 .filter(|e| e.file_type().map(|ty| ty.is_dir()).unwrap())
         };
 
-        let read_dir_res = fs::read_dir(&handler_path);
-
-        let test_cases = read_dir_res
+        let test_cases = fs::read_dir(&handler_path)
             .unwrap_or_else(|e| panic!("handler dir {} exists: {:?}", handler_path.display(), e))
             .filter_map(as_directory)
             .flat_map(|suite| fs::read_dir(suite.path()).expect("suite dir exists"))
@@ -601,15 +599,6 @@ impl<E: EthSpec + TypeName> Handler for RewardsHandler<E> {
             fork_name.altair_enabled()
         } else {
             true
-        }
-    }
-
-    fn disabled_forks(&self) -> Vec<ForkName> {
-        if self.handler_name == "inactivity_scores" {
-            // Enable Gloas for inactivity_scores tests.
-            vec![]
-        } else {
-            vec![ForkName::Gloas]
         }
     }
 }

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -86,7 +86,9 @@ pub trait Handler {
                 .filter(|e| e.file_type().map(|ty| ty.is_dir()).unwrap())
         };
 
-        let test_cases = fs::read_dir(&handler_path)
+        let read_dir_res = fs::read_dir(&handler_path);
+
+        let test_cases = read_dir_res
             .unwrap_or_else(|e| panic!("handler dir {} exists: {:?}", handler_path.display(), e))
             .filter_map(as_directory)
             .flat_map(|suite| fs::read_dir(suite.path()).expect("suite dir exists"))
@@ -601,6 +603,24 @@ impl<E: EthSpec + TypeName> Handler for RewardsHandler<E> {
 
     fn handler_name(&self) -> String {
         self.handler_name.to_string()
+    }
+
+    fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
+        if self.handler_name == "inactivity_scores" {
+            // These tests were added in v1.7.0-alpha.2 and are available for Altair and later.
+            fork_name.altair_enabled()
+        } else {
+            true
+        }
+    }
+
+    fn disabled_forks(&self) -> Vec<ForkName> {
+        if self.handler_name == "inactivity_scores" {
+            // Enable Gloas for inactivity_scores tests.
+            vec![]
+        } else {
+            vec![ForkName::Gloas]
+        }
     }
 }
 

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -1107,7 +1107,7 @@ fn kzg_inclusion_merkle_proof_validity() {
 
 #[test]
 fn rewards() {
-    for handler in &["basic", "leak", "random"] {
+    for handler in &["basic", "leak", "random", "inactivity_scores"] {
         RewardsHandler::<MinimalEthSpec>::new(handler).run();
         RewardsHandler::<MainnetEthSpec>::new(handler).run();
     }


### PR DESCRIPTION
## Issue Addressed

fixes issue #8750  

## Proposed Changes

This PR enables the inactivity_scores reward EF tests from v1.7.0-alpha.2.

- Enabled Tests: Added the inactivity_scores handler to the rewards test suite.
- Fork Filtering: Updated the runner to execute these tests only on supported forks (Altair onwards), preventing directory-not-found errors on earlier forks.
- CI Coverage: Removed exclusions in the file access check script to ensures all new test vectors are fully tracked.

