### PR TITLE
Add sync batch state metrics

### DIFF
--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -462,6 +462,13 @@ pub static SYNCING_CHAIN_BATCH_AWAITING_PROCESSING: LazyLock<Result<Histogram>> 
             ]),
         )
     });
+pub static SYNCING_CHAIN_BATCHES: LazyLock<Result<IntGaugeVec>> = LazyLock::new(|| {
+    try_create_int_gauge_vec(
+        "sync_batches",
+        "Number of batches in sync chains by sync type and state",
+        &["sync_type", "state"],
+    )
+});
 pub static SYNC_SINGLE_BLOCK_LOOKUPS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
     try_create_int_gauge(
         "sync_single_block_lookups",

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -8,6 +8,7 @@
 //! If a batch fails, the backfill sync cannot progress. In this scenario, we mark the backfill
 //! sync as failed, log an error and attempt to retry once a new peer joins the node.
 
+use crate::metrics;
 use crate::network_beacon_processor::ChainSegmentProcessId;
 use crate::sync::batch::{
     BatchConfig, BatchId, BatchInfo, BatchOperationOutcome, BatchProcessingResult, BatchState,
@@ -1179,6 +1180,22 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                 .beacon_chain
                 .genesis_backfill_slot
                 .epoch(T::EthSpec::slots_per_epoch())
+    }
+
+    pub fn register_metrics(&self) {
+        let mut counts: BTreeMap<&'static str, usize> = BTreeMap::new();
+        for batch in self.batches.values() {
+            if let Some(label) = batch.state().metrics_label() {
+                *counts.entry(label).or_default() += 1;
+            }
+        }
+        for (label, count) in &counts {
+            metrics::set_gauge_vec(
+                &metrics::SYNCING_CHAIN_BATCHES,
+                &["backfill", label],
+                *count as i64,
+            );
+        }
     }
 
     /// Updates the global network state indicating the current state of a backfill sync.

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -11,7 +11,8 @@
 use crate::metrics;
 use crate::network_beacon_processor::ChainSegmentProcessId;
 use crate::sync::batch::{
-    BatchConfig, BatchId, BatchInfo, BatchOperationOutcome, BatchProcessingResult, BatchState,
+    BatchConfig, BatchId, BatchInfo, BatchMetricsState, BatchOperationOutcome,
+    BatchProcessingResult, BatchState,
 };
 use crate::sync::block_sidecar_coupling::CouplingError;
 use crate::sync::manager::BatchProcessResult;
@@ -32,6 +33,7 @@ use std::collections::{
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::sync::Arc;
+use strum::IntoEnumIterator;
 use tracing::{debug, error, info, warn};
 use types::{ColumnIndex, Epoch, EthSpec};
 
@@ -1183,17 +1185,16 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
     }
 
     pub fn register_metrics(&self) {
-        let mut counts: BTreeMap<&'static str, usize> = BTreeMap::new();
-        for batch in self.batches.values() {
-            if let Some(label) = batch.state().metrics_label() {
-                *counts.entry(label).or_default() += 1;
-            }
-        }
-        for (label, count) in &counts {
+        for state in BatchMetricsState::iter() {
+            let count = self
+                .batches
+                .values()
+                .filter(|b| b.state().metrics_state() == state)
+                .count();
             metrics::set_gauge_vec(
                 &metrics::SYNCING_CHAIN_BATCHES,
-                &["backfill", label],
-                *count as i64,
+                &["backfill", state.into()],
+                count as i64,
             );
         }
     }

--- a/beacon_node/network/src/sync/batch.rs
+++ b/beacon_node/network/src/sync/batch.rs
@@ -10,9 +10,21 @@ use std::marker::PhantomData;
 use std::ops::Sub;
 use std::time::Duration;
 use std::time::Instant;
-use strum::Display;
+use strum::{Display, EnumIter, IntoStaticStr};
 use types::Slot;
 use types::{DataColumnSidecarList, Epoch, EthSpec};
+
+/// Batch states used as metrics labels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter, IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum BatchMetricsState {
+    AwaitingDownload,
+    Downloading,
+    AwaitingProcessing,
+    Processing,
+    AwaitingValidation,
+    Failed,
+}
 
 pub type BatchId = Epoch;
 
@@ -143,15 +155,15 @@ impl<D: Hash> BatchState<D> {
         std::mem::replace(self, BatchState::Poisoned)
     }
 
-    /// Returns the metrics label for this state, or `None` for transient/terminal states.
-    pub fn metrics_label(&self) -> Option<&'static str> {
+    /// Returns the metrics state for this batch.
+    pub fn metrics_state(&self) -> BatchMetricsState {
         match self {
-            BatchState::AwaitingDownload => Some("awaiting_download"),
-            BatchState::Downloading(_) => Some("downloading"),
-            BatchState::AwaitingProcessing(..) => Some("awaiting_processing"),
-            BatchState::Processing(_) => Some("processing"),
-            BatchState::AwaitingValidation(_) => Some("awaiting_validation"),
-            BatchState::Poisoned | BatchState::Failed => None,
+            BatchState::AwaitingDownload => BatchMetricsState::AwaitingDownload,
+            BatchState::Downloading(_) => BatchMetricsState::Downloading,
+            BatchState::AwaitingProcessing(..) => BatchMetricsState::AwaitingProcessing,
+            BatchState::Processing(_) => BatchMetricsState::Processing,
+            BatchState::AwaitingValidation(_) => BatchMetricsState::AwaitingValidation,
+            BatchState::Poisoned | BatchState::Failed => BatchMetricsState::Failed,
         }
     }
 }

