### PR TITLE
Bump `uuid` to remove duplicate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,7 +3199,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "unicode-normalization",
- "uuid 0.8.2",
+ "uuid",
  "zeroize",
 ]
 
@@ -3239,7 +3239,7 @@ dependencies = [
  "serde_repr",
  "tempfile",
  "tiny-bip39",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -5901,7 +5901,7 @@ dependencies = [
  "rustc_version 0.4.1",
  "smallvec",
  "tagptr",
- "uuid 1.19.0",
+ "uuid",
 ]
 
 [[package]]
@@ -7168,7 +7168,7 @@ checksum = "a2ebd03c29250cdf191da93a35118b4567c2ef0eacab54f65e058d6f4c9965f6"
 dependencies = [
  "r2d2",
  "rusqlite",
- "uuid 1.19.0",
+ "uuid",
 ]
 
 [[package]]
@@ -9521,16 +9521,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.16",
- "serde",
-]
-
-[[package]]
-name = "uuid"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
@@ -9538,6 +9528,7 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "rand 0.9.2",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,7 @@ tree_hash_derive = "0.12.0"
 typenum = "1"
 types = { path = "consensus/types", features = ["saturating-arith"] }
 url = "2"
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "1", features = ["serde", "v4"] }
 validator_client = { path = "validator_client" }
 validator_dir = { path = "common/validator_dir" }
 validator_http_api = { path = "validator_client/http_api" }

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ deny = [
     { crate = "pbkdf2", deny-multiple-versions = true, reason = "takes a long time to compile" },
     { crate = "scrypt", deny-multiple-versions = true, reason = "takes a long time to compile" },
     { crate = "syn", deny-multiple-versions = true, reason = "takes a long time to compile" },
+    { crate = "uuid", deny-multiple-versions = true, reason = "dependency hygiene" },
 ]
 
 [sources]


### PR DESCRIPTION
## Issue Addressed

#8547 

## Proposed Changes

Bump the version of `uuid` in our Cargo.toml to version `1` which removes `uuid 0.8` and unifies it across the workspace to version `1.19.0`.

## Additional Info

While this version of `uuid` isn't the latest, newer versions of `uuid` have bumped `getrandom` which would duplicate it for our workspace.
