### PR TITLE
fix: repair Gloas block replay crash with IncorrectStateVariant

### DIFF
--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -780,6 +780,42 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             .map(|payload| payload.is_some())
     }
 
+    /// Store a Gloas (EIP-7732) execution payload envelope in the hot database.
+    ///
+    /// The key is the execution `block_hash` committed to by the builder in the corresponding
+    /// `signed_execution_payload_bid`.  This allows efficient lookup during block replay using
+    /// only the information present in each block's bid header.
+    pub fn put_execution_payload_envelope(
+        &self,
+        exec_block_hash: &ExecutionBlockHash,
+        envelope: &SignedExecutionPayloadEnvelope<E>,
+        ops: &mut Vec<KeyValueStoreOp>,
+    ) {
+        ops.push(KeyValueStoreOp::PutKeyValue(
+            DBColumn::ExecPayloadEnvelope,
+            exec_block_hash.as_ssz_bytes(),
+            envelope.as_ssz_bytes(),
+        ));
+    }
+
+    /// Load a Gloas (EIP-7732) execution payload envelope by the execution block hash.
+    ///
+    /// Returns `None` when no envelope has been stored for the given hash (e.g. the builder did
+    /// not deliver the payload for that slot, or envelope storage is not yet implemented for the
+    /// current database schema).
+    pub fn get_execution_payload_envelope(
+        &self,
+        exec_block_hash: &ExecutionBlockHash,
+    ) -> Result<Option<SignedExecutionPayloadEnvelope<E>>, Error> {
+        let key = exec_block_hash.as_ssz_bytes();
+        match self.hot_db.get_bytes(DBColumn::ExecPayloadEnvelope, &key)? {
+            Some(bytes) => Ok(Some(SignedExecutionPayloadEnvelope::from_ssz_bytes(
+                &bytes,
+            )?)),
+            None => Ok(None),
+        }
+    }
+
     /// Get the sync committee branch for the given block root
     /// Note: we only persist sync committee branches for checkpoint slots
     pub fn get_sync_committee_branch(
@@ -2474,6 +2510,28 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         if let Some(pre_slot_hook) = pre_slot_hook {
             block_replayer = block_replayer.pre_slot_hook(pre_slot_hook);
+        }
+
+        // For Gloas (EIP-7732) replay: attempt to load the execution payload envelope for each
+        // block from the hot DB, keyed by the execution block hash that the builder committed to.
+        // If any block is a Gloas block, we build the envelope map and wire it into BlockReplayer
+        // so the look-ahead logic can apply envelopes between consecutive blocks.
+        let any_gloas = blocks
+            .iter()
+            .any(|b| b.fork_name(&self.spec).is_ok_and(|f| f.gloas_enabled()));
+        if any_gloas {
+            let mut envelopes = HashMap::new();
+            for block in &blocks {
+                if let Ok(ForkName::Gloas) = block.fork_name(&self.spec)
+                    && let BeaconBlockBodyRef::Gloas(body) = block.message().body()
+                {
+                    let bid_hash = body.signed_execution_payload_bid.message.block_hash;
+                    if let Some(envelope) = self.get_execution_payload_envelope(&bid_hash)? {
+                        envelopes.insert(bid_hash, envelope.message);
+                    }
+                }
+            }
+            block_replayer = block_replayer.payload_envelopes(envelopes);
         }
 
         block_replayer

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -310,6 +310,12 @@ pub enum DBColumn {
     /// Execution payloads for blocks more recent than the finalized checkpoint.
     #[strum(serialize = "exp")]
     ExecPayload,
+    /// Execution payload envelopes for Gloas (EIP-7732) blocks in the hot database.
+    ///
+    /// - Key: 32-byte execution `block_hash` from the block's `signed_execution_payload_bid`.
+    /// - Value: SSZ-encoded `SignedExecutionPayloadEnvelope`.
+    #[strum(serialize = "ppe")]
+    ExecPayloadEnvelope,
     /// For persisting in-memory state to the database.
     #[strum(serialize = "bch")]
     BeaconChain,
@@ -413,6 +419,7 @@ impl DBColumn {
             | Self::BeaconColdStateSummary
             | Self::BeaconStateTemporary
             | Self::ExecPayload
+            | Self::ExecPayloadEnvelope
             | Self::BeaconChain
             | Self::OpPool
             | Self::Eth1Cache

--- a/consensus/state_processing/src/block_replayer.rs
+++ b/consensus/state_processing/src/block_replayer.rs
@@ -1,14 +1,15 @@
 use crate::{
     BlockProcessingError, BlockSignatureStrategy, ConsensusContext, SlotProcessingError,
     VerifyBlockRoot, per_block_processing, per_epoch_processing::EpochProcessingSummary,
-    per_slot_processing,
+    per_slot_processing, process_execution_payload_envelope,
 };
 use itertools::Itertools;
+use std::collections::HashMap;
 use std::iter::Peekable;
 use std::marker::PhantomData;
 use types::{
-    BeaconState, BeaconStateError, BlindedPayload, ChainSpec, EthSpec, Hash256, SignedBeaconBlock,
-    Slot,
+    BeaconState, BeaconStateError, BlindedPayload, ChainSpec, EthSpec, ExecutionBlockHash,
+    ExecutionPayloadEnvelope, Hash256, SignedBeaconBlock, Slot,
 };
 
 pub type PreBlockHook<'a, E, Error> = Box<
@@ -43,6 +44,13 @@ pub struct BlockReplayer<
     post_slot_hook: Option<PostSlotHook<'a, Spec, Error>>,
     pub(crate) state_root_iter: Option<Peekable<StateRootIter>>,
     state_root_miss: bool,
+    /// Execution payload envelopes keyed by execution `block_hash` (the hash committed to in the
+    /// builder's bid for that slot).  When the look-ahead determines that block N's payload was
+    /// committed, the corresponding envelope is applied between block N and block N+1.
+    payload_envelopes: HashMap<ExecutionBlockHash, ExecutionPayloadEnvelope<Spec>>,
+    /// The first block *after* the replay range, used as the look-ahead for the last block in
+    /// `apply_blocks` so that its envelope can also be applied when appropriate.
+    lookahead_block: Option<SignedBeaconBlock<Spec, BlindedPayload<Spec>>>,
     _phantom: PhantomData<Error>,
 }
 
@@ -96,6 +104,8 @@ where
             post_slot_hook: None,
             state_root_iter: None,
             state_root_miss: false,
+            payload_envelopes: HashMap::new(),
+            lookahead_block: None,
             _phantom: PhantomData,
         }
     }
