### PR TITLE
Skip payload_invalidation tests prior to Bellatrix

### DIFF
--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -6,7 +6,7 @@ use beacon_chain::{
     INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON, NotifyExecutionLayer, OverrideForkchoiceUpdate,
     StateSkipConfig, WhenSlotSkipped,
     canonical_head::{CachedHead, CanonicalHead},
-    test_utils::{BeaconChainHarness, EphemeralHarnessType, test_spec},
+    test_utils::{BeaconChainHarness, EphemeralHarnessType, fork_name_from_env, test_spec},
 };
 use execution_layer::{
     ExecutionLayer, ForkchoiceState, PayloadAttributes,
@@ -389,6 +389,9 @@ impl InvalidPayloadRig {
 /// Simple test of the different import types.
 #[tokio::test]
 async fn valid_invalid_syncing() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let mut rig = InvalidPayloadRig::new();
     rig.move_to_terminal_block();
 
@@ -404,6 +407,9 @@ async fn valid_invalid_syncing() {
 /// `latest_valid_hash`.
 #[tokio::test]
 async fn invalid_payload_invalidates_parent() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
     rig.import_block(Payload::Valid).await; // Import a valid transition block.
@@ -460,6 +466,9 @@ async fn immediate_forkchoice_update_invalid_test(
 
 #[tokio::test]
 async fn immediate_forkchoice_update_payload_invalid() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     immediate_forkchoice_update_invalid_test(|latest_valid_hash| Payload::Invalid {
         latest_valid_hash,
     })
@@ -468,11 +477,17 @@ async fn immediate_forkchoice_update_payload_invalid() {
 
 #[tokio::test]
 async fn immediate_forkchoice_update_payload_invalid_block_hash() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     immediate_forkchoice_update_invalid_test(|_| Payload::InvalidBlockHash).await
 }
 
 #[tokio::test]
 async fn immediate_forkchoice_update_payload_invalid_terminal_block() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     immediate_forkchoice_update_invalid_test(|_| Payload::Invalid {
         latest_valid_hash: Some(ExecutionBlockHash::zero()),
     })
@@ -482,6 +497,9 @@ async fn immediate_forkchoice_update_payload_invalid_terminal_block() {
 /// Ensure the client tries to exit when the justified checkpoint is invalidated.
 #[tokio::test]
 async fn justified_checkpoint_becomes_invalid() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
     rig.import_block(Payload::Valid).await; // Import a valid transition block.
@@ -524,6 +542,9 @@ async fn justified_checkpoint_becomes_invalid() {
 /// Ensure that a `latest_valid_hash` for a pre-finality block only reverts a single block.
 #[tokio::test]
 async fn pre_finalized_latest_valid_hash() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let num_blocks = E::slots_per_epoch() * 4;
     let finalized_epoch = 2;
 
@@ -571,6 +592,9 @@ async fn pre_finalized_latest_valid_hash() {
 /// - Will not validate `latest_valid_root` and its ancestors.
 #[tokio::test]
 async fn latest_valid_hash_will_not_validate() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     const LATEST_VALID_SLOT: u64 = 3;
 
     let mut rig = InvalidPayloadRig::new().enable_attestations();
@@ -618,6 +642,9 @@ async fn latest_valid_hash_will_not_validate() {
 /// Check behaviour when the `latest_valid_hash` is a junk value.
 #[tokio::test]
 async fn latest_valid_hash_is_junk() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let num_blocks = E::slots_per_epoch() * 5;
     let finalized_epoch = 3;
 
@@ -659,6 +686,9 @@ async fn latest_valid_hash_is_junk() {
 /// Check that descendants of invalid blocks are also invalidated.
 #[tokio::test]
 async fn invalidates_all_descendants() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let num_blocks = E::slots_per_epoch() * 4 + E::slots_per_epoch() / 2;
     let finalized_epoch = 2;
     let finalized_slot = E::slots_per_epoch() * 2;
@@ -766,6 +796,9 @@ async fn invalidates_all_descendants() {
 /// Check that the head will switch after the canonical branch is invalidated.
 #[tokio::test]
 async fn switches_heads() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let num_blocks = E::slots_per_epoch() * 4 + E::slots_per_epoch() / 2;
     let finalized_epoch = 2;
     let finalized_slot = E::slots_per_epoch() * 2;
@@ -869,6 +902,9 @@ async fn switches_heads() {
 
 #[tokio::test]
 async fn invalid_during_processing() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let mut rig = InvalidPayloadRig::new();
     rig.move_to_terminal_block();
 
@@ -901,6 +937,9 @@ async fn invalid_during_processing() {
 
 #[tokio::test]
 async fn invalid_after_optimistic_sync() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
     rig.import_block(Payload::Valid).await; // Import a valid transition block.
@@ -939,6 +978,9 @@ async fn invalid_after_optimistic_sync() {
 
 #[tokio::test]
 async fn manually_validate_child() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
     rig.import_block(Payload::Valid).await; // Import a valid transition block.
@@ -957,6 +999,9 @@ async fn manually_validate_child() {
 
 #[tokio::test]
 async fn manually_validate_parent() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
     rig.import_block(Payload::Valid).await; // Import a valid transition block.
@@ -975,6 +1020,9 @@ async fn manually_validate_parent() {
 
 #[tokio::test]
 async fn payload_preparation() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let mut rig = InvalidPayloadRig::new();
     rig.move_to_terminal_block();
     rig.import_block(Payload::Valid).await;
@@ -1036,6 +1084,9 @@ async fn payload_preparation() {
 
 #[tokio::test]
 async fn invalid_parent() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let mut rig = InvalidPayloadRig::new();
     rig.move_to_terminal_block();
     rig.import_block(Payload::Valid).await; // Import a valid transition block.
@@ -1108,6 +1159,9 @@ async fn invalid_parent() {
 /// Tests to ensure that we will still send a proposer preparation
 #[tokio::test]
 async fn payload_preparation_before_transition_block() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let rig = InvalidPayloadRig::new();
     let el = rig.execution_layer();
 
@@ -1180,6 +1234,9 @@ async fn payload_preparation_before_transition_block() {
 
 #[tokio::test]
 async fn attesting_to_optimistic_head() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let mut rig = InvalidPayloadRig::new();
     rig.move_to_terminal_block();
     rig.import_block(Payload::Valid).await; // Import a valid transition block.
@@ -1392,6 +1449,9 @@ impl InvalidHeadSetup {
 
 #[tokio::test]
 async fn recover_from_invalid_head_by_importing_blocks() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let InvalidHeadSetup {
         rig,
         fork_block,
@@ -1437,6 +1497,9 @@ async fn recover_from_invalid_head_by_importing_blocks() {
 
 #[tokio::test]
 async fn recover_from_invalid_head_after_persist_and_reboot() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let InvalidHeadSetup {
         rig,
         fork_block: _,
@@ -1479,6 +1542,9 @@ async fn recover_from_invalid_head_after_persist_and_reboot() {
 
 #[tokio::test]
 async fn weights_after_resetting_optimistic_status() {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
+        return;
+    }
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
     rig.import_block(Payload::Valid).await; // Import a valid transition block.


### PR DESCRIPTION
## Issue Addressed

Fix the failure of the beacon-chain tests for phase0/altair, which now only runs nightly.

## Proposed Changes

Just skip the payload invalidation tests, they don't make any sense prior to Bellatrix anyway.

## Additional Info

This PR is redundant (and the nightly tests too) once we merge:

- https://github.com/sigp/lighthouse/pull/8761