### PR TITLE
Add unit tests for BatchInfo and fix doc comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,13 @@ All `TODO` comments must link to a GitHub issue.
 
 Avoid ambiguous abbreviations (`bb`, `bl`). Use `beacon_block`, `blob`.
 
+### 8. Writing Useful Tests
+
+- **Test the public contract, not implementation details.** Don't exhaustively test every invalid-state permutation of a state machine — that's re-stating the `match` arms and creates maintenance burden with no real safety benefit.
+- **Bug-driven tests**: When you find a bug, write a test that fails against the current code first, then fix the code. The failing test proves the bug exists and prevents regressions. A test that passes against buggy code is worthless.
+- **Each test should earn its keep.** If a test would break when refactoring internals but the public behavior hasn't changed, it's testing the wrong thing. Ask: "would a caller care if this broke?"
+- **Prefer fewer, focused tests** that cover meaningful behavior (failure limits, retry logic, blacklist decisions) over many shallow tests that check trivial getters or obvious error returns.
+
 ## Branch & PR Guidelines
 
 - Branch from `unstable`, target `unstable` for PRs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,13 +97,6 @@ All `TODO` comments must link to a GitHub issue.
 
 Avoid ambiguous abbreviations (`bb`, `bl`). Use `beacon_block`, `blob`.
 
-### 8. Writing Useful Tests
-
-- **Test the public contract, not implementation details.** Don't exhaustively test every invalid-state permutation of a state machine — that's re-stating the `match` arms and creates maintenance burden with no real safety benefit.
-- **Bug-driven tests**: When you find a bug, write a test that fails against the current code first, then fix the code. The failing test proves the bug exists and prevents regressions. A test that passes against buggy code is worthless.
-- **Each test should earn its keep.** If a test would break when refactoring internals but the public behavior hasn't changed, it's testing the wrong thing. Ask: "would a caller care if this broke?"
-- **Prefer fewer, focused tests** that cover meaningful behavior (failure limits, retry logic, blacklist decisions) over many shallow tests that check trivial getters or obvious error returns.
-
 ## Branch & PR Guidelines
 
 - Branch from `unstable`, target `unstable` for PRs