--- a/beacon_node/network/src/sync/batch.rs
+++ b/beacon_node/network/src/sync/batch.rs
@@ -142,6 +142,18 @@ impl<D: Hash> BatchState<D> {
     pub fn poison(&mut self) -> BatchState<D> {
         std::mem::replace(self, BatchState::Poisoned)
     }
+
+    /// Returns the metrics label for this state, or `None` for transient/terminal states.
+    pub fn metrics_label(&self) -> Option<&'static str> {
+        match self {
+            BatchState::AwaitingDownload => Some("awaiting_download"),
+            BatchState::Downloading(_) => Some("downloading"),
+            BatchState::AwaitingProcessing(..) => Some("awaiting_processing"),
+            BatchState::Processing(_) => Some("processing"),
+            BatchState::AwaitingValidation(_) => Some("awaiting_validation"),
+            BatchState::Poisoned | BatchState::Failed => None,
+        }
+    }
 }
 
 impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {

--- a/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
@@ -12,6 +12,7 @@ use lighthouse_network::{
 };
 use logging::crit;
 use std::hash::{DefaultHasher, Hash, Hasher};
+use strum::IntoEnumIterator;
 use tracing::{debug, error, info, info_span, warn};
 use types::{DataColumnSidecarList, Epoch, EthSpec};
 
@@ -19,8 +20,8 @@ use crate::metrics;
 use crate::sync::{
     backfill_sync::{BACKFILL_EPOCHS_PER_BATCH, ProcessResult, SyncStart},
     batch::{
-        BatchConfig, BatchId, BatchInfo, BatchOperationOutcome, BatchProcessingResult, BatchState,
-        ByRangeRequestType,
+        BatchConfig, BatchId, BatchInfo, BatchMetricsState, BatchOperationOutcome,
+        BatchProcessingResult, BatchState, ByRangeRequestType,
     },
     block_sidecar_coupling::CouplingError,
     manager::CustodyBatchProcessResult,
@@ -1116,17 +1117,16 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
     }
 
     pub fn register_metrics(&self) {
-        let mut counts: BTreeMap<&'static str, usize> = BTreeMap::new();
-        for batch in self.batches.values() {
-            if let Some(label) = batch.state().metrics_label() {
-                *counts.entry(label).or_default() += 1;
-            }
-        }
-        for (label, count) in &counts {
+        for state in BatchMetricsState::iter() {
+            let count = self
+                .batches
+                .values()
+                .filter(|b| b.state().metrics_state() == state)
+                .count();
             metrics::set_gauge_vec(
                 &metrics::SYNCING_CHAIN_BATCHES,
-                &["custody_backfill", label],
-                *count as i64,
+                &["custody_backfill", state.into()],
+                count as i64,
             );
         }
     }

--- a/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
@@ -15,6 +15,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use tracing::{debug, error, info, info_span, warn};
 use types::{DataColumnSidecarList, Epoch, EthSpec};
 
+use crate::metrics;
 use crate::sync::{
     backfill_sync::{BACKFILL_EPOCHS_PER_BATCH, ProcessResult, SyncStart},
     batch::{
@@ -1112,6 +1113,22 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
     /// Updates the global network state indicating the current state of a backfill sync.
     pub fn set_state(&self, state: CustodyBackFillState) {
         *self.network_globals.custody_sync_state.write() = state;
+    }
+
+    pub fn register_metrics(&self) {
+        let mut counts: BTreeMap<&'static str, usize> = BTreeMap::new();
+        for batch in self.batches.values() {
+            if let Some(label) = batch.state().metrics_label() {
+                *counts.entry(label).or_default() += 1;
+            }
+        }
+        for (label, count) in &counts {
+            metrics::set_gauge_vec(
+                &metrics::SYNCING_CHAIN_BATCHES,
+                &["custody_backfill", label],
+                *count as i64,
+            );
+        }
     }
 
     /// A fully synced peer has joined us.

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -40,7 +40,6 @@ use super::network_context::{
 };
 use super::peer_sync_info::{PeerSyncType, remote_sync_type};
 use super::range_sync::{EPOCHS_PER_BATCH, RangeSync, RangeSyncType};
-use crate::metrics;
 use crate::network_beacon_processor::{ChainSegmentProcessId, NetworkBeaconProcessor};
 use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
@@ -785,11 +784,6 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 }
                 _ = register_metrics_interval.tick() => {
                     self.network.register_metrics();
-                    // Reset the shared batch gauge once, then let each sync type
-                    // set its own values.
-                    if let Ok(gauge) = &*metrics::SYNCING_CHAIN_BATCHES {
-                        gauge.reset();
-                    }
                     self.range_sync.register_metrics();
                     self.backfill_sync.register_metrics();
                     self.custody_backfill_sync.register_metrics();

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -40,6 +40,7 @@ use super::network_context::{
 };
 use super::peer_sync_info::{PeerSyncType, remote_sync_type};
 use super::range_sync::{EPOCHS_PER_BATCH, RangeSync, RangeSyncType};
+use crate::metrics;
 use crate::network_beacon_processor::{ChainSegmentProcessId, NetworkBeaconProcessor};
 use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
@@ -784,6 +785,14 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 }
                 _ = register_metrics_interval.tick() => {
                     self.network.register_metrics();
+                    // Reset the shared batch gauge once, then let each sync type
+                    // set its own values.
+                    if let Ok(gauge) = &*metrics::SYNCING_CHAIN_BATCHES {
+                        gauge.reset();
+                    }
+                    self.range_sync.register_metrics();
+                    self.backfill_sync.register_metrics();
+                    self.custody_backfill_sync.register_metrics();
                 }
                 _ = epoch_interval.tick() => {
                     self.update_sync_state();

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -234,6 +234,17 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             .sum()
     }
 
+    /// Returns the count of batches grouped by state metrics label.
+    pub fn batch_state_counts(&self) -> BTreeMap<&'static str, usize> {
+        let mut counts = BTreeMap::new();
+        for batch in self.batches.values() {
+            if let Some(label) = batch.state().metrics_label() {
+                *counts.entry(label).or_default() += 1;
+            }
+        }
+        counts
+    }
+
     /// Removes a peer from the chain.
     /// If the peer has active batches, those are considered failed and re-requested.
     pub fn remove_peer(&mut self, peer_id: &PeerId) -> ProcessingResult {

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -3,7 +3,8 @@ use crate::metrics;
 use crate::network_beacon_processor::ChainSegmentProcessId;
 use crate::sync::batch::BatchId;
 use crate::sync::batch::{
-    BatchConfig, BatchInfo, BatchOperationOutcome, BatchProcessingResult, BatchState,
+    BatchConfig, BatchInfo, BatchMetricsState, BatchOperationOutcome, BatchProcessingResult,
+    BatchState,
 };
 use crate::sync::block_sidecar_coupling::CouplingError;
 use crate::sync::network_context::{RangeRequestId, RpcRequestSendError, RpcResponseError};
@@ -234,15 +235,12 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             .sum()
     }
 
-    /// Returns the count of batches grouped by state metrics label.
-    pub fn batch_state_counts(&self) -> BTreeMap<&'static str, usize> {
-        let mut counts = BTreeMap::new();
-        for batch in self.batches.values() {
-            if let Some(label) = batch.state().metrics_label() {
-                *counts.entry(label).or_default() += 1;
-            }
-        }
-        counts
+    /// Returns the number of batches in the given metrics state.
+    pub fn count_batches_in_state(&self, state: BatchMetricsState) -> usize {
+        self.batches
+            .values()
+            .filter(|b| b.state().metrics_state() == state)
+            .count()
     }
 
     /// Removes a peer from the chain.

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -14,8 +14,8 @@ use lighthouse_network::SyncInfo;
 use lighthouse_network::service::api_types::Id;
 use logging::crit;
 use smallvec::SmallVec;
-use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tracing::{debug, error};
 use types::EthSpec;
@@ -511,6 +511,28 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
                 collection.insert(id, new_chain);
                 metrics::inc_counter_vec(&metrics::SYNCING_CHAINS_ADDED, &[sync_type.as_str()]);
                 self.update_metrics();
+            }
+        }
+    }
+
+    pub fn register_metrics(&self) {
+        for (sync_type, chains) in [
+            ("range_finalized", &self.finalized_chains),
+            ("range_head", &self.head_chains),
+        ] {
+            let mut totals: BTreeMap<&'static str, usize> = BTreeMap::new();
+            for chain in chains.values() {
+                for (label, count) in chain.batch_state_counts() {
+                    *totals.entry(label).or_default() += count;
+                }
+            }
+
+            for (label, count) in &totals {
+                metrics::set_gauge_vec(
+                    &metrics::SYNCING_CHAIN_BATCHES,
+                    &[sync_type, label],
+                    *count as i64,
+                );
             }
         }
     }

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -6,6 +6,7 @@
 use super::chain::{ChainId, ProcessingResult, RemoveChain, SyncingChain};
 use super::sync_type::RangeSyncType;
 use crate::metrics;