@@ -158,6 +168,29 @@ where
     /// slot (i.e. it will not have a block applied).
     pub fn post_slot_hook(mut self, hook: PostSlotHook<'a, E, Error>) -> Self {
         self.post_slot_hook = Some(hook);
+        self
+    }
+
+    /// Supply a map of execution payload envelopes (EIP-7732 / Gloas) to be applied during replay.
+    ///
+    /// Envelopes are keyed by the execution `block_hash` that the builder committed to in the
+    /// corresponding slot's `signed_execution_payload_bid`.  When the look-ahead logic determines
+    /// that block N's payload was included, the matching envelope is applied between block N and
+    /// block N+1 via `process_execution_payload_envelope`.
+    pub fn payload_envelopes(
+        mut self,
+        envelopes: HashMap<ExecutionBlockHash, ExecutionPayloadEnvelope<E>>,
+    ) -> Self {
+        self.payload_envelopes = envelopes;
+        self
+    }
+
+    /// Supply the first block *after* the replay range as a look-ahead sentinel.
+    ///
+    /// This allows the last block in `apply_blocks` to also have its execution payload envelope
+    /// applied when the next proposer built on it.
+    pub fn lookahead_block(mut self, block: SignedBeaconBlock<E, BlindedPayload<E>>) -> Self {
+        self.lookahead_block = Some(block);
         self
     }
 
