### PR TITLE
Add getBlobsV1 and getBlobsV2 support to mock EL server

### DIFF
--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -824,8 +824,6 @@ impl<E: EthSpec> From<JsonBlobsBundleV1<E>> for BlobsBundle<E> {
     )
 )]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(untagged)]
-#[serde(bound = "E: EthSpec")]
 pub struct BlobAndProof<E: EthSpec> {
     #[serde(with = "ssz_types::serde_utils::hex_fixed_vec")]
     pub blob: Blob<E>,

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -824,6 +824,8 @@ impl<E: EthSpec> From<JsonBlobsBundleV1<E>> for BlobsBundle<E> {
     )
 )]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+#[serde(bound = "E: EthSpec")]
 pub struct BlobAndProof<E: EthSpec> {
     #[serde(with = "ssz_types::serde_utils::hex_fixed_vec")]
     pub blob: Blob<E>,

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -484,34 +484,36 @@ impl<E: EthSpec> ExecutionBlockGenerator<E> {
 
     /// Look up a blob and proof by versioned hash across all stored bundles.
     pub fn get_blob_and_proof(&self, versioned_hash: &Hash256) -> Option<BlobAndProof<E>> {
-        self.blobs_bundles.values().find_map(|blobs_bundle| {
-            let (blob_idx, _) =
-                blobs_bundle
-                    .commitments
-                    .iter()
-                    .enumerate()
-                    .find(|(_, commitment)| {
-                        &kzg_commitment_to_versioned_hash(commitment) == versioned_hash
-                    })?;
-            let is_fulu_bundle = blobs_bundle.blobs.len() < blobs_bundle.proofs.len();
-            let blob = blobs_bundle.blobs.get(blob_idx)?.clone();
-            if is_fulu_bundle {
-                let start = blob_idx * E::cells_per_ext_blob();
-                let end = start + E::cells_per_ext_blob();
-                let proofs = blobs_bundle
-                    .proofs
-                    .get(start..end)?
-                    .to_vec()
-                    .try_into()
-                    .ok()?;
-                Some(BlobAndProof::V2(BlobAndProofV2 { blob, proofs }))
-            } else {
-                Some(BlobAndProof::V1(BlobAndProofV1 {
-                    blob,
-                    proof: *blobs_bundle.proofs.get(blob_idx)?,
-                }))
-            }
-        })
+        self.blobs_bundles
+            .iter()
+            .find_map(|(payload_id, blobs_bundle)| {
+                let (blob_idx, _) =
+                    blobs_bundle
+                        .commitments
+                        .iter()
+                        .enumerate()
+                        .find(|(_, commitment)| {
+                            &kzg_commitment_to_versioned_hash(commitment) == versioned_hash
+                        })?;
+                let is_fulu = self.payload_ids.get(payload_id)?.fork_name().fulu_enabled();
+                let blob = blobs_bundle.blobs.get(blob_idx)?.clone();
+                if is_fulu {
+                    let start = blob_idx * E::cells_per_ext_blob();
+                    let end = start + E::cells_per_ext_blob();
+                    let proofs = blobs_bundle
+                        .proofs
+                        .get(start..end)?
+                        .to_vec()
+                        .try_into()
+                        .ok()?;
+                    Some(BlobAndProof::V2(BlobAndProofV2 { blob, proofs }))
+                } else {
+                    Some(BlobAndProof::V1(BlobAndProofV1 {
+                        blob,
+                        proof: *blobs_bundle.proofs.get(blob_idx)?,
+                    }))
+                }
+            })
     }
 
     pub fn new_payload(&mut self, payload: ExecutionPayload<E>) -> PayloadStatusV1 {

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -482,44 +482,33 @@ impl<E: EthSpec> ExecutionBlockGenerator<E> {
         self.blobs_bundles.get(id).cloned()
     }
 
-    pub fn get_blob_and_proofs(&self, versioned_hashes: Vec<Hash256>) -> Vec<BlobAndProof<E>> {
-        self.blobs_bundles
-            .values()
-            // Assumes all versioned hashes are present in the same bundle; short-circuit if found.
-            .find_map(|blobs_bundle| {
-                let blobs_and_proofs: Vec<_> = blobs_bundle
-                    .commitments
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, commitment)| {
-                        let hash = kzg_commitment_to_versioned_hash(commitment);
-                        versioned_hashes.contains(&hash)
-                    })
-                    .filter_map(|(blob_idx, _)| {
-                        let is_fulu_bundle = blobs_bundle.blobs.len() < blobs_bundle.proofs.len();
-                        let blob = blobs_bundle.blobs.get(blob_idx)?.clone();
-                        if is_fulu_bundle {
-                            let start = blob_idx * E::cells_per_ext_blob();
-                            let end = start + E::cells_per_ext_blob();
-                            let proofs = blobs_bundle
-                                .proofs
-                                .get(start..end)?
-                                .to_vec()
-                                .try_into()
-                                .ok()?;
-                            Some(BlobAndProof::V2(BlobAndProofV2 { blob, proofs }))
-                        } else {
-                            Some(BlobAndProof::V1(BlobAndProofV1 {
-                                blob,
-                                proof: *blobs_bundle.proofs.get(blob_idx)?,
-                            }))
-                        }
-                    })
-                    .collect();
-
-                (!blobs_and_proofs.is_empty()).then_some(blobs_and_proofs)
-            })
-            .unwrap_or_default()
+    /// Look up a blob and proof by versioned hash across all stored bundles.
+    pub fn get_blob_and_proof(&self, versioned_hash: &Hash256) -> Option<BlobAndProof<E>> {
+        self.blobs_bundles.values().find_map(|blobs_bundle| {
+            let (blob_idx, _) = blobs_bundle.commitments.iter().enumerate().find(
+                |(_, commitment)| {
+                    &kzg_commitment_to_versioned_hash(commitment) == versioned_hash
+                },
+            )?;
+            let is_fulu_bundle = blobs_bundle.blobs.len() < blobs_bundle.proofs.len();
+            let blob = blobs_bundle.blobs.get(blob_idx)?.clone();
+            if is_fulu_bundle {
+                let start = blob_idx * E::cells_per_ext_blob();
+                let end = start + E::cells_per_ext_blob();
+                let proofs = blobs_bundle
+                    .proofs
+                    .get(start..end)?
+                    .to_vec()
+                    .try_into()
+                    .ok()?;
+                Some(BlobAndProof::V2(BlobAndProofV2 { blob, proofs }))
+            } else {
+                Some(BlobAndProof::V1(BlobAndProofV1 {
+                    blob,
+                    proof: *blobs_bundle.proofs.get(blob_idx)?,
+                }))
+            }
+        })
     }
 
     pub fn new_payload(&mut self, payload: ExecutionPayload<E>) -> PayloadStatusV1 {

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -1,7 +1,8 @@
 use crate::engine_api::{
     ExecutionBlock, PayloadAttributes, PayloadId, PayloadStatusV1, PayloadStatusV1Status,
     json_structures::{
-        JsonForkchoiceUpdatedV1Response, JsonPayloadStatusV1, JsonPayloadStatusV1Status,
+        BlobAndProof, BlobAndProofV1, BlobAndProofV2, JsonForkchoiceUpdatedV1Response,
+        JsonPayloadStatusV1, JsonPayloadStatusV1Status,
     },
 };
 use crate::engines::ForkchoiceState;
@@ -15,6 +16,7 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
 use ssz::Decode;
 use ssz_types::VariableList;
+use state_processing::per_block_processing::deneb::kzg_commitment_to_versioned_hash;
 use std::cmp::max;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -478,6 +480,46 @@ impl<E: EthSpec> ExecutionBlockGenerator<E> {
 
     pub fn get_blobs_bundle(&mut self, id: &PayloadId) -> Option<BlobsBundle<E>> {
         self.blobs_bundles.get(id).cloned()
+    }
+
+    pub fn get_blob_and_proofs(&self, versioned_hashes: Vec<Hash256>) -> Vec<BlobAndProof<E>> {
+        self.blobs_bundles
+            .values()
+            // Assumes all versioned hashes are present in the same bundle; short-circuit if found.
+            .find_map(|blobs_bundle| {
+                let blobs_and_proofs: Vec<_> = blobs_bundle
+                    .commitments
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, commitment)| {
+                        let hash = kzg_commitment_to_versioned_hash(commitment);
+                        versioned_hashes.contains(&hash)
+                    })
+                    .filter_map(|(blob_idx, _)| {
+                        let is_fulu_bundle = blobs_bundle.blobs.len() < blobs_bundle.proofs.len();
+                        let blob = blobs_bundle.blobs.get(blob_idx)?.clone();
+                        if is_fulu_bundle {
+                            let start = blob_idx * E::cells_per_ext_blob();
+                            let end = start + E::cells_per_ext_blob();
+                            let proofs = blobs_bundle
+                                .proofs
+                                .get(start..end)?
+                                .to_vec()
+                                .try_into()
+                                .ok()?;
+                            Some(BlobAndProof::V2(BlobAndProofV2 { blob, proofs }))
+                        } else {
+                            Some(BlobAndProof::V1(BlobAndProofV1 {
+                                blob,
+                                proof: *blobs_bundle.proofs.get(blob_idx)?,
+                            }))
+                        }
+                    })
+                    .collect();
+
+                (!blobs_and_proofs.is_empty()).then_some(blobs_and_proofs)
+            })
+            .unwrap_or_default()
     }
 
     pub fn new_payload(&mut self, payload: ExecutionPayload<E>) -> PayloadStatusV1 {

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -485,11 +485,14 @@ impl<E: EthSpec> ExecutionBlockGenerator<E> {
     /// Look up a blob and proof by versioned hash across all stored bundles.
     pub fn get_blob_and_proof(&self, versioned_hash: &Hash256) -> Option<BlobAndProof<E>> {
         self.blobs_bundles.values().find_map(|blobs_bundle| {
-            let (blob_idx, _) = blobs_bundle.commitments.iter().enumerate().find(
-                |(_, commitment)| {
-                    &kzg_commitment_to_versioned_hash(commitment) == versioned_hash
-                },
-            )?;
+            let (blob_idx, _) =
+                blobs_bundle
+                    .commitments
+                    .iter()
+                    .enumerate()
+                    .find(|(_, commitment)| {
+                        &kzg_commitment_to_versioned_hash(commitment) == versioned_hash
+                    })?;
             let is_fulu_bundle = blobs_bundle.blobs.len() < blobs_bundle.proofs.len();
             let blob = blobs_bundle.blobs.get(blob_idx)?.clone();
             if is_fulu_bundle {

--- a/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
+++ b/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
@@ -468,38 +468,34 @@ pub async fn handle_rpc<E: EthSpec>(
                 _ => unreachable!(),
             }
         }
-        ENGINE_GET_BLOBS_V1 | ENGINE_GET_BLOBS_V2 => {
+        ENGINE_GET_BLOBS_V1 => {
             let versioned_hashes =
                 get_param::<Vec<Hash256>>(params, 0).map_err(|s| (s, BAD_PARAMS_ERROR_CODE))?;
-            let blobs_and_proofs = ctx
-                .execution_block_generator
-                .read()
-                .get_blob_and_proofs(versioned_hashes);
-
-            // Validate method called correctly according to the blob and proof type,
-            // as the blob bundle generated is based on the fork.
-            if let Some(blob_and_proof) = blobs_and_proofs.first() {
-                match blob_and_proof {
-                    BlobAndProof::V1(_) => {
-                        if method == ENGINE_GET_BLOBS_V2 {
-                            return Err((
-                                format!("{} called before Fulu fork!", method),
-                                FORK_REQUEST_MISMATCH_ERROR_CODE,
-                            ));
-                        }
-                    }
-                    BlobAndProof::V2(_) => {
-                        if method == ENGINE_GET_BLOBS_V1 {
-                            return Err((
-                                format!("{} called after Fulu fork!", method),
-                                FORK_REQUEST_MISMATCH_ERROR_CODE,
-                            ));
-                        }
-                    }
-                }
-            }
-
-            Ok(serde_json::to_value(blobs_and_proofs).unwrap())
+            let generator = ctx.execution_block_generator.read();
+            // V1: per-element nullable array, positionally matching the request.
+            let response: Vec<Option<BlobAndProofV1<E>>> = versioned_hashes
+                .iter()
+                .map(|hash| match generator.get_blob_and_proof(hash) {
+                    Some(BlobAndProof::V1(v1)) => Some(v1),
+                    _ => None,
+                })
+                .collect();
+            Ok(serde_json::to_value(response).unwrap())
+        }
+        ENGINE_GET_BLOBS_V2 => {
+            let versioned_hashes =
+                get_param::<Vec<Hash256>>(params, 0).map_err(|s| (s, BAD_PARAMS_ERROR_CODE))?;
+            let generator = ctx.execution_block_generator.read();
+            // V2: all-or-nothing — null if any blob is missing.
+            let results: Vec<Option<BlobAndProofV2<E>>> = versioned_hashes
+                .iter()
+                .map(|hash| match generator.get_blob_and_proof(hash) {
+                    Some(BlobAndProof::V2(v2)) => Some(v2),
+                    _ => None,
+                })
+                .collect();
+            let response: Option<Vec<BlobAndProofV2<E>>> = results.into_iter().collect();
+            Ok(serde_json::to_value(response).unwrap())
         }
         ENGINE_FORKCHOICE_UPDATED_V1
         | ENGINE_FORKCHOICE_UPDATED_V2

--- a/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
+++ b/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
@@ -468,6 +468,39 @@ pub async fn handle_rpc<E: EthSpec>(
                 _ => unreachable!(),
             }
         }
+        ENGINE_GET_BLOBS_V1 | ENGINE_GET_BLOBS_V2 => {
+            let versioned_hashes =
+                get_param::<Vec<Hash256>>(params, 0).map_err(|s| (s, BAD_PARAMS_ERROR_CODE))?;
+            let blobs_and_proofs = ctx
+                .execution_block_generator
+                .read()
+                .get_blob_and_proofs(versioned_hashes);
+
+            // Validate method called correctly according to the blob and proof type,
+            // as the blob bundle generated is based on the fork.
+            if let Some(blob_and_proof) = blobs_and_proofs.first() {
+                match blob_and_proof {
+                    BlobAndProof::V1(_) => {
+                        if method == ENGINE_GET_BLOBS_V2 {
+                            return Err((
+                                format!("{} called before Fulu fork!", method),
+                                FORK_REQUEST_MISMATCH_ERROR_CODE,
+                            ));
+                        }
+                    }
+                    BlobAndProof::V2(_) => {
+                        if method == ENGINE_GET_BLOBS_V1 {
+                            return Err((
+                                format!("{} called after Fulu fork!", method),
+                                FORK_REQUEST_MISMATCH_ERROR_CODE,
+                            ));
+                        }
+                    }
+                }
+            }
+
+            Ok(serde_json::to_value(blobs_and_proofs).unwrap())
+        }
         ENGINE_FORKCHOICE_UPDATED_V1
         | ENGINE_FORKCHOICE_UPDATED_V2
         | ENGINE_FORKCHOICE_UPDATED_V3 => {


### PR DESCRIPTION
## Description

Revive #7986 which was approved but closed after `network-tests` flaked repeatedly in the merge queue.

Adds `engine_getBlobsV1` and `engine_getBlobsV2` handlers to the mock EL server. When blobs have been generated during payload building (integration tests), they're returned by matching versioned hashes from the existing `blobs_bundles`. When no blobs exist (lcli paired with a real CL), empty results are returned — preventing the CL from logging "method not supported" errors.

Changes from #7986:
- `.to_vec().into()` → `.to_vec().try_into().ok()?` for V2 cell proofs (`VariableList` no longer implements `From<Vec<_>>`)
- Spec-compliant return types: V1 returns `Vec<Option<BlobAndProofV1>>` (per-element nullable, positionally matching the request), V2 returns `Option<Vec<BlobAndProofV2>>` (all-or-nothing, `null` if any blob is missing)