### PR TITLE
Remove `arbitrary-fuzz`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,8 +321,8 @@ make-ef-tests-nightly:
 
 # Verifies that crates compile with fuzzing features enabled
 arbitrary-fuzz:
-	cargo check -p state_processing --features arbitrary-fuzz,$(TEST_FEATURES)
-	cargo check -p slashing_protection --features arbitrary-fuzz,$(TEST_FEATURES)
+	cargo check -p state_processing --features arbitrary,$(TEST_FEATURES)
+	cargo check -p slashing_protection --features arbitrary,$(TEST_FEATURES)
 
 # Runs cargo audit (Audit Cargo.lock files for crates with security vulnerabilities reported to the RustSec Advisory Database)
 audit: install-audit audit-CI

--- a/common/eip_3076/Cargo.toml
+++ b/common/eip_3076/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [features]
 default = []
-arbitrary-fuzz = ["dep:arbitrary", "types/arbitrary"]
+arbitrary = ["dep:arbitrary", "types/arbitrary"]
 json = ["dep:serde_json"]
 
 [dependencies]

--- a/common/eip_3076/src/lib.rs
+++ b/common/eip_3076/src/lib.rs
@@ -13,7 +13,7 @@ pub enum Error {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct InterchangeMetadata {
     #[serde(with = "serde_utils::quoted_u64::require_quotes")]
     pub interchange_format_version: u64,
@@ -22,7 +22,7 @@ pub struct InterchangeMetadata {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct InterchangeData {
     pub pubkey: PublicKeyBytes,
     pub signed_blocks: Vec<SignedBlock>,
@@ -31,7 +31,7 @@ pub struct InterchangeData {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SignedBlock {
     #[serde(with = "serde_utils::quoted_u64::require_quotes")]
     pub slot: Slot,
@@ -41,7 +41,7 @@ pub struct SignedBlock {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SignedAttestation {
     #[serde(with = "serde_utils::quoted_u64::require_quotes")]
     pub source_epoch: Epoch,
@@ -52,7 +52,7 @@ pub struct SignedAttestation {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Interchange {
     pub metadata: InterchangeMetadata,
     pub data: Vec<InterchangeData>,

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -7,10 +7,10 @@ edition = { workspace = true }
 [features]
 default = []
 fake_crypto = ["bls/fake_crypto"]
-arbitrary-fuzz = [
+arbitrary = [
     "dep:arbitrary",
     "smallvec/arbitrary",
-    "types/arbitrary-fuzz",
+    "types/arbitrary",
     "merkle_proof/arbitrary",
     "ethereum_ssz/arbitrary",
     "ssz_types/arbitrary",

--- a/consensus/state_processing/src/envelope_processing.rs
+++ b/consensus/state_processing/src/envelope_processing.rs
@@ -21,7 +21,7 @@ macro_rules! envelope_verify {
 }
 
 /// The strategy to be used when validating the payloads state root.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(PartialEq, Clone, Copy)]
 pub enum VerifyStateRoot {
     /// Validate state root.

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -55,12 +55,12 @@ use crate::common::update_progressive_balances_cache::{
     initialize_progressive_balances_cache, update_progressive_balances_metrics,
 };
 use crate::epoch_cache::initialize_epoch_cache;
-#[cfg(feature = "arbitrary-fuzz")]
+#[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 use tracing::instrument;
 
 /// The strategy to be used when validating the block's signatures.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum BlockSignatureStrategy {
     /// Do not validate any signature. Use with caution.
@@ -74,7 +74,7 @@ pub enum BlockSignatureStrategy {
 }
 
 /// The strategy to be used when validating the block's signatures.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(PartialEq, Clone, Copy)]
 pub enum VerifySignatures {
     /// Validate all signatures encountered.
@@ -90,7 +90,7 @@ impl VerifySignatures {
 }
 
 /// Control verification of the latest block header.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(PartialEq, Clone, Copy)]
 pub enum VerifyBlockRoot {
     True,

--- a/consensus/state_processing/src/per_epoch_processing/base/validator_statuses.rs
+++ b/consensus/state_processing/src/per_epoch_processing/base/validator_statuses.rs
@@ -2,7 +2,7 @@ use crate::common::attesting_indices_base::get_attesting_indices;
 use safe_arith::SafeArith;
 use types::{BeaconState, BeaconStateError, ChainSpec, Epoch, EthSpec, PendingAttestation};
 
-#[cfg(feature = "arbitrary-fuzz")]
+#[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 
 /// Sets the boolean `var` on `self` to be true if it is true on `other`. Otherwise leaves `self`
@@ -16,7 +16,7 @@ macro_rules! set_self_if_other_is_true {
 }
 
 /// The information required to reward a block producer for including an attestation in a block.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct InclusionInfo {
     /// The distance between the attestation slot and the slot that attestation was included in a
@@ -48,7 +48,7 @@ impl InclusionInfo {
 }
 
 /// Information required to reward some validator during the current and previous epoch.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct ValidatorStatus {
     /// True if the validator has been slashed, ever.
@@ -118,7 +118,7 @@ impl ValidatorStatus {
 /// epochs.
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct TotalBalances {
     /// The effective balance increment from the spec.
     effective_balance_increment: u64,
@@ -175,7 +175,7 @@ impl TotalBalances {
 
 /// Summarised information about validator participation in the _previous and _current_ epochs of
 /// some `BeaconState`.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[derive(Debug, Clone)]
 pub struct ValidatorStatuses {
     /// Information about each individual validator from the state's validator registry.

--- a/consensus/state_processing/src/verify_operation.rs
+++ b/consensus/state_processing/src/verify_operation.rs
@@ -7,7 +7,7 @@ use crate::per_block_processing::{
     verify_attester_slashing, verify_bls_to_execution_change, verify_exit,
     verify_proposer_slashing,
 };
-#[cfg(feature = "arbitrary-fuzz")]
+#[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 use educe::Educe;
 use smallvec::{SmallVec, smallvec};
@@ -41,14 +41,14 @@ pub trait TransformPersist {
 /// The inner `op` field is private, meaning instances of this type can only be constructed
 /// by calling `validate`.
 #[derive(Educe, Debug, Clone)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[educe(
     PartialEq,
     Eq,
     Hash(bound(T: TransformPersist + std::hash::Hash, E: EthSpec))
 )]
 #[cfg_attr(
-    feature = "arbitrary-fuzz",
+    feature = "arbitrary",
     arbitrary(bound = "T: TransformPersist + Arbitrary<'arbitrary>, E: EthSpec")
 )]
 pub struct SigVerifiedOp<T: TransformPersist, E: EthSpec> {
@@ -139,7 +139,7 @@ struct SigVerifiedOpDecode<P: Decode> {
 /// We need to store multiple `ForkVersion`s because attester slashings contain two indexed
 /// attestations which may be signed using different versions.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Encode, Decode, TestRandom)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct VerifiedAgainst {
     fork_versions: SmallVec<[ForkVersion; MAX_FORKS_VERIFIED_AGAINST]>,
 }

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -22,7 +22,6 @@ arbitrary = [
     "ssz_types/arbitrary",
     "swap_or_not_shuffle/arbitrary",
 ]
-arbitrary-fuzz = ["arbitrary"]
 portable = ["bls/supranational-portable"]
 
 [dependencies]

--- a/validator_client/slashing_protection/Cargo.toml
+++ b/validator_client/slashing_protection/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 autotests = false
 
 [features]
-arbitrary-fuzz = ["dep:arbitrary", "types/arbitrary-fuzz", "eip_3076/arbitrary-fuzz"]
+arbitrary = ["dep:arbitrary", "types/arbitrary", "eip_3076/arbitrary"]
 portable = ["types/portable"]
 
 [dependencies]

--- a/validator_client/slashing_protection/src/interchange_test.rs
+++ b/validator_client/slashing_protection/src/interchange_test.rs
@@ -11,7 +11,7 @@ use tempfile::tempdir;
 use types::{Epoch, Hash256, Slot};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MultiTestCase {
     pub name: String,
     pub genesis_validators_root: Hash256,
@@ -19,7 +19,7 @@ pub struct MultiTestCase {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TestCase {
     pub should_succeed: bool,
     pub contains_slashable_data: bool,
@@ -29,7 +29,7 @@ pub struct TestCase {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TestBlock {
     pub pubkey: PublicKeyBytes,
     pub slot: Slot,
@@ -39,7 +39,7 @@ pub struct TestBlock {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TestAttestation {
     pub pubkey: PublicKeyBytes,
     pub source_epoch: Epoch,


### PR DESCRIPTION
## Proposed Changes

We have duplicated features which enable `arbitrary` throughout the codebase. These are `arbitrary` and `arbitrary-fuzz`. I think historically these were supposed to be distinct however in practice these function identically and so we can unify them into a single feature to avoid confusion.