### PR TITLE
Add --jwt-secret-path to lcli mock-el

### DIFF
--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -493,6 +493,7 @@ fn main() {
                         .value_name("PATH")
                         .action(ArgAction::Set)
                         .required_unless_present("jwt-secret-path")
+                        .conflicts_with("jwt-secret-path")
                         .help("Path to write the JWT secret.")
                         .display_order(0)
                 )

--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -492,8 +492,17 @@ fn main() {
                         .long("jwt-output-path")
                         .value_name("PATH")
                         .action(ArgAction::Set)
-                        .required(true)
+                        .required_unless_present("jwt-secret-path")
                         .help("Path to write the JWT secret.")
+                        .display_order(0)
+                )
+                .arg(
+                    Arg::new("jwt-secret-path")
+                        .long("jwt-secret-path")
+                        .value_name("PATH")
+                        .action(ArgAction::Set)
+                        .help("Path to an existing hex-encoded JWT secret file. \
+                            When provided, this secret is used instead of the default.")
                         .display_order(0)
                 )
                 .arg(

--- a/lcli/src/mock_el.rs
+++ b/lcli/src/mock_el.rs
@@ -13,7 +13,8 @@ use std::sync::Arc;
 use types::*;
 
 pub fn run<E: EthSpec>(mut env: Environment<E>, matches: &ArgMatches) -> Result<(), String> {
-    let jwt_path: PathBuf = parse_required(matches, "jwt-output-path")?;
+    let jwt_output_path: Option<PathBuf> = parse_optional(matches, "jwt-output-path")?;
+    let jwt_secret_path: Option<PathBuf> = parse_optional(matches, "jwt-secret-path")?;
     let listen_addr: Ipv4Addr = parse_required(matches, "listen-address")?;
     let listen_port: u16 = parse_required(matches, "listen-port")?;
     let all_payloads_valid: bool = parse_required(matches, "all-payloads-valid")?;
@@ -25,8 +26,22 @@ pub fn run<E: EthSpec>(mut env: Environment<E>, matches: &ArgMatches) -> Result<
 
     let handle = env.core_context().executor.handle().unwrap();
     let spec = Arc::new(E::default_spec());
-    let jwt_key = JwtKey::from_slice(&DEFAULT_JWT_SECRET).unwrap();
-    std::fs::write(jwt_path, hex::encode(DEFAULT_JWT_SECRET)).unwrap();
+
+    let jwt_key = if let Some(secret_path) = jwt_secret_path {
+        let hex_str = std::fs::read_to_string(&secret_path)
+            .map_err(|e| format!("Failed to read JWT secret file: {}", e))?;
+        let secret_bytes = hex::decode(hex_str.trim().trim_start_matches("0x"))
+            .map_err(|e| format!("Invalid hex in JWT secret file: {}", e))?;
+        JwtKey::from_slice(&secret_bytes)
+            .map_err(|e| format!("Invalid JWT secret length (expected 32 bytes): {}", e))?
+    } else {
+        JwtKey::from_slice(&DEFAULT_JWT_SECRET).expect("DEFAULT_JWT_SECRET is a valid 32-byte key")
+    };
+
+    if let Some(jwt_path) = jwt_output_path {
+        std::fs::write(&jwt_path, hex::encode(jwt_key.as_bytes()))
+            .map_err(|e| format!("Failed to write JWT secret to output path: {}", e))?;
+    }
 
     let config = MockExecutionConfig {
         server_config: Config {

--- a/lcli/src/mock_el.rs
+++ b/lcli/src/mock_el.rs
@@ -36,9 +36,9 @@ pub fn run<E: EthSpec>(mut env: Environment<E>, matches: &ArgMatches) -> Result<
             .map_err(|e| format!("Invalid JWT secret length (expected 32 bytes): {}", e))?
     } else {
         let jwt_path = jwt_output_path
-            .expect("clap ensures either --jwt-secret-path or --jwt-output-path is present");
+            .ok_or("either --jwt-secret-path or --jwt-output-path must be provided")?;
         let jwt_key = JwtKey::from_slice(&DEFAULT_JWT_SECRET)
-            .expect("DEFAULT_JWT_SECRET is a valid 32-byte key");
+            .map_err(|e| format!("Default JWT secret invalid: {}", e))?;
         std::fs::write(jwt_path, hex::encode(jwt_key.as_bytes()))
             .map_err(|e| format!("Failed to write JWT secret to output path: {}", e))?;
         jwt_key

--- a/lcli/src/mock_el.rs
+++ b/lcli/src/mock_el.rs
@@ -35,13 +35,14 @@ pub fn run<E: EthSpec>(mut env: Environment<E>, matches: &ArgMatches) -> Result<
         JwtKey::from_slice(&secret_bytes)
             .map_err(|e| format!("Invalid JWT secret length (expected 32 bytes): {}", e))?
     } else {
-        JwtKey::from_slice(&DEFAULT_JWT_SECRET).expect("DEFAULT_JWT_SECRET is a valid 32-byte key")
-    };
-
-    if let Some(jwt_path) = jwt_output_path {
+        let jwt_path = jwt_output_path
+            .expect("clap ensures either --jwt-secret-path or --jwt-output-path is present");
+        let jwt_key = JwtKey::from_slice(&DEFAULT_JWT_SECRET)
+            .expect("DEFAULT_JWT_SECRET is a valid 32-byte key");
         std::fs::write(jwt_path, hex::encode(jwt_key.as_bytes()))
             .map_err(|e| format!("Failed to write JWT secret to output path: {}", e))?;
-    }
+        jwt_key
+    };
 
     let config = MockExecutionConfig {
         server_config: Config {

--- a/lcli/src/mock_el.rs
+++ b/lcli/src/mock_el.rs
@@ -34,14 +34,14 @@ pub fn run<E: EthSpec>(mut env: Environment<E>, matches: &ArgMatches) -> Result<
             .map_err(|e| format!("Invalid hex in JWT secret file: {}", e))?;
         JwtKey::from_slice(&secret_bytes)
             .map_err(|e| format!("Invalid JWT secret length (expected 32 bytes): {}", e))?
-    } else {
-        let jwt_path = jwt_output_path
-            .ok_or("either --jwt-secret-path or --jwt-output-path must be provided")?;
+    } else if let Some(jwt_path) = jwt_output_path {
         let jwt_key = JwtKey::from_slice(&DEFAULT_JWT_SECRET)
             .map_err(|e| format!("Default JWT secret invalid: {}", e))?;
         std::fs::write(jwt_path, hex::encode(jwt_key.as_bytes()))
             .map_err(|e| format!("Failed to write JWT secret to output path: {}", e))?;
         jwt_key
+    } else {
+        return Err("either --jwt-secret-path or --jwt-output-path must be provided".to_string());
     };
 
     let config = MockExecutionConfig {

--- a/lcli/src/mock_el.rs
+++ b/lcli/src/mock_el.rs
@@ -2,7 +2,7 @@ use clap::ArgMatches;
 use clap_utils::{parse_optional, parse_required};
 use environment::Environment;
 use execution_layer::{
-    auth::JwtKey,
+    auth::{JwtKey, strip_prefix},
     test_utils::{
         Config, DEFAULT_JWT_SECRET, DEFAULT_TERMINAL_BLOCK, MockExecutionConfig, MockServer,
     },
@@ -30,7 +30,7 @@ pub fn run<E: EthSpec>(mut env: Environment<E>, matches: &ArgMatches) -> Result<
     let jwt_key = if let Some(secret_path) = jwt_secret_path {
         let hex_str = std::fs::read_to_string(&secret_path)
             .map_err(|e| format!("Failed to read JWT secret file: {}", e))?;
-        let secret_bytes = hex::decode(hex_str.trim().trim_start_matches("0x"))
+        let secret_bytes = hex::decode(strip_prefix(hex_str.trim()))
             .map_err(|e| format!("Invalid hex in JWT secret file: {}", e))?;
         JwtKey::from_slice(&secret_bytes)
             .map_err(|e| format!("Invalid JWT secret length (expected 32 bytes): {}", e))?
@@ -39,7 +39,7 @@ pub fn run<E: EthSpec>(mut env: Environment<E>, matches: &ArgMatches) -> Result<
     };
 
     if let Some(jwt_path) = jwt_output_path {
-        std::fs::write(&jwt_path, hex::encode(jwt_key.as_bytes()))
+        std::fs::write(jwt_path, hex::encode(jwt_key.as_bytes()))
             .map_err(|e| format!("Failed to write JWT secret to output path: {}", e))?;
     }
 


### PR DESCRIPTION
## Description

Allow `lcli mock-el` to read a pre-shared JWT secret from a file via `--jwt-secret-path`, instead of always using the hardcoded `DEFAULT_JWT_SECRET`. This enables external tools (e.g. kurtosis ethereum-package) to provide their own JWT secret.

The two flags are mutually exclusive:

| Flag | Behavior |
|---|---|
| `--jwt-output-path` | Current behavior: use default secret, write to file |
| `--jwt-secret-path` | Read secret from file, don't write anywhere |

The new flag accepts a hex-encoded secret file (with or without `0x` prefix).

## Additional Info

No breaking changes — existing usage with only `--jwt-output-path` is unchanged.