### PR TITLE
Bump rustls and ignore unpatched version due to Warp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,7 +5306,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls 0.23.35",
- "rustls-webpki 0.103.8",
+ "rustls-webpki 0.103.10",
  "thiserror 2.0.17",
  "x509-parser",
  "yasna",
@@ -7196,7 +7196,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7740,7 +7740,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -7789,9 +7789,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ install-audit:
 	cargo install --force cargo-audit
 
 audit-CI:
-	cargo audit
+	cargo audit --ignore RUSTSEC-2026-0049
 
 # Runs cargo deny (check for banned crates, duplicate versions, and source restrictions)
 deny: install-deny deny-CI


### PR DESCRIPTION
## Proposed Changes

Fix the cargo-audit failure caused by:

- https://rustsec.org/advisories/RUSTSEC-2026-0049

We can't fix it completely yet because `warp 0.3` is keeping us on an old version of `rustls`.

Mac's PR here will fix it:

- https://github.com/sigp/lighthouse/pull/9001

## Additional Info

Will merge this to `release-v8.1` and then backport to `unstable`.
