### PR TITLE
Fix proposer lookahead endpoint JSON return type

### DIFF
--- a/beacon_node/http_api/src/beacon/states.rs
+++ b/beacon_node/http_api/src/beacon/states.rs
@@ -9,7 +9,7 @@ use crate::version::{
 use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes, WhenSlotSkipped};
 use eth2::types::{
     self as api_types, ValidatorBalancesRequestBody, ValidatorId, ValidatorIdentitiesRequestBody,
-    ValidatorsRequestBody,
+    ValidatorIndexData, ValidatorsRequestBody,
 };
 use ssz::Encode;
 use std::sync::Arc;
@@ -213,7 +213,7 @@ pub fn get_beacon_state_proposer_lookahead<T: BeaconChainTypes>(
                             ResponseIncludesVersion::Yes(fork_name),
                             execution_optimistic,
                             finalized,
-                            data,
+                            ValidatorIndexData(data),
                         )
                         .map(|res| warp::reply::json(&res).into_response()),
                     }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1430,10 +1430,11 @@ impl ApiTester {
             }
 
             let state = state_opt.as_mut().expect("result should be none");
-            let expected = state.proposer_lookahead().unwrap();
+            let expected = state.proposer_lookahead().unwrap().to_vec();
 
             let response = result.unwrap();
-            assert_eq!(response.data(), &expected.to_vec());
+            // Compare Vec<u64> directly, not Vec<String>
+            assert_eq!(response.data().0, expected);
 
             // Check that the version header is returned in the response
             let fork_name = state.fork_name(&self.chain.spec).unwrap();

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -904,7 +904,7 @@ impl BeaconNodeHttpClient {
     pub async fn get_beacon_states_proposer_lookahead(
         &self,
         state_id: StateId,
-    ) -> Result<Option<ExecutionOptimisticFinalizedBeaconResponse<Vec<u64>>>, Error> {
+    ) -> Result<Option<ExecutionOptimisticFinalizedBeaconResponse<ValidatorIndexData>>, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -708,6 +708,15 @@ pub struct DataColumnIndicesQuery {
 #[serde(transparent)]
 pub struct ValidatorIndexData(#[serde(with = "serde_utils::quoted_u64_vec")] pub Vec<u64>);
 
+impl<'de, T> ContextDeserialize<'de, T> for ValidatorIndexData {
+    fn context_deserialize<D>(deserializer: D, _context: T) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::deserialize(deserializer)
+    }
+}
+
 /// Borrowed variant of `ValidatorIndexData`, for serializing/sending.
 #[derive(Clone, Copy, Serialize)]
 #[serde(transparent)]


### PR DESCRIPTION
I miss this when reviewing #8815 (my bad). It is returning `Vec<u64>` when it should return `Vec<String>`. This get caught by the [spec test](https://github.com/sigp/lighthouse/actions/runs/22907732516/job/66471110857?pr=8904) that the return type does not match. 

I revise the endpoint `/eth/v1/beacon/states/head/proposer_lookahead` to return `ValidatorIndexData` type, which wraps the return type to `Vec<String>` instead of `Vec<u64>`, tested and it's now returning `Vec<String>` for JSON requests. 