### PR TITLE
Add `testing` feature to validator_client/http_api

### DIFF
--- a/validator_client/http_api/Cargo.toml
+++ b/validator_client/http_api/Cargo.toml
@@ -8,14 +8,17 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 name = "validator_http_api"
 path = "src/lib.rs"
 
+[features]
+testing = ["dep:deposit_contract", "dep:doppelganger_service", "dep:tempfile"]
+
 [dependencies]
 account_utils = { workspace = true }
 beacon_node_fallback = { workspace = true }
 bls = { workspace = true }
-deposit_contract = { workspace = true }
+deposit_contract = { workspace = true, optional = true }
 directory = { workspace = true }
 dirs = { workspace = true }
-doppelganger_service = { workspace = true }
+doppelganger_service = { workspace = true, optional = true }
 eth2 = { workspace = true, features = ["lighthouse"] }
 eth2_keystore = { workspace = true }
 ethereum_serde_utils = { workspace = true }
@@ -38,7 +41,7 @@ slot_clock = { workspace = true }
 sysinfo = { workspace = true }
 system_health = { workspace = true }
 task_executor = { workspace = true }
-tempfile = { workspace = true }
+tempfile = { workspace = true, optional = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
@@ -53,7 +56,10 @@ warp_utils = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]
+deposit_contract = { workspace = true }
+doppelganger_service = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
 ssz_types = { workspace = true }
+tempfile = { workspace = true }

--- a/validator_client/http_api/src/lib.rs
+++ b/validator_client/http_api/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "testing")]
+pub mod test_utils;
+
 mod api_secret;
 mod create_signed_voluntary_exit;
 mod create_validator;
@@ -6,7 +9,6 @@ mod keystores;
 mod remotekeys;
 mod tests;
 
-pub mod test_utils;
 pub use api_secret::PK_FILENAME;
 
 use graffiti::{delete_graffiti, get_graffiti, set_graffiti};

--- a/validator_manager/Cargo.toml
+++ b/validator_manager/Cargo.toml
@@ -29,4 +29,4 @@ beacon_chain = { workspace = true }
 http_api = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
-validator_http_api = { workspace = true }
+validator_http_api = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
## Proposed Changes

Create a `testing` feature which we can use to gate off `test_utils.rs` and its associated dependencies from the rest of the crate.

## Additional Info

This allows `deposit_contract`, `doppelganger_service` and `tempfile`  to be optional. 