--- a/beacon_node/network/src/sync/batch.rs
+++ b/beacon_node/network/src/sync/batch.rs
@@ -213,6 +213,9 @@ impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {
     /// After different operations over a batch, this could be in a state that allows it to
     /// continue, or in failed state. When the batch has failed, we check if it did mainly due to
     /// processing failures. In this case the batch is considered failed and faulty.
+    ///
+    /// When failure counts are equal, `blacklist` is `false` — we assume network issues over
+    /// peer fault when the evidence is ambiguous.
     pub fn outcome(&self) -> BatchOperationOutcome {
         match self.state {
             BatchState::Poisoned => unreachable!("Poisoned batch"),
@@ -255,8 +258,10 @@ impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {
     /// Mark the batch as failed and return whether we can attempt a re-download.
     ///
     /// This can happen if a peer disconnects or some error occurred that was not the peers fault.
-    /// The `peer` parameter, when set to None, does not increment the failed attempts of
-    /// this batch and register the peer, rather attempts a re-download.
+    /// The `peer` parameter, when set to `None`, still counts toward
+    /// `max_batch_download_attempts` (to prevent infinite retries on persistent failures)
+    /// but does not register a peer in `failed_peers()`. Use
+    /// [`Self::downloading_to_awaiting_download`] to retry without counting a failed attempt.
     #[must_use = "Batch may have failed"]
     pub fn download_failed(
         &mut self,
@@ -272,7 +277,6 @@ impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {
                 {
                     BatchState::Failed
                 } else {
-                    // drop the blocks
                     BatchState::AwaitingDownload
                 };
                 Ok(self.outcome())
@@ -522,5 +526,195 @@ impl<D: Hash> BatchState<D> {
             BatchState::AwaitingProcessing(..) => 'p',
             BatchState::Poisoned => 'X',
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hasher;
+    use types::MinimalEthSpec;
+
+    struct TestBatchConfig;
+
+    impl BatchConfig for TestBatchConfig {
+        fn max_batch_download_attempts() -> u8 {
+            3
+        }
+        fn max_batch_processing_attempts() -> u8 {
+            2
+        }
+        fn batch_attempt_hash<D: Hash>(data: &D) -> u64 {
+            let mut hasher = DefaultHasher::new();
+            data.hash(&mut hasher);
+            hasher.finish()
+        }
+    }
+
+    type TestBatch = BatchInfo<MinimalEthSpec, TestBatchConfig, Vec<u64>>;
+
+    fn new_batch() -> TestBatch {
+        BatchInfo::new(&Epoch::new(0), 1, ByRangeRequestType::Blocks)
+    }
+
+    fn peer() -> PeerId {
+        PeerId::random()
+    }
+
+    fn advance_to_processing(batch: &mut TestBatch, req_id: Id, peer_id: PeerId) {
+        batch.start_downloading(req_id).unwrap();
+        batch.download_completed(vec![1, 2, 3], peer_id).unwrap();
+        batch.start_processing().unwrap();
+    }
+
+    fn advance_to_awaiting_validation(batch: &mut TestBatch, req_id: Id, peer_id: PeerId) {
+        advance_to_processing(batch, req_id, peer_id);
+        batch
+            .processing_completed(BatchProcessingResult::Success)
+            .unwrap();
+    }
+
+    #[test]
+    fn happy_path_lifecycle() {
+        let mut batch = new_batch();
+        let p = peer();
+
+        assert!(matches!(batch.state(), BatchState::AwaitingDownload));
+
+        batch.start_downloading(1).unwrap();
+        assert!(matches!(batch.state(), BatchState::Downloading(1)));
+
+        batch.download_completed(vec![10, 20], p).unwrap();
+        assert!(matches!(batch.state(), BatchState::AwaitingProcessing(..)));
+
+        let (data, _duration) = batch.start_processing().unwrap();
+        assert_eq!(data, vec![10, 20]);
+        assert!(matches!(batch.state(), BatchState::Processing(..)));
+
+        let outcome = batch
+            .processing_completed(BatchProcessingResult::Success)
+            .unwrap();
+        assert!(matches!(outcome, BatchOperationOutcome::Continue));
+        assert!(matches!(batch.state(), BatchState::AwaitingValidation(..)));
+    }
+
+    #[test]
+    fn download_failures_count_toward_limit() {
+        let mut batch = new_batch();
+
+        // Failures 1 and 2 allow retry
+        for i in 1..=2 {
+            batch.start_downloading(i).unwrap();
+            let outcome = batch.download_failed(Some(peer())).unwrap();
+            assert!(matches!(outcome, BatchOperationOutcome::Continue));
+        }
+
+        // Failure 3 hits the limit
+        batch.start_downloading(3).unwrap();
+        let outcome = batch.download_failed(Some(peer())).unwrap();
+        assert!(matches!(
+            outcome,
+            BatchOperationOutcome::Failed { blacklist: false }
+        ));
+    }
+
+    #[test]
+    fn download_failed_none_counts_but_does_not_blame_peer() {
+        let mut batch = new_batch();
+
+        // None still counts toward the limit (prevents infinite retry on persistent
+        // network failures), but doesn't register a peer in failed_peers().
+        for i in 0..3 {
+            batch.start_downloading(i).unwrap();
+            batch.download_failed(None).unwrap();
+        }
+        assert!(matches!(batch.state(), BatchState::Failed));
+        assert!(batch.failed_peers().is_empty());
+    }
+
+    #[test]
+    fn faulty_processing_failures_count_toward_limit() {
+        let mut batch = new_batch();
+
+        // First faulty failure: retry allowed
+        advance_to_processing(&mut batch, 1, peer());
+        let outcome = batch
+            .processing_completed(BatchProcessingResult::FaultyFailure)
+            .unwrap();
+        assert!(matches!(outcome, BatchOperationOutcome::Continue));
+
+        // Second faulty failure: limit reached
+        advance_to_processing(&mut batch, 2, peer());
+        let outcome = batch
+            .processing_completed(BatchProcessingResult::FaultyFailure)
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            BatchOperationOutcome::Failed { blacklist: true }
+        ));
+    }
+
+    #[test]
+    fn non_faulty_processing_failures_never_exhaust_batch() {
+        let mut batch = new_batch();
+
+        for i in 0..10 {
+            advance_to_processing(&mut batch, i, peer());
+            let outcome = batch
+                .processing_completed(BatchProcessingResult::NonFaultyFailure)
+                .unwrap();
+            assert!(matches!(outcome, BatchOperationOutcome::Continue));
+        }
+        // Non-faulty failures also don't register peers as failed
+        assert!(batch.failed_peers().is_empty());
+    }
+
+    #[test]
+    fn validation_failures_count_toward_processing_limit() {
+        let mut batch = new_batch();
+
+        advance_to_awaiting_validation(&mut batch, 1, peer());
+        let outcome = batch.validation_failed().unwrap();
+        assert!(matches!(outcome, BatchOperationOutcome::Continue));
+
+        advance_to_awaiting_validation(&mut batch, 2, peer());
+        let outcome = batch.validation_failed().unwrap();
+        assert!(matches!(
+            outcome,
+            BatchOperationOutcome::Failed { blacklist: true }
+        ));
+    }
+
+    #[test]
+    fn mixed_failure_types_interact_correctly() {
+        let mut batch = new_batch();
+
+        // Download failure, then processing failure, then non-faulty, then download to limit
+        batch.start_downloading(1).unwrap();
+        batch.download_failed(Some(peer())).unwrap();
+
+        advance_to_processing(&mut batch, 2, peer());
+        batch
+            .processing_completed(BatchProcessingResult::FaultyFailure)
+            .unwrap();
+
+        advance_to_processing(&mut batch, 3, peer());
+        batch
+            .processing_completed(BatchProcessingResult::NonFaultyFailure)
+            .unwrap();
+        assert!(matches!(batch.state(), BatchState::AwaitingDownload));
+
+        // Two more download failures reach the limit (3 total)
+        batch.start_downloading(4).unwrap();
+        batch.download_failed(Some(peer())).unwrap();
+        batch.start_downloading(5).unwrap();
+        let outcome = batch.download_failed(Some(peer())).unwrap();
+
+        // 3 download > 1 processing → blacklist: false
+        assert!(matches!(
+            outcome,
+            BatchOperationOutcome::Failed { blacklist: false }
+        ));
     }
 }

--- a/beacon_node/network/src/sync/batch.rs
+++ b/beacon_node/network/src/sync/batch.rs
@@ -532,27 +532,19 @@ impl<D: Hash> BatchState<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::Hasher;
+    use crate::sync::range_sync::RangeSyncBatchConfig;
     use types::MinimalEthSpec;
 
-    struct TestBatchConfig;
+    type Cfg = RangeSyncBatchConfig<MinimalEthSpec>;
+    type TestBatch = BatchInfo<MinimalEthSpec, Cfg, Vec<u64>>;
 
-    impl BatchConfig for TestBatchConfig {
-        fn max_batch_download_attempts() -> u8 {
-            3
-        }
-        fn max_batch_processing_attempts() -> u8 {
-            2
-        }
-        fn batch_attempt_hash<D: Hash>(data: &D) -> u64 {
-            let mut hasher = DefaultHasher::new();
-            data.hash(&mut hasher);
-            hasher.finish()
-        }
+    fn max_dl() -> u8 {
+        Cfg::max_batch_download_attempts()
     }
 
-    type TestBatch = BatchInfo<MinimalEthSpec, TestBatchConfig, Vec<u64>>;
+    fn max_proc() -> u8 {
+        Cfg::max_batch_processing_attempts()
+    }
 
     fn new_batch() -> TestBatch {
         BatchInfo::new(&Epoch::new(0), 1, ByRangeRequestType::Blocks)
@@ -603,15 +595,14 @@ mod tests {
     fn download_failures_count_toward_limit() {
         let mut batch = new_batch();
 
-        // Failures 1 and 2 allow retry
-        for i in 1..=2 {
+        for i in 1..max_dl() as Id {
             batch.start_downloading(i).unwrap();
             let outcome = batch.download_failed(Some(peer())).unwrap();
             assert!(matches!(outcome, BatchOperationOutcome::Continue));
         }
 
-        // Failure 3 hits the limit
-        batch.start_downloading(3).unwrap();
+        // Next failure hits the limit
+        batch.start_downloading(max_dl() as Id).unwrap();
         let outcome = batch.download_failed(Some(peer())).unwrap();
         assert!(matches!(
             outcome,
@@ -625,7 +616,7 @@ mod tests {
 
         // None still counts toward the limit (prevents infinite retry on persistent
         // network failures), but doesn't register a peer in failed_peers().
-        for i in 0..3 {
+        for i in 0..max_dl() as Id {
             batch.start_downloading(i).unwrap();
             batch.download_failed(None).unwrap();
         }
@@ -637,15 +628,16 @@ mod tests {
     fn faulty_processing_failures_count_toward_limit() {
         let mut batch = new_batch();
 
-        // First faulty failure: retry allowed
-        advance_to_processing(&mut batch, 1, peer());
-        let outcome = batch
-            .processing_completed(BatchProcessingResult::FaultyFailure)
-            .unwrap();
-        assert!(matches!(outcome, BatchOperationOutcome::Continue));
+        for i in 1..max_proc() as Id {
+            advance_to_processing(&mut batch, i, peer());
+            let outcome = batch
+                .processing_completed(BatchProcessingResult::FaultyFailure)
+                .unwrap();
+            assert!(matches!(outcome, BatchOperationOutcome::Continue));
+        }
 
-        // Second faulty failure: limit reached
-        advance_to_processing(&mut batch, 2, peer());
+        // Next faulty failure: limit reached
+        advance_to_processing(&mut batch, max_proc() as Id, peer());
         let outcome = batch
             .processing_completed(BatchProcessingResult::FaultyFailure)
             .unwrap();
@@ -659,7 +651,9 @@ mod tests {
     fn non_faulty_processing_failures_never_exhaust_batch() {
         let mut batch = new_batch();
 
-        for i in 0..10 {
+        // Well past both limits — non-faulty failures should never cause failure
+        let iterations = (max_dl() + max_proc()) as Id * 2;
+        for i in 0..iterations {
             advance_to_processing(&mut batch, i, peer());
             let outcome = batch
                 .processing_completed(BatchProcessingResult::NonFaultyFailure)
@@ -674,11 +668,13 @@ mod tests {
     fn validation_failures_count_toward_processing_limit() {
         let mut batch = new_batch();
 
-        advance_to_awaiting_validation(&mut batch, 1, peer());
-        let outcome = batch.validation_failed().unwrap();
-        assert!(matches!(outcome, BatchOperationOutcome::Continue));
+        for i in 1..max_proc() as Id {
+            advance_to_awaiting_validation(&mut batch, i, peer());
+            let outcome = batch.validation_failed().unwrap();
+            assert!(matches!(outcome, BatchOperationOutcome::Continue));
+        }
 
-        advance_to_awaiting_validation(&mut batch, 2, peer());
+        advance_to_awaiting_validation(&mut batch, max_proc() as Id, peer());
         let outcome = batch.validation_failed().unwrap();
         assert!(matches!(
             outcome,
@@ -689,31 +685,38 @@ mod tests {
     #[test]
     fn mixed_failure_types_interact_correctly() {
         let mut batch = new_batch();
+        let mut req_id: Id = 0;
+        let mut next_id = || {
+            req_id += 1;
+            req_id
+        };
 
-        // Download failure, then processing failure, then non-faulty, then download to limit
-        batch.start_downloading(1).unwrap();
+        // One download failure
+        batch.start_downloading(next_id()).unwrap();
         batch.download_failed(Some(peer())).unwrap();
 
-        advance_to_processing(&mut batch, 2, peer());
+        // One faulty processing failure (requires a successful download first)
+        advance_to_processing(&mut batch, next_id(), peer());
         batch
             .processing_completed(BatchProcessingResult::FaultyFailure)
             .unwrap();
 
-        advance_to_processing(&mut batch, 3, peer());
+        // One non-faulty processing failure
+        advance_to_processing(&mut batch, next_id(), peer());
         batch
             .processing_completed(BatchProcessingResult::NonFaultyFailure)
             .unwrap();
         assert!(matches!(batch.state(), BatchState::AwaitingDownload));
 
-        // Two more download failures reach the limit (3 total)
-        batch.start_downloading(4).unwrap();
-        batch.download_failed(Some(peer())).unwrap();
-        batch.start_downloading(5).unwrap();
-        let outcome = batch.download_failed(Some(peer())).unwrap();
+        // Fill remaining download failures to hit the limit
+        for _ in 1..max_dl() {
+            batch.start_downloading(next_id()).unwrap();
+            batch.download_failed(Some(peer())).unwrap();
+        }
 
-        // 3 download > 1 processing → blacklist: false
+        // Download failures > processing failures → blacklist: false
         assert!(matches!(
-            outcome,
+            batch.outcome(),
             BatchOperationOutcome::Failed { blacklist: false }
         ));
     }

--- a/beacon_node/network/src/sync/range_sync/mod.rs
+++ b/beacon_node/network/src/sync/range_sync/mod.rs
@@ -5,9 +5,9 @@ mod chain_collection;
 mod range;
 mod sync_type;
 
-pub use chain::{ChainId, EPOCHS_PER_BATCH};
 #[cfg(test)]
 pub use chain::RangeSyncBatchConfig;
+pub use chain::{ChainId, EPOCHS_PER_BATCH};
 #[cfg(test)]
 pub use chain_collection::SyncChainStatus;
 pub use range::RangeSync;

--- a/beacon_node/network/src/sync/range_sync/mod.rs
+++ b/beacon_node/network/src/sync/range_sync/mod.rs
@@ -7,6 +7,8 @@ mod sync_type;
 
 pub use chain::{ChainId, EPOCHS_PER_BATCH};
 #[cfg(test)]
+pub use chain::RangeSyncBatchConfig;
+#[cfg(test)]
 pub use chain_collection::SyncChainStatus;
 pub use range::RangeSync;
 pub use sync_type::RangeSyncType;


### PR DESCRIPTION
Adds unit tests for the `BatchInfo` state machine in `batch.rs` and fixes misleading doc comments.

