### PR TITLE
Add ai agent safety tooling

### DIFF
--- a/.ai/DEVELOPMENT.md
+++ b/.ai/DEVELOPMENT.md
@@ -171,6 +171,31 @@ Avoid using the rayon global thread pool - it causes CPU oversubscription when b
 - **Adapter pattern**: For testing `BeaconChain` dependent components, create adapter structs. See [`fetch_blobs/tests.rs`](beacon_node/beacon_chain/src/fetch_blobs/tests.rs)
 - **Local testnet**: See `scripts/local_testnet/README.md`
 
+## Test-Impact Mapping
+
+When you modify files, run the targeted tests for the affected crates:
+
+| Changed Directory | Test Command | Notes |
+|---|---|---|
+| `consensus/state_processing/` | `cargo nextest run -p state_processing` | Safe math enforced by clippy |
+| `consensus/types/` | `cargo nextest run -p types` | Also re-test dependents |
+| `consensus/fork_choice/` | `cargo nextest run -p fork_choice` | |
+| `beacon_node/beacon_chain/` | `FORK_NAME=electra cargo nextest run -p beacon_chain` | Supports `FORK_NAME` env var |
+| `beacon_node/store/` | `cargo nextest run -p store` | |
+| `beacon_node/network/` | `make test-network` | Runs phase0, electra, fulu |
+| `beacon_node/http_api/` | `make test-http-api` | Runs electra, fulu, gloas |
+| `beacon_node/operation_pool/` | `make test-op-pool` | Runs electra, fulu |
+| `slasher/` | `cargo nextest run -p slasher` | Tests lmdb, mdbx, redb backends |
+| `validator_client/` | `cargo nextest run -p validator_client` | |
+| `crypto/bls/` | `cargo nextest run -p bls` | |
+| `common/eth2/` | `cargo nextest run -p eth2` | |
+
+**Multi-crate changes**: If you change `consensus/types/`, also run tests for crates that depend on it (`state_processing`, `beacon_chain`).
+
+**Full suite**: `make test-release` (~20 min). Use for significant cross-cutting changes.
+
+**Devnet**: For critical changes, start a local testnet with `scripts/local_testnet/start_local_testnet.sh -c -a` to run Assertoor automated checks.
+
 ## Build Notes
 
 - Full builds take 5+ minutes - use large timeouts (300s+)

--- a/.claude/hooks/consensus-safety-check.sh
+++ b/.claude/hooks/consensus-safety-check.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Warn agent about unsafe patterns in critical code paths.
+# Runs after Edit/Write. Non-blocking (warns, doesn't block).
+
+set -uo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Only check .rs files in critical paths
+if [[ -z "$FILE_PATH" ]]; then exit 0; fi
+if [[ "$FILE_PATH" != *.rs ]]; then exit 0; fi
+if [[ "$FILE_PATH" != *"consensus/"* ]] && [[ "$FILE_PATH" != *"beacon_chain/"* ]]; then exit 0; fi
+if [[ "$FILE_PATH" == *"consensus/types/"* ]]; then exit 0; fi
+if [[ "$FILE_PATH" == *"/tests/"* ]] || [[ "$FILE_PATH" == *"test_utils"* ]]; then exit 0; fi
+
+WARNINGS=""
+
+# Check for .unwrap() in changed lines
+if git diff -- "$FILE_PATH" 2>/dev/null | grep '^\+' | grep -v '^\+\+\+' | grep -q '\.unwrap()'; then
+    WARNINGS="${WARNINGS}\n- .unwrap() found in changed lines — use ? or .ok_or() instead"
+fi
+
+# Check for .expect( in changed lines
+if git diff -- "$FILE_PATH" 2>/dev/null | grep '^\+' | grep -v '^\+\+\+' | grep -q '\.expect('; then
+    WARNINGS="${WARNINGS}\n- .expect() found in changed lines — use ? or .ok_or() instead"
+fi
+
+# Check for direct array indexing [var] (catches foo[i], bar[idx], etc.)
+if git diff -- "$FILE_PATH" 2>/dev/null | grep '^\+' | grep -v '^\+\+\+' | grep -qE '\[[a-z_]+\]'; then
+    WARNINGS="${WARNINGS}\n- Possible direct array indexing — use .get() instead"
+fi
+
+# Consensus-specific: check for arithmetic operators (not in comments)
+if [[ "$FILE_PATH" == *"consensus/"* ]] && [[ "$FILE_PATH" != *"consensus/types/"* ]]; then
+    if git diff -- "$FILE_PATH" 2>/dev/null | grep '^\+' | grep -v '^\+\+\+' | grep -v '//' | grep -qE '[a-z0-9_)] [+\-\*] [a-z0-9_(]'; then
+        WARNINGS="${WARNINGS}\n- Direct arithmetic in consensus crate — use saturating_add/checked_add/safe_arith"
+    fi
+fi
+
+if [ -n "$WARNINGS" ]; then
+    BASENAME=$(basename "$FILE_PATH")
+    echo "{\"systemMessage\": \"Safety warnings for ${BASENAME}:${WARNINGS}\"}"
+fi
+
+exit 0

