### PR TITLE
Change process_cpu_seconds_total from gauge to counter

### DIFF
--- a/common/health_metrics/src/metrics.rs
+++ b/common/health_metrics/src/metrics.rs
@@ -27,8 +27,8 @@ pub static PROCESS_SHR_MEM: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
         "Shared memory used by the current process",
     )
 });
-pub static PROCESS_SECONDS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
-    try_create_int_gauge(
+pub static PROCESS_SECONDS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
         "process_cpu_seconds_total",
         "Total cpu time taken by the current process",
     )
@@ -135,7 +135,7 @@ pub fn scrape_process_health_metrics() {
         set_gauge(&PROCESS_RES_MEM, health.pid_mem_resident_set_size as i64);
         set_gauge(&PROCESS_VIRT_MEM, health.pid_mem_virtual_memory_size as i64);
         set_gauge(&PROCESS_SHR_MEM, health.pid_mem_shared_memory_size as i64);
-        set_gauge(&PROCESS_SECONDS, health.pid_process_seconds_total as i64);
+        set_counter_from_absolute(&PROCESS_SECONDS, health.pid_process_seconds_total);
     }
 }
 

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -308,6 +308,21 @@ pub fn inc_counter_by(counter: &Result<IntCounter>, value: u64) {
     }
 }
 
+/// Update a counter from an observed absolute value.
+///
+/// Computes the delta between the new observed value and the current counter
+/// value, then increments the counter by that delta. This is useful for
+/// converting monotonically increasing system metrics (reported as absolute
+/// values by the OS) into Prometheus counters.
+pub fn set_counter_from_absolute(counter: &Result<IntCounter>, value: u64) {
+    if let Ok(counter) = counter {
+        let current = counter.get();
+        if value > current {
+            counter.inc_by(value - current);
+        }
+    }
+}
+
 pub fn set_gauge_vec(int_gauge_vec: &Result<IntGaugeVec>, name: &[&str], value: i64) {
     if let Some(gauge) = get_int_gauge(int_gauge_vec, name) {
         gauge.set(value);


### PR DESCRIPTION
## Summary

Closes #3108

- Changes the `process_cpu_seconds_total` Prometheus metric type from `IntGauge` to `IntCounter`
- Adds a reusable `set_counter_from_absolute()` helper function to the metrics crate that computes the delta between the new observed value and the current counter value, then increments the counter by that delta
- Enables `rate()` and `irate()` queries in PromQL for this metric, which only work on counter-type metrics

## Implementation

Following @michaelsproul's suggestion from the issue: on each scrape, the helper reads the current counter value, subtracts it from the new OS-reported value, and increments by the difference. The helper is generic and can be reused for other metrics that should also be counters (e.g., `cpu_system_seconds_total`, `disk_node_reads_total`, `network_node_bytes_total_received`).

## Additional Info

There are several other health metrics that are semantically counters but currently typed as gauges (CPU time totals, disk I/O totals, network I/O totals). These could be converted in follow-up PRs using the same `set_counter_from_absolute()` helper.

## Test plan

- [x] `cargo check` passes with zero errors/warnings
- [x] `cargo fmt --all` produces no diffs
- [x] `make lint` (clippy) passes with zero warnings
- [ ] Manual verification: start a beacon node and confirm `process_cpu_seconds_total` is reported as `# TYPE process_cpu_seconds_total counter` in `/metrics` output, and that `rate(process_cpu_seconds_total[5m])` works in PromQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)