### PR TITLE
Cleans up the `NoPeer` error handling in range sync's `send_batch`

### DIFF
--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -462,6 +462,12 @@ pub static SYNCING_CHAIN_BATCH_AWAITING_PROCESSING: LazyLock<Result<Histogram>> 
             ]),
         )
     });
+pub static SYNCING_CHAIN_FAILED_NO_PEERS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
+        "sync_range_chain_failed_no_peers_total",
+        "Total count of range sync chains failed due to stalled batches with no peers",
+    )
+});
 pub static SYNC_SINGLE_BLOCK_LOOKUPS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
     try_create_int_gauge(
         "sync_single_block_lookups",

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -1063,7 +1063,9 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
         let in_buffer = |batch: &BackFillBatchInfo<T::EthSpec>| {
             matches!(
                 batch.state(),
-                BatchState::Downloading(..) | BatchState::AwaitingProcessing(..)
+                BatchState::AwaitingDownload
+                    | BatchState::Downloading(..)
+                    | BatchState::AwaitingProcessing(..)
             )
         };
         if self

--- a/beacon_node/network/src/sync/batch.rs
+++ b/beacon_node/network/src/sync/batch.rs
@@ -96,6 +96,8 @@ pub struct BatchInfo<E: EthSpec, B: BatchConfig, D: Hash> {
     state: BatchState<D>,
     /// Whether this batch contains all blocks or all blocks and blobs.
     batch_type: ByRangeRequestType,
+    /// Timestamp when this batch was created.
+    created_at: Instant,
     /// Pin the generic
     #[educe(Debug(ignore))]
     marker: std::marker::PhantomData<(E, B)>,
@@ -169,8 +171,14 @@ impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {
             non_faulty_processing_attempts: 0,
             state: BatchState::<D>::AwaitingDownload,
             batch_type,
+            created_at: Instant::now(),
             marker: std::marker::PhantomData,
         }
+    }
+
+    /// Returns the elapsed time since this batch was created.
+    pub fn elapsed_since_created(&self) -> Duration {
+        self.created_at.elapsed()
     }
 
     /// Gives a list of peers from which this batch has had a failed download or processing

--- a/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
@@ -414,7 +414,9 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
         let in_buffer = |batch: &CustodyBackFillBatchInfo<T::EthSpec>| {
             matches!(
                 batch.state(),
-                BatchState::Downloading(..) | BatchState::AwaitingProcessing(..)
+                BatchState::AwaitingDownload
+                    | BatchState::Downloading(..)
+                    | BatchState::AwaitingProcessing(..)
             )
         };
         if self

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -763,8 +763,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
 
         let mut prune_requests = tokio::time::interval(Duration::from_secs(15));
 
-        // Periodically retry AwaitingDownload batches and check for stalled chains, as a safety
-        // net in case UpdatedPeerCgc events are missed.
+        // Periodically retry AwaitingDownload batches and check for stalled chains.
         let mut resume_range_sync_interval = tokio::time::interval(Duration::from_secs(15));
 
         let mut register_metrics_interval = tokio::time::interval(Duration::from_secs(5));

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -763,6 +763,10 @@ impl<T: BeaconChainTypes> SyncManager<T> {
 
         let mut prune_requests = tokio::time::interval(Duration::from_secs(15));
 
+        // Periodically retry AwaitingDownload batches and check for stalled chains, as a safety
+        // net in case UpdatedPeerCgc events are missed.
+        let mut resume_range_sync_interval = tokio::time::interval(Duration::from_secs(15));
+
         let mut register_metrics_interval = tokio::time::interval(Duration::from_secs(5));
 
         // Trigger a sync state update every epoch. This helps check if we need to trigger a custody backfill sync.
@@ -784,6 +788,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 }
                 _ = prune_requests.tick() => {
                     self.prune_requests();
+                }
+                _ = resume_range_sync_interval.tick() => {
+                    if !self.range_sync.is_idle() {
+                        self.range_sync.resume(&mut self.network);
+                    }
                 }
                 _ = register_metrics_interval.tick() => {
                     self.network.register_metrics();

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -16,6 +16,7 @@ use logging::crit;
 use std::collections::{BTreeMap, HashSet, btree_map::Entry};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
+use std::time::Duration;
 use strum::IntoStaticStr;
 use tracing::{Span, debug, error, instrument, warn};
 use types::{ColumnIndex, Epoch, EthSpec, Hash256, Slot};
@@ -49,6 +50,10 @@ const MAX_BATCH_DOWNLOAD_ATTEMPTS: u8 = 5;
 /// Invalid batches are attempted to be re-downloaded from other peers. If a batch cannot be processed
 /// after `MAX_BATCH_PROCESSING_ATTEMPTS` times, it is considered faulty.
 const MAX_BATCH_PROCESSING_ATTEMPTS: u8 = 3;
+
+/// Maximum duration a batch can remain in `AwaitingDownload` state before the chain is considered
+/// stalled and removed. The chain will be recreated when peers re-announce themselves via STATUS.
+const CHAIN_MAX_STALL_DURATION: Duration = Duration::from_secs(600);
 
 pub struct RangeSyncBatchConfig<E: EthSpec> {
     marker: PhantomData<E>,
@@ -1027,6 +1032,33 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 );
             }
         }
