### PR TITLE
Fix lints for Rust v1.94.0

### DIFF
--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -1,4 +1,5 @@
 #![cfg(not(debug_assertions))]
+#![allow(clippy::result_large_err)]
 
 use beacon_chain::attestation_verification::{
     Error, batch_verify_aggregated_attestations, batch_verify_unaggregated_attestations,

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -1,4 +1,5 @@
 #![cfg(not(debug_assertions))]
+#![allow(clippy::result_large_err)]
 
 use beacon_chain::block_verification_types::RpcBlock;
 use beacon_chain::{

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -1,4 +1,5 @@
 #![cfg(not(debug_assertions))]
+#![allow(clippy::result_large_err)]
 
 use beacon_chain::attestation_verification::Error as AttnError;
 use beacon_chain::block_verification_types::RpcBlock;

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2048,7 +2048,7 @@ fn verify_builder_bid<E: EthSpec>(
         .cloned()
         .map(|withdrawals| {
             Withdrawals::<E>::try_from(withdrawals)
-                .map_err(InvalidBuilderPayload::SszTypesError)
+                .map_err(|e| Box::new(InvalidBuilderPayload::SszTypesError(e)))
                 .map(|w| w.tree_hash_root())
         })
         .transpose()?;

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 //! This crate contains a HTTP server which serves the endpoints listed here:
 //!
 //! https://github.com/ethereum/beacon-APIs

--- a/slasher/service/src/lib.rs
+++ b/slasher/service/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::result_large_err)]
 mod service;
 
 pub use service::SlasherService;


### PR DESCRIPTION
## Issue Addressed

Following the release of Rust v1.94.0 there are new Clippy lints which do not pass and are blocking CI (which pulls in the latest version of Rust)

## Proposed Changes

This is pretty much the minimum just to get CI running again. Most of the errors involve error types being too large. For now I've added allows but later it might be worth doing a refactor to `Box` or otherwise remove the problematic error types.