### PR TITLE
Use `yaml_serde` in place of deprecated `serde_yaml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,10 +42,10 @@ dependencies = [
  "regex",
  "rpassword",
  "serde",
- "serde_yaml",
  "tracing",
  "types",
  "validator_dir",
+ "yaml_serde",
  "zeroize",
 ]
 
@@ -1885,8 +1885,8 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "serde_yaml",
  "types",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -1917,7 +1917,6 @@ dependencies = [
  "sensitive_url",
  "serde",
  "serde_json",
- "serde_yaml",
  "slasher",
  "slasher_service",
  "slot_clock",
@@ -1930,6 +1929,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "types",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -2855,7 +2855,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "serde_yaml",
  "snap",
  "ssz_types",
  "state_processing",
@@ -2864,6 +2863,7 @@ dependencies = [
  "tree_hash_derive",
  "typenum",
  "types",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -3164,7 +3164,7 @@ dependencies = [
  "hex",
  "num-bigint",
  "serde",
- "serde_yaml",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -3216,13 +3216,13 @@ dependencies = [
  "pretty_reqwest_error",
  "reqwest",
  "sensitive_url",
- "serde_yaml",
  "sha2",
  "tempfile",
  "tokio",
  "tracing",
  "types",
  "url",
+ "yaml_serde",
  "zip",
 ]
 
@@ -4882,7 +4882,6 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "serde_yaml",
  "snap",
  "state_processing",
  "store",
@@ -4891,6 +4890,7 @@ dependencies = [
  "tree_hash",
  "types",
  "validator_dir",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -5321,6 +5321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "libz-rs-sys"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5374,7 +5380,6 @@ dependencies = [
  "sensitive_url",
  "serde",
  "serde_json",
- "serde_yaml",
  "slasher",
  "slashing_protection",
  "store",
@@ -5388,6 +5393,7 @@ dependencies = [
  "validator_client",
  "validator_dir",
  "validator_manager",
+ "yaml_serde",
  "zeroize",
 ]
 
@@ -7017,9 +7023,9 @@ dependencies = [
  "fixed_bytes",
  "safe_arith",
  "serde",
- "serde_yaml",
  "superstruct",
  "types",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -8052,19 +8058,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.12.1",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -9361,7 +9354,6 @@ dependencies = [
  "safe_arith",
  "serde",
  "serde_json",
- "serde_yaml",
  "smallvec",
  "ssz_types",
  "state_processing",
@@ -9374,6 +9366,7 @@ dependencies = [
  "tree_hash",
  "tree_hash_derive",
  "typenum",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -9460,12 +9453,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"
@@ -9969,7 +9956,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml",
  "slashing_protection",
  "slot_clock",
  "ssz_types",
@@ -9979,6 +9965,7 @@ dependencies = [
  "types",
  "url",
  "validator_store",
+ "yaml_serde",
  "zip",
 ]
 
@@ -10491,6 +10478,19 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink 0.11.0",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap 2.12.1",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,6 @@ sensitive_url = { version = "0.1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-serde_yaml = "0.9"
 sha2 = "0.10"
 signing_method = { path = "validator_client/signing_method" }
 slasher = { path = "slasher", default-features = false }
@@ -260,6 +259,7 @@ warp = { version = "0.3.7", default-features = false, features = ["tls"] }
 warp_utils = { path = "common/warp_utils" }
 workspace_members = { path = "common/workspace_members" }
 xdelta3 = { git = "https://github.com/sigp/xdelta3-rs", rev = "fe3906605c87b6c0515bd7c8fc671f47875e3ccc" }
+yaml_serde = "0.10"
 zeroize = { version = "1", features = ["zeroize_derive", "serde"] }
 zip = { version = "6.0", default-features = false, features = ["deflate"] }
 zstd = "0.13"

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -42,6 +42,6 @@ types = { workspace = true }
 
 [dev-dependencies]
 operation_pool = { workspace = true }
-serde_yaml = { workspace = true }
 state_processing = { workspace = true }
 tokio = { workspace = true }
+yaml_serde = { workspace = true }

--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -236,7 +236,7 @@ mod tests {
     fn serde() {
         let config = Config::default();
         let serialized =
-            serde_yaml::to_string(&config).expect("should serde encode default config");
-        serde_yaml::from_str::<Config>(&serialized).expect("should serde decode default config");
+            yaml_serde::to_string(&config).expect("should serde encode default config");
+        yaml_serde::from_str::<Config>(&serialized).expect("should serde decode default config");
     }
 }

--- a/common/account_utils/Cargo.toml
+++ b/common/account_utils/Cargo.toml
@@ -14,8 +14,8 @@ rand = { workspace = true }
 regex = { workspace = true }
 rpassword = "5.0.0"
 serde = { workspace = true }
-serde_yaml = { workspace = true }
 tracing = { workspace = true }
 types = { workspace = true }
 validator_dir = { workspace = true }
+yaml_serde = { workspace = true }
 zeroize = { workspace = true }

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -31,11 +31,11 @@ pub enum Error {
     /// The config file could not be opened.
     UnableToOpenFile(io::Error),
     /// The config file could not be parsed as YAML.
-    UnableToParseFile(serde_yaml::Error),
+    UnableToParseFile(yaml_serde::Error),
     /// There was an error whilst performing the recursive keystore search function.
     UnableToSearchForKeystores(io::Error),
     /// The config file could not be serialized as YAML.
-    UnableToEncodeFile(serde_yaml::Error),
+    UnableToEncodeFile(yaml_serde::Error),
     /// The config file or temp file could not be written to the filesystem.
     UnableToWriteFile(filesystem::Error),
     /// The public key from the keystore is invalid.
@@ -248,7 +248,7 @@ impl ValidatorDefinitions {
             .create_new(false)
             .open(config_path)
             .map_err(Error::UnableToOpenFile)?;
-        serde_yaml::from_reader(file).map_err(Error::UnableToParseFile)
+        yaml_serde::from_reader(file).map_err(Error::UnableToParseFile)
     }
 
     /// Perform a recursive, exhaustive search through `validators_dir` and add any keystores
@@ -376,7 +376,7 @@ impl ValidatorDefinitions {
         let config_path = validators_dir.as_ref().join(CONFIG_FILENAME);
         let temp_path = validators_dir.as_ref().join(CONFIG_TEMP_FILENAME);
         let mut bytes = vec![];
-        serde_yaml::to_writer(&mut bytes, self).map_err(Error::UnableToEncodeFile)?;
+        yaml_serde::to_writer(&mut bytes, self).map_err(Error::UnableToEncodeFile)?;
 
         write_file_via_temporary(&config_path, &temp_path, &bytes)
             .map_err(Error::UnableToWriteFile)?;
@@ -531,7 +531,7 @@ mod tests {
         voting_keystore_path: ""
         voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
         "#;
-        let def: ValidatorDefinition = serde_yaml::from_str(no_graffiti).unwrap();
+        let def: ValidatorDefinition = yaml_serde::from_str(no_graffiti).unwrap();
         assert!(def.graffiti.is_none());
 
         let invalid_graffiti = r#"---
@@ -543,7 +543,7 @@ mod tests {
         voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
         "#;
 
-        let def: Result<ValidatorDefinition, _> = serde_yaml::from_str(invalid_graffiti);
+        let def: Result<ValidatorDefinition, _> = yaml_serde::from_str(invalid_graffiti);
         assert!(def.is_err());
 
         let valid_graffiti = r#"---
@@ -555,7 +555,7 @@ mod tests {
         voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
         "#;
 
-        let def: ValidatorDefinition = serde_yaml::from_str(valid_graffiti).unwrap();
+        let def: ValidatorDefinition = yaml_serde::from_str(valid_graffiti).unwrap();
         assert_eq!(
             def.graffiti,
             Some(GraffitiString::from_str("mrfwashere").unwrap())
@@ -571,7 +571,7 @@ mod tests {
         voting_keystore_path: ""
         voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
         "#;
-        let def: ValidatorDefinition = serde_yaml::from_str(no_suggested_fee_recipient).unwrap();
+        let def: ValidatorDefinition = yaml_serde::from_str(no_suggested_fee_recipient).unwrap();
         assert!(def.suggested_fee_recipient.is_none());
 
         let invalid_suggested_fee_recipient = r#"---
@@ -584,7 +584,7 @@ mod tests {
         "#;
 
         let def: Result<ValidatorDefinition, _> =
-            serde_yaml::from_str(invalid_suggested_fee_recipient);
+            yaml_serde::from_str(invalid_suggested_fee_recipient);
         assert!(def.is_err());
 
         let valid_suggested_fee_recipient = r#"---
@@ -596,7 +596,7 @@ mod tests {
         voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
         "#;
 
-        let def: ValidatorDefinition = serde_yaml::from_str(valid_suggested_fee_recipient).unwrap();
+        let def: ValidatorDefinition = yaml_serde::from_str(valid_suggested_fee_recipient).unwrap();
         assert_eq!(
             def.suggested_fee_recipient,
             Some(Address::from_str("0xa2e334e71511686bcfe38bb3ee1ad8f6babcc03d").unwrap())
@@ -613,7 +613,7 @@ mod tests {
         voting_keystore_path: ""
         voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
         "#;
-        let def: ValidatorDefinition = serde_yaml::from_str(no_gas_limit).unwrap();
+        let def: ValidatorDefinition = yaml_serde::from_str(no_gas_limit).unwrap();
         assert!(def.gas_limit.is_none());
 
         let invalid_gas_limit = r#"---
@@ -626,7 +626,7 @@ mod tests {
         voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
         "#;
 
-        let def: Result<ValidatorDefinition, _> = serde_yaml::from_str(invalid_gas_limit);
+        let def: Result<ValidatorDefinition, _> = yaml_serde::from_str(invalid_gas_limit);
         assert!(def.is_err());
 
         let valid_gas_limit = r#"---
@@ -639,7 +639,7 @@ mod tests {
         voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
         "#;
 
-        let def: ValidatorDefinition = serde_yaml::from_str(valid_gas_limit).unwrap();
+        let def: ValidatorDefinition = yaml_serde::from_str(valid_gas_limit).unwrap();
         assert_eq!(def.gas_limit, Some(35000000));
     }
 
@@ -653,7 +653,7 @@ mod tests {
         voting_keystore_path: ""
         voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
         "#;
-        let def: ValidatorDefinition = serde_yaml::from_str(no_builder_proposals).unwrap();
+        let def: ValidatorDefinition = yaml_serde::from_str(no_builder_proposals).unwrap();
         assert!(def.builder_proposals.is_none());
 
         let invalid_builder_proposals = r#"---
@@ -666,7 +666,7 @@ mod tests {
         voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
         "#;
 
-        let def: Result<ValidatorDefinition, _> = serde_yaml::from_str(invalid_builder_proposals);
+        let def: Result<ValidatorDefinition, _> = yaml_serde::from_str(invalid_builder_proposals);
         assert!(def.is_err());
 
         let valid_builder_proposals = r#"---
@@ -679,7 +679,7 @@ mod tests {
         voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
         "#;
 
-        let def: ValidatorDefinition = serde_yaml::from_str(valid_builder_proposals).unwrap();
+        let def: ValidatorDefinition = yaml_serde::from_str(valid_builder_proposals).unwrap();
         assert_eq!(def.builder_proposals, Some(true));
     }
 }

--- a/common/clap_utils/Cargo.toml
+++ b/common/clap_utils/Cargo.toml
@@ -14,5 +14,5 @@ ethereum_ssz = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 types = { workspace = true }
+yaml_serde = { workspace = true }

--- a/common/clap_utils/src/lib.rs
+++ b/common/clap_utils/src/lib.rs
@@ -159,7 +159,7 @@ where
         let chain_config = Config::from_chain_spec::<E>(spec);
         let mut file = std::fs::File::create(dump_path)
             .map_err(|e| format!("Failed to open file for writing chain config: {:?}", e))?;
-        serde_yaml::to_writer(&mut file, &chain_config)
+        yaml_serde::to_writer(&mut file, &chain_config)
             .map_err(|e| format!("Error serializing config: {:?}", e))?;
     }
     Ok(())

--- a/common/eth2_interop_keypairs/Cargo.toml
+++ b/common/eth2_interop_keypairs/Cargo.toml
@@ -12,7 +12,7 @@ ethereum_hashing = { workspace = true }
 hex = { workspace = true }
 num-bigint = "0.4.2"
 serde = { workspace = true }
-serde_yaml = { workspace = true }
+yaml_serde = { workspace = true }
 
 [dev-dependencies]
 base64 = "0.13.0"

--- a/common/eth2_interop_keypairs/src/lib.rs
+++ b/common/eth2_interop_keypairs/src/lib.rs
@@ -118,7 +118,7 @@ fn string_to_bytes(string: &str) -> Result<Vec<u8>, String> {
 pub fn keypairs_from_yaml_file(path: PathBuf) -> Result<Vec<Keypair>, String> {
     let file = File::open(path).map_err(|e| format!("Unable to open YAML key file: {}", e))?;
 
-    serde_yaml::from_reader::<_, Vec<YamlKeypair>>(file)
+    yaml_serde::from_reader::<_, Vec<YamlKeypair>>(file)
         .map_err(|e| format!("Could not parse YAML: {:?}", e))?
         .into_iter()
         .map(TryInto::try_into)

--- a/common/eth2_network_config/Cargo.toml
+++ b/common/eth2_network_config/Cargo.toml
@@ -15,11 +15,11 @@ kzg = { workspace = true }
 pretty_reqwest_error = { workspace = true }
 reqwest = { workspace = true }
 sensitive_url = { workspace = true }
-serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 tracing = { workspace = true }
 types = { workspace = true }
 url = { workspace = true }
+yaml_serde = { workspace = true }
 
 [build-dependencies]
 eth2_config = { workspace = true }

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -101,14 +101,14 @@ impl Eth2NetworkConfig {
 
     /// Instantiates `Self` from a `HardcodedNet`.
     fn from_hardcoded_net(net: &HardcodedNet) -> Result<Self, String> {
-        let config: Config = serde_yaml::from_reader(net.config)
+        let config: Config = yaml_serde::from_reader(net.config)
             .map_err(|e| format!("Unable to parse yaml config: {:?}", e))?;
         let kzg_trusted_setup = get_trusted_setup();
         Ok(Self {
-            deposit_contract_deploy_block: serde_yaml::from_reader(net.deploy_block)
+            deposit_contract_deploy_block: yaml_serde::from_reader(net.deploy_block)
                 .map_err(|e| format!("Unable to parse deploy block: {:?}", e))?,
             boot_enr: Some(
-                serde_yaml::from_reader(net.boot_enr)
+                yaml_serde::from_reader(net.boot_enr)
                     .map_err(|e| format!("Unable to parse boot enr: {:?}", e))?,
             ),
             genesis_state_source: net.genesis_state_source,
@@ -286,7 +286,7 @@ impl Eth2NetworkConfig {
                 File::create(base_dir.join($file))
                     .map_err(|e| format!("Unable to create {}: {:?}", $file, e))
                     .and_then(|mut file| {
-                        let yaml = serde_yaml::to_string(&$variable)
+                        let yaml = yaml_serde::to_string(&$variable)
                             .map_err(|e| format!("Unable to YAML encode {}: {:?}", $file, e))?;
 
                         // Remove the doc header from the YAML file.
@@ -334,7 +334,7 @@ impl Eth2NetworkConfig {
                 File::open(base_dir.join($file))
                     .map_err(|e| format!("Unable to open {}: {:?}", $file, e))
                     .and_then(|file| {
-                        serde_yaml::from_reader(file)
+                        yaml_serde::from_reader(file)
                             .map_err(|e| format!("Unable to parse {}: {:?}", $file, e))
                     })?
             };

--- a/consensus/proto_array/Cargo.toml
+++ b/consensus/proto_array/Cargo.toml
@@ -14,6 +14,6 @@ ethereum_ssz_derive = { workspace = true }
 fixed_bytes = { workspace = true }
 safe_arith = { workspace = true }
 serde = { workspace = true }
-serde_yaml = { workspace = true }
 superstruct = { workspace = true }
 types = { workspace = true }
+yaml_serde = { workspace = true }

--- a/consensus/proto_array/src/bin.rs
+++ b/consensus/proto_array/src/bin.rs
@@ -22,5 +22,5 @@ fn main() {
 
 fn write_test_def_to_yaml(filename: &str, def: ForkChoiceTestDefinition) {
     let file = File::create(filename).expect("Should be able to open file");
-    serde_yaml::to_writer(file, &def).expect("Should be able to write YAML to file");
+    yaml_serde::to_writer(file, &def).expect("Should be able to write YAML to file");
 }

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -53,7 +53,6 @@ rusqlite = { workspace = true, optional = true }
 safe_arith = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 smallvec = { workspace = true }
 ssz_types = { workspace = true }
 superstruct = { workspace = true }
@@ -64,6 +63,7 @@ tracing = { workspace = true }
 tree_hash = { workspace = true }
 tree_hash_derive = { workspace = true }
 typenum = { workspace = true }
+yaml_serde = { workspace = true }
 
 [dev-dependencies]
 beacon_chain = { workspace = true }

--- a/consensus/types/src/core/chain_spec.rs
+++ b/consensus/types/src/core/chain_spec.rs
@@ -2531,7 +2531,7 @@ impl Config {
     pub fn from_file(filename: &Path) -> Result<Self, String> {
         let f = File::open(filename)
             .map_err(|e| format!("Error opening spec at {}: {:?}", filename.display(), e))?;
-        serde_yaml::from_reader(f)
+        yaml_serde::from_reader(f)
             .map_err(|e| format!("Error parsing spec at {}: {:?}", filename.display(), e))
     }
 
@@ -2869,7 +2869,7 @@ mod yaml_tests {
 
         let yamlconfig = Config::from_chain_spec::<MinimalEthSpec>(&minimal_spec);
         // write fresh minimal config to file
-        serde_yaml::to_writer(writer, &yamlconfig).expect("failed to write or serialize");
+        yaml_serde::to_writer(writer, &yamlconfig).expect("failed to write or serialize");
 
         let reader = File::options()
             .read(true)
@@ -2877,7 +2877,7 @@ mod yaml_tests {
             .open(tmp_file.as_ref())
             .expect("error while opening the file");
         // deserialize minimal config from file
-        let from: Config = serde_yaml::from_reader(reader).expect("error while deserializing");
+        let from: Config = yaml_serde::from_reader(reader).expect("error while deserializing");
         assert_eq!(from, yamlconfig);
     }
 
@@ -2891,14 +2891,14 @@ mod yaml_tests {
             .expect("error opening file");
         let mainnet_spec = ChainSpec::mainnet();
         let yamlconfig = Config::from_chain_spec::<MainnetEthSpec>(&mainnet_spec);
-        serde_yaml::to_writer(writer, &yamlconfig).expect("failed to write or serialize");
+        yaml_serde::to_writer(writer, &yamlconfig).expect("failed to write or serialize");
 
         let reader = File::options()
             .read(true)
             .write(false)
             .open(tmp_file.as_ref())
             .expect("error while opening the file");
-        let from: Config = serde_yaml::from_reader(reader).expect("error while deserializing");
+        let from: Config = yaml_serde::from_reader(reader).expect("error while deserializing");
         assert_eq!(from, yamlconfig);
     }
 
@@ -2960,7 +2960,7 @@ mod yaml_tests {
             MAX_BLOBS_PER_BLOCK: 20
         "#;
         let config: Config =
-            serde_yaml::from_str(spec_contents).expect("error while deserializing");
+            yaml_serde::from_str(spec_contents).expect("error while deserializing");
         let spec =
             ChainSpec::from_config::<MainnetEthSpec>(&config).expect("error while creating spec");
 
@@ -3042,11 +3042,11 @@ mod yaml_tests {
         assert_eq!(spec.max_blobs_per_block_within_fork(ForkName::Fulu), 20);
 
         // Check that serialization is in ascending order
-        let yaml = serde_yaml::to_string(&spec.blob_schedule).expect("should serialize");
+        let yaml = yaml_serde::to_string(&spec.blob_schedule).expect("should serialize");
 
         // Deserialize back to Vec<BlobParameters> to check order
         let deserialized: Vec<BlobParameters> =
-            serde_yaml::from_str(&yaml).expect("should deserialize");
+            yaml_serde::from_str(&yaml).expect("should deserialize");
 
         // Should be in ascending order by epoch
         assert!(
@@ -3113,7 +3113,7 @@ mod yaml_tests {
             MAX_BLOBS_PER_BLOCK: 300
         "#;
         let config: Config =
-            serde_yaml::from_str(spec_contents).expect("error while deserializing");
+            yaml_serde::from_str(spec_contents).expect("error while deserializing");
         let spec =
             ChainSpec::from_config::<MainnetEthSpec>(&config).expect("error while creating spec");
 
@@ -3203,7 +3203,7 @@ mod yaml_tests {
         SAMPLES_PER_SLOT: 8
         "#;
 
-        let chain_spec: Config = serde_yaml::from_str(spec).unwrap();
+        let chain_spec: Config = yaml_serde::from_str(spec).unwrap();
 
         // Asserts that `chain_spec.$name` and `default_$name()` are equal.
         macro_rules! check_default {

--- a/consensus/types/src/core/config_and_preset.rs
+++ b/consensus/types/src/core/config_and_preset.rs
@@ -174,7 +174,7 @@ mod test {
         yamlconfig.extra_fields_mut().insert(k3.into(), v3.into());
         yamlconfig.extra_fields_mut().insert(k4.into(), v4);
 
-        serde_yaml::to_writer(writer, &yamlconfig).expect("failed to write or serialize");
+        yaml_serde::to_writer(writer, &yamlconfig).expect("failed to write or serialize");
 
         let reader = File::options()
             .read(true)
@@ -182,7 +182,7 @@ mod test {
             .open(tmp_file.as_ref())
             .expect("error while opening the file");
         let from: ConfigAndPresetGloas =
-            serde_yaml::from_reader(reader).expect("error while deserializing");
+            yaml_serde::from_reader(reader).expect("error while deserializing");
         assert_eq!(ConfigAndPreset::Gloas(from), yamlconfig);
     }
 

--- a/consensus/types/src/core/preset.rs
+++ b/consensus/types/src/core/preset.rs
@@ -359,7 +359,7 @@ mod test {
     fn preset_from_file<T: DeserializeOwned>(preset_name: &str, filename: &str) -> T {
         let f = File::open(presets_base_path().join(preset_name).join(filename))
             .expect("preset file exists");
-        serde_yaml::from_reader(f).unwrap()
+        yaml_serde::from_reader(f).unwrap()
     }
 
     fn preset_test<E: EthSpec>() {

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ deny = [
     { crate = "ark-ff", reason = "present in Cargo.lock but not needed by Lighthouse" },
     { crate = "openssl", reason = "non-Rust dependency, use rustls instead" },
     { crate = "c-kzg", reason = "non-Rust dependency, use rust_eth_kzg instead" },
+    { crate = "serde_yaml", reason = "deprecated, use yaml_serde instead" },
     { crate = "strum", deny-multiple-versions = true, reason = "takes a long time to compile" },
     { crate = "reqwest", deny-multiple-versions = true, reason = "takes a long time to compile" },
     { crate = "aes", deny-multiple-versions = true, reason = "takes a long time to compile" },

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -35,7 +35,6 @@ network_utils = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 snap = { workspace = true }
 state_processing = { workspace = true }
 store = { workspace = true }
@@ -44,6 +43,7 @@ tracing-subscriber = { workspace = true }
 tree_hash = { workspace = true }
 types = { workspace = true }
 validator_dir = { workspace = true }
+yaml_serde = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 malloc_utils = { workspace = true, features = ["jemalloc"] }

--- a/lcli/src/parse_ssz.rs
+++ b/lcli/src/parse_ssz.rs
@@ -141,7 +141,7 @@ fn decode_and_print<T: Serialize>(
         OutputFormat::Yaml => {
             println!(
                 "{}",
-                serde_yaml::to_string(&item)
+                yaml_serde::to_string(&item)
                     .map_err(|e| format!("Unable to write object to YAML: {e:?}"))?
             );
         }

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -62,7 +62,6 @@ opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 slasher = { workspace = true }
 store = { workspace = true }
 task_executor = { workspace = true }
@@ -73,6 +72,7 @@ tracing_samplers = { workspace = true }
 types = { workspace = true }
 validator_client = { workspace = true }
 validator_manager = { path = "../validator_manager" }
+yaml_serde = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 malloc_utils = { workspace = true, features = ["jemalloc"] }

--- a/lighthouse/tests/exec.rs
+++ b/lighthouse/tests/exec.rs
@@ -65,7 +65,7 @@ pub trait CommandLineTestExec {
         let spec_file =
             File::open(tmp_chain_config_path).expect("Unable to open dumped chain spec");
         let chain_config: Config =
-            serde_yaml::from_reader(spec_file).expect("Unable to deserialize config");
+            yaml_serde::from_reader(spec_file).expect("Unable to deserialize config");
 
         CompletedTest::new(config, chain_config, tmp_dir)
     }
@@ -102,7 +102,7 @@ pub trait CommandLineTestExec {
         let spec_file =
             File::open(tmp_chain_config_path).expect("Unable to open dumped chain spec");
         let chain_config: Config =
-            serde_yaml::from_reader(spec_file).expect("Unable to deserialize config");
+            yaml_serde::from_reader(spec_file).expect("Unable to deserialize config");
 
         CompletedTest::new(config, chain_config, tmp_dir)
     }

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -32,7 +32,6 @@ rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_repr = { workspace = true }
-serde_yaml = { workspace = true }
 snap = { workspace = true }
 ssz_types = { workspace = true }
 state_processing = { workspace = true }
@@ -41,3 +40,4 @@ tree_hash = { workspace = true }
 tree_hash_derive = { workspace = true }
 typenum = { workspace = true }
 types = { workspace = true }
+yaml_serde = { workspace = true }

--- a/testing/ef_tests/src/decode.rs
+++ b/testing/ef_tests/src/decode.rs
@@ -33,14 +33,14 @@ pub fn log_file_access<P: AsRef<Path>>(file_accessed: P) {
 }
 
 pub fn yaml_decode<T: serde::de::DeserializeOwned>(string: &str) -> Result<T, Error> {
-    serde_yaml::from_str(string).map_err(|e| Error::FailedToParseTest(format!("{:?}", e)))
+    yaml_serde::from_str(string).map_err(|e| Error::FailedToParseTest(format!("{:?}", e)))
 }
 
 pub fn context_yaml_decode<'de, T, C>(string: &'de str, context: C) -> Result<T, Error>
 where
     T: ContextDeserialize<'de, C>,
 {
-    let deserializer = serde_yaml::Deserializer::from_str(string);
+    let deserializer = yaml_serde::Deserializer::from_str(string);
     T::context_deserialize(deserializer, context)
         .map_err(|e| Error::FailedToParseTest(format!("{:?}", e)))
 }

--- a/testing/web3signer_tests/Cargo.toml
+++ b/testing/web3signer_tests/Cargo.toml
@@ -23,7 +23,6 @@ parking_lot = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 slashing_protection = { workspace = true }
 slot_clock = { workspace = true }
 ssz_types = { workspace = true }
@@ -33,4 +32,5 @@ tokio = { workspace = true }
 types = { workspace = true }
 url = { workspace = true }
 validator_store = { workspace = true }
+yaml_serde = { workspace = true }
 zip = { workspace = true }

--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -210,7 +210,7 @@ mod tests {
             };
             let key_config_file =
                 File::create(keystore_dir.path().join("key-config.yaml")).unwrap();
-            serde_yaml::to_writer(key_config_file, &key_config).unwrap();
+            yaml_serde::to_writer(key_config_file, &key_config).unwrap();
 
             let tls_keystore_file = tls_dir().join("web3signer").join("key.p12");
             let tls_keystore_password_file = tls_dir().join("web3signer").join("password.txt");


### PR DESCRIPTION
## Issue Addressed

`serde_yaml` is now deprecated. The API-compatible `yaml_serde` should be used instead.

## Proposed Changes

Replace `serde_yaml` with `yaml_serde`. This is purely mechanical as the API is 1-to-1.
