### PR TITLE
Fix cargo-sort errors

### DIFF
--- a/account_manager/Cargo.toml
+++ b/account_manager/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "account_manager"
 version = { workspace = true }
-authors = [
-    "Paul Hauner <paul@paulhauner.com>",
-    "Luke Anderson <luke@sigmaprime.io>",
-]
+authors = ["Paul Hauner <paul@paulhauner.com>", "Luke Anderson <luke@sigmaprime.io>"]
 edition = { workspace = true }
 
 [dependencies]

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "beacon_node"
 version = { workspace = true }
-authors = [
-    "Paul Hauner <paul@paulhauner.com>",
-    "Age Manning <Age@AgeManning.com",
-]
+authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com"]
 edition = { workspace = true }
 
 [lib]
@@ -12,10 +9,10 @@ name = "beacon_node"
 path = "src/lib.rs"
 
 [features]
-write_ssz_files = [
-    "beacon_chain/write_ssz_files",
-] # Writes debugging .ssz files to /tmp during block processing.
-testing = [] # Enables testing-only CLI flags
+# Writes debugging .ssz files to /tmp during block processing.
+write_ssz_files = ["beacon_chain/write_ssz_files"]
+# Enables testing-only CLI flags.
+testing = []
 
 [dependencies]
 account_utils = { workspace = true }

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -8,9 +8,12 @@ autotests = false # using a single test binary compiles faster
 
 [features]
 default = ["participation_metrics"]
-write_ssz_files = []  # Writes debugging .ssz files to /tmp during block processing.
-participation_metrics = []  # Exposes validator participation metrics to Prometheus.
-fork_from_env = [] # Initialise the harness chain spec from the FORK_NAME env variable
+# Writes debugging .ssz files to /tmp during block processing.
+write_ssz_files = []
+# Exposes validator participation metrics to Prometheus.
+participation_metrics = []
+# Initialise the harness chain spec from the FORK_NAME env variable
+fork_from_env = []
 portable = ["bls/supranational-portable"]
 test_backfill = []
 

--- a/common/logging/Cargo.toml
+++ b/common/logging/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["blacktemplar <blacktemplar@a1.net>"]
 edition = { workspace = true }
 
 [features]
-test_logger = [] # Print log output to stderr when running tests instead of dropping it
+# Print log output to stderr when running tests instead of dropping it.
+test_logger = []
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "types"
 version = "0.2.1"
-authors = [
-    "Paul Hauner <paul@paulhauner.com>",
-    "Age Manning <Age@AgeManning.com>",
-]
+authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com>"]
 edition = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Issue Addressed

<!-- Which issue # does this PR address? -->

The `cargo-sort` job in CI is [failing](https://github.com/sigp/lighthouse/actions/runs/22781651620/job/66088700318?pr=8932) since [cargo-sort v2.1.1](https://github.com/DevinR528/cargo-sort/releases/tag/v2.1.1) has been released, which reports new errors for our Cargo.toml files.

## Proposed Changes

<!-- Please list or describe the changes introduced by this PR. -->

Ran `cargo-sort` formatter locally with the new version.

<!--
## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->