### PR TITLE
Use BTreeMap for state.validators pending updates

### DIFF
--- a/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
+++ b/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
@@ -4,8 +4,8 @@ use milhouse::List;
 use std::sync::Arc;
 use types::{
     BeaconStateError, Epoch, EthSpec, ParticipationFlags, ProgressiveBalancesCache, SyncCommittee,
-    Validator,
     consts::altair::{TIMELY_HEAD_FLAG_INDEX, TIMELY_SOURCE_FLAG_INDEX, TIMELY_TARGET_FLAG_INDEX},
+    state::Validators,
 };
 
 /// Provides a summary of validator participation during the epoch.
@@ -26,7 +26,7 @@ pub enum EpochProcessingSummary<E: EthSpec> {
 #[derive(PartialEq, Debug)]
 pub struct ParticipationEpochSummary<E: EthSpec> {
     /// Copy of the validator registry prior to mutation.
-    validators: List<Validator, E::ValidatorRegistryLimit>,
+    validators: Validators<E>,
     /// Copy of the participation flags for the previous epoch.
     previous_epoch_participation: List<ParticipationFlags, E::ValidatorRegistryLimit>,
     /// Copy of the participation flags for the current epoch.
@@ -37,7 +37,7 @@ pub struct ParticipationEpochSummary<E: EthSpec> {
 
 impl<E: EthSpec> ParticipationEpochSummary<E> {
     pub fn new(
-        validators: List<Validator, E::ValidatorRegistryLimit>,
+        validators: Validators<E>,
         previous_epoch_participation: List<ParticipationFlags, E::ValidatorRegistryLimit>,
         current_epoch_participation: List<ParticipationFlags, E::ValidatorRegistryLimit>,
         previous_epoch: Epoch,

--- a/consensus/types/src/state/beacon_state.rs
+++ b/consensus/types/src/state/beacon_state.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use ssz::{Decode, DecodeError, Encode, ssz_encode};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{BitVector, FixedVector};
+use std::collections::BTreeMap;
 use superstruct::superstruct;
 use swap_or_not_shuffle::compute_shuffled_index;
 use test_random_derive::TestRandom;
@@ -58,7 +59,8 @@ pub const CACHED_EPOCHS: usize = 3;
 const MAX_RANDOM_BYTE: u64 = (1 << 8) - 1;
 const MAX_RANDOM_VALUE: u64 = (1 << 16) - 1;
 
-pub type Validators<E> = List<Validator, <E as EthSpec>::ValidatorRegistryLimit>;
+pub type Validators<E> =
+    List<Validator, <E as EthSpec>::ValidatorRegistryLimit, BTreeMap<usize, Validator>>;
 pub type Balances<E> = List<u64, <E as EthSpec>::ValidatorRegistryLimit>;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -453,7 +455,7 @@ where
     // Registry
     #[compare_fields(as_iter)]
     #[test_random(default)]
-    pub validators: List<Validator, E::ValidatorRegistryLimit>,
+    pub validators: Validators<E>,
     #[serde(with = "ssz_types::serde_utils::quoted_u64_var_list")]
     #[compare_fields(as_iter)]
     #[test_random(default)]

--- a/consensus/types/src/state/mod.rs
+++ b/consensus/types/src/state/mod.rs
@@ -17,7 +17,7 @@ pub use balance::Balance;
 pub use beacon_state::{
     BeaconState, BeaconStateAltair, BeaconStateBase, BeaconStateBellatrix, BeaconStateCapella,
     BeaconStateDeneb, BeaconStateElectra, BeaconStateError, BeaconStateFulu, BeaconStateGloas,
-    BeaconStateHash, BeaconStateRef, CACHED_EPOCHS,
+    BeaconStateHash, BeaconStateRef, CACHED_EPOCHS, Validators,
 };
 pub use committee_cache::{
     CommitteeCache, compute_committee_index_in_epoch, compute_committee_range_in_epoch,


### PR DESCRIPTION
## Issue Addressed

Closes:

- https://github.com/sigp/lighthouse/issues/9003

## Proposed Changes

Milhouse `List`s use a map in front of the binary tree to cache updates. Ever since we adopted Milhouse, we've been using `VecMap`, which is essentially `Vec<Option<T>>`. Turns out, when you've got 2M indices and only 2 non-`None` entries (changes), this is inefficient.

Milhouse is generic in the choice of map (`U: UpdateMap`) and has always supported `BTreeMap`, so this PR switches us over to `BTreeMap`. In previous benchmarks (years ago) it had been slower than `VecMap`, but now it is vastly superior.

## Benchmark

Quick little benchmark (data formatted by Claude but double-checked):

### Ordinary block (slot 13920749)

| Metric | v8.1.2 (VecMap) | BTreeMap | Change |
|---|---|---|---|
| Build caches | 2390ms | 2407ms | +0.7% |
| Initial tree hash | 141ms | 142ms | +0.2% |
| Process block | 20.3ms | 20.4ms | +0.8% |
| Post-block tree hash | 15.4ms | 15.1ms | -1.8% |
| **Total** | **2589ms** | **2614ms** | **+1.0%** |

### Previously slow block (slot 13919998)

| Metric | v8.1.2 (VecMap) | BTreeMap | Change |
|---|---|---|---|
| Build caches | 2370ms | 2401ms | +1.3% |
| Initial tree hash | 135ms | 132ms | -1.9% |
| Process block | 92.4ms | 12.5ms | **-86.5%** |
| Post-block tree hash | 132ms | 15.4ms | **-88.4%** |
| **Total** | **2749ms** | **2581ms** | **-6.1%** |

I think the "Build caches" changes are 1) Irrelevant (because we almost always have them pre-built), and 2) Likely just noise.

The main result is that block processing + post-block tree hash, which happen on the hot-path for every block, are now much more similar to the times for an ordinary (no exits) block.
