### PR TITLE
Scrap redundant docker builds on releases

### DIFF
--- a/.github/workflows/docker-reproducible.yml
+++ b/.github/workflows/docker-reproducible.yml
@@ -173,7 +173,7 @@ jobs:
 
           # For version tags, also create/update the latest tag to keep stable up to date
           # Only create latest tag for proper release versions (e.g. v1.2.3, not v1.2.3-alpha)
-          if [[ "${GITHUB_REF}" == refs/tags/* ]] && [[ "${VERSION}" =~ ^v\d{1,2}\.\d{1,2}\.\d{1,2}$ ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/* ]] && [[ "${VERSION}" =~ ^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
             docker manifest create \
               ${IMAGE_NAME}:latest \
               ${IMAGE_NAME}:${VERSION}-amd64 \

--- a/.github/workflows/docker-reproducible.yml
+++ b/.github/workflows/docker-reproducible.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - unstable
-      - stable
     tags:
       - v*
   workflow_dispatch: # allows manual triggering for testing purposes and skips publishing an image
@@ -25,9 +24,6 @@ jobs:
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             # It's a tag (e.g., v1.2.3)
             VERSION="${GITHUB_REF#refs/tags/}"
-          elif [[ "${{ github.ref }}" == refs/heads/stable ]]; then
-            # stable branch -> latest
-            VERSION="latest"
           elif [[ "${{ github.ref }}" == refs/heads/unstable ]]; then
             # unstable branch -> latest-unstable
             VERSION="latest-unstable"
@@ -174,3 +170,14 @@ jobs:
             ${IMAGE_NAME}:${VERSION}-arm64
 
           docker manifest push ${IMAGE_NAME}:${VERSION}
+
+          # For version tags, also create/update the latest tag to keep stable up to date
+          # Only create latest tag for proper release versions (e.g. v1.2.3, not v1.2.3-alpha)
+          if [[ "${GITHUB_REF}" == refs/tags/* ]] && [[ "${VERSION}" =~ ^v\d{1,2}\.\d{1,2}\.\d{1,2}$ ]]; then
+            docker manifest create \
+              ${IMAGE_NAME}:latest \
+              ${IMAGE_NAME}:${VERSION}-amd64 \
+              ${IMAGE_NAME}:${VERSION}-arm64
+
+            docker manifest push ${IMAGE_NAME}:latest
+          fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -160,7 +160,7 @@ jobs:
 
                   # For version tags, also create/update the latest tag to keep stable up to date
                   # Only create latest tag for proper release versions (e.g. v1.2.3, not v1.2.3-alpha)
-                  if [[ "${GITHUB_REF}" == refs/tags/* ]] && [[ "${VERSION}" =~ ^v[.\d]{5,8}$ ]]; then
+                  if [[ "${GITHUB_REF}" == refs/tags/* ]] && [[ "${VERSION}" =~ ^v\d{1,2}\.\d{1,2}\.\d{1,2}$ ]]; then
                     docker buildx imagetools create -t ${{ github.repository_owner}}/${{ matrix.binary }}:latest \
                         ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-arm64${VERSION_SUFFIX} \
                         ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-amd64${VERSION_SUFFIX};

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - unstable
-            - stable
         tags:
             - v*
 
@@ -28,11 +27,6 @@ jobs:
     extract-version:
         runs-on: ubuntu-22.04
         steps:
-            - name: Extract version (if stable)
-              if: github.event.ref == 'refs/heads/stable'
-              run: |
-                    echo "VERSION=latest" >> $GITHUB_ENV
-                    echo "VERSION_SUFFIX=" >> $GITHUB_ENV
             - name: Extract version (if unstable)
               if: github.event.ref == 'refs/heads/unstable'
               run: |
@@ -159,7 +153,16 @@ jobs:
 
             - name: Create and push multiarch manifests
               run: |
+                  # Create the main tag (versioned for releases, latest-unstable for unstable)
                   docker buildx imagetools create -t ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}${VERSION_SUFFIX} \
                       ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-arm64${VERSION_SUFFIX} \
                       ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-amd64${VERSION_SUFFIX};
+
+                  # For version tags, also create/update the latest tag to keep stable up to date
+                  # Only create latest tag for proper release versions (e.g. v1.2.3, not v1.2.3-alpha)
+                  if [[ "${GITHUB_REF}" == refs/tags/* ]] && [[ "${VERSION}" =~ ^v[.\d]{5,8}$ ]]; then
+                    docker buildx imagetools create -t ${{ github.repository_owner}}/${{ matrix.binary }}:latest \
+                        ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-arm64${VERSION_SUFFIX} \
+                        ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-amd64${VERSION_SUFFIX};
+                  fi
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -160,7 +160,7 @@ jobs:
 
                   # For version tags, also create/update the latest tag to keep stable up to date
                   # Only create latest tag for proper release versions (e.g. v1.2.3, not v1.2.3-alpha)
-                  if [[ "${GITHUB_REF}" == refs/tags/* ]] && [[ "${VERSION}" =~ ^v\d{1,2}\.\d{1,2}\.\d{1,2}$ ]]; then
+                  if [[ "${GITHUB_REF}" == refs/tags/* ]] && [[ "${VERSION}" =~ ^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
                     docker buildx imagetools create -t ${{ github.repository_owner}}/${{ matrix.binary }}:latest \
                         ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-arm64${VERSION_SUFFIX} \
                         ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-amd64${VERSION_SUFFIX};


### PR DESCRIPTION
## Issue Addressed

Our release workflow is pretty inefficient and slow. This PR aims to consolidate and cut down on duplicate tasks. 

## Proposed Changes

1) We now run the whole build process both on pushing to the `stable` branch and pushing a version tag. 
    A quick win is to not fire off separate builds. 
    
~~2) The Docker release workflow could re-use the binaries being built instead of doing its own cross-compilation. ~~
we won't take this on _right now_
