### PR TITLE
Remove unreachable void pattern for ConnectionLimits

### DIFF
--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -1861,8 +1861,6 @@ impl<E: EthSpec> Network<E> {
                     self.inject_upnp_event(e);
                     None
                 }
-                #[allow(unreachable_patterns)]
-                BehaviourEvent::ConnectionLimits(le) => libp2p::core::util::unreachable(le),
             },
             SwarmEvent::ConnectionEstablished { .. } => None,
             SwarmEvent::ConnectionClosed { .. } => None,


### PR DESCRIPTION
## Description

Remove the `#[allow(unreachable_patterns)]` and unreachable `BehaviourEvent::ConnectionLimits` match arm. The MSRV is well above 1.82, so the compiler natively recognises that `ConnectionLimits` events are uninhabited (`Infallible`).

Closes #6356