### PR TITLE
Add debug spans to DB write paths

### DIFF
--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use store::metadata::DataColumnInfo;
 use store::{AnchorInfo, BlobInfo, DBColumn, Error as StoreError, KeyValueStore, KeyValueStoreOp};
 use strum::IntoStaticStr;
-use tracing::{debug, instrument};
+use tracing::{debug, debug_span, instrument};
 use types::{Hash256, Slot};
 
 /// Use a longer timeout on the pubkey cache.
@@ -256,9 +256,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // Write the I/O batches to disk, writing the blocks themselves first, as it's better
         // for the hot DB to contain extra blocks than for the cold DB to point to blocks that
         // do not exist.
-        self.store.blobs_db.do_atomically(blob_batch)?;
-        self.store.hot_db.do_atomically(hot_batch)?;
-        self.store.cold_db.do_atomically(cold_batch)?;
+        {
+            let _span = debug_span!("backfill_write_blobs_db").entered();
+            self.store.blobs_db.do_atomically(blob_batch)?;
+        }
+        {
+            let _span = debug_span!("backfill_write_hot_db").entered();
+            self.store.hot_db.do_atomically(hot_batch)?;
+        }
+        {
+            let _span = debug_span!("backfill_write_cold_db").entered();
+            self.store.cold_db.do_atomically(cold_batch)?;
+        }
 
         let mut anchor_and_blob_batch = Vec::with_capacity(3);
 

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -38,7 +38,7 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, debug_span, error, info, instrument, warn};
 use typenum::Unsigned;
 use types::data::{ColumnIndex, DataColumnSidecar, DataColumnSidecarList};
 use types::*;
@@ -1518,14 +1518,27 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         let blob_cache_ops = blobs_ops.clone();
         // Try to execute blobs store ops.
-        self.blobs_db
-            .do_atomically(self.convert_to_kv_batch(blobs_ops)?)?;
+        let kv_blob_ops = {
+            let _span = debug_span!("convert_blob_ops").entered();
+            self.convert_to_kv_batch(blobs_ops)?
+        };
+        {
+            let _span = debug_span!("write_blobs_db").entered();
+            self.blobs_db.do_atomically(kv_blob_ops)?;
+        }
 
         let hot_db_cache_ops = hot_db_ops.clone();
         // Try to execute hot db store ops.
-        let tx_res = match self.convert_to_kv_batch(hot_db_ops) {
-            Ok(kv_store_ops) => self.hot_db.do_atomically(kv_store_ops),
-            Err(e) => Err(e),
+        let tx_res = {
+            let _convert_span = debug_span!("convert_hot_db_ops").entered();
+            match self.convert_to_kv_batch(hot_db_ops) {
+                Ok(kv_store_ops) => {
+                    drop(_convert_span);
+                    let _span = debug_span!("write_hot_db").entered();
+                    self.hot_db.do_atomically(kv_store_ops)
+                }
+                Err(e) => Err(e),
+            }
         };
         // Rollback on failure
         if let Err(e) = tx_res {

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1518,10 +1518,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         let blob_cache_ops = blobs_ops.clone();
         // Try to execute blobs store ops.
-        let kv_blob_ops = {
-            let _span = debug_span!("convert_blob_ops").entered();
-            self.convert_to_kv_batch(blobs_ops)?
-        };
+        let kv_blob_ops = self.convert_to_kv_batch(blobs_ops)?;
         {
             let _span = debug_span!("write_blobs_db").entered();
             self.blobs_db.do_atomically(kv_blob_ops)?;


### PR DESCRIPTION
## Description

When backfill rate limiting is disabled, `persist_blocks_and_blobs` has been observed taking 27s. We suspect backfill is hogging LevelDB write locks on `hot_db`/`blobs_db`, but there's no breakdown within the span to confirm.

Adds `debug_span!` to both the head import (`do_atomically_with_block_and_blobs_cache`) and backfill (`import_historical_block_batch`) DB write paths so we can see which DB write is the bottleneck.