--- a/.claude/hooks/stop-check.sh
+++ b/.claude/hooks/stop-check.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Block agent from finishing if code doesn't compile.
+# Only runs if .rs files were actually modified.
+
+set -uo pipefail
+
+MODIFIED_RS=$(git diff --name-only HEAD -- '*.rs' 2>/dev/null | head -1)
+if [ -z "$MODIFIED_RS" ]; then
+    exit 0 # No Rust files changed, allow stop
+fi
+
+# Run cargo fmt (fast, fixes formatting silently)
+cargo fmt --all --quiet 2>/dev/null
+
+# Run cargo check (the real test)
+OUTPUT=$(cargo check 2>&1)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "cargo check failed. Fix compilation errors before finishing:" >&2
+    echo "$OUTPUT" | tail -50 >&2
+    exit 2 # Block stop
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,21 @@
           {
             "type": "command",
             "command": "echo '\n[Reminder] Run: cargo fmt --all && make lint-fix'"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/consensus-safety-check.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stop-check.sh",
+            "timeout": 300
           }
         ]
       }

--- a/.claude/skills/devnet/SKILL.md
+++ b/.claude/skills/devnet/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: devnet
+description: Start a local devnet to test Lighthouse changes end-to-end. Runs a Kurtosis testnet with Geth + Lighthouse.
+argument-hint: "[start|stop|status|test]"
+---
+
+# Local Devnet
+
+Manage a local Ethereum testnet for end-to-end testing. Uses Kurtosis with Geth execution clients and Lighthouse consensus clients built from the current working tree.
+
+## Prerequisites
+
+Check that these tools are installed before proceeding:
+```bash
+docker --version && kurtosis version && yq --version
+```
+If any are missing, tell the user to install them and stop.
+
+## Commands
+
+### `/devnet start` — Start a basic devnet
+
+1. Start the local testnet in CI mode (no Grafana/Dora):
+   ```bash
+   scripts/local_testnet/start_local_testnet.sh -c
+   ```
+   This builds a Docker image from the current working tree and deploys 4 beacon nodes + 4 validator clients + 4 Geth nodes.
+
+2. Wait for the testnet to be healthy:
+   ```bash
+   kurtosis enclave inspect local-testnet
+   ```
+
+3. Report the enclave status, node endpoints, and any errors.
+
+### `/devnet test` — Start devnet with automated tests
+
+1. Start with Assertoor integration tests:
+   ```bash
+   scripts/local_testnet/start_local_testnet.sh -c -a
+   ```
+   This enables automated checks:
+   - Block stability check
+   - Block proposal check
+   - Transaction test
+   - Blob transaction test
+
+2. Monitor Assertoor test results. Check the Assertoor service logs for pass/fail:
+   ```bash
+   kurtosis service logs local-testnet $(kurtosis enclave inspect local-testnet | grep assertoor | awk '{print $1}') 2>&1 | tail -100
+   ```
+
+3. Report which tests passed and which failed.
+
+### `/devnet stop` — Stop the devnet
+
+```bash
+scripts/local_testnet/stop_local_testnet.sh
+```
+
+### `/devnet status` — Check devnet status
+
+```bash
+kurtosis enclave inspect local-testnet
+```
+
+Report: running services, their ports, and health status.
+
+## Configuration
+
+The testnet configuration is in `scripts/local_testnet/network_params.yaml`:
+- 4 Lighthouse beacon nodes (2 supernodes, 2 regular)
+- 4 Geth execution clients
+- Fulu fork at epoch 0
+- 3-second slot duration
+- Debug logging
+
+## Notes
+
+- Building the Docker image takes several minutes on first run
+- The testnet uses `spec-minimal` feature (not mainnet parameters)
+- Use `-k` flag to keep the enclave when restarting: `scripts/local_testnet/start_local_testnet.sh -c -k`
+- Logs are available via `kurtosis service logs local-testnet <service-name>`
+- The testnet modifies `network_params.yaml` in-place when using `-a` or `-p` flags — reset with `git checkout scripts/local_testnet/network_params.yaml`

