### PR TITLE
Update yanked keccak 0.1.5 to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4832,9 +4832,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]


### PR DESCRIPTION
## Description

`keccak v0.1.5` is yanked from crates.io. Bump to v0.1.6 to silence the `--locked` build warning. Lockfile-only change.