### PR TITLE
fix(backfill): only download custody columns during backfill sync

### DIFF
--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -1682,7 +1682,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         let columns_by_range_peers_to_request = {
             let column_indexes = self
                 .chain
-                .sampling_columns_for_epoch(batch_id.epoch)
+                .custody_columns_for_epoch(Some(batch_id.epoch))
                 .iter()
                 .cloned()
                 .collect();


### PR DESCRIPTION
## Issue Addressed

#8308

## Proposed Changes

During backfill of finalized blocks, full nodes download all sampling columns (custody + additional sampling columns) via `sampling_columns_for_epoch()`. The extra columns are validated and discarded without being stored — wasting bandwidth and compute.

Since backfill serves the network with historical data rather than providing data availability guarantees, there is no need to sample beyond the node's custody responsibility.

This replaces `sampling_columns_for_epoch()` with `custody_columns_for_epoch()` in `custody_backfill_data_columns_batch_request()`, so that only the columns the node actually custodies are downloaded during backfill.

As [noted](https://github.com/sigp/lighthouse/issues/8308#issuecomment-3655190852) by @PoulavBhowmick03, the fix is a single call-site change in `network_context.rs`.

## Additional Info

For a full node custodying 4 columns that currently samples 8, this halves the backfill download volume.