--- a/.claude/skills/safety-check/SKILL.md
+++ b/.claude/skills/safety-check/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: safety-check
+description: Analyze changed code for safety violations — panics, unsafe arithmetic, missing bounds checks. Run this before submitting PRs.
+---
+
+# Safety Check
+
+Analyze all changed Rust files for Lighthouse safety violations. This catches real bugs that cause consensus failures or crashes.
+
+## Steps
+
+1. **Get changed files**:
+   ```bash
+   git diff --name-only HEAD -- '*.rs'
+   ```
+   If no files changed, report "No Rust files modified" and stop.
+
+2. **For each changed file**, read the diff and check for these violations:
+
+### Critical (consensus/beacon_chain — excluding consensus/types/ and test files)
+
+- **`.unwrap()`** — Must use `?`, `.ok_or()`, or `.ok_or_else()` instead. Only acceptable during startup for CLI/config validation.
+- **`.expect(`** — Same as unwrap. Use `?` operator.
+- **Direct indexing `[i]`** — Must use `.get(i)?` or `.get(i).ok_or()`. Direct indexing panics on out-of-bounds.
+- **Direct arithmetic** (`a + b`, `a - b`, `a * b`) in `consensus/` (excluding `types/`) — Must use `a.saturating_add(b)`, `a.checked_add(b)`, or `safe_arith::SafeArith` methods. The `state_processing` crate enforces this at compile time via clippy deny attributes.
+
+### Important (all non-test code)
+
+- **`TODO` without issue link** — All TODO comments must reference a GitHub issue: `// TODO(#1234): description`
+- **Ambiguous variable names** — `bb`, `bl`, `bc` should be `beacon_block`, `blob`, `beacon_chain`
+- **Blocking in async** — `std::thread::sleep`, `std::sync::Mutex` in async functions. Use tokio equivalents.
+- **Global rayon pool** — `rayon::iter::ParallelIterator` without scoped pool. Use beacon processor rayon pools.
+
+3. **Run cargo check**:
+   ```bash
+   cargo check 2>&1
+   ```
+   Report any compilation errors.
+
+4. **Run clippy**:
+   ```bash
+   make lint 2>&1
+   ```
+   Report any clippy warnings.
+
+5. **Report findings** in this format:
+
+   ```
+   ## Safety Check Results
+
+   ### Critical Issues
+   - `file.rs:42` — .unwrap() in consensus code (use ? instead)
+
+   ### Warnings
+   - `file.rs:15` — TODO without issue link
+
+   ### Compilation: PASS/FAIL
+   ### Clippy: PASS/FAIL
+   ```
+
+   Include the specific line numbers and the offending code snippet for each finding.
+
+## Notes
+
+- Focus on **changed lines** (lines starting with `+` in the diff), not the entire file
+- `consensus/state_processing/` already has compile-time enforcement via clippy deny attributes (`arithmetic_side_effects`, `unwrap_used`, `expect_used`, `indexing_slicing`, `panic`). Violations there will be caught by `cargo check`.
+- `consensus/types/` is exempt from the strict arithmetic rules (it's pure data types)
+- Test files (`**/tests/**`, `**/test_utils**`, `testing/**`) are exempt from unwrap/expect rules

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: test
+description: Run targeted tests based on changed files. Automatically maps modified crates to the correct test commands.
+argument-hint: "[fork-name] [--all]"
+---
+
+# Run Targeted Tests
+
+Run the right tests for what was changed. Don't waste time with the full suite unless asked.
+
+## Steps
+
+1. **Find changed files**: Run `git diff --name-only HEAD -- '*.rs'` to see which Rust files were modified.
+
+2. **Gate on compilation**: Run `cargo check` first. If it fails, fix errors before running tests.
+
+3. **Map files to test commands** using this table:
+
+| Changed path prefix | Test command |
+|---|---|
+| `consensus/state_processing/` | `cargo nextest run -p state_processing` |
+| `consensus/types/` | `cargo nextest run -p types` |
+| `consensus/fork_choice/` | `cargo nextest run -p fork_choice` |
+| `consensus/proto_array/` | `cargo nextest run -p proto_array` |
+| `beacon_node/beacon_chain/` | `FORK_NAME=electra cargo nextest run -p beacon_chain` |
+| `beacon_node/store/` | `cargo nextest run -p store` |
+| `beacon_node/network/` | `make test-network` |
+| `beacon_node/http_api/` | `make test-http-api` |
+| `beacon_node/operation_pool/` | `make test-op-pool` |
+| `beacon_node/execution_layer/` | `cargo nextest run -p execution_layer` |
+| `beacon_node/beacon_processor/` | `cargo nextest run -p beacon_processor` |
+| `slasher/` | `cargo nextest run -p slasher` |
+| `validator_client/` | `cargo nextest run -p validator_client` |
+| `crypto/bls/` | `cargo nextest run -p bls` |
+| `crypto/kzg/` | `cargo nextest run -p kzg` |
+| `common/eth2/` | `cargo nextest run -p eth2` |
+| Other crate | `cargo nextest run -p <crate-name>` (read Cargo.toml to find the package name) |
+
+4. **Fork-specific testing**: If `$ARGUMENTS` contains a fork name (phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas), use that as the `FORK_NAME` environment variable for beacon_chain, http_api, op_pool, and network tests.
+
+5. **Full suite**: If `$ARGUMENTS` contains `--all`, skip the mapping and run `make test-release` instead.
+
+6. **Dependency-aware testing**: If `consensus/types/` was changed, also run tests for `state_processing` and `beacon_chain` since they depend on types.
+
+7. **Report results**: Summarize which tests passed and which failed. For failures, include the failing test names and error output.
+
+## Notes
+
+- Prefer `cargo nextest run` over `cargo test` for parallel execution
+- beacon_chain tests default to electra fork. For broader coverage, run with multiple forks
+- Network tests run phase0, electra, fulu by default via `make test-network`
+- Full test suite takes ~20 minutes. Targeted tests are usually under 5 minutes
+- Use `--no-fail-fast` flag for network tests (they continue despite individual failures)

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,38 @@
 #!/bin/sh
-# Pre-commit hook: runs cargo fmt --check
+# Pre-commit hook: formatting + safety checks
 # Install with: make install-hooks
 
-exec cargo fmt --check
+# Check formatting
+cargo fmt --check || {
+    echo "Formatting check failed. Run 'cargo fmt --all' to fix."
+    exit 1
+}
+
+# Quick safety check on staged consensus files (excluding types/ and tests)
+STAGED_CONSENSUS=$(git diff --cached --name-only --diff-filter=ACMR -- 'consensus/*.rs' | \
+    grep -v 'consensus/types/' | \
+    grep -v '/tests/' | \
+    grep -v 'test_utils' || true)
+
+if [ -n "$STAGED_CONSENSUS" ]; then
+    FOUND_ISSUES=false
+    for file in $STAGED_CONSENSUS; do
+        # Check for .unwrap() in added lines
+        if git diff --cached -- "$file" | grep '^\+' | grep -v '^\+\+\+' | grep -q '\.unwrap()'; then
+            echo "ERROR: .unwrap() in consensus file: $file"
+            echo "  Use ? operator or .ok_or() instead."
+            FOUND_ISSUES=true
+        fi
+        # Check for .expect( in added lines
+        if git diff --cached -- "$file" | grep '^\+' | grep -v '^\+\+\+' | grep -q '\.expect('; then
+            echo "ERROR: .expect() in consensus file: $file"
+            echo "  Use ? operator or .ok_or() instead."
+            FOUND_ISSUES=true
+        fi
+    done
+    if [ "$FOUND_ISSUES" = true ]; then
+        echo ""
+        echo "Consensus crate safety violations found. Fix before committing."
+        exit 1
+    fi
+fi

--- a/beacon_node/beacon_chain/CLAUDE.md
+++ b/beacon_node/beacon_chain/CLAUDE.md
@@ -1,0 +1,57 @@
+# beacon_chain crate
+
+The core consensus engine. Orchestrates state transitions, block verification, attestations, and fork choice.
+
+## Critical: Lock Ordering
+
+`BeaconChain<T>` has **29+ RwLock/Mutex fields**. The `canonical_head` module uses a 3-lock system:
+
+1. `RwLock<BeaconForkChoice>` — proto-array fork choice
+2. `RwLock<CachedHead>` — cached block/state from last head computation
+3. `Mutex<()>` — prevents concurrent `recompute_head`
+
+**Rules** (see `src/canonical_head.rs:9-32`):
+- Never expose `RwLockWriteGuard` or `RwLockReadGuard` publicly — only return data
+- This prevents external code from acquiring locks in conflicting orders
+- Any lock changes need deadlock review
+
+## Critical: Async Safety
+
+Never block the async runtime:
+```rust
+// WRONG
+async fn process() { expensive_work(); }
+
+// RIGHT
+async fn process() {
+    self.spawn_blocking_handle(|| expensive_work(), "task-name").await?;
+}
+```
+
+Use `BeaconChain::spawn_blocking_handle()` or `spawn_blocking_with_rayon_async()` — not `tokio::task::spawn_blocking` directly.
+
+## Key Files
+
+| File | Size | Purpose |
+|---|---|---|
+| `beacon_chain.rs` | 310KB | Main `BeaconChain<T>` struct and state machine |
+| `canonical_head.rs` | 61KB | Head management, lock ordering docs |
+| `block_verification.rs` | 86KB | Multi-stage block validation pipeline |
+| `attestation_verification.rs` | 61KB | Attestation validation |
+| `validator_monitor.rs` | 82KB | Validator performance tracking |
+| `test_utils.rs` | 127KB | `BeaconChainHarness` for testing |
+
+## Testing
+
+```bash
+# Default (electra fork)
+FORK_NAME=electra cargo nextest run -p beacon_chain
+
+# Other forks
+FORK_NAME=fulu cargo nextest run -p beacon_chain
+
+# Specific test
+FORK_NAME=electra cargo nextest run -p beacon_chain <test_name>
+```
+
+Requires `fork_from_env` feature (enabled by default in test config).

--- a/beacon_node/store/CLAUDE.md
+++ b/beacon_node/store/CLAUDE.md
@@ -1,0 +1,60 @@
+# store crate
+
+Persistent storage with hot/cold split. All beacon state, blocks, and blobs are stored here.
+
+## Architecture: Hot/Cold Split
+
+- **Hot DB**: Recent data (~27 hours). Stores **diffs**, not full states. Fast access.
+- **Cold DB**: Finalized data. Stores snapshots + diffs at epoch boundaries.
+- **Migration**: Happens automatically at finalization boundaries.
+
+Full states in hot DB are **deprecated** — use `BeaconStateHotDiff` for compact storage.
+
+## Critical: Atomic Operations
+
+Multi-key writes must be atomic to prevent corruption:
+
+```rust
+// ALWAYS use do_atomically for multi-key updates
+store.do_atomically(vec![
+    StoreOp::PutBlock(block_root, Arc::new(block)),
+    StoreOp::PutState(state_root, &state),
+    StoreOp::PutPayload(block_root, payload),
+])?;
+```
+
+Never write related keys in separate operations — partial writes on failure corrupt the database.
+
+## Critical: DBColumn Selection
+
+Each data type maps to a specific `DBColumn` variant. **Wrong column = data loss or silent corruption.**
+
+Key columns:
+- `BeaconBlock` — signed beacon blocks
+- `BeaconStateHotDiff` — hot state diffs (replaces deprecated `BeaconState`)
+- `BeaconStateDiff` — cold state diffs
+- `ExecPayload` — execution payloads
+- `ForkChoice` — persisted fork choice
+
+## Schema Migrations
+
+- Schema version tracked in metadata (`SchemaVersion`)
+- Migrations run on startup
+- Adding new columns or changing key formats requires a migration
+- Test migrations with both upgrade and downgrade paths
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `hot_cold_store.rs` (159KB) | Main `HotColdDB` implementation |
+| `state_cache.rs` | In-memory state cache |
+| `hdiff.rs` | Hot state diff computation |
+| `reconstruct.rs` | Reconstruct full states from diffs |
+| `metadata.rs` | Schema versions, anchor info |
+
+## Testing
+
+```bash
+cargo nextest run -p store
+```

--- a/consensus/state_processing/CLAUDE.md
+++ b/consensus/state_processing/CLAUDE.md
@@ -1,0 +1,60 @@
+# state_processing crate
+
+Implements Ethereum consensus spec state transitions. **Strictest safety rules in the repo.**
+
+## Compile-Time Enforcement
+
+This crate denies unsafe patterns via clippy attributes in `src/lib.rs`:
+
+```rust
+#[deny(
+    clippy::arithmetic_side_effects,  // No a + b, a - b, a * b
+    clippy::disallowed_methods,
+    clippy::indexing_slicing,         // No array[i]
+    clippy::unwrap_used,              // No .unwrap()
+    clippy::expect_used,              // No .expect()
+    clippy::panic,                    // No panic!()
+    clippy::let_underscore_must_use
+)]
+```
+
+These are **not conventions** — they are compiler errors. Code that violates them will not build.
+
+## Required Patterns
+
+```rust
+// Arithmetic: always safe
+let result = a.saturating_add(b);
+let result = a.safe_add(b)?;          // via safe_arith::SafeArith
+let result = a.checked_sub(b).ok_or(Error::Underflow)?;
+
+// Indexing: always bounds-checked
+let item = slice.get(i).ok_or(Error::OutOfBounds)?;
+
+// Errors: always propagated
+let value = fallible_call()?;
+```
+
+## Spec Compliance
+
+Code must match the Ethereum consensus spec. Reference spec sections in comments:
+```rust
+// Spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#deposits
+```
+
+## Structure
+
+- `per_block_processing/` — Process individual block operations (attestations, deposits, slashings, exits)
+- `per_epoch_processing/` — Rewards, penalties, validator activations, slashing
+- `per_slot_processing.rs` — Slot increment, RANDAO
+- `consensus_context.rs` — Consensus parameters passed through processing
+
+## Testing
+
+```bash
+# Unit tests
+cargo nextest run -p state_processing
+
+# Ethereum Foundation spec vectors (downloads ~500MB first time)
+make test-ef
+```


### PR DESCRIPTION
Claude recommended this strategies to enforce some of our agent rules programatically. Looks interesting, opening as work-in-progress to discuss it

- stop hook: blocks agent if cargo check fails
- consensus safety hook: warns on .unwrap(), unsafe arithmetic in consensus/
- /test skill: maps changed files to correct test commands
- /safety-check skill: diff-based safety analysis
- /devnet skill: local testnet with assertoor checks
- test-impact mapping in DEVELOPMENT.md
- crate-level CLAUDE.md for beacon_chain, state_processing, store
- enhanced pre-commit hook with consensus safety checks

## Issue Addressed

Which issue # does this PR address?

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