+
+        // After all send attempts, check if any batch has been stuck in AwaitingDownload
+        // beyond the stall timeout. This catches both NoPeer from the network layer and no
+        // peers on sampling subnets.
+        self.check_stalled_batches()
+    }
+
+    /// Fail the chain if any batch has been stuck in `AwaitingDownload` longer than
+    /// [`CHAIN_MAX_STALL_DURATION`]. The chain will be recreated when peers re-announce
+    /// themselves via STATUS.
+    fn check_stalled_batches(&self) -> ProcessingResult {
+        for (batch_id, batch) in &self.batches {
+            if matches!(batch.state(), BatchState::AwaitingDownload)
+                && batch.elapsed_since_created() > CHAIN_MAX_STALL_DURATION
+            {
+                debug!(
+                    %batch_id,
+                    elapsed = ?batch.elapsed_since_created(),
+                    "Range sync batch stalled with no peers, failing chain"
+                );
+                metrics::inc_counter(&metrics::SYNCING_CHAIN_FAILED_NO_PEERS);
+                return Err(RemoveChain::ChainFailed {
+                    blacklist: false,
+                    failing_batch: *batch_id,
+                });
+            }
+        }
         Ok(KeepChain)
     }
 
@@ -1082,16 +1114,12 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                     return Ok(KeepChain);
                 }
                 Err(e) => match e {
-                    // TODO(das): Handle the NoPeer case explicitly and don't drop the batch. For
-                    // sync to work properly it must be okay to have "stalled" batches in
-                    // AwaitingDownload state. Currently it will error with invalid state if
-                    // that happens. Sync manager must periodicatlly prune stalled batches like
-                    // we do for lookup sync. Then we can deprecate the redundant
-                    // `good_peers_on_sampling_subnets` checks.
-                    e
-                    @ (RpcRequestSendError::NoPeer(_) | RpcRequestSendError::InternalError(_)) => {
+                    RpcRequestSendError::NoPeer(err) => {
+                        debug!(error = ?err, "Did not send batch request due to insufficient peers");
+                    }
+                    RpcRequestSendError::InternalError(err) => {
                         // NOTE: under normal conditions this shouldn't happen but we handle it anyway
-                        warn!(%batch_id, error = ?e, "batch_id" = %batch_id, %batch, "Could not send batch request");
+                        warn!(%batch_id, error = ?err, "batch_id" = %batch_id, %batch, "Could not send batch request");
                         // register the failed download and check if the batch can be retried
                         batch.start_downloading(1)?; // fake request_id = 1 is not relevant
                         match batch.download_failed(None)? {
@@ -1269,7 +1297,9 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         let in_buffer = |batch: &RangeSyncBatchInfo<T::EthSpec>| {
             matches!(
                 batch.state(),
-                BatchState::Downloading(..) | BatchState::AwaitingProcessing(..)
+                BatchState::AwaitingDownload
+                    | BatchState::Downloading(..)
+                    | BatchState::AwaitingProcessing(..)
             )
         };
         if self

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -107,6 +107,11 @@ where
         self.chains.state()
     }
 
+    /// Returns true if there are no active syncing chains.
+    pub fn is_idle(&self) -> bool {
+        matches!(self.chains.state(), Ok(None))
+    }
+
     /// A useful peer has been added. The SyncManager has identified this peer as needing either
     /// a finalized or head chain sync. This processes the peer and starts/resumes any chain that
     /// may need to be synced as a result. A new peer, may increase the peer pool of a finalized


### PR DESCRIPTION
## Description

Split out from #8039. Cleans up the `NoPeer` handling in range sync's `send_batch` so it no longer fake-starts a download and calls `download_failed` — which incorrectly penalised the batch for something that wasn't a real download failure. `NoPeer` now logs at debug and leaves the batch in `AwaitingDownload`, letting it retry when peers become available.

Since `AwaitingDownload` is now a valid steady-state for batches, this PR also:

- Counts `AwaitingDownload` batches in the buffer size check across range sync, backfill sync, and custody backfill sync, so they don't accumulate unbounded.
- Adds stall detection: if any batch stays in `AwaitingDownload` for over 10 minutes, the chain is failed and will be recreated when peers re-announce via STATUS.
- Adds a 15-second periodic retry interval in the sync manager as a safety net, in case `UpdatedPeerCgc` events are missed.