@@ -265,6 +298,48 @@ where
 
             if let Some(ref mut post_block_hook) = self.post_block_hook {
                 post_block_hook(&mut self.state, block)?;
+            }
+
+            // EIP-7732 (Gloas) look-ahead: determine whether block N's execution payload
+            // envelope should be applied before we process block N+1.
+            //
+            // The decision rule: if the next block's builder bid says its *parent* execution
+            // hash is equal to the hash that the *current* block's builder promised to deliver,
+            // then the current block's payload was committed and we must apply the envelope now.
+            //
+            // We look at `blocks[i+1]` first; if this is the last block we fall back to
+            // `self.lookahead_block` (the first block after the replay range).
+            if self.state.fork_name_unchecked().gloas_enabled()
+                && !self.payload_envelopes.is_empty()
+            {
+                let next_idx = i.saturating_add(1);
+                let next_block = blocks.get(next_idx).or(self.lookahead_block.as_ref());
+
+                // Extract the next block's bid parent_block_hash, if it is a Gloas block.
+                let next_parent_block_hash = next_block.and_then(|nb| match nb.message().body() {
+                    types::BeaconBlockBodyRef::Gloas(body) => {
+                        Some(body.signed_execution_payload_bid.message.parent_block_hash)
+                    }
+                    _ => None,
+                });
+
+                // The hash that the current block's builder promised to deliver.
+                let current_bid_block_hash = if let types::BeaconState::Gloas(gs) = &self.state {
+                    Some(gs.latest_execution_payload_bid.block_hash)
+                } else {
+                    None
+                };
+
+                // If the next block builds on this slot's promised payload, apply the envelope.
+                if let (Some(next_parent), Some(bid_hash)) =
+                    (next_parent_block_hash, current_bid_block_hash)
+                    && next_parent == bid_hash
+                    && let Some(envelope) = self.payload_envelopes.get(&bid_hash)
+                {
+                    let envelope = envelope.clone();
+                    process_execution_payload_envelope(&mut self.state, &envelope, self.spec)
+                        .map_err(BlockReplayError::from)?;
+                }
             }
         }
 

--- a/consensus/state_processing/src/lib.rs
+++ b/consensus/state_processing/src/lib.rs
@@ -38,7 +38,8 @@ pub use genesis::{
 };
 pub use per_block_processing::{
     BlockSignatureStrategy, BlockSignatureVerifier, VerifyBlockRoot, VerifySignatures,
-    block_signature_verifier, errors::BlockProcessingError, per_block_processing, signature_sets,
+    block_signature_verifier, errors::BlockProcessingError, per_block_processing,
+    process_execution_payload_envelope, signature_sets,
 };
 pub use per_epoch_processing::{
     errors::EpochProcessingError, process_epoch as per_epoch_processing,

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -170,7 +170,12 @@ pub fn per_block_processing<E: EthSpec, Payload: AbstractExecPayload<E>>(
     // The call to the `process_execution_payload` must happen before the call to the
     // `process_randao` as the former depends on the `randao_mix` computed with the reveal of the
     // previous block.
-    if is_execution_enabled(state, block.body()) {
+    //
+    // For Gloas (EIP-7732) the execution payload is decoupled from the beacon block: the block
+    // carries only a `signed_execution_payload_bid`, while the actual payload arrives via a
+    // separate `SignedExecutionPayloadEnvelope`.  The envelope is processed independently (see
+    // `process_execution_payload_envelope`), so we skip the pre-Gloas inline-payload path here.
+    if is_execution_enabled(state, block.body()) && !state.fork_name_unchecked().gloas_enabled() {
         let body = block.body();
         // TODO(EIP-7732): build out process_withdrawals variant for gloas
         process_withdrawals::<E, Payload>(state, body.execution_payload()?, spec)?;
@@ -457,6 +462,47 @@ pub fn process_execution_payload<E: EthSpec, Payload: AbstractExecPayload<E>>(
             }
         }
     }
+
+    Ok(())
+}
+
+/// Process a `SignedExecutionPayloadEnvelope` for a Gloas state.
+///
+/// In EIP-7732 (Gloas) the execution payload is decoupled from the beacon block and arrives
+/// separately as an `ExecutionPayloadEnvelope`.  This function validates the chain-continuity
+/// invariant (`envelope.payload.parent_hash == state.latest_block_hash`) and advances
+/// `state.latest_block_hash` to the delivered payload's `block_hash`.
+///
+/// The function must be called **between** block N and block N+1 when it has been determined
+/// (via the look-ahead described in `BlockReplayer`) that block N's payload was committed.
+///
+/// ## Errors
+///
+/// Returns `BlockProcessingError::ParentBlockHashMismatch` when the envelope does not extend
+/// the current execution chain tip recorded in the state.  Returns
+/// `BlockProcessingError::IncorrectStateType` if called on a non-Gloas state.
+pub fn process_execution_payload_envelope<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    envelope: &ExecutionPayloadEnvelope<E>,
+    _spec: &ChainSpec,
+) -> Result<(), BlockProcessingError> {
+    let BeaconState::Gloas(gloas_state) = state else {
+        return Err(BlockProcessingError::IncorrectStateType);
+    };
+
+    // Verify chain continuity: the envelope must extend the current execution tip.
+    if envelope.payload.parent_hash != gloas_state.latest_block_hash {
+        return Err(BlockProcessingError::ExecutionHashChainIncontiguous {
+            expected: gloas_state.latest_block_hash,
+            found: envelope.payload.parent_hash,
+        });
+    }
+
+    // Advance the execution chain tip.
+    gloas_state.latest_block_hash = envelope.payload.block_hash;
+
+    // TODO(EIP-7732): apply withdrawals, execution_requests, and other state changes
+    //                 from the envelope (process_withdrawals_gloas, deposit processing, etc.)
 
     Ok(())
 }

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -38,7 +38,11 @@ pub fn process_operations<E: EthSpec, Payload: AbstractExecPayload<E>>(
         process_bls_to_execution_changes(state, bls_to_execution_changes, verify_signatures, spec)?;
     }
 
