### PR TITLE
Process head_chains in descending order of number of peers

### DIFF
--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -351,7 +351,8 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
             .iter()
             .map(|(id, chain)| (chain.available_peers(), !chain.is_syncing(), *id))
             .collect::<Vec<_>>();
-        preferred_ids.sort_unstable();
+        // Sort in descending order
+        preferred_ids.sort_unstable_by(|a,b| b.cmp(a));
 
         let mut syncing_chains = SmallVec::<[Id; PARALLEL_HEAD_CHAINS]>::new();
         for (_, _, id) in preferred_ids {

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -352,7 +352,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
             .map(|(id, chain)| (chain.available_peers(), !chain.is_syncing(), *id))
             .collect::<Vec<_>>();
         // Sort in descending order
-        preferred_ids.sort_unstable_by(|a,b| b.cmp(a));
+        preferred_ids.sort_unstable_by(|a, b| b.cmp(a));
 
         let mut syncing_chains = SmallVec::<[Id; PARALLEL_HEAD_CHAINS]>::new();
         for (_, _, id) in preferred_ids {


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Another find by @gitToki. Sort the preferred_ids in descending order as originally intended from the comment in the function.

