### PR TITLE
Reduce slow test runtimes to under 60s

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -3081,6 +3081,9 @@ mod tests {
         const MAX_TEST_PEERS: usize = 300;
 
         proptest! {
+            // 64 cases (down from default 256) keeps this test under 10s while
+            // still providing good random coverage of the pruning logic.
+            #![proptest_config(ProptestConfig::with_cases(64))]
             #[test]
             fn prune_excess_peers(peer_conditions in proptest::collection::vec(peer_condition_strategy(), DEFAULT_TARGET_PEERS..=MAX_TEST_PEERS)) {
                 let target_peer_count = DEFAULT_TARGET_PEERS;

--- a/beacon_node/lighthouse_network/src/rpc/codec.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec.rs
@@ -1028,9 +1028,11 @@ mod tests {
         let mut block: BeaconBlockBellatrix<_, FullPayload<Spec>> =
             BeaconBlockBellatrix::empty(spec);
 
+        // 11,000 × 1KB ≈ 11MB, just above the 10MB max_payload_size.
+        // Previously used 100,000 txs (~100MB) which made this test take >60s.
         let tx = VariableList::try_from(vec![0; 1024]).unwrap();
         let txs =
-            VariableList::try_from(std::iter::repeat_n(tx, 100000).collect::<Vec<_>>()).unwrap();
+            VariableList::try_from(std::iter::repeat_n(tx, 11000).collect::<Vec<_>>()).unwrap();
 
         block.body.execution_payload.execution_payload.transactions = txs;
 

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -46,8 +46,10 @@ fn bellatrix_block_small(spec: &ChainSpec) -> BeaconBlock<E> {
 /// Hence, we generate a bellatrix block just greater than `MAX_RPC_SIZE` to test rejection on the rpc layer.
 fn bellatrix_block_large(spec: &ChainSpec) -> BeaconBlock<E> {
     let mut block = BeaconBlockBellatrix::<E>::empty(spec);
+    // 11,000 × 1KB ≈ 11MB, just above the 10MB max_payload_size.
+    // Previously used 100,000 txs (~100MB) which caused hangs and timeouts.
     let tx = VariableList::try_from(vec![0; 1024]).unwrap();
-    let txs = VariableList::try_from(std::iter::repeat_n(tx, 100000).collect::<Vec<_>>()).unwrap();
+    let txs = VariableList::try_from(std::iter::repeat_n(tx, 11000).collect::<Vec<_>>()).unwrap();
 
     block.body.execution_payload.execution_payload.transactions = txs;
 

--- a/validator_client/initialized_validators/src/key_cache.rs
+++ b/validator_client/initialized_validators/src/key_cache.rs
@@ -1,7 +1,7 @@
 use account_utils::write_file_via_temporary;
 use bls::{Keypair, PublicKey};
 use eth2_keystore::json_keystore::{
-    Aes128Ctr, ChecksumModule, Cipher, CipherModule, Crypto, EmptyMap, EmptyString, KdfModule,
+    Aes128Ctr, ChecksumModule, Cipher, CipherModule, Crypto, EmptyMap, EmptyString, Kdf, KdfModule,
     Sha256Checksum,
 };
 use eth2_keystore::{
@@ -65,10 +65,14 @@ impl KeyCache {
     }
 
     pub fn init_crypto() -> Crypto {
+        Self::build_crypto(default_kdf)
+    }
+
+    fn build_crypto(kdf_fn: fn(Vec<u8>) -> Kdf) -> Crypto {
         let salt = rand::rng().random::<[u8; SALT_SIZE]>();
         let iv = rand::rng().random::<[u8; IV_SIZE]>().to_vec().into();
 
-        let kdf = default_kdf(salt.to_vec());
+        let kdf = kdf_fn(salt.to_vec());
         let cipher = Cipher::Aes128Ctr(Aes128Ctr { iv });
 
         Crypto {
@@ -116,7 +120,11 @@ impl KeyCache {
     }
 
     fn encrypt(&mut self) -> Result<(), Error> {
-        self.crypto = Self::init_crypto();
+        self.encrypt_with(default_kdf)
+    }
+
+    fn encrypt_with(&mut self, kdf_fn: fn(Vec<u8>) -> Kdf) -> Result<(), Error> {
+        self.crypto = Self::build_crypto(kdf_fn);
         let secret_map: SerializedKeyMap = self
             .pairs
             .iter()
@@ -268,7 +276,19 @@ pub enum Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use eth2_keystore::json_keystore::HexBytes;
+    use eth2_keystore::json_keystore::{HexBytes, Scrypt};
+
+    /// Scrypt with minimal cost (n=1024) for fast test execution.
+    /// Production uses n=262144 which takes ~45s per derivation.
+    fn insecure_kdf(salt: Vec<u8>) -> Kdf {
+        Kdf::Scrypt(Scrypt {
+            dklen: 32,
+            n: 1024,
+            p: 1,
+            r: 8,
+            salt: salt.into(),
+        })
+    }
 
     #[tokio::test]
     async fn test_serialization() {
@@ -302,7 +322,7 @@ mod tests {
             key_cache.add(keypair.clone(), uuid, password.clone());
         }
 
-        key_cache.encrypt().unwrap();
+        key_cache.encrypt_with(insecure_kdf).unwrap();
         key_cache.state = State::DecryptedAndSaved;
 
         assert_eq!(&key_cache.uuids, &uuids);


### PR DESCRIPTION
## Description

Four tests exceeded the 60s slow-test threshold. Each had unnecessary
computational overhead that could be reduced without affecting test coverage.

Closes #4743

## Changes

* `key_cache::test_encryption` (93s → <1s) — the test validates the
  encrypt/decrypt round-trip (AES cipher, checksum, serialization), not KDF
  brute-force resistance. Refactored `init_crypto` to accept a KDF factory
  and use Scrypt n=1024 in the test. The same code paths are exercised
  regardless of iteration count — only the computational cost changes, not
  the algorithm or key size.

* `codec::test_encode_then_decode_v2` (112s → 23s) — generated a ~100MB
  Bellatrix block (100K txs) to test oversized-message rejection, when ~11MB
  (11K txs) exceeds the 10MB `max_payload_size` just the same.

* `rpc_tests::bellatrix_block_large` — same 100K → 11K tx reduction. The
  100MB block was also causing intermittent hangs over the test TCP socket.

* `prune_excess_peers` (38s → 10s) — proptest defaulted to 256 cases, each
  creating ~250 peers with a full tokio runtime. Reduced to 64 cases which
  still provides good random coverage of the pruning invariants.

Tests in the 10-30s range (RPC integration, beacon chain harness, committee
shuffling with MinimalEthSpec) are inherently slow due to the infrastructure
they exercise and are already under 60s.

## Additional Info

AI-assisted: yes

Tested with `cargo nextest run --workspace` — 973 passed, 0 slow tests,
7 pre-existing failures (unrelated beacon_chain SIGABRT issues).