### PR TITLE
Optionally check DB invariants at runtime

### DIFF
--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -3,7 +3,7 @@
 //! This module extends the store-level invariant checks with additional checks that require
 //! access to fork choice, state cache, and other beacon chain components.
 //!
-//! See: https://hackmd.io/@sproul/database-invariants
+//! See `BeaconChain::check_database_invariants` for the full list.
 
 use crate::BeaconChain;
 use crate::beacon_chain::BeaconChainTypes;
@@ -15,8 +15,7 @@ use types::*;
 impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Run all database invariant checks, including those requiring fork choice and state cache.
     ///
-    /// This is the top-level entry point that checks all 12 invariants from:
-    /// https://hackmd.io/@sproul/database-invariants
+    /// This is the top-level entry point that checks all 12 database invariants.
     ///
     /// Invariants 2-4, 10-12 are checked at the store level via `HotColdDB::check_invariants`.
     /// Invariants 1, 5-9 are checked here at the beacon chain level.

--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -22,7 +22,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn check_database_invariants(&self) -> Result<InvariantCheckResult, store::Error> {
         let mut result = self.store.check_invariants()?;
 
-        result.merge(self.check_fork_choice_block_consistency());
+        result.merge(self.check_fork_choice_block_consistency()?);
         result.merge(self.check_execution_payload_consistency()?);
         result.merge(self.check_blob_consistency()?);
         result.merge(self.check_data_column_consistency()?);
@@ -40,7 +40,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// Every block tracked by the fork choice proto-array must exist in the hot database.
     /// This ensures the fork choice tree never references blocks that have been pruned or lost.
-    fn check_fork_choice_block_consistency(&self) -> InvariantCheckResult {
+    fn check_fork_choice_block_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
         let mut result = InvariantCheckResult::new();
         let invariant_name = "fork_choice_block_consistency";
 
@@ -59,33 +59,23 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         for (block_root, slot) in block_roots {
             result.inc_checks();
 
-            match self
+            let exists = self
                 .store
                 .hot_db
-                .key_exists(DBColumn::BeaconBlock, block_root.as_slice())
-            {
-                Ok(true) => {}
-                Ok(false) => {
-                    result.add_violation(InvariantViolation {
-                        invariant: invariant_name.to_string(),
-                        message: format!(
-                            "block {block_root:?} at slot {slot} exists in fork choice \
-                             but not in hot DB",
-                        ),
-                    });
-                }
-                Err(e) => {
-                    result.add_violation(InvariantViolation {
-                        invariant: invariant_name.to_string(),
-                        message: format!(
-                            "error checking block {block_root:?} existence in hot DB: {e:?}"
-                        ),
-                    });
-                }
+                .key_exists(DBColumn::BeaconBlock, block_root.as_slice())?;
+
+            if !exists {
+                result.add_violation(InvariantViolation {
+                    invariant: invariant_name.to_string(),
+                    message: format!(
+                        "block {block_root:?} at slot {slot} exists in fork choice \
+                         but not in hot DB",
+                    ),
+                });
             }
         }
 
-        result
+        Ok(result)
     }
 
     /// Invariant 5 (Hot DB): Execution payload consistency.

--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -17,13 +17,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// This is the top-level entry point that checks all 12 database invariants.
     ///
-    /// Invariants 2-6, 8, 10-12 are checked at the store level via `HotColdDB::check_invariants`.
-    /// Invariants 1, 7, 9 are checked here at the beacon chain level.
+    /// Invariants 2-7, 8, 10-12 are checked at the store level via `HotColdDB::check_invariants`.
+    /// Invariants 1, 9 are checked here at the beacon chain level.
     pub fn check_database_invariants(&self) -> Result<InvariantCheckResult, store::Error> {
-        let mut result = self.store.check_invariants()?;
+        // Compute custody columns to pass to store-level block invariant checks.
+        let custody_context = self.data_availability_checker.custody_context();
+        let custody_columns: Vec<ColumnIndex> = custody_context
+            .custody_columns_for_epoch(None, &self.spec)
+            .to_vec();
+
+        let mut result = self.store.check_invariants(Some(&custody_columns))?;
 
         result.merge(self.check_fork_choice_block_consistency()?);
-        result.merge(self.check_data_column_consistency()?);
         result.merge(self.check_pubkey_cache_consistency()?);
 
         Ok(result)
@@ -63,71 +68,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             if !exists {
                 result
                     .add_violation(InvariantViolation::ForkChoiceBlockMissing { block_root, slot });
-            }
-        }
-
-        Ok(result)
-    }
-
-    /// Invariant 7 (Hot DB): Data column consistency (post-Fulu).
-    ///
-    /// ```text
-    /// block in hot_db && block.slot >= fulu_fork_slot
-    ///   && block.slot >= oldest_data_column_slot
-    ///   && data_column_idx in custody_columns
-    ///   -> (block_root, data_column_idx) in blob_db
-    /// ```
-    ///
-    /// Every post-Fulu block within data column availability should have all custody columns
-    /// stored. Note: custody column requirements may vary by epoch, but this check uses the
-    /// current head epoch's custody columns. Historical blocks may have had different custody
-    /// requirements; see https://github.com/sigp/lighthouse/issues/6572.
-    fn check_data_column_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
-        let mut result = InvariantCheckResult::new();
-
-        let fulu_fork_slot = match self.spec.fulu_fork_epoch {
-            Some(epoch) => epoch.start_slot(T::EthSpec::slots_per_epoch()),
-            None => return Ok(result),
-        };
-
-        let data_column_info = self.store.get_data_column_info();
-        let Some(oldest_data_column_slot) = data_column_info.oldest_data_column_slot else {
-            return Ok(result);
-        };
-
-        // Get custody columns for the current head epoch. Historical epochs may have different
-        // requirements but we use the current set as an approximation.
-        let custody_context = self.data_availability_checker.custody_context();
-        let custody_columns: Vec<ColumnIndex> = custody_context
-            .custody_columns_for_epoch(None, &self.spec)
-            .to_vec();
-
-        for res in self
-            .store
-            .hot_db
-            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
-        {
-            let block_root = res?;
-
-            let Some(block) = self.store.get_blinded_block(&block_root)? else {
-                continue;
-            };
-
-            if block.slot() < fulu_fork_slot || block.slot() < oldest_data_column_slot {
-                continue;
-            }
-
-            result.inc_checks();
-
-            let stored_columns = self.store.get_data_column_keys(block_root)?;
-            for col_idx in &custody_columns {
-                if !stored_columns.contains(col_idx) {
-                    result.add_violation(InvariantViolation::DataColumnMissing {
-                        block_root,
-                        slot: block.slot(),
-                        column_index: *col_idx,
-                    });
-                }
             }
         }
 

--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -1,0 +1,371 @@
+//! Beacon chain database invariant checks.
+//!
+//! This module extends the store-level invariant checks with additional checks that require
+//! access to fork choice, state cache, and other beacon chain components.
+//!
+//! See: https://hackmd.io/@sproul/database-invariants
+
+use crate::BeaconChain;
+use crate::beacon_chain::BeaconChainTypes;
+use store::DBColumn;
+use store::KeyValueStore;
+use store::invariants::{InvariantCheckResult, InvariantViolation};
+use types::*;
+
+impl<T: BeaconChainTypes> BeaconChain<T> {
+    /// Run all database invariant checks, including those requiring fork choice and state cache.
+    ///
+    /// This is the top-level entry point that checks all 12 invariants from:
+    /// https://hackmd.io/@sproul/database-invariants
+    ///
+    /// Invariants 2-4, 10-12 are checked at the store level via `HotColdDB::check_invariants`.
+    /// Invariants 1, 5-9 are checked here at the beacon chain level.
+    pub fn check_database_invariants(&self) -> Result<InvariantCheckResult, store::Error> {
+        let mut result = self.store.check_invariants()?;
+
+        result.merge(self.check_fork_choice_block_consistency());
+        result.merge(self.check_execution_payload_consistency()?);
+        result.merge(self.check_blob_consistency()?);
+        result.merge(self.check_data_column_consistency()?);
+        result.merge(self.check_state_cache_consistency()?);
+        result.merge(self.check_pubkey_cache_consistency()?);
+
+        Ok(result)
+    }
+
+    /// Invariant 1 (Hot DB): Fork choice block consistency.
+    ///
+    /// ```text
+    /// block in fork_choice -> block in hot_db
+    /// ```
+    ///
+    /// Every block tracked by the fork choice proto-array must exist in the hot database.
+    /// This ensures the fork choice tree never references blocks that have been pruned or lost.
+    fn check_fork_choice_block_consistency(&self) -> InvariantCheckResult {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "fork_choice_block_consistency";
+
+        // Collect block roots from fork choice under the read lock, then drop the lock before
+        // performing DB I/O to avoid blocking fork choice writes (recompute_head).
+        let block_roots: Vec<(Hash256, Slot)> = {
+            let fc = self.canonical_head.fork_choice_read_lock();
+            let proto_array = fc.proto_array().core_proto_array();
+            proto_array
+                .nodes
+                .iter()
+                .map(|node| (node.root, node.slot))
+                .collect()
+        };
+
+        for (block_root, slot) in block_roots {
+            result.inc_checks();
+
+            match self
+                .store
+                .hot_db
+                .key_exists(DBColumn::BeaconBlock, block_root.as_slice())
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    result.add_violation(InvariantViolation {
+                        invariant: invariant_name.to_string(),
+                        message: format!(
+                            "block {block_root:?} at slot {slot} exists in fork choice \
+                             but not in hot DB",
+                        ),
+                    });
+                }
+                Err(e) => {
+                    result.add_violation(InvariantViolation {
+                        invariant: invariant_name.to_string(),
+                        message: format!(
+                            "error checking block {block_root:?} existence in hot DB: {e:?}"
+                        ),
+                    });
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Invariant 5 (Hot DB): Execution payload consistency.
+    ///
+    /// ```text
+    /// block in hot_db && !prune_payloads
+    ///   -> execution payload or payload envelope for block.root in hot_db
+    /// ```
+    ///
+    /// When payload pruning is disabled, every post-Bellatrix block should have its execution
+    /// payload (pre-Gloas) or payload envelope (post-Gloas) stored. When `prune_payloads` is
+    /// true (the default), payloads are pruned at finalization and this check is skipped.
+    fn check_execution_payload_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "execution_payload_consistency";
+
+        if self.store.get_config().prune_payloads {
+            return Ok(result);
+        }
+
+        let bellatrix_fork_slot = match self.spec.bellatrix_fork_epoch {
+            Some(epoch) => epoch.start_slot(T::EthSpec::slots_per_epoch()),
+            None => return Ok(result),
+        };
+
+        for res in self
+            .store
+            .hot_db
+            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
+        {
+            let block_root = res?;
+
+            let Some(block) = self.store.get_blinded_block(&block_root)? else {
+                continue;
+            };
+
+            // Only post-merge blocks have execution payloads.
+            if block.slot() < bellatrix_fork_slot {
+                continue;
+            }
+
+            result.inc_checks();
+
+            let has_payload = self.store.execution_payload_exists(&block_root)?;
+            if !has_payload {
+                // Post-Gloas blocks store a payload envelope instead.
+                let has_envelope = self.store.payload_envelope_exists(&block_root)?;
+                if !has_envelope {
+                    result.add_violation(InvariantViolation {
+                        invariant: invariant_name.to_string(),
+                        message: format!(
+                            "block {block_root:?} at slot {} has no execution payload \
+                             or payload envelope (prune_payloads=false)",
+                            block.slot()
+                        ),
+                    });
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 6 (Hot DB): Blob sidecar consistency (Deneb to Fulu).
+    ///
+    /// ```text
+    /// block in hot_db && block.slot >= deneb_fork_slot && block.slot < fulu_fork_slot
+    ///   && block.slot >= oldest_blob_slot
+    ///   -> blob sidecar list for block.root in blob_db
+    /// ```
+    ///
+    /// Every post-Deneb, pre-Fulu block within the blob availability window should have a blob
+    /// sidecar entry (which may be an empty list for blocks with no blobs). Post-Fulu blocks
+    /// use data columns instead of blobs and are checked by invariant 7.
+    fn check_blob_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "blob_consistency";
+
+        let deneb_fork_slot = match self.spec.deneb_fork_epoch {
+            Some(epoch) => epoch.start_slot(T::EthSpec::slots_per_epoch()),
+            None => return Ok(result),
+        };
+
+        // Post-Fulu blocks use data columns, not blobs.
+        let fulu_fork_slot = self
+            .spec
+            .fulu_fork_epoch
+            .map(|epoch| epoch.start_slot(T::EthSpec::slots_per_epoch()));
+
+        let blob_info = self.store.get_blob_info();
+        let oldest_blob_slot = match blob_info.oldest_blob_slot {
+            Some(slot) => slot,
+            None => return Ok(result),
+        };
+
+        for res in self
+            .store
+            .hot_db
+            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
+        {
+            let block_root = res?;
+
+            let Some(block) = self.store.get_blinded_block(&block_root)? else {
+                continue;
+            };
+
+            let slot = block.slot();
+
+            // Only check Deneb+ blocks within blob availability, excluding Fulu+ blocks.
+            if slot < deneb_fork_slot || slot < oldest_blob_slot {
+                continue;
+            }
+            if let Some(fulu_slot) = fulu_fork_slot
+                && slot >= fulu_slot
+            {
+                continue;
+            }
+
+            result.inc_checks();
+
+            let has_blob_entry = self
+                .store
+                .blobs_db
+                .key_exists(DBColumn::BeaconBlob, block_root.as_slice())?;
+
+            if !has_blob_entry {
+                result.add_violation(InvariantViolation {
+                    invariant: invariant_name.to_string(),
+                    message: format!(
+                        "block {block_root:?} at slot {slot} has no blob sidecar entry",
+                    ),
+                });
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 7 (Hot DB): Data column consistency (post-Fulu).
+    ///
+    /// ```text
+    /// block in hot_db && block.slot >= fulu_fork_slot
+    ///   && block.slot >= oldest_data_column_slot
+    ///   && data_column_idx in custody_columns
+    ///   -> (block_root, data_column_idx) in blob_db
+    /// ```
+    ///
+    /// Every post-Fulu block within data column availability should have all custody columns
+    /// stored. Note: custody column requirements may vary by epoch, but this check uses the
+    /// current head epoch's custody columns. Historical blocks may have had different custody
+    /// requirements; see https://github.com/sigp/lighthouse/issues/6572.
+    fn check_data_column_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "data_column_consistency";
+
+        let fulu_fork_slot = match self.spec.fulu_fork_epoch {
+            Some(epoch) => epoch.start_slot(T::EthSpec::slots_per_epoch()),
+            None => return Ok(result),
+        };
+
+        let data_column_info = self.store.get_data_column_info();
+        let oldest_data_column_slot = match data_column_info.oldest_data_column_slot {
+            Some(slot) => slot,
+            None => return Ok(result),
+        };
+
+        // Get custody columns for the current head epoch. Historical epochs may have different
+        // requirements but we use the current set as an approximation.
+        let custody_context = self.data_availability_checker.custody_context();
+        let custody_columns: Vec<ColumnIndex> = custody_context
+            .custody_columns_for_epoch(None, &self.spec)
+            .to_vec();
+
+        for res in self
+            .store
+            .hot_db
+            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
+        {
+            let block_root = res?;
+
+            let Some(block) = self.store.get_blinded_block(&block_root)? else {
+                continue;
+            };
+
+            if block.slot() < fulu_fork_slot || block.slot() < oldest_data_column_slot {
+                continue;
+            }
+
+            result.inc_checks();
+
+            let stored_columns = self.store.get_data_column_keys(block_root)?;
+            for col_idx in &custody_columns {
+                if !stored_columns.contains(col_idx) {
+                    result.add_violation(InvariantViolation {
+                        invariant: invariant_name.to_string(),
+                        message: format!(
+                            "block {block_root:?} at slot {} missing custody data column {col_idx}",
+                            block.slot()
+                        ),
+                    });
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 8 (Hot DB): State cache and disk consistency.
+    ///
+    /// ```text
+    /// state in state_cache -> state_summary in hot_db
+    /// ```
+    ///
+    /// Every state held in the in-memory state cache (including the finalized state) should
+    /// have a corresponding hot state summary on disk.
+    fn check_state_cache_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "state_cache_consistency";
+
+        let state_roots = self.store.state_cache.lock().state_roots();
+
+        for state_root in state_roots {
+            result.inc_checks();
+
+            let has_summary = self
+                .store
+                .hot_db
+                .key_exists(DBColumn::BeaconStateHotSummary, state_root.as_slice())?;
+            if !has_summary {
+                result.add_violation(InvariantViolation {
+                    invariant: invariant_name.to_string(),
+                    message: format!(
+                        "state {state_root:?} is in state cache but has no hot state summary"
+                    ),
+                });
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 9 (Hot DB): Pubkey cache consistency.
+    ///
+    /// ```text
+    /// all validator pubkeys from states are in hot_db(PubkeyCache)
+    /// ```
+    ///
+    /// The number of pubkeys in the in-memory validator pubkey cache should match the number
+    /// stored on disk in the PubkeyCache column. This is a count-based check; individual
+    /// pubkey values are not compared.
+    fn check_pubkey_cache_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "pubkey_cache_consistency";
+
+        result.inc_checks();
+
+        let pubkey_cache = self.validator_pubkey_cache.read();
+        let in_memory_count = pubkey_cache.len();
+
+        let mut on_disk_count = 0usize;
+        for res in self
+            .store
+            .hot_db
+            .iter_column_keys::<Vec<u8>>(DBColumn::PubkeyCache)
+        {
+            let _ = res?;
+            on_disk_count += 1;
+        }
+
+        if in_memory_count != on_disk_count {
+            result.add_violation(InvariantViolation {
+                invariant: invariant_name.to_string(),
+                message: format!(
+                    "pubkey cache has {in_memory_count} keys in memory \
+                     but {on_disk_count} on disk"
+                ),
+            });
+        }
+
+        Ok(result)
+    }
+}

--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -1,53 +1,19 @@
 //! Beacon chain database invariant checks.
 //!
-//! This module extends the store-level invariant checks with additional checks that require
-//! access to fork choice, data availability checker, and validator pubkey cache.
-//!
-//! See `BeaconChain::check_database_invariants` for the full list.
+//! Builds the `InvariantContext` from beacon chain state and delegates all checks
+//! to `HotColdDB::check_invariants`.
 
 use crate::BeaconChain;
 use crate::beacon_chain::BeaconChainTypes;
-use store::DBColumn;
-use store::KeyValueStore;
-use store::invariants::{InvariantCheckResult, InvariantViolation};
-use types::*;
+use store::invariants::{InvariantCheckResult, InvariantContext};
 
 impl<T: BeaconChainTypes> BeaconChain<T> {
-    /// Run all database invariant checks, including those requiring fork choice and state cache.
+    /// Run all database invariant checks.
     ///
-    /// This is the top-level entry point that checks all 12 database invariants.
-    ///
-    /// Invariants 2-7, 8, 10-12 are checked at the store level via `HotColdDB::check_invariants`.
-    /// Invariants 1, 9 are checked here at the beacon chain level.
+    /// Collects context from fork choice, state cache, custody columns, and pubkey cache,
+    /// then delegates to the store-level `check_invariants` method.
     pub fn check_database_invariants(&self) -> Result<InvariantCheckResult, store::Error> {
-        // Compute custody columns to pass to store-level block invariant checks.
-        let custody_context = self.data_availability_checker.custody_context();
-        let custody_columns: Vec<ColumnIndex> = custody_context
-            .custody_columns_for_epoch(None, &self.spec)
-            .to_vec();
-
-        let mut result = self.store.check_invariants(Some(&custody_columns))?;
-
-        result.merge(self.check_fork_choice_block_consistency()?);
-        result.merge(self.check_pubkey_cache_consistency()?);
-
-        Ok(result)
-    }
-
-    /// Invariant 1 (Hot DB): Fork choice block consistency.
-    ///
-    /// ```text
-    /// block in fork_choice -> block in hot_db
-    /// ```
-    ///
-    /// Every block tracked by the fork choice proto-array must exist in the hot database.
-    /// This ensures the fork choice tree never references blocks that have been pruned or lost.
-    fn check_fork_choice_block_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
-        let mut result = InvariantCheckResult::new();
-
-        // Collect block roots from fork choice under the read lock, then drop the lock before
-        // performing DB I/O to avoid blocking fork choice writes (recompute_head).
-        let block_roots: Vec<(Hash256, Slot)> = {
+        let fork_choice_blocks = {
             let fc = self.canonical_head.fork_choice_read_lock();
             let proto_array = fc.proto_array().core_proto_array();
             proto_array
@@ -57,57 +23,17 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .collect()
         };
 
-        for (block_root, slot) in block_roots {
-            result.inc_checks();
+        let custody_context = self.data_availability_checker.custody_context();
 
-            let exists = self
-                .store
-                .hot_db
-                .key_exists(DBColumn::BeaconBlock, block_root.as_slice())?;
+        let ctx = InvariantContext {
+            fork_choice_blocks,
+            state_cache_roots: self.store.state_cache.lock().state_roots(),
+            custody_columns: custody_context
+                .custody_columns_for_epoch(None, &self.spec)
+                .to_vec(),
+            pubkey_cache_count: self.validator_pubkey_cache.read().len(),
+        };
 
-            if !exists {
-                result
-                    .add_violation(InvariantViolation::ForkChoiceBlockMissing { block_root, slot });
-            }
-        }
-
-        Ok(result)
-    }
-
-    /// Invariant 9 (Hot DB): Pubkey cache consistency.
-    ///
-    /// ```text
-    /// all validator pubkeys from states are in hot_db(PubkeyCache)
-    /// ```
-    ///
-    /// The number of pubkeys in the in-memory validator pubkey cache should match the number
-    /// stored on disk in the PubkeyCache column. This is a count-based check; individual
-    /// pubkey values are not compared.
-    fn check_pubkey_cache_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
-        let mut result = InvariantCheckResult::new();
-
-        result.inc_checks();
-
-        let pubkey_cache = self.validator_pubkey_cache.read();
-        let in_memory_count = pubkey_cache.len();
-
-        let mut on_disk_count = 0usize;
-        for res in self
-            .store
-            .hot_db
-            .iter_column_keys::<Vec<u8>>(DBColumn::PubkeyCache)
-        {
-            let _ = res?;
-            on_disk_count += 1;
-        }
-
-        if in_memory_count != on_disk_count {
-            result.add_violation(InvariantViolation::PubkeyCacheCountMismatch {
-                in_memory: in_memory_count,
-                on_disk: on_disk_count,
-            });
-        }
-
-        Ok(result)
+        self.store.check_invariants(&ctx)
     }
 }

--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -110,7 +110,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let block_root = res?;
 
             let Some(block) = self.store.get_blinded_block(&block_root)? else {
-                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
                 continue;
             };
 

--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -37,7 +37,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             custody_columns: custody_context
                 .custody_columns_for_epoch(None, &self.spec)
                 .to_vec(),
-            pubkey_cache_count: self.validator_pubkey_cache.read().len(),
+            pubkey_cache_pubkeys: {
+                let cache = self.validator_pubkey_cache.read();
+                (0..cache.len())
+                    .filter_map(|i| {
+                        cache.get(i).map(|pk| {
+                            use store::StoreItem;
+                            crate::validator_pubkey_cache::DatabasePubkey::from_pubkey(pk)
+                                .as_store_bytes()
+                        })
+                    })
+                    .collect()
+            },
         };
 
         self.store.check_invariants(&ctx)

--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -19,6 +19,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             proto_array
                 .nodes
                 .iter()
+                .filter(|node| {
+                    // Only check blocks that are descendants of the finalized checkpoint.
+                    // Pruned non-canonical fork blocks may linger in the proto-array but
+                    // are legitimately absent from the database.
+                    fc.is_finalized_checkpoint_or_descendant(node.root)
+                })
                 .map(|node| (node.root, node.slot))
                 .collect()
         };

--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -42,7 +42,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// This ensures the fork choice tree never references blocks that have been pruned or lost.
     fn check_fork_choice_block_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "fork_choice_block_consistency";
 
         // Collect block roots from fork choice under the read lock, then drop the lock before
         // performing DB I/O to avoid blocking fork choice writes (recompute_head).
@@ -65,13 +64,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .key_exists(DBColumn::BeaconBlock, block_root.as_slice())?;
 
             if !exists {
-                result.add_violation(InvariantViolation {
-                    invariant: invariant_name.to_string(),
-                    message: format!(
-                        "block {block_root:?} at slot {slot} exists in fork choice \
-                         but not in hot DB",
-                    ),
-                });
+                result
+                    .add_violation(InvariantViolation::ForkChoiceBlockMissing { block_root, slot });
             }
         }
 
@@ -90,7 +84,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// true (the default), payloads are pruned at finalization and this check is skipped.
     fn check_execution_payload_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "execution_payload_consistency";
 
         if self.store.get_config().prune_payloads {
             return Ok(result);
@@ -109,6 +102,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let block_root = res?;
 
             let Some(block) = self.store.get_blinded_block(&block_root)? else {
+                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
                 continue;
             };
 
@@ -124,13 +118,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 // Post-Gloas blocks store a payload envelope instead.
                 let has_envelope = self.store.payload_envelope_exists(&block_root)?;
                 if !has_envelope {
-                    result.add_violation(InvariantViolation {
-                        invariant: invariant_name.to_string(),
-                        message: format!(
-                            "block {block_root:?} at slot {} has no execution payload \
-                             or payload envelope (prune_payloads=false)",
-                            block.slot()
-                        ),
+                    result.add_violation(InvariantViolation::ExecutionPayloadMissing {
+                        block_root,
+                        slot: block.slot(),
                     });
                 }
             }
@@ -152,7 +142,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// use data columns instead of blobs and are checked by invariant 7.
     fn check_blob_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "blob_consistency";
 
         let deneb_fork_slot = match self.spec.deneb_fork_epoch {
             Some(epoch) => epoch.start_slot(T::EthSpec::slots_per_epoch()),
@@ -179,6 +168,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let block_root = res?;
 
             let Some(block) = self.store.get_blinded_block(&block_root)? else {
+                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
                 continue;
             };
 
@@ -202,12 +192,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .key_exists(DBColumn::BeaconBlob, block_root.as_slice())?;
 
             if !has_blob_entry {
-                result.add_violation(InvariantViolation {
-                    invariant: invariant_name.to_string(),
-                    message: format!(
-                        "block {block_root:?} at slot {slot} has no blob sidecar entry",
-                    ),
-                });
+                result.add_violation(InvariantViolation::BlobSidecarMissing { block_root, slot });
             }
         }
 
@@ -229,7 +214,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// requirements; see https://github.com/sigp/lighthouse/issues/6572.
     fn check_data_column_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "data_column_consistency";
 
         let fulu_fork_slot = match self.spec.fulu_fork_epoch {
             Some(epoch) => epoch.start_slot(T::EthSpec::slots_per_epoch()),
@@ -257,6 +241,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let block_root = res?;
 
             let Some(block) = self.store.get_blinded_block(&block_root)? else {
+                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
                 continue;
             };
 
@@ -269,12 +254,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let stored_columns = self.store.get_data_column_keys(block_root)?;
             for col_idx in &custody_columns {
                 if !stored_columns.contains(col_idx) {
-                    result.add_violation(InvariantViolation {
-                        invariant: invariant_name.to_string(),
-                        message: format!(
-                            "block {block_root:?} at slot {} missing custody data column {col_idx}",
-                            block.slot()
-                        ),
+                    result.add_violation(InvariantViolation::DataColumnMissing {
+                        block_root,
+                        slot: block.slot(),
+                        column_index: *col_idx,
                     });
                 }
             }
@@ -293,7 +276,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// have a corresponding hot state summary on disk.
     fn check_state_cache_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "state_cache_consistency";
 
         let state_roots = self.store.state_cache.lock().state_roots();
 
@@ -305,12 +287,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .hot_db
                 .key_exists(DBColumn::BeaconStateHotSummary, state_root.as_slice())?;
             if !has_summary {
-                result.add_violation(InvariantViolation {
-                    invariant: invariant_name.to_string(),
-                    message: format!(
-                        "state {state_root:?} is in state cache but has no hot state summary"
-                    ),
-                });
+                result.add_violation(InvariantViolation::StateCacheMissingSummary { state_root });
             }
         }
 
@@ -328,7 +305,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// pubkey values are not compared.
     fn check_pubkey_cache_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "pubkey_cache_consistency";
 
         result.inc_checks();
 
@@ -346,12 +322,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         if in_memory_count != on_disk_count {
-            result.add_violation(InvariantViolation {
-                invariant: invariant_name.to_string(),
-                message: format!(
-                    "pubkey cache has {in_memory_count} keys in memory \
-                     but {on_disk_count} on disk"
-                ),
+            result.add_violation(InvariantViolation::PubkeyCacheCountMismatch {
+                in_memory: in_memory_count,
+                on_disk: on_disk_count,
             });
         }
 

--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -1,7 +1,7 @@
 //! Beacon chain database invariant checks.
 //!
 //! This module extends the store-level invariant checks with additional checks that require
-//! access to fork choice, state cache, and other beacon chain components.
+//! access to fork choice, data availability checker, and validator pubkey cache.
 //!
 //! See `BeaconChain::check_database_invariants` for the full list.
 
@@ -17,16 +17,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// This is the top-level entry point that checks all 12 database invariants.
     ///
-    /// Invariants 2-4, 10-12 are checked at the store level via `HotColdDB::check_invariants`.
-    /// Invariants 1, 5-9 are checked here at the beacon chain level.
+    /// Invariants 2-6, 8, 10-12 are checked at the store level via `HotColdDB::check_invariants`.
+    /// Invariants 1, 7, 9 are checked here at the beacon chain level.
     pub fn check_database_invariants(&self) -> Result<InvariantCheckResult, store::Error> {
         let mut result = self.store.check_invariants()?;
 
         result.merge(self.check_fork_choice_block_consistency()?);
-        result.merge(self.check_execution_payload_consistency()?);
-        result.merge(self.check_blob_consistency()?);
         result.merge(self.check_data_column_consistency()?);
-        result.merge(self.check_state_cache_consistency()?);
         result.merge(self.check_pubkey_cache_consistency()?);
 
         Ok(result)
@@ -72,133 +69,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         Ok(result)
     }
 
-    /// Invariant 5 (Hot DB): Execution payload consistency.
-    ///
-    /// ```text
-    /// block in hot_db && !prune_payloads
-    ///   -> execution payload or payload envelope for block.root in hot_db
-    /// ```
-    ///
-    /// When payload pruning is disabled, every post-Bellatrix block should have its execution
-    /// payload (pre-Gloas) or payload envelope (post-Gloas) stored. When `prune_payloads` is
-    /// true (the default), payloads are pruned at finalization and this check is skipped.
-    fn check_execution_payload_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
-        let mut result = InvariantCheckResult::new();
-
-        if self.store.get_config().prune_payloads {
-            return Ok(result);
-        }
-
-        let bellatrix_fork_slot = match self.spec.bellatrix_fork_epoch {
-            Some(epoch) => epoch.start_slot(T::EthSpec::slots_per_epoch()),
-            None => return Ok(result),
-        };
-
-        for res in self
-            .store
-            .hot_db
-            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
-        {
-            let block_root = res?;
-
-            let Some(block) = self.store.get_blinded_block(&block_root)? else {
-                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
-                continue;
-            };
-
-            // Only post-merge blocks have execution payloads.
-            if block.slot() < bellatrix_fork_slot {
-                continue;
-            }
-
-            result.inc_checks();
-
-            let has_payload = self.store.execution_payload_exists(&block_root)?;
-            if !has_payload {
-                // Post-Gloas blocks store a payload envelope instead.
-                let has_envelope = self.store.payload_envelope_exists(&block_root)?;
-                if !has_envelope {
-                    result.add_violation(InvariantViolation::ExecutionPayloadMissing {
-                        block_root,
-                        slot: block.slot(),
-                    });
-                }
-            }
-        }
-
-        Ok(result)
-    }
-
-    /// Invariant 6 (Hot DB): Blob sidecar consistency (Deneb to Fulu).
-    ///
-    /// ```text
-    /// block in hot_db && block.slot >= deneb_fork_slot && block.slot < fulu_fork_slot
-    ///   && block.slot >= oldest_blob_slot
-    ///   -> blob sidecar list for block.root in blob_db
-    /// ```
-    ///
-    /// Every post-Deneb, pre-Fulu block within the blob availability window should have a blob
-    /// sidecar entry (which may be an empty list for blocks with no blobs). Post-Fulu blocks
-    /// use data columns instead of blobs and are checked by invariant 7.
-    fn check_blob_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
-        let mut result = InvariantCheckResult::new();
-
-        let deneb_fork_slot = match self.spec.deneb_fork_epoch {
-            Some(epoch) => epoch.start_slot(T::EthSpec::slots_per_epoch()),
-            None => return Ok(result),
-        };
-
-        // Post-Fulu blocks use data columns, not blobs.
-        let fulu_fork_slot = self
-            .spec
-            .fulu_fork_epoch
-            .map(|epoch| epoch.start_slot(T::EthSpec::slots_per_epoch()));
-
-        let blob_info = self.store.get_blob_info();
-        let oldest_blob_slot = match blob_info.oldest_blob_slot {
-            Some(slot) => slot,
-            None => return Ok(result),
-        };
-
-        for res in self
-            .store
-            .hot_db
-            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
-        {
-            let block_root = res?;
-
-            let Some(block) = self.store.get_blinded_block(&block_root)? else {
-                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
-                continue;
-            };
-
-            let slot = block.slot();
-
-            // Only check Deneb+ blocks within blob availability, excluding Fulu+ blocks.
-            if slot < deneb_fork_slot || slot < oldest_blob_slot {
-                continue;
-            }
-            if let Some(fulu_slot) = fulu_fork_slot
-                && slot >= fulu_slot
-            {
-                continue;
-            }
-
-            result.inc_checks();
-
-            let has_blob_entry = self
-                .store
-                .blobs_db
-                .key_exists(DBColumn::BeaconBlob, block_root.as_slice())?;
-
-            if !has_blob_entry {
-                result.add_violation(InvariantViolation::BlobSidecarMissing { block_root, slot });
-            }
-        }
-
-        Ok(result)
-    }
-
     /// Invariant 7 (Hot DB): Data column consistency (post-Fulu).
     ///
     /// ```text
@@ -221,9 +91,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         };
 
         let data_column_info = self.store.get_data_column_info();
-        let oldest_data_column_slot = match data_column_info.oldest_data_column_slot {
-            Some(slot) => slot,
-            None => return Ok(result),
+        let Some(oldest_data_column_slot) = data_column_info.oldest_data_column_slot else {
+            return Ok(result);
         };
 
         // Get custody columns for the current head epoch. Historical epochs may have different
@@ -260,34 +129,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         column_index: *col_idx,
                     });
                 }
-            }
-        }
-
-        Ok(result)
-    }
-
-    /// Invariant 8 (Hot DB): State cache and disk consistency.
-    ///
-    /// ```text
-    /// state in state_cache -> state_summary in hot_db
-    /// ```
-    ///
-    /// Every state held in the in-memory state cache (including the finalized state) should
-    /// have a corresponding hot state summary on disk.
-    fn check_state_cache_consistency(&self) -> Result<InvariantCheckResult, store::Error> {
-        let mut result = InvariantCheckResult::new();
-
-        let state_roots = self.store.state_cache.lock().state_roots();
-
-        for state_root in state_roots {
-            result.inc_checks();
-
-            let has_summary = self
-                .store
-                .hot_db
-                .key_exists(DBColumn::BeaconStateHotSummary, state_root.as_slice())?;
-            if !has_summary {
-                result.add_violation(InvariantViolation::StateCacheMissingSummary { state_root });
             }
         }
 

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -29,6 +29,7 @@ pub mod fork_choice_signal;
 pub mod graffiti_calculator;
 pub mod historical_blocks;
 pub mod historical_data_columns;
+pub mod invariants;
 pub mod kzg_utils;
 pub mod light_client_finality_update_verification;
 pub mod light_client_optimistic_update_verification;

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -3402,13 +3402,9 @@ async fn weak_subjectivity_sync_test(
         .expect("invariant check should not error");
     assert!(
         invariants_result.is_ok(),
-        "database invariant violations after weak subjectivity sync:\n{}",
-        invariants_result
-            .violations
-            .iter()
-            .map(|v| v.to_string())
-            .collect::<Vec<_>>()
-            .join("\n")
+        "database invariant violations after weak subjectivity sync ({} checks):\n{:#?}",
+        invariants_result.checks_performed,
+        invariants_result.violations
     );
 }
 

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -159,14 +159,9 @@ fn check_db_invariants(harness: &TestHarness) {
 
     assert!(
         result.is_ok(),
-        "database invariant violations found ({} checks performed):\n{}",
+        "database invariant violations found ({} checks performed):\n{:#?}",
         result.checks_performed,
-        result
-            .violations
-            .iter()
-            .map(|v| v.to_string())
-            .collect::<Vec<_>>()
-            .join("\n")
+        result.violations,
     );
 }
 

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -148,6 +148,28 @@ fn get_harness_generic(
     harness
 }
 
+/// Check that all database invariants hold.
+///
+/// Panics with a descriptive message if any invariant is violated.
+fn check_db_invariants(harness: &TestHarness) {
+    let result = harness
+        .chain
+        .check_database_invariants()
+        .expect("invariant check should not error");
+
+    assert!(
+        result.is_ok(),
+        "database invariant violations found ({} checks performed):\n{}",
+        result.checks_performed,
+        result
+            .violations
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
 fn get_states_descendant_of_block(
     store: &HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>,
     block_root: Hash256,
@@ -308,6 +330,7 @@ async fn full_participation_no_skips() {
     check_split_slot(&harness, store);
     check_chain_dump(&harness, num_blocks_produced + 1);
     check_iterators(&harness);
+    check_db_invariants(&harness);
 }
 
 #[tokio::test]
@@ -352,6 +375,7 @@ async fn randomised_skips() {
     check_split_slot(&harness, store.clone());
     check_chain_dump(&harness, num_blocks_produced + 1);
     check_iterators(&harness);
+    check_db_invariants(&harness);
 }
 
 #[tokio::test]
@@ -400,6 +424,7 @@ async fn long_skip() {
     check_split_slot(&harness, store);
     check_chain_dump(&harness, initial_blocks + final_blocks + 1);
     check_iterators(&harness);
+    check_db_invariants(&harness);
 }
 
 /// Go forward to the point where the genesis randao value is no longer part of the vector.
@@ -1769,6 +1794,8 @@ async fn prunes_abandoned_fork_between_two_finalized_checkpoints() {
     }
 
     assert!(!rig.knows_head(&stray_head));
+
+    check_db_invariants(&rig);
 }
 
 #[tokio::test]
@@ -1897,6 +1924,8 @@ async fn pruning_does_not_touch_abandoned_block_shared_with_canonical_chain() {
     assert!(!rig.knows_head(&stray_head));
     let chain_dump = rig.chain.chain_dump().unwrap();
     assert!(get_blocks(&chain_dump).contains(&shared_head));
+
+    check_db_invariants(&rig);
 }
 
 #[tokio::test]
@@ -1988,6 +2017,8 @@ async fn pruning_does_not_touch_blocks_prior_to_finalization() {
     }
 
     rig.assert_knows_head(stray_head.into());
+
+    check_db_invariants(&rig);
 }
 
 #[tokio::test]
@@ -2127,6 +2158,8 @@ async fn prunes_fork_growing_past_youngest_finalized_checkpoint() {
     }
 
     assert!(!rig.knows_head(&stray_head));
+
+    check_db_invariants(&rig);
 }
 
 // This is to check if state outside of normal block processing are pruned correctly.
@@ -2377,6 +2410,8 @@ async fn finalizes_non_epoch_start_slot() {
             state_hash
         );
     }
+
+    check_db_invariants(&rig);
 }
 
 fn check_all_blocks_exist<'a>(
@@ -2643,6 +2678,8 @@ async fn pruning_test(
     check_all_states_exist(&harness, all_canonical_states.iter());
     check_no_states_exist(&harness, stray_states.difference(&all_canonical_states));
     check_no_blocks_exist(&harness, stray_blocks.values());
+
+    check_db_invariants(&harness);
 }
 
 #[tokio::test]
@@ -2707,6 +2744,8 @@ async fn garbage_collect_temp_states_from_failed_block_on_finalization() {
         vec![(genesis_state_root, Slot::new(0))],
         "get_states_descendant_of_block({bad_block_parent_root:?})"
     );
+
+    check_db_invariants(&harness);
 }
 
 #[tokio::test]
@@ -3361,6 +3400,21 @@ async fn weak_subjectivity_sync_test(
     store.clone().reconstruct_historic_states(None).unwrap();
     assert_eq!(store.get_anchor_info().anchor_slot, wss_aligned_slot);
     assert_eq!(store.get_anchor_info().state_upper_limit, Slot::new(0));
+
+    // Check database invariants after full checkpoint sync + backfill + reconstruction.
+    let invariants_result = beacon_chain
+        .check_database_invariants()
+        .expect("invariant check should not error");
+    assert!(
+        invariants_result.is_ok(),
+        "database invariant violations after weak subjectivity sync:\n{}",
+        invariants_result
+            .violations
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
 }
 
 // This test prunes data columns from epoch 0 and then tries to re-import them via

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -3397,14 +3397,14 @@ async fn weak_subjectivity_sync_test(
     assert_eq!(store.get_anchor_info().state_upper_limit, Slot::new(0));
 
     // Check database invariants after full checkpoint sync + backfill + reconstruction.
-    let invariants_result = beacon_chain
+    let result = beacon_chain
         .check_database_invariants()
         .expect("invariant check should not error");
     assert!(
-        invariants_result.is_ok(),
-        "database invariant violations after weak subjectivity sync ({} checks):\n{:#?}",
-        invariants_result.checks_performed,
-        invariants_result.violations
+        result.is_ok(),
+        "database invariant violations ({} checks):\n{:#?}",
+        result.checks_performed,
+        result.violations,
     );
 }
 

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -159,8 +159,7 @@ fn check_db_invariants(harness: &TestHarness) {
 
     assert!(
         result.is_ok(),
-        "database invariant violations found ({} checks performed):\n{:#?}",
-        result.checks_performed,
+        "database invariant violations found:\n{:#?}",
         result.violations,
     );
 }
@@ -3402,8 +3401,7 @@ async fn weak_subjectivity_sync_test(
         .expect("invariant check should not error");
     assert!(
         result.is_ok(),
-        "database invariant violations ({} checks):\n{:#?}",
-        result.checks_performed,
+        "database invariant violations:\n{:#?}",
         result.violations,
     );
 }

--- a/beacon_node/http_api/src/database.rs
+++ b/beacon_node/http_api/src/database.rs
@@ -2,6 +2,7 @@ use beacon_chain::store::metadata::CURRENT_SCHEMA_VERSION;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use serde::Serialize;
 use std::sync::Arc;
+use store::invariants::InvariantCheckResult;
 use store::{AnchorInfo, BlobInfo, Split, StoreConfig};
 
 #[derive(Debug, Serialize)]
@@ -28,5 +29,13 @@ pub fn info<T: BeaconChainTypes>(
         split,
         anchor,
         blob_info,
+    })
+}
+
+pub fn check_invariants<T: BeaconChainTypes>(
+    chain: Arc<BeaconChain<T>>,
+) -> Result<InvariantCheckResult, warp::Rejection> {
+    chain.check_database_invariants().map_err(|e| {
+        warp_utils::reject::custom_bad_request(format!("error checking database invariants: {e:?}"))
     })
 }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -3007,6 +3007,19 @@ pub fn serve<T: BeaconChainTypes>(
             },
         );
 
+    // GET lighthouse/database/invariants
+    let get_lighthouse_database_invariants = database_path
+        .and(warp::path("invariants"))
+        .and(warp::path::end())
+        .and(task_spawner_filter.clone())
+        .and(chain_filter.clone())
+        .then(
+            |task_spawner: TaskSpawner<T::EthSpec>, chain: Arc<BeaconChain<T>>| {
+                task_spawner
+                    .blocking_json_task(Priority::P1, move || database::check_invariants(chain))
+            },
+        );
+
     // POST lighthouse/database/reconstruct
     let post_lighthouse_database_reconstruct = database_path
         .and(warp::path("reconstruct"))
@@ -3336,6 +3349,7 @@ pub fn serve<T: BeaconChainTypes>(
                 .uor(get_lighthouse_validator_inclusion)
                 .uor(get_lighthouse_staking)
                 .uor(get_lighthouse_database_info)
+                .uor(get_lighthouse_database_invariants)
                 .uor(get_lighthouse_custody_info)
                 .uor(get_lighthouse_attestation_performance)
                 .uor(get_beacon_light_client_optimistic_update)

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -3939,6 +3939,12 @@ pub struct DiffBaseState {
     state_root: Hash256,
 }
 
+impl DiffBaseState {
+    pub fn state_root(&self) -> Hash256 {
+        self.state_root
+    }
+}
+
 impl OptionalDiffBaseState {
     pub fn new(slot: Slot, state_root: Hash256) -> Self {
         Self::BaseState(DiffBaseState { slot, state_root })

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -3939,12 +3939,6 @@ pub struct DiffBaseState {
     state_root: Hash256,
 }
 
-impl DiffBaseState {
-    pub fn state_root(&self) -> Hash256 {
-        self.state_root
-    }
-}
-
 impl OptionalDiffBaseState {
     pub fn new(slot: Slot, state_root: Hash256) -> Self {
         Self::BaseState(DiffBaseState { slot, state_root })

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -134,15 +134,16 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     /// - Invariant 9 (pubkey cache) — requires validator pubkey cache
     ///
     /// Use `BeaconChain::check_database_invariants` for a complete check.
-    pub fn check_invariants(&self) -> Result<InvariantCheckResult, Error> {
+    pub fn check_invariants(
+        &self,
+        custody_columns: Option<&[ColumnIndex]>,
+    ) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
         let split = self.get_split_info();
 
-        result.merge(self.check_hot_block_state_consistency(&split)?);
+        result.merge(self.check_hot_block_invariants(&split, custody_columns)?);
         result.merge(self.check_hot_state_summary_diff_consistency(&split)?);
         result.merge(self.check_hot_state_summary_chain_consistency(&split)?);
-        result.merge(self.check_execution_payload_consistency()?);
-        result.merge(self.check_blob_consistency()?);
         result.merge(self.check_state_cache_consistency()?);
         result.merge(self.check_cold_block_root_indices(&split)?);
         result.merge(self.check_cold_state_root_indices(&split)?);
@@ -151,33 +152,47 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         Ok(result)
     }
 
-    /// Invariant 2 (Hot DB): Block-state consistency.
+    /// Invariants 2, 5, 6, 7 (Hot DB): Block-related consistency checks.
     ///
-    /// ```text
-    /// block in hot_db && block.slot >= split.slot
-    ///   -> state_summary for block.state_root() in hot_db
-    /// ```
-    ///
-    /// Every block in the hot DB at or above the split should have a corresponding hot state
-    /// summary. Blocks below the split are in the cold range and are not checked here.
-    fn check_hot_block_state_consistency(
+    /// Iterates hot DB blocks once and checks:
+    /// - Invariant 2: block-state summary consistency
+    /// - Invariant 5: execution payload consistency (when prune_payloads=false)
+    /// - Invariant 6: blob sidecar consistency (Deneb to Fulu)
+    /// - Invariant 7: data column consistency (post-Fulu, when custody_columns provided)
+    fn check_hot_block_invariants(
         &self,
         split: &Split,
+        custody_columns: Option<&[ColumnIndex]>,
     ) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
 
-        for res in self
-            .hot_db
-            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
-        {
-            let block_root = res?;
+        let check_payloads = !self.get_config().prune_payloads;
+        let bellatrix_fork_slot = self
+            .spec
+            .bellatrix_fork_epoch
+            .map(|epoch| epoch.start_slot(E::slots_per_epoch()));
+        let deneb_fork_slot = self
+            .spec
+            .deneb_fork_epoch
+            .map(|epoch| epoch.start_slot(E::slots_per_epoch()));
+        let fulu_fork_slot = self
+            .spec
+            .fulu_fork_epoch
+            .map(|epoch| epoch.start_slot(E::slots_per_epoch()));
+        let oldest_blob_slot = self.get_blob_info().oldest_blob_slot;
+        let oldest_data_column_slot = self.get_data_column_info().oldest_data_column_slot;
+
+        for res in self.hot_db.iter_column::<Hash256>(DBColumn::BeaconBlock) {
+            let (block_root, block_bytes) = res?;
+            let block = SignedBeaconBlock::<E, BlindedPayload<E>>::from_ssz_bytes(
+                &block_bytes,
+                &self.spec,
+            )?;
+            let slot = block.slot();
+
+            // Invariant 2: block-state consistency.
             result.inc_checks();
-
-            let Some(block) = self.get_blinded_block(&block_root)? else {
-                continue;
-            };
-
-            if block.slot() >= split.slot {
+            if slot >= split.slot {
                 let state_root = block.state_root();
                 let has_summary = self
                     .hot_db
@@ -185,9 +200,66 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 if !has_summary {
                     result.add_violation(InvariantViolation::HotBlockMissingStateSummary {
                         block_root,
-                        slot: block.slot(),
+                        slot,
                         state_root,
                     });
+                }
+            }
+
+            // Invariant 5: execution payload consistency.
+            if check_payloads {
+                if let Some(bellatrix_slot) = bellatrix_fork_slot {
+                    if slot >= bellatrix_slot {
+                        result.inc_checks();
+                        if !self.execution_payload_exists(&block_root)?
+                            && !self.payload_envelope_exists(&block_root)?
+                        {
+                            result.add_violation(InvariantViolation::ExecutionPayloadMissing {
+                                block_root,
+                                slot,
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Invariant 6: blob sidecar consistency.
+            if let Some(deneb_slot) = deneb_fork_slot {
+                if let Some(oldest_blob) = oldest_blob_slot {
+                    let is_pre_fulu = fulu_fork_slot.is_none_or(|fulu_slot| slot < fulu_slot);
+                    if slot >= deneb_slot && slot >= oldest_blob && is_pre_fulu {
+                        result.inc_checks();
+                        let has_blob = self
+                            .blobs_db
+                            .key_exists(DBColumn::BeaconBlob, block_root.as_slice())?;
+                        if !has_blob {
+                            result.add_violation(InvariantViolation::BlobSidecarMissing {
+                                block_root,
+                                slot,
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Invariant 7: data column consistency.
+            if let Some(custody_cols) = custody_columns {
+                if let Some(fulu_slot) = fulu_fork_slot {
+                    if let Some(oldest_dc) = oldest_data_column_slot {
+                        if slot >= fulu_slot && slot >= oldest_dc {
+                            result.inc_checks();
+                            let stored_columns = self.get_data_column_keys(block_root)?;
+                            for col_idx in custody_cols {
+                                if !stored_columns.contains(col_idx) {
+                                    result.add_violation(InvariantViolation::DataColumnMissing {
+                                        block_root,
+                                        slot,
+                                        column_index: *col_idx,
+                                    });
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -307,123 +379,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         previous_state_root: prev_root,
                     });
                 }
-            }
-        }
-
-        Ok(result)
-    }
-
-    /// Invariant 5 (Hot DB): Execution payload consistency.
-    ///
-    /// ```text
-    /// block in hot_db && !prune_payloads
-    ///   -> execution payload or payload envelope for block.root in hot_db
-    /// ```
-    ///
-    /// When payload pruning is disabled, every post-Bellatrix block should have its execution
-    /// payload (pre-Gloas) or payload envelope (post-Gloas) stored. When `prune_payloads` is
-    /// true (the default), payloads are pruned at finalization and this check is skipped.
-    fn check_execution_payload_consistency(&self) -> Result<InvariantCheckResult, Error> {
-        let mut result = InvariantCheckResult::new();
-
-        if self.get_config().prune_payloads {
-            return Ok(result);
-        }
-
-        let bellatrix_fork_slot = match self.spec.bellatrix_fork_epoch {
-            Some(epoch) => epoch.start_slot(E::slots_per_epoch()),
-            None => return Ok(result),
-        };
-
-        for res in self
-            .hot_db
-            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
-        {
-            let block_root = res?;
-
-            let Some(block) = self.get_blinded_block(&block_root)? else {
-                continue;
-            };
-
-            if block.slot() < bellatrix_fork_slot {
-                continue;
-            }
-
-            result.inc_checks();
-
-            let has_payload = self.execution_payload_exists(&block_root)?;
-            if !has_payload {
-                let has_envelope = self.payload_envelope_exists(&block_root)?;
-                if !has_envelope {
-                    result.add_violation(InvariantViolation::ExecutionPayloadMissing {
-                        block_root,
-                        slot: block.slot(),
-                    });
-                }
-            }
-        }
-
-        Ok(result)
-    }
-
-    /// Invariant 6 (Hot DB): Blob sidecar consistency (Deneb to Fulu).
-    ///
-    /// ```text
-    /// block in hot_db && block.slot >= deneb_fork_slot && block.slot < fulu_fork_slot
-    ///   && block.slot >= oldest_blob_slot
-    ///   -> blob sidecar list for block.root in blob_db
-    /// ```
-    ///
-    /// Every post-Deneb, pre-Fulu block within the blob availability window should have a blob
-    /// sidecar entry (which may be an empty list for blocks with no blobs). Post-Fulu blocks
-    /// use data columns instead of blobs and are checked by invariant 7.
-    fn check_blob_consistency(&self) -> Result<InvariantCheckResult, Error> {
-        let mut result = InvariantCheckResult::new();
-
-        let deneb_fork_slot = match self.spec.deneb_fork_epoch {
-            Some(epoch) => epoch.start_slot(E::slots_per_epoch()),
-            None => return Ok(result),
-        };
-
-        let fulu_fork_slot = self
-            .spec
-            .fulu_fork_epoch
-            .map(|epoch| epoch.start_slot(E::slots_per_epoch()));
-
-        let blob_info = self.get_blob_info();
-        let Some(oldest_blob_slot) = blob_info.oldest_blob_slot else {
-            return Ok(result);
-        };
-
-        for res in self
-            .hot_db
-            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
-        {
-            let block_root = res?;
-
-            let Some(block) = self.get_blinded_block(&block_root)? else {
-                continue;
-            };
-
-            let slot = block.slot();
-
-            if slot < deneb_fork_slot || slot < oldest_blob_slot {
-                continue;
-            }
-            if let Some(fulu_slot) = fulu_fork_slot
-                && slot >= fulu_slot
-            {
-                continue;
-            }
-
-            result.inc_checks();
-
-            let has_blob_entry = self
-                .blobs_db
-                .key_exists(DBColumn::BeaconBlob, block_root.as_slice())?;
-
-            if !has_blob_entry {
-                result.add_violation(InvariantViolation::BlobSidecarMissing { block_root, slot });
             }
         }
 

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -56,6 +56,21 @@ impl Default for InvariantCheckResult {
     }
 }
 
+/// Context data from the beacon chain needed for invariant checks.
+///
+/// This allows all invariant checks to live in the store crate while still checking
+/// invariants that depend on fork choice, state cache, and custody context.
+pub struct InvariantContext {
+    /// Block roots tracked by fork choice (invariant 1).
+    pub fork_choice_blocks: Vec<(Hash256, Slot)>,
+    /// State roots held in the in-memory state cache (invariant 8).
+    pub state_cache_roots: Vec<Hash256>,
+    /// Custody columns for the current epoch (invariant 7).
+    pub custody_columns: Vec<ColumnIndex>,
+    /// Number of pubkeys in the in-memory validator pubkey cache (invariant 9).
+    pub pubkey_cache_count: usize,
+}
+
 /// A single invariant violation.
 #[derive(Debug, Clone, Serialize)]
 pub enum InvariantViolation {
@@ -124,30 +139,50 @@ pub enum InvariantViolation {
 }
 
 impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> {
-    /// Run all store-level database invariant checks.
+    /// Run all database invariant checks.
     ///
-    /// Checks invariants 2-6, 8, 10-12.
-    ///
-    /// This function does NOT check invariants requiring beacon chain state:
-    /// - Invariant 1 (fork choice block consistency) — requires fork choice
-    /// - Invariant 7 (data column consistency) — requires custody context
-    /// - Invariant 9 (pubkey cache) — requires validator pubkey cache
-    ///
-    /// Use `BeaconChain::check_database_invariants` for a complete check.
-    pub fn check_invariants(
-        &self,
-        custody_columns: Option<&[ColumnIndex]>,
-    ) -> Result<InvariantCheckResult, Error> {
+    /// The `ctx` parameter provides data from the beacon chain layer (fork choice, state cache,
+    /// custody columns, pubkey cache) so that all invariant checks can live in this single file.
+    pub fn check_invariants(&self, ctx: &InvariantContext) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
         let split = self.get_split_info();
 
-        result.merge(self.check_hot_block_invariants(&split, custody_columns)?);
+        result.merge(self.check_fork_choice_block_consistency(ctx)?);
+        result.merge(self.check_hot_block_invariants(&split, ctx)?);
         result.merge(self.check_hot_state_summary_diff_consistency(&split)?);
         result.merge(self.check_hot_state_summary_chain_consistency(&split)?);
-        result.merge(self.check_state_cache_consistency()?);
+        result.merge(self.check_state_cache_consistency(ctx)?);
         result.merge(self.check_cold_block_root_indices(&split)?);
         result.merge(self.check_cold_state_root_indices(&split)?);
         result.merge(self.check_cold_state_diff_consistency(&split)?);
+        result.merge(self.check_pubkey_cache_consistency(ctx)?);
+
+        Ok(result)
+    }
+
+    /// Invariant 1 (Hot DB): Fork choice block consistency.
+    ///
+    /// ```text
+    /// block in fork_choice -> block in hot_db
+    /// ```
+    ///
+    /// Every block tracked by the fork choice proto-array must exist in the hot database.
+    fn check_fork_choice_block_consistency(
+        &self,
+        ctx: &InvariantContext,
+    ) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+
+        for &(block_root, slot) in &ctx.fork_choice_blocks {
+            result.inc_checks();
+            let exists = self
+                .hot_db
+                .key_exists(DBColumn::BeaconBlock, block_root.as_slice())?;
+            if !exists {
+                result
+                    .add_violation(InvariantViolation::ForkChoiceBlockMissing { block_root, slot });
+            }
+        }
 
         Ok(result)
     }
@@ -162,7 +197,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     fn check_hot_block_invariants(
         &self,
         split: &Split,
-        custody_columns: Option<&[ColumnIndex]>,
+        ctx: &InvariantContext,
     ) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
 
@@ -207,58 +242,54 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             }
 
             // Invariant 5: execution payload consistency.
-            if check_payloads {
-                if let Some(bellatrix_slot) = bellatrix_fork_slot {
-                    if slot >= bellatrix_slot {
-                        result.inc_checks();
-                        if !self.execution_payload_exists(&block_root)?
-                            && !self.payload_envelope_exists(&block_root)?
-                        {
-                            result.add_violation(InvariantViolation::ExecutionPayloadMissing {
-                                block_root,
-                                slot,
-                            });
-                        }
-                    }
+            if check_payloads
+                && let Some(bellatrix_slot) = bellatrix_fork_slot
+                && slot >= bellatrix_slot
+            {
+                result.inc_checks();
+                if !self.execution_payload_exists(&block_root)?
+                    && !self.payload_envelope_exists(&block_root)?
+                {
+                    result.add_violation(InvariantViolation::ExecutionPayloadMissing {
+                        block_root,
+                        slot,
+                    });
                 }
             }
 
             // Invariant 6: blob sidecar consistency.
-            if let Some(deneb_slot) = deneb_fork_slot {
-                if let Some(oldest_blob) = oldest_blob_slot {
-                    let is_pre_fulu = fulu_fork_slot.is_none_or(|fulu_slot| slot < fulu_slot);
-                    if slot >= deneb_slot && slot >= oldest_blob && is_pre_fulu {
-                        result.inc_checks();
-                        let has_blob = self
-                            .blobs_db
-                            .key_exists(DBColumn::BeaconBlob, block_root.as_slice())?;
-                        if !has_blob {
-                            result.add_violation(InvariantViolation::BlobSidecarMissing {
-                                block_root,
-                                slot,
-                            });
-                        }
-                    }
+            if let Some(deneb_slot) = deneb_fork_slot
+                && let Some(oldest_blob) = oldest_blob_slot
+                && slot >= deneb_slot
+                && slot >= oldest_blob
+                && fulu_fork_slot.is_none_or(|fulu_slot| slot < fulu_slot)
+            {
+                result.inc_checks();
+                let has_blob = self
+                    .blobs_db
+                    .key_exists(DBColumn::BeaconBlob, block_root.as_slice())?;
+                if !has_blob {
+                    result
+                        .add_violation(InvariantViolation::BlobSidecarMissing { block_root, slot });
                 }
             }
 
             // Invariant 7: data column consistency.
-            if let Some(custody_cols) = custody_columns {
-                if let Some(fulu_slot) = fulu_fork_slot {
-                    if let Some(oldest_dc) = oldest_data_column_slot {
-                        if slot >= fulu_slot && slot >= oldest_dc {
-                            result.inc_checks();
-                            let stored_columns = self.get_data_column_keys(block_root)?;
-                            for col_idx in custody_cols {
-                                if !stored_columns.contains(col_idx) {
-                                    result.add_violation(InvariantViolation::DataColumnMissing {
-                                        block_root,
-                                        slot,
-                                        column_index: *col_idx,
-                                    });
-                                }
-                            }
-                        }
+            if !ctx.custody_columns.is_empty()
+                && let Some(fulu_slot) = fulu_fork_slot
+                && let Some(oldest_dc) = oldest_data_column_slot
+                && slot >= fulu_slot
+                && slot >= oldest_dc
+            {
+                result.inc_checks();
+                let stored_columns = self.get_data_column_keys(block_root)?;
+                for col_idx in &ctx.custody_columns {
+                    if !stored_columns.contains(col_idx) {
+                        result.add_violation(InvariantViolation::DataColumnMissing {
+                            block_root,
+                            slot,
+                            column_index: *col_idx,
+                        });
                     }
                 }
             }
@@ -393,12 +424,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ///
     /// Every state held in the in-memory state cache (including the finalized state) should
     /// have a corresponding hot state summary on disk.
-    fn check_state_cache_consistency(&self) -> Result<InvariantCheckResult, Error> {
+    fn check_state_cache_consistency(
+        &self,
+        ctx: &InvariantContext,
+    ) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
 
-        let state_roots = self.state_cache.lock().state_roots();
-
-        for state_root in state_roots {
+        for &state_root in &ctx.state_cache_roots {
             result.inc_checks();
 
             let has_summary = self
@@ -622,6 +654,41 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     base_slot,
                 });
             }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 9 (Hot DB): Pubkey cache consistency.
+    ///
+    /// ```text
+    /// all validator pubkeys from states are in hot_db(PubkeyCache)
+    /// ```
+    ///
+    /// The number of pubkeys in the in-memory validator pubkey cache should match the number
+    /// stored on disk in the PubkeyCache column.
+    fn check_pubkey_cache_consistency(
+        &self,
+        ctx: &InvariantContext,
+    ) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+
+        result.inc_checks();
+
+        let mut on_disk_count = 0usize;
+        for res in self
+            .hot_db
+            .iter_column_keys::<Vec<u8>>(DBColumn::PubkeyCache)
+        {
+            let _ = res?;
+            on_disk_count += 1;
+        }
+
+        if ctx.pubkey_cache_count != on_disk_count {
+            result.add_violation(InvariantViolation::PubkeyCacheCountMismatch {
+                in_memory: ctx.pubkey_cache_count,
+                on_disk: on_disk_count,
+            });
         }
 
         Ok(result)

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -58,8 +58,6 @@ impl Default for InvariantCheckResult {
 /// A single invariant violation.
 #[derive(Debug, Clone, Serialize)]
 pub enum InvariantViolation {
-    /// Block root exists in BeaconBlock column but block failed to load.
-    BlockFailedToLoad { block_root: Hash256 },
     /// Hot block has no corresponding hot state summary.
     HotBlockMissingStateSummary {
         block_root: Hash256,
@@ -177,7 +175,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             result.inc_checks();
 
             let Some(block) = self.get_blinded_block(&block_root)? else {
-                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
                 continue;
             };
 
@@ -225,15 +222,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             let summary = HotStateSummary::from_ssz_bytes(&value)?;
             result.inc_checks();
 
-            let strategy = match self.hierarchy.storage_strategy(summary.slot, anchor_slot) {
-                Ok(s) => s,
-                Err(crate::hdiff::Error::LessThanStart(_, _)) => {
-                    // States with slot < anchor_slot are expected during checkpoint sync before
-                    // backfill completes. Skip these rather than treating them as violations.
-                    continue;
-                }
-                Err(e) => return Err(e.into()),
-            };
+            let strategy = self.hierarchy.storage_strategy(summary.slot, anchor_slot)?;
 
             match strategy {
                 StorageStrategy::Snapshot => {
@@ -336,7 +325,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             let block_root = res?;
 
             let Some(block) = self.get_blinded_block(&block_root)? else {
-                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
                 continue;
             };
 
@@ -397,7 +385,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             let block_root = res?;
 
             let Some(block) = self.get_blinded_block(&block_root)? else {
-                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
                 continue;
             };
 
@@ -469,13 +456,12 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         let mut result = InvariantCheckResult::new();
 
         let anchor_info = self.get_anchor_info();
-        let start_slot = anchor_info.oldest_block_slot;
 
-        if start_slot >= split.slot {
+        if anchor_info.oldest_block_slot >= split.slot {
             return Ok(result);
         }
 
-        for slot_val in start_slot.as_u64()..split.slot.as_u64() {
+        for slot_val in anchor_info.oldest_block_slot.as_u64()..split.slot.as_u64() {
             let slot = Slot::new(slot_val);
             result.inc_checks();
 
@@ -507,7 +493,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 None => {
                     result.add_violation(InvariantViolation::ColdBlockRootMissing {
                         slot,
-                        oldest_block_slot: start_slot,
+                        oldest_block_slot: anchor_info.oldest_block_slot,
                         split_slot: split.slot,
                     });
                 }
@@ -539,13 +525,12 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         //
         // Expected slots are: (i <= state_lower_limit || i >= effective_upper) && i < split.slot
         // where effective_upper = min(split.slot, state_upper_limit).
-        let state_lower = anchor_info.state_lower_limit;
-        let effective_upper = cmp::min(split.slot, anchor_info.state_upper_limit);
-
         for slot_val in 0..split.slot.as_u64() {
             let slot = Slot::new(slot_val);
 
-            if slot <= state_lower || slot >= effective_upper {
+            if slot <= anchor_info.state_lower_limit
+                || slot >= cmp::min(split.slot, anchor_info.state_upper_limit)
+            {
                 result.inc_checks();
                 let slot_bytes = slot_val.to_be_bytes();
                 let has_entry = self
@@ -554,7 +539,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 if !has_entry {
                     result.add_violation(InvariantViolation::ColdStateRootMissing {
                         slot,
-                        state_lower_limit: state_lower,
+                        state_lower_limit: anchor_info.state_lower_limit,
                         state_upper_limit: anchor_info.state_upper_limit,
                         split_slot: split.slot,
                     });

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -1,0 +1,535 @@
+//! Database invariant checks for the hot and cold databases.
+//!
+//! These checks verify the consistency of data stored in the database. They are designed to be
+//! called from the HTTP API and from tests to detect data corruption or bugs in the store logic.
+//!
+//! See: https://hackmd.io/@sproul/database-invariants
+
+use crate::hdiff::StorageStrategy;
+use crate::hot_cold_store::{ColdStateSummary, HotStateSummary};
+use crate::{DBColumn, Error, ItemStore};
+use crate::{HotColdDB, Split};
+use serde::Serialize;
+use ssz::Decode;
+use std::cmp;
+use std::fmt;
+use types::*;
+
+/// Result of running invariant checks on the database.
+#[derive(Debug, Clone, Serialize)]
+pub struct InvariantCheckResult {
+    /// List of invariant violations found.
+    pub violations: Vec<InvariantViolation>,
+    /// Total number of checks performed.
+    pub checks_performed: usize,
+}
+
+impl InvariantCheckResult {
+    pub fn new() -> Self {
+        Self {
+            violations: Vec::new(),
+            checks_performed: 0,
+        }
+    }
+
+    pub fn is_ok(&self) -> bool {
+        self.violations.is_empty()
+    }
+
+    pub fn add_violation(&mut self, violation: InvariantViolation) {
+        self.violations.push(violation);
+    }
+
+    pub fn inc_checks(&mut self) {
+        self.checks_performed += 1;
+    }
+
+    pub fn merge(&mut self, other: InvariantCheckResult) {
+        self.violations.extend(other.violations);
+        self.checks_performed += other.checks_performed;
+    }
+}
+
+impl Default for InvariantCheckResult {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A single invariant violation.
+#[derive(Debug, Clone, Serialize)]
+pub struct InvariantViolation {
+    pub invariant: String,
+    pub message: String,
+}
+
+impl fmt::Display for InvariantViolation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}]: {}", self.invariant, self.message)
+    }
+}
+
+impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> {
+    /// Run all store-level database invariant checks.
+    ///
+    /// Checks invariants 2-4 (hot DB) and 10-12 (cold DB) from the spec at
+    /// https://hackmd.io/@sproul/database-invariants.
+    ///
+    /// This function does NOT check fork-choice related invariants (1) or those requiring
+    /// beacon chain state (5-9), as those live outside the store. Use
+    /// `BeaconChain::check_database_invariants` for a complete check including all 12 invariants.
+    pub fn check_invariants(&self) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+        let split = self.get_split_info();
+
+        result.merge(self.check_hot_block_state_consistency(&split)?);
+        result.merge(self.check_hot_state_summary_diff_consistency(&split)?);
+        result.merge(self.check_hot_state_summary_chain_consistency(&split)?);
+        result.merge(self.check_cold_block_root_indices(&split)?);
+        result.merge(self.check_cold_state_root_indices(&split)?);
+        result.merge(self.check_cold_state_diff_consistency(&split)?);
+
+        Ok(result)
+    }
+
+    /// Invariant 2 (Hot DB): Block-state consistency.
+    ///
+    /// ```text
+    /// block in hot_db && block.slot >= split.slot
+    ///   -> state_summary for block.state_root() in hot_db
+    /// ```
+    ///
+    /// Every block in the hot DB at or above the split should have a corresponding hot state
+    /// summary. Blocks below the split are in the cold range and are not checked here.
+    fn check_hot_block_state_consistency(
+        &self,
+        split: &Split,
+    ) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "hot_block_state_consistency";
+
+        for res in self
+            .hot_db
+            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
+        {
+            let block_root = res?;
+            result.inc_checks();
+
+            // Load the block to check its slot.
+            let Some(block) = self.get_blinded_block(&block_root)? else {
+                result.add_violation(InvariantViolation {
+                    invariant: invariant_name.to_string(),
+                    message: format!(
+                        "block root {block_root:?} exists in BeaconBlock column but failed to load"
+                    ),
+                });
+                continue;
+            };
+
+            if block.slot() >= split.slot {
+                // This block is in the hot range, check for a state summary.
+                let state_root = block.state_root();
+                let has_summary = self
+                    .hot_db
+                    .key_exists(DBColumn::BeaconStateHotSummary, state_root.as_slice())?;
+                if !has_summary {
+                    result.add_violation(InvariantViolation {
+                        invariant: invariant_name.to_string(),
+                        message: format!(
+                            "hot block {block_root:?} at slot {} has state root {state_root:?} \
+                             but no hot state summary exists",
+                            block.slot()
+                        ),
+                    });
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 3 (Hot DB): State summary diff/snapshot consistency.
+    ///
+    /// ```text
+    /// state_summary in hot_db
+    ///   -> state diff/snapshot/nothing in hot_db per HDiff hierarchy rules
+    /// ```
+    ///
+    /// Each hot state summary should have the correct storage artifact (snapshot, diff, or
+    /// nothing) according to the HDiff hierarchy configuration. The hierarchy uses the
+    /// anchor_slot as its start point for the hot DB.
+    fn check_hot_state_summary_diff_consistency(
+        &self,
+        _split: &Split,
+    ) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "hot_state_summary_diff_consistency";
+
+        let anchor_slot = self.get_anchor_info().anchor_slot;
+
+        for res in self
+            .hot_db
+            .iter_column::<Hash256>(DBColumn::BeaconStateHotSummary)
+        {
+            let (state_root, value) = res?;
+            let summary = HotStateSummary::from_ssz_bytes(&value)?;
+            result.inc_checks();
+
+            let strategy = match self.hierarchy.storage_strategy(summary.slot, anchor_slot) {
+                Ok(s) => s,
+                Err(crate::hdiff::Error::LessThanStart(_, _)) => {
+                    // States with slot < anchor_slot are expected during checkpoint sync before
+                    // backfill completes. Skip these rather than treating them as violations.
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+            match strategy {
+                StorageStrategy::Snapshot => {
+                    let has_snapshot = self
+                        .hot_db
+                        .key_exists(DBColumn::BeaconStateHotSnapshot, state_root.as_slice())?;
+                    if !has_snapshot {
+                        result.add_violation(InvariantViolation {
+                            invariant: invariant_name.to_string(),
+                            message: format!(
+                                "state {state_root:?} at slot {} should have a snapshot \
+                                 but none found",
+                                summary.slot
+                            ),
+                        });
+                    }
+                }
+                StorageStrategy::DiffFrom(_base_slot) => {
+                    let has_diff = self
+                        .hot_db
+                        .key_exists(DBColumn::BeaconStateHotDiff, state_root.as_slice())?;
+                    if !has_diff {
+                        result.add_violation(InvariantViolation {
+                            invariant: invariant_name.to_string(),
+                            message: format!(
+                                "state {state_root:?} at slot {} should have a diff \
+                                 but none found",
+                                summary.slot
+                            ),
+                        });
+                    }
+                }
+                StorageStrategy::ReplayFrom(_) => {
+                    // ReplayFrom means no diff or snapshot is stored; just the summary.
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 4 (Hot DB): State summary chain consistency.
+    ///
+    /// ```text
+    /// state_summary in hot_db && state_summary.slot > split.slot
+    ///   -> state_summary for previous_state_root in hot_db
+    /// ```
+    ///
+    /// The chain of `previous_state_root` links must be continuous back to the split state.
+    /// The split state itself is the boundary and does not need a predecessor in the hot DB.
+    fn check_hot_state_summary_chain_consistency(
+        &self,
+        split: &Split,
+    ) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "hot_state_summary_chain_consistency";
+
+        for res in self
+            .hot_db
+            .iter_column::<Hash256>(DBColumn::BeaconStateHotSummary)
+        {
+            let (_state_root, value) = res?;
+            let summary = HotStateSummary::from_ssz_bytes(&value)?;
+            result.inc_checks();
+
+            if summary.slot > split.slot {
+                let prev_root = summary.previous_state_root;
+                let has_prev = self
+                    .hot_db
+                    .key_exists(DBColumn::BeaconStateHotSummary, prev_root.as_slice())?;
+                if !has_prev {
+                    result.add_violation(InvariantViolation {
+                        invariant: invariant_name.to_string(),
+                        message: format!(
+                            "state summary at slot {} references previous_state_root \
+                             {prev_root:?} which has no hot state summary",
+                            summary.slot
+                        ),
+                    });
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 10 (Cold DB): Block root indices.
+    ///
+    /// ```text
+    /// oldest_block_slot <= i < split.slot
+    ///   -> block_root for slot i in cold_db
+    ///   && block for block_root in hot_db
+    /// ```
+    ///
+    /// Every slot in the cold range (from `oldest_block_slot` to `split.slot`) should have a
+    /// block root index entry, and the referenced block should exist in the hot DB. Note that
+    /// skip slots store the most recent non-skipped block's root, so `block.slot()` may differ
+    /// from the index slot.
+    fn check_cold_block_root_indices(&self, split: &Split) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "cold_block_root_indices";
+
+        let anchor_info = self.get_anchor_info();
+        let start_slot = anchor_info.oldest_block_slot;
+
+        if start_slot >= split.slot {
+            return Ok(result);
+        }
+
+        for slot_val in start_slot.as_u64()..split.slot.as_u64() {
+            let slot = Slot::new(slot_val);
+            result.inc_checks();
+
+            let slot_bytes = slot_val.to_be_bytes();
+            let block_root_bytes = self
+                .cold_db
+                .get_bytes(DBColumn::BeaconBlockRoots, &slot_bytes)?;
+
+            match block_root_bytes {
+                Some(root_bytes) => {
+                    if root_bytes.len() == 32 {
+                        let block_root = Hash256::from_slice(&root_bytes);
+                        let block_exists = self
+                            .hot_db
+                            .key_exists(DBColumn::BeaconBlock, block_root.as_slice())?;
+                        if !block_exists {
+                            result.add_violation(InvariantViolation {
+                                invariant: invariant_name.to_string(),
+                                message: format!(
+                                    "cold block root index at slot {slot} references block root \
+                                     {block_root:?} which does not exist in hot DB"
+                                ),
+                            });
+                        }
+                    } else {
+                        result.add_violation(InvariantViolation {
+                            invariant: invariant_name.to_string(),
+                            message: format!(
+                                "cold block root index at slot {slot} has invalid length {}",
+                                root_bytes.len()
+                            ),
+                        });
+                    }
+                }
+                None => {
+                    result.add_violation(InvariantViolation {
+                        invariant: invariant_name.to_string(),
+                        message: format!(
+                            "missing cold block root index at slot {slot} \
+                             (oldest_block_slot={start_slot}, split.slot={})",
+                            split.slot
+                        ),
+                    });
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 11 (Cold DB): State root indices.
+    ///
+    /// ```text
+    /// (i <= state_lower_limit || i >= min(split.slot, state_upper_limit)) && i < split.slot
+    ///   -> i |-> state_root in cold_db(BeaconStateRoots)
+    ///   && state_root |-> cold_state_summary in cold_db(BeaconColdStateSummary)
+    ///   && cold_state_summary.slot == i
+    /// ```
+    ///
+    /// Checks both directions:
+    /// - **Forward**: every slot in the expected range has a state root entry.
+    /// - **Reverse**: every existing state root entry has a valid cold state summary with
+    ///   matching slot.
+    fn check_cold_state_root_indices(&self, split: &Split) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "cold_state_root_indices";
+
+        let anchor_info = self.get_anchor_info();
+
+        // Forward check: verify that every expected slot has a state root entry.
+        //
+        // Expected slots are: (i <= state_lower_limit || i >= effective_upper) && i < split.slot
+        // where effective_upper = min(split.slot, state_upper_limit).
+        let state_lower = anchor_info.state_lower_limit;
+        let effective_upper = cmp::min(split.slot, anchor_info.state_upper_limit);
+
+        for slot_val in 0..split.slot.as_u64() {
+            let slot = Slot::new(slot_val);
+
+            if slot <= state_lower || slot >= effective_upper {
+                result.inc_checks();
+                let slot_bytes = slot_val.to_be_bytes();
+                let has_entry = self
+                    .cold_db
+                    .key_exists(DBColumn::BeaconStateRoots, &slot_bytes)?;
+                if !has_entry {
+                    result.add_violation(InvariantViolation {
+                        invariant: invariant_name.to_string(),
+                        message: format!(
+                            "missing cold state root index at slot {slot} \
+                             (state_lower_limit={state_lower}, state_upper_limit={}, \
+                             split.slot={})",
+                            anchor_info.state_upper_limit, split.slot
+                        ),
+                    });
+                }
+            }
+        }
+
+        // Reverse check: verify every existing state root entry has a valid summary.
+        for res in self
+            .cold_db
+            .iter_column::<Vec<u8>>(DBColumn::BeaconStateRoots)
+        {
+            let (slot_bytes, root_bytes) = res?;
+            result.inc_checks();
+
+            if slot_bytes.len() != 8 {
+                result.add_violation(InvariantViolation {
+                    invariant: invariant_name.to_string(),
+                    message: format!(
+                        "state root index has invalid key length {}",
+                        slot_bytes.len()
+                    ),
+                });
+                continue;
+            }
+
+            let slot_val = u64::from_be_bytes(slot_bytes.try_into().map_err(|_| {
+                Error::InvalidKey("cold state root index key conversion failed".to_string())
+            })?);
+            let slot = Slot::new(slot_val);
+
+            if root_bytes.len() != 32 {
+                result.add_violation(InvariantViolation {
+                    invariant: invariant_name.to_string(),
+                    message: format!(
+                        "state root index at slot {slot} has invalid root length {}",
+                        root_bytes.len()
+                    ),
+                });
+                continue;
+            }
+
+            let state_root = Hash256::from_slice(&root_bytes);
+
+            match self
+                .cold_db
+                .get_bytes(DBColumn::BeaconColdStateSummary, state_root.as_slice())?
+            {
+                None => {
+                    result.add_violation(InvariantViolation {
+                        invariant: invariant_name.to_string(),
+                        message: format!(
+                            "state root index at slot {slot} has state root {state_root:?} \
+                             but no cold state summary exists"
+                        ),
+                    });
+                }
+                Some(summary_bytes) => {
+                    let summary = ColdStateSummary::from_ssz_bytes(&summary_bytes)?;
+                    if summary.slot != slot {
+                        result.add_violation(InvariantViolation {
+                            invariant: invariant_name.to_string(),
+                            message: format!(
+                                "cold state summary for {state_root:?} has slot {} \
+                                 but state root index has slot {slot}",
+                                summary.slot
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 12 (Cold DB): Cold state diff/snapshot consistency.
+    ///
+    /// ```text
+    /// cold_state_summary in cold_db
+    ///   -> state diff/snapshot/nothing in cold_db per HDiff hierarchy rules
+    /// ```
+    ///
+    /// Each cold state summary should have the correct storage artifact according to the
+    /// HDiff hierarchy. Cold states always use genesis (slot 0) as the hierarchy start since
+    /// they are finalized and have no anchor_slot dependency.
+    fn check_cold_state_diff_consistency(
+        &self,
+        _split: &Split,
+    ) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+        let invariant_name = "cold_state_diff_consistency";
+
+        for res in self
+            .cold_db
+            .iter_column::<Hash256>(DBColumn::BeaconColdStateSummary)
+        {
+            let (state_root, value) = res?;
+            let summary = ColdStateSummary::from_ssz_bytes(&value)?;
+            result.inc_checks();
+
+            let strategy = self
+                .hierarchy
+                .storage_strategy(summary.slot, Slot::new(0))?;
+
+            let slot_bytes = summary.slot.as_u64().to_be_bytes();
+
+            match strategy {
+                StorageStrategy::Snapshot => {
+                    let has_snapshot = self
+                        .cold_db
+                        .key_exists(DBColumn::BeaconStateSnapshot, &slot_bytes)?;
+                    if !has_snapshot {
+                        result.add_violation(InvariantViolation {
+                            invariant: invariant_name.to_string(),
+                            message: format!(
+                                "cold state {state_root:?} at slot {} should have a snapshot \
+                                 but none found",
+                                summary.slot
+                            ),
+                        });
+                    }
+                }
+                StorageStrategy::DiffFrom(_) => {
+                    let has_diff = self
+                        .cold_db
+                        .key_exists(DBColumn::BeaconStateDiff, &slot_bytes)?;
+                    if !has_diff {
+                        result.add_violation(InvariantViolation {
+                            invariant: invariant_name.to_string(),
+                            message: format!(
+                                "cold state {state_root:?} at slot {} should have a diff \
+                                 but none found",
+                                summary.slot
+                            ),
+                        });
+                    }
+                }
+                StorageStrategy::ReplayFrom(_) => {
+                    // No diff or snapshot needed.
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -74,68 +74,168 @@ pub struct InvariantContext {
 /// A single invariant violation.
 #[derive(Debug, Clone, Serialize)]
 pub enum InvariantViolation {
-    /// Hot block has no corresponding hot state summary.
+    /// Invariant 1: fork choice block consistency.
+    ///
+    /// ```text
+    /// block in fork_choice -> block in hot_db
+    /// ```
+    ForkChoiceBlockMissing { block_root: Hash256, slot: Slot },
+    /// Invariant 2: block and state consistency.
+    ///
+    /// ```text
+    /// block in hot_db && block.slot >= split.slot
+    ///   -> state_summary for block.state_root() in hot_db
+    /// ```
     HotBlockMissingStateSummary {
         block_root: Hash256,
         slot: Slot,
         state_root: Hash256,
     },
-    /// Hot state summary should have a snapshot but none found.
+    /// Invariant 3: state summary diff consistency.
+    ///
+    /// ```text
+    /// state_summary in hot_db
+    ///   -> state diff/snapshot/nothing in hot_db according to hierarchy rules
+    /// ```
     HotStateMissingSnapshot { state_root: Hash256, slot: Slot },
-    /// Hot state summary should have a diff but none found.
+    /// Invariant 3: state summary diff consistency (missing diff).
+    ///
+    /// ```text
+    /// state_summary in hot_db
+    ///   -> state diff/snapshot/nothing in hot_db according to hierarchy rules
+    /// ```
     HotStateMissingDiff { state_root: Hash256, slot: Slot },
-    /// Hot state summary's DiffFrom/ReplayFrom base slot has no summary.
+    /// Invariant 3: DiffFrom/ReplayFrom base slot must reference an existing summary.
+    ///
+    /// ```text
+    /// state_summary in hot_db
+    ///   -> state diff/snapshot/nothing in hot_db according to hierarchy rules
+    /// ```
     HotStateBaseSummaryMissing { slot: Slot, base_slot: Slot },
-    /// Hot state summary's previous_state_root has no summary.
+    /// Invariant 4: state summary chain consistency.
+    ///
+    /// ```text
+    /// state_summary in hot_db && state_summary.slot > split.slot
+    ///   -> state_summary for previous_state_root in hot_db
+    /// ```
     HotStateMissingPreviousSummary {
         slot: Slot,
         previous_state_root: Hash256,
     },
-    /// Block has no execution payload or envelope (prune_payloads=false).
+    /// Invariant 5: block and execution payload consistency.
+    ///
+    /// ```text
+    /// block in hot_db && !prune_payloads -> payload for block.root in hot_db
+    /// ```
     ExecutionPayloadMissing { block_root: Hash256, slot: Slot },
-    /// Block has no blob sidecar entry.
+    /// Invariant 6: block and blobs consistency.
+    ///
+    /// ```text
+    /// block in hot_db -> blob_list for block.root in hot_db
+    /// ```
     BlobSidecarMissing { block_root: Hash256, slot: Slot },
-    /// State in cache has no hot state summary on disk.
+    /// Invariant 7: block and data columns consistency.
+    ///
+    /// ```text
+    /// block in hot_db && block.slot >= earliest_available_slot
+    ///   && data_column_idx in custody_columns
+    ///   -> (block_root, data_column_idx) in hot_db
+    /// ```
+    DataColumnMissing {
+        block_root: Hash256,
+        slot: Slot,
+        column_index: ColumnIndex,
+    },
+    /// Invariant 8: state cache and disk consistency.
+    ///
+    /// ```text
+    /// state in state_cache -> state_summary in hot_db
+    /// ```
     StateCacheMissingSummary { state_root: Hash256 },
-    /// Cold block root index missing for a slot.
+    /// Invariant 9: pubkey cache consistency.
+    ///
+    /// ```text
+    /// state_summary in hot_db
+    ///   -> all validator pubkeys from state.validators are in the hot_db
+    /// ```
+    PubkeyCacheCountMismatch { in_memory: usize, on_disk: usize },
+    /// Invariant 10: block root indices mapping.
+    ///
+    /// ```text
+    /// oldest_block_slot <= i < split.slot
+    ///   -> block_root for slot i in cold_db
+    ///   && block for block_root in hot_db
+    /// ```
     ColdBlockRootMissing {
         slot: Slot,
         oldest_block_slot: Slot,
         split_slot: Slot,
     },
-    /// Cold block root index references a block not in hot DB.
+    /// Invariant 10: block root index references a block that must exist.
+    ///
+    /// ```text
+    /// oldest_block_slot <= i < split.slot
+    ///   -> block_root for slot i in cold_db
+    ///   && block for block_root in hot_db
+    /// ```
     ColdBlockRootOrphan { slot: Slot, block_root: Hash256 },
-    /// Cold state root index missing for a slot.
+    /// Invariant 11: state root indices mapping.
+    ///
+    /// ```text
+    /// (i <= state_lower_limit || i >= min(split.slot, state_upper_limit)) && i < split.slot
+    ///   -> i |-> state_root in cold_db(BeaconStateRoots)
+    ///   && state_root |-> cold_state_summary in cold_db(BeaconColdStateSummary)
+    ///   && cold_state_summary.slot == i
+    /// ```
     ColdStateRootMissing {
         slot: Slot,
         state_lower_limit: Slot,
         state_upper_limit: Slot,
         split_slot: Slot,
     },
-    /// Cold state root index references a state with no cold summary.
+    /// Invariant 11: state root index must have a cold state summary.
+    ///
+    /// ```text
+    /// (i <= state_lower_limit || i >= min(split.slot, state_upper_limit)) && i < split.slot
+    ///   -> i |-> state_root in cold_db(BeaconStateRoots)
+    ///   && state_root |-> cold_state_summary in cold_db(BeaconColdStateSummary)
+    ///   && cold_state_summary.slot == i
+    /// ```
     ColdStateRootMissingSummary { slot: Slot, state_root: Hash256 },
-    /// Cold state summary slot doesn't match the state root index slot.
+    /// Invariant 11: cold state summary slot must match index slot.
+    ///
+    /// ```text
+    /// (i <= state_lower_limit || i >= min(split.slot, state_upper_limit)) && i < split.slot
+    ///   -> i |-> state_root in cold_db(BeaconStateRoots)
+    ///   && state_root |-> cold_state_summary in cold_db(BeaconColdStateSummary)
+    ///   && cold_state_summary.slot == i
+    /// ```
     ColdStateRootSlotMismatch {
         slot: Slot,
         state_root: Hash256,
         summary_slot: Slot,
     },
-    /// Cold state summary should have a snapshot but none found.
+    /// Invariant 12: cold state diff consistency.
+    ///
+    /// ```text
+    /// cold_state_summary in cold_db
+    ///   -> slot |-> state diff/snapshot/nothing in cold_db according to diff hierarchy
+    /// ```
     ColdStateMissingSnapshot { state_root: Hash256, slot: Slot },
-    /// Cold state summary should have a diff but none found.
+    /// Invariant 12: cold state diff consistency (missing diff).
+    ///
+    /// ```text
+    /// cold_state_summary in cold_db
+    ///   -> slot |-> state diff/snapshot/nothing in cold_db according to diff hierarchy
+    /// ```
     ColdStateMissingDiff { state_root: Hash256, slot: Slot },
-    /// Cold state summary's DiffFrom/ReplayFrom base slot has no summary.
+    /// Invariant 12: DiffFrom/ReplayFrom base slot must reference an existing summary.
+    ///
+    /// ```text
+    /// cold_state_summary in cold_db
+    ///   -> slot |-> state diff/snapshot/nothing in cold_db according to diff hierarchy
+    /// ```
     ColdStateBaseSummaryMissing { slot: Slot, base_slot: Slot },
-    /// Fork choice references a block not in hot DB.
-    ForkChoiceBlockMissing { block_root: Hash256, slot: Slot },
-    /// Block missing a custody data column.
-    DataColumnMissing {
-        block_root: Hash256,
-        slot: Slot,
-        column_index: ColumnIndex,
-    },
-    /// Pubkey cache count mismatch between memory and disk.
-    PubkeyCacheCountMismatch { in_memory: usize, on_disk: usize },
 }
 
 impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> {

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -3,7 +3,7 @@
 //! These checks verify the consistency of data stored in the database. They are designed to be
 //! called from the HTTP API and from tests to detect data corruption or bugs in the store logic.
 //!
-//! See: https://hackmd.io/@sproul/database-invariants
+//! See the `check_invariants` and `check_database_invariants` methods for the full list.
 
 use crate::hdiff::StorageStrategy;
 use crate::hot_cold_store::{ColdStateSummary, HotStateSummary};
@@ -72,8 +72,7 @@ impl fmt::Display for InvariantViolation {
 impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> {
     /// Run all store-level database invariant checks.
     ///
-    /// Checks invariants 2-4 (hot DB) and 10-12 (cold DB) from the spec at
-    /// https://hackmd.io/@sproul/database-invariants.
+    /// Checks invariants 2-4 (hot DB) and 10-12 (cold DB).
     ///
     /// This function does NOT check fork-choice related invariants (1) or those requiring
     /// beacon chain state (5-9), as those live outside the store. Use

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -12,7 +12,6 @@ use crate::{HotColdDB, Split};
 use serde::Serialize;
 use ssz::Decode;
 use std::cmp;
-use std::fmt;
 use types::*;
 
 /// Result of running invariant checks on the database.
@@ -76,6 +75,12 @@ pub enum InvariantViolation {
         slot: Slot,
         previous_state_root: Hash256,
     },
+    /// Block has no execution payload or envelope (prune_payloads=false).
+    ExecutionPayloadMissing { block_root: Hash256, slot: Slot },
+    /// Block has no blob sidecar entry.
+    BlobSidecarMissing { block_root: Hash256, slot: Slot },
+    /// State in cache has no hot state summary on disk.
+    StateCacheMissingSummary { state_root: Hash256 },
     /// Cold block root index missing for a slot.
     ColdBlockRootMissing {
         slot: Slot,
@@ -111,195 +116,27 @@ pub enum InvariantViolation {
     ColdStateMissingDiff { state_root: Hash256, slot: Slot },
     /// Fork choice references a block not in hot DB.
     ForkChoiceBlockMissing { block_root: Hash256, slot: Slot },
-    /// Block has no execution payload or envelope (prune_payloads=false).
-    ExecutionPayloadMissing { block_root: Hash256, slot: Slot },
-    /// Block has no blob sidecar entry.
-    BlobSidecarMissing { block_root: Hash256, slot: Slot },
     /// Block missing a custody data column.
     DataColumnMissing {
         block_root: Hash256,
         slot: Slot,
         column_index: ColumnIndex,
     },
-    /// State in cache has no hot state summary on disk.
-    StateCacheMissingSummary { state_root: Hash256 },
     /// Pubkey cache count mismatch between memory and disk.
     PubkeyCacheCountMismatch { in_memory: usize, on_disk: usize },
-}
-
-impl fmt::Display for InvariantViolation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::BlockFailedToLoad { block_root } => {
-                write!(
-                    f,
-                    "block root {block_root:?} exists in BeaconBlock column but failed to load"
-                )
-            }
-            Self::HotBlockMissingStateSummary {
-                block_root,
-                slot,
-                state_root,
-            } => {
-                write!(
-                    f,
-                    "hot block {block_root:?} at slot {slot} has state root {state_root:?} \
-                     but no hot state summary exists"
-                )
-            }
-            Self::HotStateMissingSnapshot { state_root, slot } => {
-                write!(
-                    f,
-                    "state {state_root:?} at slot {slot} should have a snapshot but none found"
-                )
-            }
-            Self::HotStateMissingDiff { state_root, slot } => {
-                write!(
-                    f,
-                    "state {state_root:?} at slot {slot} should have a diff but none found"
-                )
-            }
-            Self::HotStateMissingPreviousSummary {
-                slot,
-                previous_state_root,
-            } => {
-                write!(
-                    f,
-                    "state summary at slot {slot} references previous_state_root \
-                     {previous_state_root:?} which has no hot state summary"
-                )
-            }
-            Self::ColdBlockRootMissing {
-                slot,
-                oldest_block_slot,
-                split_slot,
-            } => {
-                write!(
-                    f,
-                    "missing cold block root index at slot {slot} \
-                     (oldest_block_slot={oldest_block_slot}, split.slot={split_slot})"
-                )
-            }
-            Self::ColdBlockRootInvalidLength { slot, length } => {
-                write!(
-                    f,
-                    "cold block root index at slot {slot} has invalid length {length}"
-                )
-            }
-            Self::ColdBlockRootOrphan { slot, block_root } => {
-                write!(
-                    f,
-                    "cold block root index at slot {slot} references block root \
-                     {block_root:?} which does not exist in hot DB"
-                )
-            }
-            Self::ColdStateRootMissing {
-                slot,
-                state_lower_limit,
-                state_upper_limit,
-                split_slot,
-            } => {
-                write!(
-                    f,
-                    "missing cold state root index at slot {slot} \
-                     (state_lower_limit={state_lower_limit}, \
-                     state_upper_limit={state_upper_limit}, split.slot={split_slot})"
-                )
-            }
-            Self::ColdStateRootInvalidKeyLength { length } => {
-                write!(f, "state root index has invalid key length {length}")
-            }
-            Self::ColdStateRootInvalidRootLength { slot, length } => {
-                write!(
-                    f,
-                    "state root index at slot {slot} has invalid root length {length}"
-                )
-            }
-            Self::ColdStateRootMissingSummary { slot, state_root } => {
-                write!(
-                    f,
-                    "state root index at slot {slot} has state root {state_root:?} \
-                     but no cold state summary exists"
-                )
-            }
-            Self::ColdStateRootSlotMismatch {
-                slot,
-                state_root,
-                summary_slot,
-            } => {
-                write!(
-                    f,
-                    "cold state summary for {state_root:?} has slot {summary_slot} \
-                     but state root index has slot {slot}"
-                )
-            }
-            Self::ColdStateMissingSnapshot { state_root, slot } => {
-                write!(
-                    f,
-                    "cold state {state_root:?} at slot {slot} should have a snapshot \
-                     but none found"
-                )
-            }
-            Self::ColdStateMissingDiff { state_root, slot } => {
-                write!(
-                    f,
-                    "cold state {state_root:?} at slot {slot} should have a diff but none found"
-                )
-            }
-            Self::ForkChoiceBlockMissing { block_root, slot } => {
-                write!(
-                    f,
-                    "block {block_root:?} at slot {slot} exists in fork choice but not in hot DB"
-                )
-            }
-            Self::ExecutionPayloadMissing { block_root, slot } => {
-                write!(
-                    f,
-                    "block {block_root:?} at slot {slot} has no execution payload \
-                     or payload envelope (prune_payloads=false)"
-                )
-            }
-            Self::BlobSidecarMissing { block_root, slot } => {
-                write!(
-                    f,
-                    "block {block_root:?} at slot {slot} has no blob sidecar entry"
-                )
-            }
-            Self::DataColumnMissing {
-                block_root,
-                slot,
-                column_index,
-            } => {
-                write!(
-                    f,
-                    "block {block_root:?} at slot {slot} missing custody data column \
-                     {column_index}"
-                )
-            }
-            Self::StateCacheMissingSummary { state_root } => {
-                write!(
-                    f,
-                    "state {state_root:?} is in state cache but has no hot state summary"
-                )
-            }
-            Self::PubkeyCacheCountMismatch { in_memory, on_disk } => {
-                write!(
-                    f,
-                    "pubkey cache has {in_memory} keys in memory but {on_disk} on disk"
-                )
-            }
-        }
-    }
 }
 
 impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> {
     /// Run all store-level database invariant checks.
     ///
-    /// Checks invariants 2-4 (hot DB) and 10-12 (cold DB).
+    /// Checks invariants 2-6, 8, 10-12.
     ///
-    /// This function does NOT check fork-choice related invariants (1) or those requiring
-    /// beacon chain state (5-9), as those live outside the store. Use
-    /// `BeaconChain::check_database_invariants` for a complete check including all 12 invariants.
+    /// This function does NOT check invariants requiring beacon chain state:
+    /// - Invariant 1 (fork choice block consistency) — requires fork choice
+    /// - Invariant 7 (data column consistency) — requires custody context
+    /// - Invariant 9 (pubkey cache) — requires validator pubkey cache
+    ///
+    /// Use `BeaconChain::check_database_invariants` for a complete check.
     pub fn check_invariants(&self) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
         let split = self.get_split_info();
@@ -307,6 +144,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         result.merge(self.check_hot_block_state_consistency(&split)?);
         result.merge(self.check_hot_state_summary_diff_consistency(&split)?);
         result.merge(self.check_hot_state_summary_chain_consistency(&split)?);
+        result.merge(self.check_execution_payload_consistency()?);
+        result.merge(self.check_blob_consistency()?);
+        result.merge(self.check_state_cache_consistency()?);
         result.merge(self.check_cold_block_root_indices(&split)?);
         result.merge(self.check_cold_state_root_indices(&split)?);
         result.merge(self.check_cold_state_diff_consistency(&split)?);
@@ -461,6 +301,152 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         previous_state_root: prev_root,
                     });
                 }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 5 (Hot DB): Execution payload consistency.
+    ///
+    /// ```text
+    /// block in hot_db && !prune_payloads
+    ///   -> execution payload or payload envelope for block.root in hot_db
+    /// ```
+    ///
+    /// When payload pruning is disabled, every post-Bellatrix block should have its execution
+    /// payload (pre-Gloas) or payload envelope (post-Gloas) stored. When `prune_payloads` is
+    /// true (the default), payloads are pruned at finalization and this check is skipped.
+    fn check_execution_payload_consistency(&self) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+
+        if self.get_config().prune_payloads {
+            return Ok(result);
+        }
+
+        let bellatrix_fork_slot = match self.spec.bellatrix_fork_epoch {
+            Some(epoch) => epoch.start_slot(E::slots_per_epoch()),
+            None => return Ok(result),
+        };
+
+        for res in self
+            .hot_db
+            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
+        {
+            let block_root = res?;
+
+            let Some(block) = self.get_blinded_block(&block_root)? else {
+                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
+                continue;
+            };
+
+            if block.slot() < bellatrix_fork_slot {
+                continue;
+            }
+
+            result.inc_checks();
+
+            let has_payload = self.execution_payload_exists(&block_root)?;
+            if !has_payload {
+                let has_envelope = self.payload_envelope_exists(&block_root)?;
+                if !has_envelope {
+                    result.add_violation(InvariantViolation::ExecutionPayloadMissing {
+                        block_root,
+                        slot: block.slot(),
+                    });
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 6 (Hot DB): Blob sidecar consistency (Deneb to Fulu).
+    ///
+    /// ```text
+    /// block in hot_db && block.slot >= deneb_fork_slot && block.slot < fulu_fork_slot
+    ///   && block.slot >= oldest_blob_slot
+    ///   -> blob sidecar list for block.root in blob_db
+    /// ```
+    ///
+    /// Every post-Deneb, pre-Fulu block within the blob availability window should have a blob
+    /// sidecar entry (which may be an empty list for blocks with no blobs). Post-Fulu blocks
+    /// use data columns instead of blobs and are checked by invariant 7.
+    fn check_blob_consistency(&self) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+
+        let deneb_fork_slot = match self.spec.deneb_fork_epoch {
+            Some(epoch) => epoch.start_slot(E::slots_per_epoch()),
+            None => return Ok(result),
+        };
+
+        let fulu_fork_slot = self
+            .spec
+            .fulu_fork_epoch
+            .map(|epoch| epoch.start_slot(E::slots_per_epoch()));
+
+        let blob_info = self.get_blob_info();
+        let Some(oldest_blob_slot) = blob_info.oldest_blob_slot else {
+            return Ok(result);
+        };
+
+        for res in self
+            .hot_db
+            .iter_column_keys::<Hash256>(DBColumn::BeaconBlock)
+        {
+            let block_root = res?;
+
+            let Some(block) = self.get_blinded_block(&block_root)? else {
+                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
+                continue;
+            };
+
+            let slot = block.slot();
+
+            if slot < deneb_fork_slot || slot < oldest_blob_slot {
+                continue;
+            }
+            if let Some(fulu_slot) = fulu_fork_slot
+                && slot >= fulu_slot
+            {
+                continue;
+            }
+
+            result.inc_checks();
+
+            let has_blob_entry = self
+                .blobs_db
+                .key_exists(DBColumn::BeaconBlob, block_root.as_slice())?;
+
+            if !has_blob_entry {
+                result.add_violation(InvariantViolation::BlobSidecarMissing { block_root, slot });
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Invariant 8 (Hot DB): State cache and disk consistency.
+    ///
+    /// ```text
+    /// state in state_cache -> state_summary in hot_db
+    /// ```
+    ///
+    /// Every state held in the in-memory state cache (including the finalized state) should
+    /// have a corresponding hot state summary on disk.
+    fn check_state_cache_consistency(&self) -> Result<InvariantCheckResult, Error> {
+        let mut result = InvariantCheckResult::new();
+
+        let state_roots = self.state_cache.lock().state_roots();
+
+        for state_root in state_roots {
+            result.inc_checks();
+
+            let has_summary = self
+                .hot_db
+                .key_exists(DBColumn::BeaconStateHotSummary, state_root.as_slice())?;
+            if !has_summary {
+                result.add_violation(InvariantViolation::StateCacheMissingSummary { state_root });
             }
         }
 

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -131,13 +131,15 @@ pub enum InvariantViolation {
     /// Invariant 6: block and blobs consistency.
     ///
     /// ```text
-    /// block in hot_db -> blob_list for block.root in hot_db
+    /// block in hot_db && num_blob_commitments > 0
+    ///   -> blob_list for block.root in hot_db
     /// ```
     BlobSidecarMissing { block_root: Hash256, slot: Slot },
     /// Invariant 7: block and data columns consistency.
     ///
     /// ```text
-    /// block in hot_db && block.slot >= earliest_available_slot
+    /// block in hot_db && num_blob_commitments > 0
+    ///   && block.slot >= earliest_available_slot
     ///   && data_column_idx in custody_columns
     ///   -> (block_root, data_column_idx) in hot_db
     /// ```
@@ -358,11 +360,14 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             }
 
             // Invariant 6: blob sidecar consistency.
+            // Only check blocks that actually have blob KZG commitments — blocks with 0
+            // commitments legitimately have no blob sidecars stored.
             if let Some(deneb_slot) = deneb_fork_slot
                 && let Some(oldest_blob) = oldest_blob_slot
                 && slot >= deneb_slot
                 && slot >= oldest_blob
                 && fulu_fork_slot.is_none_or(|fulu_slot| slot < fulu_slot)
+                && block.num_expected_blobs() > 0
             {
                 result.inc_checks();
                 let has_blob = self
@@ -375,11 +380,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             }
 
             // Invariant 7: data column consistency.
+            // Only check blocks that actually have blob KZG commitments.
             if !ctx.custody_columns.is_empty()
                 && let Some(fulu_slot) = fulu_fork_slot
                 && let Some(oldest_dc) = oldest_data_column_slot
                 && slot >= fulu_slot
                 && slot >= oldest_dc
+                && block.num_expected_blobs() > 0
             {
                 result.inc_checks();
                 let stored_columns = self.get_data_column_keys(block_root)?;

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -12,6 +12,7 @@ use crate::{HotColdDB, Split};
 use serde::Serialize;
 use ssz::Decode;
 use std::cmp;
+use std::collections::HashSet;
 use types::*;
 
 /// Result of running invariant checks on the database.
@@ -68,6 +69,8 @@ pub enum InvariantViolation {
     HotStateMissingSnapshot { state_root: Hash256, slot: Slot },
     /// Hot state summary should have a diff but none found.
     HotStateMissingDiff { state_root: Hash256, slot: Slot },
+    /// Hot state summary's DiffFrom/ReplayFrom base slot has no summary.
+    HotStateBaseSummaryMissing { slot: Slot, base_slot: Slot },
     /// Hot state summary's previous_state_root has no summary.
     HotStateMissingPreviousSummary {
         slot: Slot,
@@ -106,6 +109,8 @@ pub enum InvariantViolation {
     ColdStateMissingSnapshot { state_root: Hash256, slot: Slot },
     /// Cold state summary should have a diff but none found.
     ColdStateMissingDiff { state_root: Hash256, slot: Slot },
+    /// Cold state summary's DiffFrom/ReplayFrom base slot has no summary.
+    ColdStateBaseSummaryMissing { slot: Slot, base_slot: Slot },
     /// Fork choice references a block not in hot DB.
     ForkChoiceBlockMissing { block_root: Hash256, slot: Slot },
     /// Block missing a custody data column.
@@ -208,6 +213,10 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         let anchor_slot = self.get_anchor_info().anchor_slot;
 
+        // Collect all summary slots and their strategies in a first pass.
+        let mut summary_slots = HashSet::new();
+        let mut base_slot_refs = Vec::new();
+
         for res in self
             .hot_db
             .iter_column::<Hash256>(DBColumn::BeaconStateHotSummary)
@@ -215,6 +224,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             let (state_root, value) = res?;
             let summary = HotStateSummary::from_ssz_bytes(&value)?;
             result.inc_checks();
+
+            summary_slots.insert(summary.slot);
 
             let strategy = self.hierarchy.storage_strategy(summary.slot, anchor_slot)?;
 
@@ -230,7 +241,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         });
                     }
                 }
-                StorageStrategy::DiffFrom(_base_slot) => {
+                StorageStrategy::DiffFrom(base_slot) => {
                     let has_diff = self
                         .hot_db
                         .key_exists(DBColumn::BeaconStateHotDiff, state_root.as_slice())?;
@@ -240,10 +251,22 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                             slot: summary.slot,
                         });
                     }
+                    base_slot_refs.push((summary.slot, base_slot));
                 }
-                StorageStrategy::ReplayFrom(_) => {
-                    // ReplayFrom means no diff or snapshot is stored; just the summary.
+                StorageStrategy::ReplayFrom(base_slot) => {
+                    base_slot_refs.push((summary.slot, base_slot));
                 }
+            }
+        }
+
+        // Verify that all DiffFrom/ReplayFrom base slots reference existing summaries.
+        for (slot, base_slot) in base_slot_refs {
+            result.inc_checks();
+            if !summary_slots.contains(&base_slot) {
+                result.add_violation(InvariantViolation::HotStateBaseSummaryMissing {
+                    slot,
+                    base_slot,
+                });
             }
         }
 
@@ -586,6 +609,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
 
+        let mut summary_slots = HashSet::new();
+        let mut base_slot_refs = Vec::new();
+
         for res in self
             .cold_db
             .iter_column::<Hash256>(DBColumn::BeaconColdStateSummary)
@@ -593,6 +619,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             let (state_root, value) = res?;
             let summary = ColdStateSummary::from_ssz_bytes(&value)?;
             result.inc_checks();
+
+            summary_slots.insert(summary.slot);
 
             let strategy = self
                 .hierarchy
@@ -612,7 +640,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         });
                     }
                 }
-                StorageStrategy::DiffFrom(_) => {
+                StorageStrategy::DiffFrom(base_slot) => {
                     let has_diff = self
                         .cold_db
                         .key_exists(DBColumn::BeaconStateDiff, &slot_bytes)?;
@@ -622,10 +650,22 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                             slot: summary.slot,
                         });
                     }
+                    base_slot_refs.push((summary.slot, base_slot));
                 }
-                StorageStrategy::ReplayFrom(_) => {
-                    // No diff or snapshot needed.
+                StorageStrategy::ReplayFrom(base_slot) => {
+                    base_slot_refs.push((summary.slot, base_slot));
                 }
+            }
+        }
+
+        // Verify that all DiffFrom/ReplayFrom base slots reference existing summaries.
+        for (slot, base_slot) in base_slot_refs {
+            result.inc_checks();
+            if !summary_slots.contains(&base_slot) {
+                result.add_violation(InvariantViolation::ColdStateBaseSummaryMissing {
+                    slot,
+                    base_slot,
+                });
             }
         }
 

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -85,8 +85,6 @@ pub enum InvariantViolation {
         oldest_block_slot: Slot,
         split_slot: Slot,
     },
-    /// Cold block root index has invalid byte length.
-    ColdBlockRootInvalidLength { slot: Slot, length: usize },
     /// Cold block root index references a block not in hot DB.
     ColdBlockRootOrphan { slot: Slot, block_root: Hash256 },
     /// Cold state root index missing for a slot.
@@ -96,10 +94,6 @@ pub enum InvariantViolation {
         state_upper_limit: Slot,
         split_slot: Slot,
     },
-    /// Cold state root index has invalid key length.
-    ColdStateRootInvalidKeyLength { length: usize },
-    /// Cold state root index has invalid root length.
-    ColdStateRootInvalidRootLength { slot: Slot, length: usize },
     /// Cold state root index references a state with no cold summary.
     ColdStateRootMissingSummary { slot: Slot, state_root: Hash256 },
     /// Cold state summary slot doesn't match the state root index slot.
@@ -470,33 +464,28 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 .cold_db
                 .get_bytes(DBColumn::BeaconBlockRoots, &slot_bytes)?;
 
-            match block_root_bytes {
-                Some(root_bytes) => {
-                    if root_bytes.len() == 32 {
-                        let block_root = Hash256::from_slice(&root_bytes);
-                        let block_exists = self
-                            .hot_db
-                            .key_exists(DBColumn::BeaconBlock, block_root.as_slice())?;
-                        if !block_exists {
-                            result.add_violation(InvariantViolation::ColdBlockRootOrphan {
-                                slot,
-                                block_root,
-                            });
-                        }
-                    } else {
-                        result.add_violation(InvariantViolation::ColdBlockRootInvalidLength {
-                            slot,
-                            length: root_bytes.len(),
-                        });
-                    }
-                }
-                None => {
-                    result.add_violation(InvariantViolation::ColdBlockRootMissing {
-                        slot,
-                        oldest_block_slot: anchor_info.oldest_block_slot,
-                        split_slot: split.slot,
-                    });
-                }
+            let Some(root_bytes) = block_root_bytes else {
+                result.add_violation(InvariantViolation::ColdBlockRootMissing {
+                    slot,
+                    oldest_block_slot: anchor_info.oldest_block_slot,
+                    split_slot: split.slot,
+                });
+                continue;
+            };
+
+            if root_bytes.len() != 32 {
+                return Err(Error::InvalidKey(format!(
+                    "cold block root at slot {slot} has invalid length {}",
+                    root_bytes.len()
+                )));
+            }
+
+            let block_root = Hash256::from_slice(&root_bytes);
+            let block_exists = self
+                .hot_db
+                .key_exists(DBColumn::BeaconBlock, block_root.as_slice())?;
+            if !block_exists {
+                result.add_violation(InvariantViolation::ColdBlockRootOrphan { slot, block_root });
             }
         }
 
@@ -521,8 +510,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         let anchor_info = self.get_anchor_info();
 
-        // Forward check: verify that every expected slot has a state root entry.
-        //
         // Expected slots are: (i <= state_lower_limit || i >= effective_upper) && i < split.slot
         // where effective_upper = min(split.slot, state_upper_limit).
         for slot_val in 0..split.slot.as_u64() {
@@ -532,69 +519,49 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 || slot >= cmp::min(split.slot, anchor_info.state_upper_limit)
             {
                 result.inc_checks();
+
                 let slot_bytes = slot_val.to_be_bytes();
-                let has_entry = self
+                let Some(root_bytes) = self
                     .cold_db
-                    .key_exists(DBColumn::BeaconStateRoots, &slot_bytes)?;
-                if !has_entry {
+                    .get_bytes(DBColumn::BeaconStateRoots, &slot_bytes)?
+                else {
                     result.add_violation(InvariantViolation::ColdStateRootMissing {
                         slot,
                         state_lower_limit: anchor_info.state_lower_limit,
                         state_upper_limit: anchor_info.state_upper_limit,
                         split_slot: split.slot,
                     });
+                    continue;
+                };
+
+                if root_bytes.len() != 32 {
+                    return Err(Error::InvalidKey(format!(
+                        "cold state root at slot {slot} has invalid length {}",
+                        root_bytes.len()
+                    )));
                 }
-            }
-        }
 
-        // Reverse check: verify every existing state root entry has a valid summary.
-        for res in self
-            .cold_db
-            .iter_column::<Vec<u8>>(DBColumn::BeaconStateRoots)
-        {
-            let (slot_bytes, root_bytes) = res?;
-            result.inc_checks();
+                let state_root = Hash256::from_slice(&root_bytes);
 
-            if slot_bytes.len() != 8 {
-                result.add_violation(InvariantViolation::ColdStateRootInvalidKeyLength {
-                    length: slot_bytes.len(),
-                });
-                continue;
-            }
-
-            let slot_val = u64::from_be_bytes(slot_bytes.try_into().map_err(|_| {
-                Error::InvalidKey("cold state root index key conversion failed".to_string())
-            })?);
-            let slot = Slot::new(slot_val);
-
-            if root_bytes.len() != 32 {
-                result.add_violation(InvariantViolation::ColdStateRootInvalidRootLength {
-                    slot,
-                    length: root_bytes.len(),
-                });
-                continue;
-            }
-
-            let state_root = Hash256::from_slice(&root_bytes);
-
-            match self
-                .cold_db
-                .get_bytes(DBColumn::BeaconColdStateSummary, state_root.as_slice())?
-            {
-                None => {
-                    result.add_violation(InvariantViolation::ColdStateRootMissingSummary {
-                        slot,
-                        state_root,
-                    });
-                }
-                Some(summary_bytes) => {
-                    let summary = ColdStateSummary::from_ssz_bytes(&summary_bytes)?;
-                    if summary.slot != slot {
-                        result.add_violation(InvariantViolation::ColdStateRootSlotMismatch {
+                match self
+                    .cold_db
+                    .get_bytes(DBColumn::BeaconColdStateSummary, state_root.as_slice())?
+                {
+                    None => {
+                        result.add_violation(InvariantViolation::ColdStateRootMissingSummary {
                             slot,
                             state_root,
-                            summary_slot: summary.slot,
                         });
+                    }
+                    Some(summary_bytes) => {
+                        let summary = ColdStateSummary::from_ssz_bytes(&summary_bytes)?;
+                        if summary.slot != slot {
+                            result.add_violation(InvariantViolation::ColdStateRootSlotMismatch {
+                                slot,
+                                state_root,
+                                summary_slot: summary.slot,
+                            });
+                        }
                     }
                 }
             }

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -58,14 +58,237 @@ impl Default for InvariantCheckResult {
 
 /// A single invariant violation.
 #[derive(Debug, Clone, Serialize)]
-pub struct InvariantViolation {
-    pub invariant: String,
-    pub message: String,
+pub enum InvariantViolation {
+    /// Block root exists in BeaconBlock column but block failed to load.
+    BlockFailedToLoad { block_root: Hash256 },
+    /// Hot block has no corresponding hot state summary.
+    HotBlockMissingStateSummary {
+        block_root: Hash256,
+        slot: Slot,
+        state_root: Hash256,
+    },
+    /// Hot state summary should have a snapshot but none found.
+    HotStateMissingSnapshot { state_root: Hash256, slot: Slot },
+    /// Hot state summary should have a diff but none found.
+    HotStateMissingDiff { state_root: Hash256, slot: Slot },
+    /// Hot state summary's previous_state_root has no summary.
+    HotStateMissingPreviousSummary {
+        slot: Slot,
+        previous_state_root: Hash256,
+    },
+    /// Cold block root index missing for a slot.
+    ColdBlockRootMissing {
+        slot: Slot,
+        oldest_block_slot: Slot,
+        split_slot: Slot,
+    },
+    /// Cold block root index has invalid byte length.
+    ColdBlockRootInvalidLength { slot: Slot, length: usize },
+    /// Cold block root index references a block not in hot DB.
+    ColdBlockRootOrphan { slot: Slot, block_root: Hash256 },
+    /// Cold state root index missing for a slot.
+    ColdStateRootMissing {
+        slot: Slot,
+        state_lower_limit: Slot,
+        state_upper_limit: Slot,
+        split_slot: Slot,
+    },
+    /// Cold state root index has invalid key length.
+    ColdStateRootInvalidKeyLength { length: usize },
+    /// Cold state root index has invalid root length.
+    ColdStateRootInvalidRootLength { slot: Slot, length: usize },
+    /// Cold state root index references a state with no cold summary.
+    ColdStateRootMissingSummary { slot: Slot, state_root: Hash256 },
+    /// Cold state summary slot doesn't match the state root index slot.
+    ColdStateRootSlotMismatch {
+        slot: Slot,
+        state_root: Hash256,
+        summary_slot: Slot,
+    },
+    /// Cold state summary should have a snapshot but none found.
+    ColdStateMissingSnapshot { state_root: Hash256, slot: Slot },
+    /// Cold state summary should have a diff but none found.
+    ColdStateMissingDiff { state_root: Hash256, slot: Slot },
+    /// Fork choice references a block not in hot DB.
+    ForkChoiceBlockMissing { block_root: Hash256, slot: Slot },
+    /// Block has no execution payload or envelope (prune_payloads=false).
+    ExecutionPayloadMissing { block_root: Hash256, slot: Slot },
+    /// Block has no blob sidecar entry.
+    BlobSidecarMissing { block_root: Hash256, slot: Slot },
+    /// Block missing a custody data column.
+    DataColumnMissing {
+        block_root: Hash256,
+        slot: Slot,
+        column_index: ColumnIndex,
+    },
+    /// State in cache has no hot state summary on disk.
+    StateCacheMissingSummary { state_root: Hash256 },
+    /// Pubkey cache count mismatch between memory and disk.
+    PubkeyCacheCountMismatch { in_memory: usize, on_disk: usize },
 }
 
 impl fmt::Display for InvariantViolation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{}]: {}", self.invariant, self.message)
+        match self {
+            Self::BlockFailedToLoad { block_root } => {
+                write!(
+                    f,
+                    "block root {block_root:?} exists in BeaconBlock column but failed to load"
+                )
+            }
+            Self::HotBlockMissingStateSummary {
+                block_root,
+                slot,
+                state_root,
+            } => {
+                write!(
+                    f,
+                    "hot block {block_root:?} at slot {slot} has state root {state_root:?} \
+                     but no hot state summary exists"
+                )
+            }
+            Self::HotStateMissingSnapshot { state_root, slot } => {
+                write!(
+                    f,
+                    "state {state_root:?} at slot {slot} should have a snapshot but none found"
+                )
+            }
+            Self::HotStateMissingDiff { state_root, slot } => {
+                write!(
+                    f,
+                    "state {state_root:?} at slot {slot} should have a diff but none found"
+                )
+            }
+            Self::HotStateMissingPreviousSummary {
+                slot,
+                previous_state_root,
+            } => {
+                write!(
+                    f,
+                    "state summary at slot {slot} references previous_state_root \
+                     {previous_state_root:?} which has no hot state summary"
+                )
+            }
+            Self::ColdBlockRootMissing {
+                slot,
+                oldest_block_slot,
+                split_slot,
+            } => {
+                write!(
+                    f,
+                    "missing cold block root index at slot {slot} \
+                     (oldest_block_slot={oldest_block_slot}, split.slot={split_slot})"
+                )
+            }
+            Self::ColdBlockRootInvalidLength { slot, length } => {
+                write!(
+                    f,
+                    "cold block root index at slot {slot} has invalid length {length}"
+                )
+            }
+            Self::ColdBlockRootOrphan { slot, block_root } => {
+                write!(
+                    f,
+                    "cold block root index at slot {slot} references block root \
+                     {block_root:?} which does not exist in hot DB"
+                )
+            }
+            Self::ColdStateRootMissing {
+                slot,
+                state_lower_limit,
+                state_upper_limit,
+                split_slot,
+            } => {
+                write!(
+                    f,
+                    "missing cold state root index at slot {slot} \
+                     (state_lower_limit={state_lower_limit}, \
+                     state_upper_limit={state_upper_limit}, split.slot={split_slot})"
+                )
+            }
+            Self::ColdStateRootInvalidKeyLength { length } => {
+                write!(f, "state root index has invalid key length {length}")
+            }
+            Self::ColdStateRootInvalidRootLength { slot, length } => {
+                write!(
+                    f,
+                    "state root index at slot {slot} has invalid root length {length}"
+                )
+            }
+            Self::ColdStateRootMissingSummary { slot, state_root } => {
+                write!(
+                    f,
+                    "state root index at slot {slot} has state root {state_root:?} \
+                     but no cold state summary exists"
+                )
+            }
+            Self::ColdStateRootSlotMismatch {
+                slot,
+                state_root,
+                summary_slot,
+            } => {
+                write!(
+                    f,
+                    "cold state summary for {state_root:?} has slot {summary_slot} \
+                     but state root index has slot {slot}"
+                )
+            }
+            Self::ColdStateMissingSnapshot { state_root, slot } => {
+                write!(
+                    f,
+                    "cold state {state_root:?} at slot {slot} should have a snapshot \
+                     but none found"
+                )
+            }
+            Self::ColdStateMissingDiff { state_root, slot } => {
+                write!(
+                    f,
+                    "cold state {state_root:?} at slot {slot} should have a diff but none found"
+                )
+            }
+            Self::ForkChoiceBlockMissing { block_root, slot } => {
+                write!(
+                    f,
+                    "block {block_root:?} at slot {slot} exists in fork choice but not in hot DB"
+                )
+            }
+            Self::ExecutionPayloadMissing { block_root, slot } => {
+                write!(
+                    f,
+                    "block {block_root:?} at slot {slot} has no execution payload \
+                     or payload envelope (prune_payloads=false)"
+                )
+            }
+            Self::BlobSidecarMissing { block_root, slot } => {
+                write!(
+                    f,
+                    "block {block_root:?} at slot {slot} has no blob sidecar entry"
+                )
+            }
+            Self::DataColumnMissing {
+                block_root,
+                slot,
+                column_index,
+            } => {
+                write!(
+                    f,
+                    "block {block_root:?} at slot {slot} missing custody data column \
+                     {column_index}"
+                )
+            }
+            Self::StateCacheMissingSummary { state_root } => {
+                write!(
+                    f,
+                    "state {state_root:?} is in state cache but has no hot state summary"
+                )
+            }
+            Self::PubkeyCacheCountMismatch { in_memory, on_disk } => {
+                write!(
+                    f,
+                    "pubkey cache has {in_memory} keys in memory but {on_disk} on disk"
+                )
+            }
+        }
     }
 }
 
@@ -105,7 +328,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         split: &Split,
     ) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "hot_block_state_consistency";
 
         for res in self
             .hot_db
@@ -114,31 +336,21 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             let block_root = res?;
             result.inc_checks();
 
-            // Load the block to check its slot.
             let Some(block) = self.get_blinded_block(&block_root)? else {
-                result.add_violation(InvariantViolation {
-                    invariant: invariant_name.to_string(),
-                    message: format!(
-                        "block root {block_root:?} exists in BeaconBlock column but failed to load"
-                    ),
-                });
+                result.add_violation(InvariantViolation::BlockFailedToLoad { block_root });
                 continue;
             };
 
             if block.slot() >= split.slot {
-                // This block is in the hot range, check for a state summary.
                 let state_root = block.state_root();
                 let has_summary = self
                     .hot_db
                     .key_exists(DBColumn::BeaconStateHotSummary, state_root.as_slice())?;
                 if !has_summary {
-                    result.add_violation(InvariantViolation {
-                        invariant: invariant_name.to_string(),
-                        message: format!(
-                            "hot block {block_root:?} at slot {} has state root {state_root:?} \
-                             but no hot state summary exists",
-                            block.slot()
-                        ),
+                    result.add_violation(InvariantViolation::HotBlockMissingStateSummary {
+                        block_root,
+                        slot: block.slot(),
+                        state_root,
                     });
                 }
             }
@@ -162,7 +374,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         _split: &Split,
     ) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "hot_state_summary_diff_consistency";
 
         let anchor_slot = self.get_anchor_info().anchor_slot;
 
@@ -190,13 +401,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         .hot_db
                         .key_exists(DBColumn::BeaconStateHotSnapshot, state_root.as_slice())?;
                     if !has_snapshot {
-                        result.add_violation(InvariantViolation {
-                            invariant: invariant_name.to_string(),
-                            message: format!(
-                                "state {state_root:?} at slot {} should have a snapshot \
-                                 but none found",
-                                summary.slot
-                            ),
+                        result.add_violation(InvariantViolation::HotStateMissingSnapshot {
+                            state_root,
+                            slot: summary.slot,
                         });
                     }
                 }
@@ -205,13 +412,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         .hot_db
                         .key_exists(DBColumn::BeaconStateHotDiff, state_root.as_slice())?;
                     if !has_diff {
-                        result.add_violation(InvariantViolation {
-                            invariant: invariant_name.to_string(),
-                            message: format!(
-                                "state {state_root:?} at slot {} should have a diff \
-                                 but none found",
-                                summary.slot
-                            ),
+                        result.add_violation(InvariantViolation::HotStateMissingDiff {
+                            state_root,
+                            slot: summary.slot,
                         });
                     }
                 }
@@ -238,7 +441,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         split: &Split,
     ) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "hot_state_summary_chain_consistency";
 
         for res in self
             .hot_db
@@ -254,13 +456,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     .hot_db
                     .key_exists(DBColumn::BeaconStateHotSummary, prev_root.as_slice())?;
                 if !has_prev {
-                    result.add_violation(InvariantViolation {
-                        invariant: invariant_name.to_string(),
-                        message: format!(
-                            "state summary at slot {} references previous_state_root \
-                             {prev_root:?} which has no hot state summary",
-                            summary.slot
-                        ),
+                    result.add_violation(InvariantViolation::HotStateMissingPreviousSummary {
+                        slot: summary.slot,
+                        previous_state_root: prev_root,
                     });
                 }
             }
@@ -283,7 +481,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     /// from the index slot.
     fn check_cold_block_root_indices(&self, split: &Split) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "cold_block_root_indices";
 
         let anchor_info = self.get_anchor_info();
         let start_slot = anchor_info.oldest_block_slot;
@@ -309,32 +506,23 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                             .hot_db
                             .key_exists(DBColumn::BeaconBlock, block_root.as_slice())?;
                         if !block_exists {
-                            result.add_violation(InvariantViolation {
-                                invariant: invariant_name.to_string(),
-                                message: format!(
-                                    "cold block root index at slot {slot} references block root \
-                                     {block_root:?} which does not exist in hot DB"
-                                ),
+                            result.add_violation(InvariantViolation::ColdBlockRootOrphan {
+                                slot,
+                                block_root,
                             });
                         }
                     } else {
-                        result.add_violation(InvariantViolation {
-                            invariant: invariant_name.to_string(),
-                            message: format!(
-                                "cold block root index at slot {slot} has invalid length {}",
-                                root_bytes.len()
-                            ),
+                        result.add_violation(InvariantViolation::ColdBlockRootInvalidLength {
+                            slot,
+                            length: root_bytes.len(),
                         });
                     }
                 }
                 None => {
-                    result.add_violation(InvariantViolation {
-                        invariant: invariant_name.to_string(),
-                        message: format!(
-                            "missing cold block root index at slot {slot} \
-                             (oldest_block_slot={start_slot}, split.slot={})",
-                            split.slot
-                        ),
+                    result.add_violation(InvariantViolation::ColdBlockRootMissing {
+                        slot,
+                        oldest_block_slot: start_slot,
+                        split_slot: split.slot,
                     });
                 }
             }
@@ -358,7 +546,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ///   matching slot.
     fn check_cold_state_root_indices(&self, split: &Split) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "cold_state_root_indices";
 
         let anchor_info = self.get_anchor_info();
 
@@ -379,14 +566,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     .cold_db
                     .key_exists(DBColumn::BeaconStateRoots, &slot_bytes)?;
                 if !has_entry {
-                    result.add_violation(InvariantViolation {
-                        invariant: invariant_name.to_string(),
-                        message: format!(
-                            "missing cold state root index at slot {slot} \
-                             (state_lower_limit={state_lower}, state_upper_limit={}, \
-                             split.slot={})",
-                            anchor_info.state_upper_limit, split.slot
-                        ),
+                    result.add_violation(InvariantViolation::ColdStateRootMissing {
+                        slot,
+                        state_lower_limit: state_lower,
+                        state_upper_limit: anchor_info.state_upper_limit,
+                        split_slot: split.slot,
                     });
                 }
             }
@@ -401,12 +585,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             result.inc_checks();
 
             if slot_bytes.len() != 8 {
-                result.add_violation(InvariantViolation {
-                    invariant: invariant_name.to_string(),
-                    message: format!(
-                        "state root index has invalid key length {}",
-                        slot_bytes.len()
-                    ),
+                result.add_violation(InvariantViolation::ColdStateRootInvalidKeyLength {
+                    length: slot_bytes.len(),
                 });
                 continue;
             }
@@ -417,12 +597,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             let slot = Slot::new(slot_val);
 
             if root_bytes.len() != 32 {
-                result.add_violation(InvariantViolation {
-                    invariant: invariant_name.to_string(),
-                    message: format!(
-                        "state root index at slot {slot} has invalid root length {}",
-                        root_bytes.len()
-                    ),
+                result.add_violation(InvariantViolation::ColdStateRootInvalidRootLength {
+                    slot,
+                    length: root_bytes.len(),
                 });
                 continue;
             }
@@ -434,24 +611,18 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 .get_bytes(DBColumn::BeaconColdStateSummary, state_root.as_slice())?
             {
                 None => {
-                    result.add_violation(InvariantViolation {
-                        invariant: invariant_name.to_string(),
-                        message: format!(
-                            "state root index at slot {slot} has state root {state_root:?} \
-                             but no cold state summary exists"
-                        ),
+                    result.add_violation(InvariantViolation::ColdStateRootMissingSummary {
+                        slot,
+                        state_root,
                     });
                 }
                 Some(summary_bytes) => {
                     let summary = ColdStateSummary::from_ssz_bytes(&summary_bytes)?;
                     if summary.slot != slot {
-                        result.add_violation(InvariantViolation {
-                            invariant: invariant_name.to_string(),
-                            message: format!(
-                                "cold state summary for {state_root:?} has slot {} \
-                                 but state root index has slot {slot}",
-                                summary.slot
-                            ),
+                        result.add_violation(InvariantViolation::ColdStateRootSlotMismatch {
+                            slot,
+                            state_root,
+                            summary_slot: summary.slot,
                         });
                     }
                 }
@@ -476,7 +647,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         _split: &Split,
     ) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
-        let invariant_name = "cold_state_diff_consistency";
 
         for res in self
             .cold_db
@@ -498,13 +668,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         .cold_db
                         .key_exists(DBColumn::BeaconStateSnapshot, &slot_bytes)?;
                     if !has_snapshot {
-                        result.add_violation(InvariantViolation {
-                            invariant: invariant_name.to_string(),
-                            message: format!(
-                                "cold state {state_root:?} at slot {} should have a snapshot \
-                                 but none found",
-                                summary.slot
-                            ),
+                        result.add_violation(InvariantViolation::ColdStateMissingSnapshot {
+                            state_root,
+                            slot: summary.slot,
                         });
                     }
                 }
@@ -513,13 +679,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         .cold_db
                         .key_exists(DBColumn::BeaconStateDiff, &slot_bytes)?;
                     if !has_diff {
-                        result.add_violation(InvariantViolation {
-                            invariant: invariant_name.to_string(),
-                            message: format!(
-                                "cold state {state_root:?} at slot {} should have a diff \
-                                 but none found",
-                                summary.slot
-                            ),
+                        result.add_violation(InvariantViolation::ColdStateMissingDiff {
+                            state_root,
+                            slot: summary.slot,
                         });
                     }
                 }

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -250,12 +250,12 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         result.merge(self.check_fork_choice_block_consistency(ctx)?);
         result.merge(self.check_hot_block_invariants(&split, ctx)?);
-        result.merge(self.check_hot_state_summary_diff_consistency(&split)?);
+        result.merge(self.check_hot_state_summary_diff_consistency()?);
         result.merge(self.check_hot_state_summary_chain_consistency(&split)?);
         result.merge(self.check_state_cache_consistency(ctx)?);
         result.merge(self.check_cold_block_root_indices(&split)?);
         result.merge(self.check_cold_state_root_indices(&split)?);
-        result.merge(self.check_cold_state_diff_consistency(&split)?);
+        result.merge(self.check_cold_state_diff_consistency()?);
         result.merge(self.check_pubkey_cache_consistency(ctx)?);
 
         Ok(result)
@@ -411,10 +411,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     /// Each hot state summary should have the correct storage artifact (snapshot, diff, or
     /// nothing) according to the HDiff hierarchy configuration. The hierarchy uses the
     /// anchor_slot as its start point for the hot DB.
-    fn check_hot_state_summary_diff_consistency(
-        &self,
-        _split: &Split,
-    ) -> Result<InvariantCheckResult, Error> {
+    fn check_hot_state_summary_diff_consistency(&self) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
 
         let anchor_slot = self.get_anchor_info().anchor_slot;
@@ -685,10 +682,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     /// Each cold state summary should have the correct storage artifact according to the
     /// HDiff hierarchy. Cold states always use genesis (slot 0) as the hierarchy start since
     /// they are finalized and have no anchor_slot dependency.
-    fn check_cold_state_diff_consistency(
-        &self,
-        _split: &Split,
-    ) -> Result<InvariantCheckResult, Error> {
+    fn check_cold_state_diff_consistency(&self) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
 
         let mut summary_slots = HashSet::new();

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -67,8 +67,9 @@ pub struct InvariantContext {
     pub state_cache_roots: Vec<Hash256>,
     /// Custody columns for the current epoch (invariant 7).
     pub custody_columns: Vec<ColumnIndex>,
-    /// Number of pubkeys in the in-memory validator pubkey cache (invariant 9).
-    pub pubkey_cache_count: usize,
+    /// Compressed pubkey bytes from the in-memory validator pubkey cache, indexed by validator index
+    /// (invariant 9).
+    pub pubkey_cache_pubkeys: Vec<Vec<u8>>,
 }
 
 /// A single invariant violation.
@@ -161,6 +162,12 @@ pub enum InvariantViolation {
     ///   -> all validator pubkeys from state.validators are in the hot_db
     /// ```
     PubkeyCacheCountMismatch { in_memory: usize, on_disk: usize },
+    /// Invariant 9b: pubkey cache value mismatch.
+    ///
+    /// ```text
+    /// pubkey_cache[i] == hot_db(PubkeyCache)[i]
+    /// ```
+    PubkeyCacheMismatch { validator_index: usize },
     /// Invariant 10: block root indices mapping.
     ///
     /// ```text
@@ -774,8 +781,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     /// all validator pubkeys from states are in hot_db(PubkeyCache)
     /// ```
     ///
-    /// The number of pubkeys in the in-memory validator pubkey cache should match the number
-    /// stored on disk in the PubkeyCache column.
+    /// Checks that the in-memory pubkey cache and the on-disk PubkeyCache column have the same
+    /// number of entries AND that each pubkey matches at every validator index.
     fn check_pubkey_cache_consistency(
         &self,
         ctx: &InvariantContext,
@@ -784,20 +791,44 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         result.inc_checks();
 
-        let mut on_disk_count = 0usize;
-        for res in self
-            .hot_db
-            .iter_column_keys::<Vec<u8>>(DBColumn::PubkeyCache)
-        {
-            let _ = res?;
-            on_disk_count += 1;
+        // Read all on-disk pubkeys keyed by validator index.
+        // Keys are Hash256::from_low_u64_be(index), values are SSZ-encoded uncompressed pubkeys.
+        let mut on_disk_pubkeys: Vec<(usize, Vec<u8>)> = Vec::new();
+        for res in self.hot_db.iter_column::<Vec<u8>>(DBColumn::PubkeyCache) {
+            let (key_bytes, value) = res?;
+            // Key is a big-endian u64 encoded as Hash256, extract the index from the last 8 bytes.
+            let index = if key_bytes.len() >= 8 {
+                let mut buf = [0u8; 8];
+                buf.copy_from_slice(&key_bytes[..8]);
+                u64::from_be_bytes(buf) as usize
+            } else {
+                continue;
+            };
+            on_disk_pubkeys.push((index, value));
         }
 
-        if ctx.pubkey_cache_count != on_disk_count {
+        let on_disk_count = on_disk_pubkeys.len();
+        let in_memory_count = ctx.pubkey_cache_pubkeys.len();
+
+        if in_memory_count != on_disk_count {
             result.add_violation(InvariantViolation::PubkeyCacheCountMismatch {
-                in_memory: ctx.pubkey_cache_count,
+                in_memory: in_memory_count,
                 on_disk: on_disk_count,
             });
+        }
+
+        // Compare pubkey values at each index. On-disk values are raw SSZ bytes; we compare
+        // them directly against the in-memory compressed bytes re-encoded the same way.
+        // Both sides are passed as opaque byte vectors to avoid pulling crypto types into the
+        // store crate.
+        for (index, on_disk_bytes) in &on_disk_pubkeys {
+            if let Some(in_memory_bytes) = ctx.pubkey_cache_pubkeys.get(*index) {
+                if in_memory_bytes != on_disk_bytes {
+                    result.add_violation(InvariantViolation::PubkeyCacheMismatch {
+                        validator_index: *index,
+                    });
+                }
+            }
         }
 
         Ok(result)

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -20,15 +20,12 @@ use types::*;
 pub struct InvariantCheckResult {
     /// List of invariant violations found.
     pub violations: Vec<InvariantViolation>,
-    /// Total number of checks performed.
-    pub checks_performed: usize,
 }
 
 impl InvariantCheckResult {
     pub fn new() -> Self {
         Self {
             violations: Vec::new(),
-            checks_performed: 0,
         }
     }
 
@@ -40,13 +37,8 @@ impl InvariantCheckResult {
         self.violations.push(violation);
     }
 
-    pub fn inc_checks(&mut self) {
-        self.checks_performed += 1;
-    }
-
     pub fn merge(&mut self, other: InvariantCheckResult) {
         self.violations.extend(other.violations);
-        self.checks_performed += other.checks_performed;
     }
 }
 
@@ -285,7 +277,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         let mut result = InvariantCheckResult::new();
 
         for &(block_root, slot) in &ctx.fork_choice_blocks {
-            result.inc_checks();
             let exists = self
                 .hot_db
                 .key_exists(DBColumn::BeaconBlock, block_root.as_slice())?;
@@ -330,14 +321,10 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         for res in self.hot_db.iter_column::<Hash256>(DBColumn::BeaconBlock) {
             let (block_root, block_bytes) = res?;
-            let block = SignedBeaconBlock::<E, BlindedPayload<E>>::from_ssz_bytes(
-                &block_bytes,
-                &self.spec,
-            )?;
+            let block = SignedBlindedBeaconBlock::<E>::from_ssz_bytes(&block_bytes, &self.spec)?;
             let slot = block.slot();
 
             // Invariant 2: block-state consistency.
-            result.inc_checks();
             if slot >= split.slot {
                 let state_root = block.state_root();
                 let has_summary = self
@@ -353,11 +340,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             }
 
             // Invariant 5: execution payload consistency.
+            // TODO(gloas): reconsider this invariant
             if check_payloads
                 && let Some(bellatrix_slot) = bellatrix_fork_slot
                 && slot >= bellatrix_slot
             {
-                result.inc_checks();
                 if !self.execution_payload_exists(&block_root)?
                     && !self.payload_envelope_exists(&block_root)?
                 {
@@ -378,7 +365,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 && fulu_fork_slot.is_none_or(|fulu_slot| slot < fulu_slot)
                 && block.num_expected_blobs() > 0
             {
-                result.inc_checks();
                 let has_blob = self
                     .blobs_db
                     .key_exists(DBColumn::BeaconBlob, block_root.as_slice())?;
@@ -397,7 +383,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 && slot >= oldest_dc
                 && block.num_expected_blobs() > 0
             {
-                result.inc_checks();
                 let stored_columns = self.get_data_column_keys(block_root)?;
                 for col_idx in &ctx.custody_columns {
                     if !stored_columns.contains(col_idx) {
@@ -442,7 +427,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         {
             let (state_root, value) = res?;
             let summary = HotStateSummary::from_ssz_bytes(&value)?;
-            result.inc_checks();
 
             summary_slots.insert(summary.slot);
 
@@ -480,7 +464,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         // Verify that all DiffFrom/ReplayFrom base slots reference existing summaries.
         for (slot, base_slot) in base_slot_refs {
-            result.inc_checks();
             if !summary_slots.contains(&base_slot) {
                 result.add_violation(InvariantViolation::HotStateBaseSummaryMissing {
                     slot,
@@ -513,7 +496,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         {
             let (_state_root, value) = res?;
             let summary = HotStateSummary::from_ssz_bytes(&value)?;
-            result.inc_checks();
 
             if summary.slot > split.slot {
                 let prev_root = summary.previous_state_root;
@@ -547,8 +529,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         let mut result = InvariantCheckResult::new();
 
         for &state_root in &ctx.state_cache_roots {
-            result.inc_checks();
-
             let has_summary = self
                 .hot_db
                 .key_exists(DBColumn::BeaconStateHotSummary, state_root.as_slice())?;
@@ -583,7 +563,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         for slot_val in anchor_info.oldest_block_slot.as_u64()..split.slot.as_u64() {
             let slot = Slot::new(slot_val);
-            result.inc_checks();
 
             let slot_bytes = slot_val.to_be_bytes();
             let block_root_bytes = self
@@ -644,8 +623,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             if slot <= anchor_info.state_lower_limit
                 || slot >= cmp::min(split.slot, anchor_info.state_upper_limit)
             {
-                result.inc_checks();
-
                 let slot_bytes = slot_val.to_be_bytes();
                 let Some(root_bytes) = self
                     .cold_db
@@ -721,7 +698,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         {
             let (state_root, value) = res?;
             let summary = ColdStateSummary::from_ssz_bytes(&value)?;
-            result.inc_checks();
 
             summary_slots.insert(summary.slot);
 
@@ -763,7 +739,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         // Verify that all DiffFrom/ReplayFrom base slots reference existing summaries.
         for (slot, base_slot) in base_slot_refs {
-            result.inc_checks();
             if !summary_slots.contains(&base_slot) {
                 result.add_violation(InvariantViolation::ColdStateBaseSummaryMissing {
                     slot,
@@ -788,8 +763,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         ctx: &InvariantContext,
     ) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
-
-        result.inc_checks();
 
         // Read all on-disk pubkeys keyed by validator index.
         // Keys are Hash256::from_low_u64_be(index), values are SSZ-encoded uncompressed pubkeys.

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -429,9 +429,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
             summary_slots.insert(summary.slot);
 
-            let strategy = self.hierarchy.storage_strategy(summary.slot, anchor_slot)?;
-
-            match strategy {
+            match self.hierarchy.storage_strategy(summary.slot, anchor_slot)? {
                 StorageStrategy::Snapshot => {
                     let has_snapshot = self
                         .hot_db
@@ -697,13 +695,12 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
             summary_slots.insert(summary.slot);
 
-            let strategy = self
-                .hierarchy
-                .storage_strategy(summary.slot, Slot::new(0))?;
-
             let slot_bytes = summary.slot.as_u64().to_be_bytes();
 
-            match strategy {
+            match self
+                .hierarchy
+                .storage_strategy(summary.slot, Slot::new(0))?
+            {
                 StorageStrategy::Snapshot => {
                     let has_snapshot = self
                         .cold_db

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -6,7 +6,7 @@
 //! See the `check_invariants` and `check_database_invariants` methods for the full list.
 
 use crate::hdiff::StorageStrategy;
-use crate::hot_cold_store::{ColdStateSummary, HotStateSummary};
+use crate::hot_cold_store::{ColdStateSummary, HotStateSummary, OptionalDiffBaseState};
 use crate::{DBColumn, Error, ItemStore};
 use crate::{HotColdDB, Split};
 use serde::Serialize;
@@ -104,7 +104,10 @@ pub enum InvariantViolation {
     /// state_summary in hot_db
     ///   -> state diff/snapshot/nothing in hot_db according to hierarchy rules
     /// ```
-    HotStateBaseSummaryMissing { slot: Slot, base_slot: Slot },
+    HotStateBaseSummaryMissing {
+        slot: Slot,
+        base_state_root: Hash256,
+    },
     /// Invariant 4: state summary chain consistency.
     ///
     /// ```text
@@ -417,8 +420,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         let anchor_slot = self.get_anchor_info().anchor_slot;
 
         // Collect all summary slots and their strategies in a first pass.
-        let mut summary_slots = HashSet::new();
-        let mut base_slot_refs = Vec::new();
+        let mut known_state_roots = HashSet::new();
+        let mut base_state_refs: Vec<(Slot, Hash256)> = Vec::new();
 
         for res in self
             .hot_db
@@ -427,7 +430,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             let (state_root, value) = res?;
             let summary = HotStateSummary::from_ssz_bytes(&value)?;
 
-            summary_slots.insert(summary.slot);
+            known_state_roots.insert(state_root);
 
             match self.hierarchy.storage_strategy(summary.slot, anchor_slot)? {
                 StorageStrategy::Snapshot => {
@@ -441,7 +444,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         });
                     }
                 }
-                StorageStrategy::DiffFrom(base_slot) => {
+                StorageStrategy::DiffFrom(_) => {
                     let has_diff = self
                         .hot_db
                         .key_exists(DBColumn::BeaconStateHotDiff, state_root.as_slice())?;
@@ -451,20 +454,24 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                             slot: summary.slot,
                         });
                     }
-                    base_slot_refs.push((summary.slot, base_slot));
+                    if let OptionalDiffBaseState::BaseState(base) = summary.diff_base_state {
+                        base_state_refs.push((summary.slot, base.state_root()));
+                    }
                 }
-                StorageStrategy::ReplayFrom(base_slot) => {
-                    base_slot_refs.push((summary.slot, base_slot));
+                StorageStrategy::ReplayFrom(_) => {
+                    if let OptionalDiffBaseState::BaseState(base) = summary.diff_base_state {
+                        base_state_refs.push((summary.slot, base.state_root()));
+                    }
                 }
             }
         }
 
-        // Verify that all DiffFrom/ReplayFrom base slots reference existing summaries.
-        for (slot, base_slot) in base_slot_refs {
-            if !summary_slots.contains(&base_slot) {
+        // Verify that all diff base state roots reference existing summaries.
+        for (slot, base_state_root) in base_state_refs {
+            if !known_state_roots.contains(&base_state_root) {
                 result.add_violation(InvariantViolation::HotStateBaseSummaryMissing {
                     slot,
-                    base_slot,
+                    base_state_root,
                 });
             }
         }

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -347,15 +347,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             if check_payloads
                 && let Some(bellatrix_slot) = bellatrix_fork_slot
                 && slot >= bellatrix_slot
+                && !self.execution_payload_exists(&block_root)?
+                && !self.payload_envelope_exists(&block_root)?
             {
-                if !self.execution_payload_exists(&block_root)?
-                    && !self.payload_envelope_exists(&block_root)?
-                {
-                    result.add_violation(InvariantViolation::ExecutionPayloadMissing {
-                        block_root,
-                        slot,
-                    });
-                }
+                result.add_violation(InvariantViolation::ExecutionPayloadMissing {
+                    block_root,
+                    slot,
+                });
             }
 
             // Invariant 6: blob sidecar consistency.
@@ -764,44 +762,35 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
 
-        // Read all on-disk pubkeys keyed by validator index.
-        // Keys are Hash256::from_low_u64_be(index), values are SSZ-encoded uncompressed pubkeys.
-        let mut on_disk_pubkeys: Vec<(usize, Vec<u8>)> = Vec::new();
-        for res in self.hot_db.iter_column::<Vec<u8>>(DBColumn::PubkeyCache) {
-            let (key_bytes, value) = res?;
-            // Key is a big-endian u64 encoded as Hash256, extract the index from the last 8 bytes.
-            let index = if key_bytes.len() >= 8 {
-                let mut buf = [0u8; 8];
-                buf.copy_from_slice(&key_bytes[..8]);
-                u64::from_be_bytes(buf) as usize
-            } else {
-                continue;
-            };
-            on_disk_pubkeys.push((index, value));
+        // Read on-disk pubkeys by sequential validator index (matching how they are stored
+        // with Hash256::from_low_u64_be(index) as key).
+        let mut on_disk_count = 0usize;
+        for validator_index in 0.. {
+            // Construct the key the same way as DatabasePubkey::key_for_index:
+            // Hash256 with the u64 index in the last 8 bytes (big-endian), rest zeros.
+            let mut key = [0u8; 32];
+            key[24..].copy_from_slice(&(validator_index as u64).to_be_bytes());
+            match self.hot_db.get_bytes(DBColumn::PubkeyCache, &key)? {
+                Some(on_disk_bytes) => {
+                    if let Some(in_memory_bytes) = ctx.pubkey_cache_pubkeys.get(validator_index)
+                        && in_memory_bytes != &on_disk_bytes
+                    {
+                        result.add_violation(InvariantViolation::PubkeyCacheMismatch {
+                            validator_index,
+                        });
+                    }
+                    on_disk_count += 1;
+                }
+                None => break,
+            }
         }
 
-        let on_disk_count = on_disk_pubkeys.len();
         let in_memory_count = ctx.pubkey_cache_pubkeys.len();
-
         if in_memory_count != on_disk_count {
             result.add_violation(InvariantViolation::PubkeyCacheCountMismatch {
                 in_memory: in_memory_count,
                 on_disk: on_disk_count,
             });
-        }
-
-        // Compare pubkey values at each index. On-disk values are raw SSZ bytes; we compare
-        // them directly against the in-memory compressed bytes re-encoded the same way.
-        // Both sides are passed as opaque byte vectors to avoid pulling crypto types into the
-        // store crate.
-        for (index, on_disk_bytes) in &on_disk_pubkeys {
-            if let Some(in_memory_bytes) = ctx.pubkey_cache_pubkeys.get(*index) {
-                if in_memory_bytes != on_disk_bytes {
-                    result.add_violation(InvariantViolation::PubkeyCacheMismatch {
-                        validator_index: *index,
-                    });
-                }
-            }
         }
 
         Ok(result)

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -156,7 +156,7 @@ pub enum InvariantViolation {
     /// state_summary in hot_db
     ///   -> all validator pubkeys from state.validators are in the hot_db
     /// ```
-    PubkeyCacheCountMismatch { in_memory: usize, on_disk: usize },
+    PubkeyCacheMissing { validator_index: usize },
     /// Invariant 9b: pubkey cache value mismatch.
     ///
     /// ```text
@@ -759,33 +759,21 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         // Read on-disk pubkeys by sequential validator index (matching how they are stored
         // with Hash256::from_low_u64_be(index) as key).
-        let mut on_disk_count = 0usize;
-        for validator_index in 0.. {
-            // Construct the key the same way as DatabasePubkey::key_for_index:
-            // Hash256 with the u64 index in the last 8 bytes (big-endian), rest zeros.
+        // Iterate in-memory pubkeys and verify each matches on disk.
+        for (validator_index, in_memory_bytes) in ctx.pubkey_cache_pubkeys.iter().enumerate() {
             let mut key = [0u8; 32];
             key[24..].copy_from_slice(&(validator_index as u64).to_be_bytes());
             match self.hot_db.get_bytes(DBColumn::PubkeyCache, &key)? {
-                Some(on_disk_bytes) => {
-                    if let Some(in_memory_bytes) = ctx.pubkey_cache_pubkeys.get(validator_index)
-                        && in_memory_bytes != &on_disk_bytes
-                    {
-                        result.add_violation(InvariantViolation::PubkeyCacheMismatch {
-                            validator_index,
-                        });
-                    }
-                    on_disk_count += 1;
+                Some(on_disk_bytes) if in_memory_bytes != &on_disk_bytes => {
+                    result
+                        .add_violation(InvariantViolation::PubkeyCacheMismatch { validator_index });
                 }
-                None => break,
+                None => {
+                    result
+                        .add_violation(InvariantViolation::PubkeyCacheMissing { validator_index });
+                }
+                _ => {}
             }
-        }
-
-        let in_memory_count = ctx.pubkey_cache_pubkeys.len();
-        if in_memory_count != on_disk_count {
-            result.add_violation(InvariantViolation::PubkeyCacheCountMismatch {
-                in_memory: in_memory_count,
-                on_disk: on_disk_count,
-            });
         }
 
         Ok(result)

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -376,6 +376,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
             // Invariant 7: data column consistency.
             // Only check blocks that actually have blob KZG commitments.
+            // TODO(gloas): reconsider this invariant — non-canonical payloads won't have
+            // their data column sidecars stored.
             if !ctx.custody_columns.is_empty()
                 && let Some(fulu_slot) = fulu_fork_slot
                 && let Some(oldest_dc) = oldest_data_column_slot

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -6,7 +6,7 @@
 //! See the `check_invariants` and `check_database_invariants` methods for the full list.
 
 use crate::hdiff::StorageStrategy;
-use crate::hot_cold_store::{ColdStateSummary, HotStateSummary, OptionalDiffBaseState};
+use crate::hot_cold_store::{ColdStateSummary, HotStateSummary};
 use crate::{DBColumn, Error, ItemStore};
 use crate::{HotColdDB, Split};
 use serde::Serialize;
@@ -442,7 +442,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                         });
                     }
                 }
-                StorageStrategy::DiffFrom(_) => {
+                StorageStrategy::DiffFrom(base_slot) => {
                     let has_diff = self
                         .hot_db
                         .key_exists(DBColumn::BeaconStateHotDiff, state_root.as_slice())?;
@@ -452,13 +452,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                             slot: summary.slot,
                         });
                     }
-                    if let OptionalDiffBaseState::BaseState(base) = summary.diff_base_state {
-                        base_state_refs.push((summary.slot, base.state_root()));
+                    if let Ok(base_root) = summary.diff_base_state.get_root(base_slot) {
+                        base_state_refs.push((summary.slot, base_root));
                     }
                 }
-                StorageStrategy::ReplayFrom(_) => {
-                    if let OptionalDiffBaseState::BaseState(base) = summary.diff_base_state {
-                        base_state_refs.push((summary.slot, base.state_root()));
+                StorageStrategy::ReplayFrom(base_slot) => {
+                    if let Ok(base_root) = summary.diff_base_state.get_root(base_slot) {
+                        base_state_refs.push((summary.slot, base_root));
                     }
                 }
             }
@@ -607,11 +607,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ///   && state_root |-> cold_state_summary in cold_db(BeaconColdStateSummary)
     ///   && cold_state_summary.slot == i
     /// ```
-    ///
-    /// Checks both directions:
-    /// - **Forward**: every slot in the expected range has a state root entry.
-    /// - **Reverse**: every existing state root entry has a valid cold state summary with
-    ///   matching slot.
     fn check_cold_state_root_indices(&self, split: &Split) -> Result<InvariantCheckResult, Error> {
         let mut result = InvariantCheckResult::new();
 

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -77,7 +77,7 @@ pub enum InvariantViolation {
     /// Invariant 1: fork choice block consistency.
     ///
     /// ```text
-    /// block in fork_choice -> block in hot_db
+    /// block in fork_choice && descends_from_finalized -> block in hot_db
     /// ```
     ForkChoiceBlockMissing { block_root: Hash256, slot: Slot },
     /// Invariant 2: block and state consistency.
@@ -265,10 +265,12 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     /// Invariant 1 (Hot DB): Fork choice block consistency.
     ///
     /// ```text
-    /// block in fork_choice -> block in hot_db
+    /// block in fork_choice && descends_from_finalized -> block in hot_db
     /// ```
     ///
-    /// Every block tracked by the fork choice proto-array must exist in the hot database.
+    /// Every canonical fork choice block (descending from finalized) must exist in the hot
+    /// database. Pruned non-canonical fork blocks may linger in the proto-array and are
+    /// excluded from this check.
     fn check_fork_choice_block_consistency(
         &self,
         ctx: &InvariantContext,

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -15,6 +15,7 @@ pub mod hdiff;
 pub mod historic_state_cache;
 pub mod hot_cold_store;
 mod impls;
+pub mod invariants;
 mod memory_store;
 pub mod metadata;
 pub mod metrics;

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -111,6 +111,19 @@ impl<E: EthSpec> StateCache<E> {
         self.hdiff_buffers.mem_usage()
     }
 
+    /// Return all state roots currently held in the cache, including the finalized state.
+    pub fn state_roots(&self) -> Vec<Hash256> {
+        let mut roots: Vec<Hash256> = self
+            .states
+            .iter()
+            .map(|(&state_root, _)| state_root)
+            .collect();
+        if let Some(ref finalized) = self.finalized_state {
+            roots.push(finalized.state_root);
+        }
+        roots
+    }
+
     pub fn update_finalized_state(
         &mut self,
         state_root: Hash256,


### PR DESCRIPTION
Codify Lighthouse DB invariants, and check them during tests and optionally on an API call.

This makes store tests much more robusts and documents key knowledge that previously only existed in @michaelsproul head. AI agents should greatly benefit from this too as they can programmatically verify the invariants.

# Invariants

## Notation

- `key |-> value` ("maps to") means there is a `value` stored under `key` in the database.

## Hot DB

### Fork choice block consistency

```
block in fork_choice ->
   block in hot_db
```

### Block and state consistency

```
block in hot_db && block.slot >= split.slot  ->
   state_summary for block.state_root() in hot_db
```

### State summary diff consistency

```
state_summary in hot_db ->
    state diff/snapshot/nothing in hot_db according to hierarchy rules
```

### State summary chain consistency

```
state_summary in hot_db && state_summary.slot > split.slot ->
   state_summary for previous_state_root in hot_db
```

### Block and execution payload consistency

_Pre-Gloas_

```
block in hot_db && !prune_payloads ->
   payload for block.root in hot_db
```

### Block and blobs consistency

_Pre-Fulu_.

```
block in hot_db && num_blob_commitments > 0 ->
  blob_list for block.root in hot_db
```

### Block and data columns consistency

_Post-Fulu_.

TODO: This is really fucked for some reason. There are 3 sources of truth between `DataColumnInfo`, `DataColumnCustodyInfo` and `CustodyContext`. https://github.com/sigp/lighthouse/issues/6572

```
block in hot_db
&& num_blob_commitments > 0
&& block.slot >= earliest_available_slot
&& data_column_idx in custody_columns
-> (block_root, data_column_idx) in hot_db
```

### State cache and disk consistency

```
state in state_cache ->
  state_summary in hot_db
```

### Pubkey Cache

We assume that a validator index maps to a unique pubkey _across all forks_.

```
state_summary in hot_db ->
    all validator pubkeys from state.validators are in the hot_db
```

## Cold DB

### Block root indices mapping

```
oldest_block_slot <= i < split.slot
-> block_root for slot i in cold_db
  && block for block_root in hot_db
  && block.slot == i
```

### State root indices mapping

```
(i <= state_lower_limit
|| i >= min(split.slot, state_upper_limit))
&& i < split.slot
-> i |-> state_root in cold_db(BeaconStateRoots)
   && state_root |-> cold_state_summary in cold_db(BeaconColdStateSummary)
   && cold_state_summary.slot == i
```

### Cold state diff consistency

```
cold_state_summary in cold_db ->
  slot |-> state diff/snapshot/nothing in cold_db according to diff hierarchy
```