### PR TITLE
Fix flaky `data_column_reconstruction_at_deadline` test

### DIFF
--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -257,9 +257,7 @@ struct ReprocessQueue<S> {
     /// Light Client Updates per parent_root.
     awaiting_lc_updates_per_parent_root: HashMap<Hash256, Vec<QueuedLightClientUpdateId>>,
     /// Column reconstruction per block root.
-    /// `Some(key)` = active timer in the delay queue.
-    /// `None` = reconstruction already fired, reject late messages.
-    queued_column_reconstructions: HashMap<Hash256, Option<DelayKey>>,
+    queued_column_reconstructions: HashMap<Hash256, DelayKey>,
     /// Queued backfill batches
     queued_backfill_batches: Vec<QueuedBackfillBatch>,
 
@@ -272,6 +270,10 @@ struct ReprocessQueue<S> {
     attestation_delay_debounce: TimeLatch,
     lc_update_delay_debounce: TimeLatch,
     next_backfill_batch_event: Option<Pin<Box<tokio::time::Sleep>>>,
+    /// Block root of the most recently fired column reconstruction. Prevents late
+    /// `DelayColumnReconstruction` messages from re-queuing after the timer has
+    /// already fired (race between delay queue and message channel polling order).
+    last_fired_column_reconstruction: Option<Hash256>,
     slot_clock: Arc<S>,
 }
 
@@ -439,6 +441,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
             attestation_delay_debounce: TimeLatch::default(),
             lc_update_delay_debounce: TimeLatch::default(),
             next_backfill_batch_event: None,
+            last_fired_column_reconstruction: None,
             slot_clock,
         }
     }
@@ -775,17 +778,20 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 }
                 match self.queued_column_reconstructions.entry(request.block_root) {
                     Entry::Occupied(entry) => {
-                        if let Some(delay_key) = entry.get() {
-                            self.column_reconstructions_delay_queue
-                                .reset(delay_key, reconstruction_delay);
-                        }
-                        // None → reconstruction already fired, skip
+                        self.column_reconstructions_delay_queue
+                            .reset(entry.get(), reconstruction_delay);
                     }
                     Entry::Vacant(vacant) => {
+                        // Skip if reconstruction already fired for this block root.
+                        // This prevents a race where poll_next() fires the delay queue
+                        // entry before remaining channel messages are drained.
+                        if self.last_fired_column_reconstruction == Some(request.block_root) {
+                            return;
+                        }
                         let delay_key = self
                             .column_reconstructions_delay_queue
                             .insert(request, reconstruction_delay);
-                        vacant.insert(Some(delay_key));
+                        vacant.insert(delay_key);
                     }
                 }
             }
@@ -926,12 +932,9 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 }
             }
             InboundEvent::ReadyColumnReconstruction(column_reconstruction) => {
-                let block_root = column_reconstruction.block_root;
-                // Prune old fired entries before marking current
                 self.queued_column_reconstructions
-                    .retain(|_, v| v.is_some());
-                // Mark as fired (prevents duplicate reconstruction from late messages)
-                self.queued_column_reconstructions.insert(block_root, None);
+                    .remove(&column_reconstruction.block_root);
+                self.last_fired_column_reconstruction = Some(column_reconstruction.block_root);
                 if self
                     .ready_work_tx
                     .try_send(ReadyWork::ColumnReconstruction(column_reconstruction))

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -257,7 +257,9 @@ struct ReprocessQueue<S> {
     /// Light Client Updates per parent_root.
     awaiting_lc_updates_per_parent_root: HashMap<Hash256, Vec<QueuedLightClientUpdateId>>,
     /// Column reconstruction per block root.
-    queued_column_reconstructions: HashMap<Hash256, DelayKey>,
+    /// `Some(key)` = active timer in the delay queue.
+    /// `None` = reconstruction already fired, reject late messages.
+    queued_column_reconstructions: HashMap<Hash256, Option<DelayKey>>,
     /// Queued backfill batches
     queued_backfill_batches: Vec<QueuedBackfillBatch>,
 
@@ -772,15 +774,18 @@ impl<S: SlotClock> ReprocessQueue<S> {
                     reconstruction_delay = Duration::from_secs(0);
                 }
                 match self.queued_column_reconstructions.entry(request.block_root) {
-                    Entry::Occupied(key) => {
-                        self.column_reconstructions_delay_queue
-                            .reset(key.get(), reconstruction_delay);
+                    Entry::Occupied(entry) => {
+                        if let Some(delay_key) = entry.get() {
+                            self.column_reconstructions_delay_queue
+                                .reset(delay_key, reconstruction_delay);
+                        }
+                        // None → reconstruction already fired, skip
                     }
                     Entry::Vacant(vacant) => {
                         let delay_key = self
                             .column_reconstructions_delay_queue
                             .insert(request, reconstruction_delay);
-                        vacant.insert(delay_key);
+                        vacant.insert(Some(delay_key));
                     }
                 }
             }
@@ -921,8 +926,12 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 }
             }
             InboundEvent::ReadyColumnReconstruction(column_reconstruction) => {
+                let block_root = column_reconstruction.block_root;
+                // Prune old fired entries before marking current
                 self.queued_column_reconstructions
-                    .remove(&column_reconstruction.block_root);
+                    .retain(|_, v| v.is_some());
+                // Mark as fired (prevents duplicate reconstruction from late messages)
+                self.queued_column_reconstructions.insert(block_root, None);
                 if self
                     .ready_work_tx
                     .try_send(ReadyWork::ColumnReconstruction(column_reconstruction))


### PR DESCRIPTION
## Description

Fix a race condition where column reconstruction fires twice when gossip columns arrive at the reconstruction deadline.

When columns arrive at the deadline, each triggers a `DelayColumnReconstruction` with `Duration::ZERO`. Because `poll_next()` polls the delay queue before the message channel, `ReadyColumnReconstruction` fires and removes the entry from `queued_column_reconstructions`. Remaining messages then hit the `Vacant` path, creating a second reconstruction.

Fix by changing `queued_column_reconstructions` value type from `DelayKey` to `Option<DelayKey>`. When reconstruction fires, mark the entry as `None` instead of removing it. Late messages see the `None` and skip, preventing duplicate work.

Supersedes #8855 — same fix with a smaller change to the existing data structure instead of introducing a new `fired_column_reconstructions` map.

## Additional Info

This change also fixes the flaky `data_column_reconstruction_at_deadline` test - passes (20/20 runs) with this fix.