### PR TITLE
Gloas new payload v5

### DIFF
--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -5,7 +5,7 @@ use crate::http::{
     ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1, ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1,
     ENGINE_GET_PAYLOAD_V1, ENGINE_GET_PAYLOAD_V2, ENGINE_GET_PAYLOAD_V3, ENGINE_GET_PAYLOAD_V4,
     ENGINE_GET_PAYLOAD_V5, ENGINE_NEW_PAYLOAD_V1, ENGINE_NEW_PAYLOAD_V2, ENGINE_NEW_PAYLOAD_V3,
-    ENGINE_NEW_PAYLOAD_V4,
+    ENGINE_NEW_PAYLOAD_V4, ENGINE_NEW_PAYLOAD_V5,
 };
 use eth2::types::{
     BlobsBundle, SsePayloadAttributes, SsePayloadAttributesV1, SsePayloadAttributesV2,
@@ -551,6 +551,7 @@ pub struct EngineCapabilities {
     pub new_payload_v2: bool,
     pub new_payload_v3: bool,
     pub new_payload_v4: bool,
+    pub new_payload_v5: bool,
     pub forkchoice_updated_v1: bool,
     pub forkchoice_updated_v2: bool,
     pub forkchoice_updated_v3: bool,
@@ -580,6 +581,9 @@ impl EngineCapabilities {
         }
         if self.new_payload_v4 {
             response.push(ENGINE_NEW_PAYLOAD_V4);
+        }
+        if self.new_payload_v5 {
+            response.push(ENGINE_NEW_PAYLOAD_V5);
         }
         if self.forkchoice_updated_v1 {
             response.push(ENGINE_FORKCHOICE_UPDATED_V1);

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -35,6 +35,7 @@ pub const ENGINE_NEW_PAYLOAD_V1: &str = "engine_newPayloadV1";
 pub const ENGINE_NEW_PAYLOAD_V2: &str = "engine_newPayloadV2";
 pub const ENGINE_NEW_PAYLOAD_V3: &str = "engine_newPayloadV3";
 pub const ENGINE_NEW_PAYLOAD_V4: &str = "engine_newPayloadV4";
+pub const ENGINE_NEW_PAYLOAD_V5: &str = "engine_newPayloadV5";
 pub const ENGINE_NEW_PAYLOAD_TIMEOUT: Duration = Duration::from_secs(8);
 
 pub const ENGINE_GET_PAYLOAD_V1: &str = "engine_getPayloadV1";
@@ -74,6 +75,7 @@ pub static LIGHTHOUSE_CAPABILITIES: &[&str] = &[
     ENGINE_NEW_PAYLOAD_V2,
     ENGINE_NEW_PAYLOAD_V3,
     ENGINE_NEW_PAYLOAD_V4,
+    ENGINE_NEW_PAYLOAD_V5,
     ENGINE_GET_PAYLOAD_V1,
     ENGINE_GET_PAYLOAD_V2,
     ENGINE_GET_PAYLOAD_V3,
@@ -883,7 +885,7 @@ impl HttpJsonRpc {
         Ok(response.into())
     }
 
-    pub async fn new_payload_v4_gloas<E: EthSpec>(
+    pub async fn new_payload_v5_gloas<E: EthSpec>(
         &self,
         new_payload_request_gloas: NewPayloadRequestGloas<'_, E>,
     ) -> Result<PayloadStatusV1, Error> {
@@ -903,7 +905,7 @@ impl HttpJsonRpc {
 
         let response: JsonPayloadStatusV1 = self
             .rpc_request(
-                ENGINE_NEW_PAYLOAD_V4,
+                ENGINE_NEW_PAYLOAD_V5,
                 params,
                 ENGINE_NEW_PAYLOAD_TIMEOUT * self.execution_timeout_multiplier,
             )
@@ -1198,6 +1200,7 @@ impl HttpJsonRpc {
             new_payload_v2: capabilities.contains(ENGINE_NEW_PAYLOAD_V2),
             new_payload_v3: capabilities.contains(ENGINE_NEW_PAYLOAD_V3),
             new_payload_v4: capabilities.contains(ENGINE_NEW_PAYLOAD_V4),
+            new_payload_v5: capabilities.contains(ENGINE_NEW_PAYLOAD_V5),
             forkchoice_updated_v1: capabilities.contains(ENGINE_FORKCHOICE_UPDATED_V1),
             forkchoice_updated_v2: capabilities.contains(ENGINE_FORKCHOICE_UPDATED_V2),
             forkchoice_updated_v3: capabilities.contains(ENGINE_FORKCHOICE_UPDATED_V3),
@@ -1353,10 +1356,10 @@ impl HttpJsonRpc {
                 }
             }
             NewPayloadRequest::Gloas(new_payload_request_gloas) => {
-                if engine_capabilities.new_payload_v4 {
-                    self.new_payload_v4_gloas(new_payload_request_gloas).await
+                if engine_capabilities.new_payload_v5 {
+                    self.new_payload_v5_gloas(new_payload_request_gloas).await
                 } else {
-                    Err(Error::RequiredMethodUnsupported("engine_newPayloadV4"))
+                    Err(Error::RequiredMethodUnsupported("engine_newPayloadV5"))
                 }
             }
         }

--- a/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
+++ b/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
@@ -102,7 +102,8 @@ pub async fn handle_rpc<E: EthSpec>(
         ENGINE_NEW_PAYLOAD_V1
         | ENGINE_NEW_PAYLOAD_V2
         | ENGINE_NEW_PAYLOAD_V3
-        | ENGINE_NEW_PAYLOAD_V4 => {
+        | ENGINE_NEW_PAYLOAD_V4
+        | ENGINE_NEW_PAYLOAD_V5 => {
             let request = match method {
                 ENGINE_NEW_PAYLOAD_V1 => JsonExecutionPayload::Bellatrix(
                     get_param::<JsonExecutionPayloadBellatrix<E>>(params, 0)
@@ -118,16 +119,15 @@ pub async fn handle_rpc<E: EthSpec>(
                 ENGINE_NEW_PAYLOAD_V3 => get_param::<JsonExecutionPayloadDeneb<E>>(params, 0)
                     .map(|jep| JsonExecutionPayload::Deneb(jep))
                     .map_err(|s| (s, BAD_PARAMS_ERROR_CODE))?,
-                ENGINE_NEW_PAYLOAD_V4 => get_param::<JsonExecutionPayloadGloas<E>>(params, 0)
-                    .map(|jep| JsonExecutionPayload::Gloas(jep))
-                    .or_else(|_| {
-                        get_param::<JsonExecutionPayloadFulu<E>>(params, 0)
-                            .map(|jep| JsonExecutionPayload::Fulu(jep))
-                    })
+                ENGINE_NEW_PAYLOAD_V4 => get_param::<JsonExecutionPayloadFulu<E>>(params, 0)
+                    .map(|jep| JsonExecutionPayload::Fulu(jep))
                     .or_else(|_| {
                         get_param::<JsonExecutionPayloadElectra<E>>(params, 0)
                             .map(|jep| JsonExecutionPayload::Electra(jep))
                     })
+                    .map_err(|s| (s, BAD_PARAMS_ERROR_CODE))?,
+                ENGINE_NEW_PAYLOAD_V5 => get_param::<JsonExecutionPayloadGloas<E>>(params, 0)
+                    .map(|jep| JsonExecutionPayload::Gloas(jep))
                     .map_err(|s| (s, BAD_PARAMS_ERROR_CODE))?,
                 _ => unreachable!(),
             };
@@ -192,7 +192,7 @@ pub async fn handle_rpc<E: EthSpec>(
                         ));
                     }
                 }
-                ForkName::Electra | ForkName::Fulu | ForkName::Gloas => {
+                ForkName::Electra | ForkName::Fulu => {
                     if method == ENGINE_NEW_PAYLOAD_V1
                         || method == ENGINE_NEW_PAYLOAD_V2
                         || method == ENGINE_NEW_PAYLOAD_V3
@@ -226,6 +226,14 @@ pub async fn handle_rpc<E: EthSpec>(
                                 "{} called with `ExecutionPayloadDeneb` after Electra fork!",
                                 method
                             ),
+                            GENERIC_ERROR_CODE,
+                        ));
+                    }
+                }
+                ForkName::Gloas => {
+                    if method != ENGINE_NEW_PAYLOAD_V5 {
+                        return Err((
+                            format!("{} called after Gloas fork!", method),
                             GENERIC_ERROR_CODE,
                         ));
                     }

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -43,6 +43,7 @@ pub const DEFAULT_ENGINE_CAPABILITIES: EngineCapabilities = EngineCapabilities {
     new_payload_v2: true,
     new_payload_v3: true,
     new_payload_v4: true,
+    new_payload_v5: true,
     forkchoice_updated_v1: true,
     forkchoice_updated_v2: true,
     forkchoice_updated_v3: true,

--- a/testing/ef_tests/src/cases/transition.rs
+++ b/testing/ef_tests/src/cases/transition.rs
@@ -9,7 +9,6 @@ use state_processing::{
 use std::str::FromStr;
 use types::{BeaconState, Epoch, SignedBeaconBlock};
 
-
 #[derive(Debug, Clone, Deserialize)]
 pub struct Metadata {
     pub post_fork: String,

--- a/testing/ef_tests/src/cases/transition.rs
+++ b/testing/ef_tests/src/cases/transition.rs
@@ -9,6 +9,7 @@ use state_processing::{
 use std::str::FromStr;
 use types::{BeaconState, Epoch, SignedBeaconBlock};
 
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct Metadata {
     pub post_fork: String,


### PR DESCRIPTION
## Issue Addressed

Use the new payload v5 engine api for gloas. This is required for ePBS devnets

In a separate PR we can implement the full engine api spec changes for glamsterdam
https://github.com/ethereum/execution-apis/blob/main/src/engine/amsterdam.md