-    if state.fork_name_unchecked().electra_enabled() {
+    // For Gloas (EIP-7732) execution requests are carried in the ExecutionPayloadEnvelope,
+    // not in the beacon block body.  The envelope is processed separately via
+    // `process_execution_payload_envelope`, so we skip this block for Gloas.
+    if state.fork_name_unchecked().electra_enabled() && !state.fork_name_unchecked().gloas_enabled()
+    {
         state.update_pubkey_cache()?;
         process_deposit_requests(state, &block_body.execution_requests()?.deposits, spec)?;
         process_withdrawal_requests(state, &block_body.execution_requests()?.withdrawals, spec)?;

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -1153,3 +1153,71 @@ async fn block_replayer_peeking_state_roots() {
         (dummy_state_root, dummy_slot)
     );
 }
+
+/// Regression test for https://github.com/sigp/lighthouse/issues/8869
+///
+/// When replaying blocks on a Gloas state, `per_block_processing` previously called
+/// `body.execution_payload()` which returns `Err(IncorrectStateVariant)` for Gloas blocks
+/// (they use `signed_execution_payload_bid` instead of an inline payload).
+///
+/// This test creates a minimal Gloas genesis state, advances it one slot, then applies an
+/// empty Gloas blinded block via `BlockReplayer::apply_blocks`.  Before the fix this
+/// returns `BlockProcessingError::BeaconStateError(IncorrectStateVariant)`; after
+/// the fix it must succeed.
+#[tokio::test]
+async fn gloas_block_replay_no_incorrect_state_variant() {
+    use beacon_chain::test_utils::InteropGenesisBuilder;
+
+    type E = MinimalEthSpec;
+
+    // Build a Gloas-at-genesis spec using the minimal preset.
+    let spec = ForkName::Gloas.make_genesis_spec(E::default_spec());
+
+    // Build a genesis state with a small set of interop validators.
+    let keypairs = &KEYPAIRS[0..8];
+    let genesis_time = 1_000_000_u64;
+    let genesis_state = InteropGenesisBuilder::<E>::new()
+        .build_genesis_state(
+            keypairs,
+            genesis_time,
+            Hash256::from_slice(&[0x42; 32]),
+            &spec,
+        )
+        .expect("should build Gloas genesis state");
+
+    // Sanity-check: the state must be a Gloas state.
+    assert_eq!(genesis_state.fork_name_unchecked(), ForkName::Gloas);
+
+    // Build a minimal blinded Gloas block at slot 1.
+    // We use the genesis state (slot 0) as input to BlockReplayer so that the block at slot 1
+    // is not mistakenly treated as a "state-root-only" sentinel (which happens when
+    // block.slot() <= state.slot()).
+    // However, we compute the expected parent_root from the state *after* slot processing,
+    // because per_slot_processing fills in latest_block_header.state_root.
+    let mut slot1_state = genesis_state.clone();
+    crate::per_slot_processing(&mut slot1_state, None, &spec)
+        .expect("slot processing should succeed");
+
+    let mut block = BeaconBlockGloas::<E, BlindedPayload<E>>::empty(&spec);
+    block.slot = Slot::new(1);
+    block.proposer_index = slot1_state
+        .get_beacon_proposer_index(block.slot, &spec)
+        .expect("should get proposer index") as u64;
+    // parent_root must equal state.latest_block_header().tree_hash_root() *after* slot processing.
+    block.parent_root = slot1_state.latest_block_header().canonical_root();
+
+    let signed_block = SignedBeaconBlock::from_block(BeaconBlock::Gloas(block), Signature::empty());
+
+    // Before the fix this returned Err(BlockProcessing(BeaconStateError(IncorrectStateVariant))).
+    // After the fix it must succeed (no-signature-verification mode skips the sig checks).
+    // Pass genesis_state (slot 0) so the block at slot 1 is not skipped by BlockReplayer.
+    let result = BlockReplayer::<E, BlockReplayError>::new(genesis_state, &spec)
+        .no_signature_verification()
+        .apply_blocks(vec![signed_block], None);
+
+    assert!(
+        result.is_ok(),
+        "Gloas block replay must succeed, got: {:?}",
+        result.err()
+    );
+}


### PR DESCRIPTION
## Issue Addressed
Fixes #8869

## Proposed Changes
Gloas (EIP-7732) decouples the execution payload from the beacon block, the block body carries only a `signed_execution_payload_bid`, while the actual payload arrives separately as a `SignedExecutionPayloadEnvelope`. Two code paths in `per_block_processing` were calling pre-Gloas accessors that don't exist on Gloas block bodies, causing block replay to crash with `IncorrectStateVariant` and the HTTP API to return `500 UNHANDLED_ERROR` for any finalized
Gloas state.

**Bug 1: execution payload path** (`per_block_processing.rs`)
`is_execution_enabled()` returns `true` for Gloas (Capella is always enabled, making `is_merge_transition_complete` return true). This caused `body.execution_payload()?` to be called on a Gloas body, which returns `Err(IncorrectStateVariant)`.
Fix: guard the `process_withdrawals` / `process_execution_payload` block with `&& !gloas_enabled()`.

**Bug 2: Electra operations path** (`process_operations.rs`)
`electra_enabled()` is also `true` for Gloas, causing `block_body.execution_requests()?` to be called. That field only exists on Electra/Fulu bodies, so Gloas returned `Err(IncorrectStateVariant)`.
Fix: guard the execution-requests block with `&& !gloas_enabled()`.

**Envelope processing architecture**
Following the EIP-7732 spec design, envelopes are applied between blocks using a look-ahead:
after applying block N, if block N+1's `bid.parent_block_hash` matches `state.latest_execution_payload_bid.block_hash`, the envelope for block N is applied before continuing. This is wired through:
- `process_execution_payload_envelope()`: new function that validates the hash chain and updates `state.latest_block_hash`.
- `BlockReplayer`: new `payload_envelopes` map and look-ahead loop in `apply_blocks`.
- `HotColdDB`: new `DBColumn::ExecPayloadEnvelope`, `put/get_execution_payload_envelope` methods, and `replay_blocks` wired to load and pass envelopes for any Gloas blocks in the replay range.

**Regression test**
`gloas_block_replay_no_incorrect_state_variant`:  builds a minimal Gloas genesis, constructs a
valid blinded Gloas block at slot 1, and asserts `BlockReplayer::apply_blocks` succeeds.

## Additional Info
- The envelope processing in `process_execution_payload_envelope` is intentionally minimal for now (updates latest_block_hash`, validates parent hash chain). Withdrawals, execution requests, and other envelope contents are left as TODOs, consistent with the broader in-progress EIP-7732 implementation in this codebase.
- `put_execution_payload_envelope` is added but not yet called at block import time; that wiring belongs in the beacon chain's block processing pipeline and can be done as a follow-up once the full Gloas block import path is built out.
- All 39 existing `state_processing` unit tests pass. `cargo clippy -D warnings` and `cargo fmt` are clean on the changed packages.