### PR TITLE
  fix(network): set ENR nfd to zero bytes when next fork is unknown

### DIFF
--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -187,10 +187,12 @@ impl<E: EthSpec> Network<E> {
 
         // set up a collection of variables accessible outside of the network crate
         // Create an ENR or load from disk if appropriate
+        // Per [spec](https://github.com/ethereum/consensus-specs/blob/1baa05e71148b0975e28918ac6022d2256b56f4a/specs/fulu/p2p-interface.md?plain=1#L636-L637)
+        // `nfd` must be zero-valued when no next fork is scheduled. 
         let next_fork_digest = ctx
             .fork_context
             .next_fork_digest()
-            .unwrap_or_else(|| ctx.fork_context.current_fork_digest());
+            .unwrap_or_default();
 
         let advertised_cgc = config
             .advertise_false_custody_group_count

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -188,11 +188,8 @@ impl<E: EthSpec> Network<E> {
         // set up a collection of variables accessible outside of the network crate
         // Create an ENR or load from disk if appropriate
         // Per [spec](https://github.com/ethereum/consensus-specs/blob/1baa05e71148b0975e28918ac6022d2256b56f4a/specs/fulu/p2p-interface.md?plain=1#L636-L637)
-        // `nfd` must be zero-valued when no next fork is scheduled. 
-        let next_fork_digest = ctx
-            .fork_context
-            .next_fork_digest()
-            .unwrap_or_default();
+        // `nfd` must be zero-valued when no next fork is scheduled.
+        let next_fork_digest = ctx.fork_context.next_fork_digest().unwrap_or_default();
 
         let advertised_cgc = config
             .advertise_false_custody_group_count


### PR DESCRIPTION
## Issue Addressed

Fixes #8996 

## Proposed Changes

When no next fork is scheduled, the `nfd` field in the ENR was set to the current fork digest via 
`.unwrap_or_else(|| ctx.fork_context.current_fork_digest())`.

According to the [spec](https://github.com/ethereum/consensus-specs/blob/1baa05e71148b0975e28918ac6022d2256b56f4a/specs/fulu/p2p-interface.md?plain=1#L636-L637), `nfd` should be zero-valued bytes when the next fork is unknown.

## Testing
- `cargo check -p lighthouse_network` passed.
- `cargo test -p lighthouse_network` failed with: 
```
failures:
    rpc_tests::test_tcp_blocks_by_range_chunked_rpc
    rpc_tests::test_tcp_blocks_by_root_chunked_rpc
```
which seems not introduced by this PR.

Built a patched Docker image and verified the fix by decoding the node's ENR and confirming `nfd` is correctly set to `0x00000000` when no next fork is scheduled:
```
enr:-Ou4QEtO_UZsnG2Spnq-oc9Bw0Uo5F_a7pWvtLoSph__pM5HDx3x2PWYKbrLbOnab_-ZKJeKnrTgNvNhXPh01wZxYrkIh2F0dG5ldHOIAAAAAMAAAACDY2djC4ZjbGllbnTRikxpZ2h0aG91c2WFOC4xLjKEZXRoMpB8SiHMcAAAOP__________gmlkgnY0gmlwhKwQABODbmZkhAAAAACEcXVpY4IjKYlzZWNwMjU2azGhAj74ZgXVp0NUA15uSYO4Bv8Xtz5O2gzAhY1ID1XiEA_QiHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo
```


