### PR TITLE
feat(execution_layer): log more detail when JWT auth fails

### DIFF
--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -79,13 +79,7 @@ impl From<reqwest::Error> for Error {
             e.status(),
             Some(StatusCode::UNAUTHORIZED) | Some(StatusCode::FORBIDDEN)
         ) {
-            let status = e.status().map(|s| s.to_string()).unwrap_or_default();
-            let url = e.url().map(|u| u.to_string()).unwrap_or_default();
-            Error::Auth(auth::Error::InvalidToken(format!(
-                "Execution engine responded with {status} for {url}. \
-                 Ensure the JWT secret is correct and matches the execution client. \
-                 Detail: {e}"
-            )))
+            Error::Auth(auth::Error::InvalidToken(e.to_string()))
         } else {
             Error::HttpClient(e.into())
         }

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -79,7 +79,13 @@ impl From<reqwest::Error> for Error {
             e.status(),
             Some(StatusCode::UNAUTHORIZED) | Some(StatusCode::FORBIDDEN)
         ) {
-            Error::Auth(auth::Error::InvalidToken)
+            let status = e.status().map(|s| s.to_string()).unwrap_or_default();
+            let url = e.url().map(|u| u.to_string()).unwrap_or_default();
+            Error::Auth(auth::Error::InvalidToken(format!(
+                "Execution engine responded with {status} for {url}. \
+                 Ensure the JWT secret is correct and matches the execution client. \
+                 Detail: {e}"
+            )))
         } else {
             Error::HttpClient(e.into())
         }

--- a/beacon_node/execution_layer/src/engine_api/auth.rs
+++ b/beacon_node/execution_layer/src/engine_api/auth.rs
@@ -18,16 +18,6 @@ pub enum Error {
     InvalidKey(String),
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::JWT(e) => write!(f, "JWT error: {}", e),
-            Error::InvalidToken(reason) => write!(f, "Invalid JWT token: {}", reason),
-            Error::InvalidKey(reason) => write!(f, "Invalid JWT key: {}", reason),
-        }
-    }
-}
-
 impl From<jsonwebtoken::errors::Error> for Error {
     fn from(e: jsonwebtoken::errors::Error) -> Self {
         Error::JWT(e)

--- a/beacon_node/execution_layer/src/engine_api/auth.rs
+++ b/beacon_node/execution_layer/src/engine_api/auth.rs
@@ -14,8 +14,18 @@ pub const JWT_SECRET_LENGTH: usize = 32;
 #[derive(Debug)]
 pub enum Error {
     JWT(jsonwebtoken::errors::Error),
-    InvalidToken,
+    InvalidToken(String),
     InvalidKey(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::JWT(e) => write!(f, "JWT error: {}", e),
+            Error::InvalidToken(reason) => write!(f, "Invalid JWT token: {}", reason),
+            Error::InvalidKey(reason) => write!(f, "Invalid JWT key: {}", reason),
+        }
+    }
 }
 
 impl From<jsonwebtoken::errors::Error> for Error {


### PR DESCRIPTION
## Summary

- Preserve HTTP status code, URL, and error detail when the execution engine returns 401/403, instead of discarding the original `reqwest::Error` and replacing it with a bare `InvalidToken` variant
- Add `Display` impl for `auth::Error` for human-readable log output

Previously users saw:
```
Failed jwt authorization, error = InvalidToken
```

Now:
```
Failed jwt authorization, error = InvalidToken("Execution engine responded with 401 Unauthorized for http://localhost:8551/. Ensure the JWT secret is correct and matches the execution client. Detail: ...")
```

Closes #3435

## Test plan

- [x] `cargo check -p execution_layer` passes
- [x] `cargo test -p execution_layer` — all 34 tests pass
- [x] `cargo fmt --all` — no formatting issues