+use crate::sync::batch::BatchMetricsState;
 use crate::sync::network_context::SyncNetworkContext;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use fnv::FnvHashMap;
@@ -14,9 +15,10 @@ use lighthouse_network::SyncInfo;
 use lighthouse_network::service::api_types::Id;
 use logging::crit;
 use smallvec::SmallVec;
+use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
+use strum::IntoEnumIterator;
 use tracing::{debug, error};
 use types::EthSpec;
 use types::{Epoch, Hash256, Slot};
@@ -520,18 +522,15 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
             ("range_finalized", &self.finalized_chains),
             ("range_head", &self.head_chains),
         ] {
-            let mut totals: BTreeMap<&'static str, usize> = BTreeMap::new();
-            for chain in chains.values() {
-                for (label, count) in chain.batch_state_counts() {
-                    *totals.entry(label).or_default() += count;
-                }
-            }
-
-            for (label, count) in &totals {
+            for state in BatchMetricsState::iter() {
+                let count: usize = chains
+                    .values()
+                    .map(|chain| chain.count_batches_in_state(state))
+                    .sum();
                 metrics::set_gauge_vec(
                     &metrics::SYNCING_CHAIN_BATCHES,
-                    &[sync_type, label],
-                    *count as i64,
+                    &[sync_type, state.into()],
+                    count as i64,
                 );
             }
         }

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -371,6 +371,10 @@ where
             .update(network, &local, &mut self.awaiting_head_peers);
     }
 
+    pub fn register_metrics(&self) {
+        self.chains.register_metrics();
+    }
+
     /// Kickstarts sync.
     pub fn resume(&mut self, network: &mut SyncNetworkContext<T>) {
         for (removed_chain, sync_type, remove_reason) in


### PR DESCRIPTION
## Description

This PR contains metrics that compliments the fixes made in #8039.

Add `sync_batches` metric to track the number of batches in each state across all sync types. Labels are `sync_type` (`range_finalized`/`range_head`/`backfill`/`custody_backfill`) and `state` (`awaiting_download`, `downloading`, `awaiting_processing`, `processing`, `awaiting_validation`).

This gives production visibility into the batch buffer depth across range sync, backfill sync, and custody backfill sync. Reported every 5 seconds alongside existing network request metrics.
