### PR TITLE
Fix eth2 compilation by feature gating `SseEventSource`

### DIFF
--- a/common/eth2/src/error.rs
+++ b/common/eth2/src/error.rs
@@ -102,6 +102,7 @@ impl Error {
                     None
                 }
             }
+            #[cfg(feature = "events")]
             Error::SseEventSource(_) => None,
             Error::ServerMessage(msg) => StatusCode::try_from(msg.code).ok(),
             Error::ServerIndexedMessage(msg) => StatusCode::try_from(msg.code).ok(),


### PR DESCRIPTION
## Issue Addressed

`eth2` is currently unable to be built without the `events` feature.

## Proposed Changes

Feature gates the `SseEventSource` match arm in the `status` function.

## Additional Info

We could consider adding some build checks to CI for `eth2` and `types` and each feature combination to avoid this in the future. 
