### PR TITLE
Spec v1.7.0 alpha.3

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1940,6 +1940,7 @@ fn load_parent<T: BeaconChainTypes, B: AsBlock<T::EthSpec>>(
             {
                 if block.as_block().is_parent_block_full(parent_bid_block_hash) {
                     // TODO(gloas): loading the envelope here is not very efficient
+                    // TODO(gloas): check parent payload existence prior to this point?
                     let envelope = chain.store.get_payload_envelope(&root)?.ok_or_else(|| {
                         BeaconChainError::DBInconsistent(format!(
                             "Missing envelope for parent block {root:?}",

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -918,7 +918,8 @@ pub fn process_deposit_requests_post_gloas<E: EthSpec>(
 }
 
 /// Check if there is a pending deposit for a new validator with the given pubkey.
-// TODO(gloas): cache the deposit signature validation
+// TODO(gloas): cache the deposit signature validation or remove this loop entirely if possible,
+// it is `O(n * m)` where `n` is max 8192 and `m` is max 128M.
 fn is_pending_validator<E: EthSpec>(
     state: &BeaconState<E>,
     pubkey: &PublicKeyBytes,

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -4,7 +4,10 @@ use crate::common::{
     get_attestation_participation_flag_indices, increase_balance, initiate_validator_exit,
     slash_validator,
 };
-use crate::per_block_processing::errors::{BlockProcessingError, IntoWithIndex};
+use crate::per_block_processing::builder::{
+    convert_validator_index_to_builder_index, is_builder_index,
+};
+use crate::per_block_processing::errors::{BlockProcessingError, ExitInvalid, IntoWithIndex};
 use crate::per_block_processing::verify_payload_attestation::verify_payload_attestation;
 use bls::{PublicKeyBytes, SignatureBytes};
 use ssz_types::FixedVector;
@@ -507,11 +510,100 @@ pub fn process_exits<E: EthSpec>(
     // Verify and apply each exit in series. We iterate in series because higher-index exits may
     // become invalid due to the application of lower-index ones.
     for (i, exit) in voluntary_exits.iter().enumerate() {
+        // [New in Gloas:EIP7732]
+        if state.fork_name_unchecked().gloas_enabled()
+            && is_builder_index(exit.message.validator_index)
+        {
+            process_builder_voluntary_exit(state, exit, verify_signatures, spec)
+                .map_err(|e| e.into_with_index(i))?;
+            continue;
+        }
+
         verify_exit(state, None, exit, verify_signatures, spec)
             .map_err(|e| e.into_with_index(i))?;
 
         initiate_validator_exit(state, exit.message.validator_index as usize, spec)?;
     }
+    Ok(())
+}
+
+/// Process a builder voluntary exit. [New in Gloas:EIP7732]
+fn process_builder_voluntary_exit<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    signed_exit: &SignedVoluntaryExit,
+    verify_signatures: VerifySignatures,
+    spec: &ChainSpec,
+) -> Result<(), BlockOperationError<ExitInvalid>> {
+    let builder_index =
+        convert_validator_index_to_builder_index(signed_exit.message.validator_index);
+
+    let builder = state
+        .builders()?
+        .get(builder_index as usize)
+        .cloned()
+        .ok_or(BlockOperationError::invalid(ExitInvalid::ValidatorUnknown(
+            signed_exit.message.validator_index,
+        )))?;
+
+    // Verify the builder is active
+    let finalized_epoch = state.finalized_checkpoint().epoch;
+    if !builder.is_active_at_finalized_epoch(finalized_epoch, spec) {
+        return Err(BlockOperationError::invalid(ExitInvalid::NotActive(
+            signed_exit.message.validator_index,
+        )));
+    }
+
+    // Only exit builder if it has no pending withdrawals in the queue
+    let pending_balance = state.get_pending_balance_to_withdraw_for_builder(builder_index)?;
+    if pending_balance != 0 {
+        return Err(BlockOperationError::invalid(
+            ExitInvalid::PendingWithdrawalInQueue(signed_exit.message.validator_index),
+        ));
+    }
+
+    // Verify signature (using EIP-7044 domain: capella_fork_version for Deneb+)
+    if verify_signatures.is_true() {
+        let pubkey = builder.pubkey;
+        let domain = spec.compute_domain(
+            Domain::VoluntaryExit,
+            spec.capella_fork_version,
+            state.genesis_validators_root(),
+        );
+        let message = signed_exit.message.signing_root(domain);
+        let bls_pubkey = pubkey
+            .decompress()
+            .map_err(|_| BlockOperationError::invalid(ExitInvalid::BadSignature))?;
+        if !signed_exit.signature.verify(&bls_pubkey, message) {
+            return Err(BlockOperationError::invalid(ExitInvalid::BadSignature));
+        }
+    }
+
+    // Initiate builder exit
+    initiate_builder_exit(state, builder_index, spec)?;
+
+    Ok(())
+}
+
+/// Initiate the exit of a builder. [New in Gloas:EIP7732]
+fn initiate_builder_exit<E: EthSpec>(
+    state: &mut BeaconState<E>,
+    builder_index: u64,
+    spec: &ChainSpec,
+) -> Result<(), BeaconStateError> {
+    let current_epoch = state.current_epoch();
+    let builder = state
+        .builders_mut()?
+        .get_mut(builder_index as usize)
+        .ok_or(BeaconStateError::UnknownBuilder(builder_index))?;
+
+    // Return if builder already initiated exit
+    if builder.withdrawable_epoch != spec.far_future_epoch {
+        return Ok(());
+    }
+
+    // Set builder exit epoch
+    builder.withdrawable_epoch = current_epoch.safe_add(spec.min_builder_withdrawability_delay)?;
+
     Ok(())
 }
 
@@ -814,6 +906,30 @@ pub fn process_deposit_requests_post_gloas<E: EthSpec>(
     Ok(())
 }
 
+/// Check if there is a pending deposit for a new validator with the given pubkey.
+///
+/// Per spec: "Implementations SHOULD cache verification results to avoid repeated work."
+fn is_pending_validator<E: EthSpec>(
+    state: &BeaconState<E>,
+    pubkey: &PublicKeyBytes,
+    spec: &ChainSpec,
+) -> Result<bool, BlockProcessingError> {
+    for deposit in state.pending_deposits()?.iter() {
+        if deposit.pubkey == *pubkey {
+            let deposit_data = DepositData {
+                pubkey: deposit.pubkey,
+                withdrawal_credentials: deposit.withdrawal_credentials,
+                amount: deposit.amount,
+                signature: deposit.signature.clone(),
+            };
+            if is_valid_deposit_signature(&deposit_data, spec).is_ok() {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
 pub fn process_deposit_request_post_gloas<E: EthSpec>(
     state: &mut BeaconState<E>,
     deposit_request: &DepositRequest,
@@ -833,7 +949,9 @@ pub fn process_deposit_request_post_gloas<E: EthSpec>(
     let is_builder = builder_index.is_some();
 
     let validator_index = state.get_validator_index(&deposit_request.pubkey)?;
-    let is_validator = validator_index.is_some();
+    let is_existing_validator = validator_index.is_some();
+    let is_validator =
+        is_existing_validator || is_pending_validator(state, &deposit_request.pubkey, spec)?;
 
     let is_builder_prefix =
         is_builder_withdrawal_credential(deposit_request.withdrawal_credentials, spec);

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -917,8 +917,7 @@ pub fn process_deposit_requests_post_gloas<E: EthSpec>(
 }
 
 /// Check if there is a pending deposit for a new validator with the given pubkey.
-///
-/// Per spec: "Implementations SHOULD cache verification results to avoid repeated work."
+// TODO(gloas): cache the deposit signature validation
 fn is_pending_validator<E: EthSpec>(
     state: &BeaconState<E>,
     pubkey: &PublicKeyBytes,

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -958,14 +958,16 @@ pub fn process_deposit_request_post_gloas<E: EthSpec>(
     let is_builder = builder_index.is_some();
 
     let validator_index = state.get_validator_index(&deposit_request.pubkey)?;
-    let is_existing_validator = validator_index.is_some();
-    let is_validator =
-        is_existing_validator || is_pending_validator(state, &deposit_request.pubkey, spec)?;
+    let is_validator = validator_index.is_some();
 
-    let is_builder_prefix =
+    let has_builder_prefix =
         is_builder_withdrawal_credential(deposit_request.withdrawal_credentials, spec);
 
-    if is_builder || (is_builder_prefix && !is_validator) {
+    if is_builder
+        || (has_builder_prefix
+            && !is_validator
+            && !is_pending_validator(state, &deposit_request.pubkey, spec)?)
+    {
         // Apply builder deposits immediately
         apply_deposit_for_builder(
             state,

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -580,6 +580,7 @@ fn process_builder_voluntary_exit<E: EthSpec>(
             state.genesis_validators_root(),
         );
         let message = signed_exit.message.signing_root(domain);
+        // TODO(gloas): use builder pubkey cache once available
         let bls_pubkey = pubkey
             .decompress()
             .map_err(|_| BlockOperationError::invalid(ExitInvalid::BadSignature))?;

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -510,6 +510,16 @@ pub fn process_exits<E: EthSpec>(
     // Verify and apply each exit in series. We iterate in series because higher-index exits may
     // become invalid due to the application of lower-index ones.
     for (i, exit) in voluntary_exits.iter().enumerate() {
+        // Exits must specify an epoch when they become valid; they are not valid before then.
+        let current_epoch = state.current_epoch();
+        if current_epoch < exit.message.epoch {
+            return Err(BlockOperationError::invalid(ExitInvalid::FutureEpoch {
+                state: current_epoch,
+                exit: exit.message.epoch,
+            })
+            .into_with_index(i));
+        }
+
         // [New in Gloas:EIP7732]
         if state.fork_name_unchecked().gloas_enabled()
             && is_builder_index(exit.message.validator_index)
@@ -519,7 +529,7 @@ pub fn process_exits<E: EthSpec>(
             continue;
         }
 
-        verify_exit(state, None, exit, verify_signatures, spec)
+        verify_exit(state, Some(current_epoch), exit, verify_signatures, spec)
             .map_err(|e| e.into_with_index(i))?;
 
         initiate_validator_exit(state, exit.message.validator_index as usize, spec)?;

--- a/consensus/types/src/core/consts.rs
+++ b/consensus/types/src/core/consts.rs
@@ -31,9 +31,9 @@ pub mod gloas {
 
     // Fork choice constants
     pub type PayloadStatus = u8;
-    pub const PAYLOAD_STATUS_PENDING: PayloadStatus = 0;
-    pub const PAYLOAD_STATUS_EMPTY: PayloadStatus = 1;
-    pub const PAYLOAD_STATUS_FULL: PayloadStatus = 2;
+    pub const PAYLOAD_STATUS_EMPTY: PayloadStatus = 0;
+    pub const PAYLOAD_STATUS_FULL: PayloadStatus = 1;
+    pub const PAYLOAD_STATUS_PENDING: PayloadStatus = 2;
 
     pub const ATTESTATION_TIMELINESS_INDEX: usize = 0;
     pub const PTC_TIMELINESS_INDEX: usize = 1;

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,6 +1,6 @@
 # To download/extract nightly tests, run:
 # CONSENSUS_SPECS_TEST_VERSION=nightly make
-CONSENSUS_SPECS_TEST_VERSION ?= v1.7.0-alpha.2
+CONSENSUS_SPECS_TEST_VERSION ?= v1.7.0-alpha.3
 REPO_NAME := consensus-spec-tests
 OUTPUT_DIR := ./$(REPO_NAME)
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -47,6 +47,8 @@ excluded_paths = [
     "bls12-381-tests/hash_to_G2",
     "tests/.*/eip7732",
     "tests/.*/eip7805",
+    # Heze fork is not implemented
+    "tests/.*/heze/.*",
     # TODO(gloas): remove these ignores as Gloas consensus is implemented
     "tests/.*/gloas/fork_choice/.*",
     # Ignore MatrixEntry SSZ tests for now.

--- a/testing/ef_tests/download_test_vectors.sh
+++ b/testing/ef_tests/download_test_vectors.sh
@@ -10,7 +10,7 @@ if [[ "$version" == "nightly" || "$version" =~ ^nightly-[0-9]+$ ]]; then
 		exit 1
 	fi
 
-	for cmd in unzip jq; do
+	for cmd in jq; do
 		if ! command -v "${cmd}" >/dev/null 2>&1; then
 			echo "Error ${cmd} is not installed"
 			exit 1
@@ -48,13 +48,10 @@ if [[ "$version" == "nightly" || "$version" =~ ^nightly-[0-9]+$ ]]; then
 			echo "Downloading artifact: ${name}"
 			curl --progress-bar --location --show-error --retry 3 --retry-all-errors --fail \
 				-H "${auth_header}" -H "Accept: application/vnd.github+json" \
-				--output "${name}.zip" "${url}" || {
+				--output "${name}" "${url}" || {
 				echo "Failed to download ${name}"
 				exit 1
 			}
-
-			unzip -qo "${name}.zip"
-			rm -f "${name}.zip"
 		done
 else
 	for test in "${TESTS[@]}"; do

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -719,6 +719,7 @@ impl<E: EthSpec, O: Operation<E>> LoadCase for Operations<E, O> {
         let operation_path = path.join(O::filename());
         let (operation, bls_error) = if !operation_path.is_file() {
             // Some test cases (e.g. builder_voluntary_exit__success) have no operation file.
+            // TODO(gloas): remove this once the test vectors are fixed
             (None, None)
         } else if metadata.bls_setting.unwrap_or_default().check().is_ok() {
             match O::decode(&operation_path, fork_name, spec) {

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -716,8 +716,12 @@ impl<E: EthSpec, O: Operation<E>> LoadCase for Operations<E, O> {
 
         // Check BLS setting here before SSZ deserialization, as most types require signatures
         // to be valid.
-        let (operation, bls_error) = if metadata.bls_setting.unwrap_or_default().check().is_ok() {
-            match O::decode(&path.join(O::filename()), fork_name, spec) {
+        let operation_path = path.join(O::filename());
+        let (operation, bls_error) = if !operation_path.is_file() {
+            // Some test cases (e.g. builder_voluntary_exit__success) have no operation file.
+            (None, None)
+        } else if metadata.bls_setting.unwrap_or_default().check().is_ok() {
+            match O::decode(&operation_path, fork_name, spec) {
                 Ok(op) => (Some(op), None),
                 Err(Error::InvalidBLSInput(error)) => (None, Some(error)),
                 Err(e) => return Err(e),

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -537,11 +537,6 @@ impl<E: EthSpec + TypeName> Handler for RandomHandler<E> {
     fn handler_name(&self) -> String {
         "random".into()
     }
-
-    fn disabled_forks(&self) -> Vec<ForkName> {
-        // TODO(gloas): remove once we have Gloas random tests
-        vec![ForkName::Gloas]
-    }
 }
 
 #[derive(Educe)]


### PR DESCRIPTION
## Proposed Changes

Update spec code for compliance with spec v1.7.0-alpha.3: https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.3

The actual consensus changes are minimal. There are few more changes that are only relevant to fork choice or P2P validation that we will pick up in future PRs.

The change "Ignore beacon block if parent payload unknown" is currently covered in a hacky way by `load_parent` and can be improved once we have fork choice.

The change "Add parent_block_root to bid filtering key" is relevant to bid gossip validation, which we don't have at all in unstable yet.

## Additional Info

Partly written with Claude, but manually reviewed and tweaked.
