### PR TITLE
Fix local testnet Tempo and Prometheus/Grafana config

### DIFF
--- a/scripts/local_testnet/network_params.yaml
+++ b/scripts/local_testnet/network_params.yaml
@@ -21,10 +21,13 @@ network_params:
   slot_duration_ms: 3000
 snooper_enabled: false
 global_log_level: debug
+tempo_params:
+  image: grafana/tempo:2.10.3
 additional_services:
   - dora
   - spamoor
-  - prometheus_grafana
+  - prometheus
+  - grafana
   - tempo
 spamoor_params:
   image: ethpandaops/spamoor:master


### PR DESCRIPTION
## Proposed Changes
- Pin Tempo image to `grafana/tempo:2.10.3` — `grafana/tempo:latest` now resolves to an unreleased 3.0 build that removed the `compactor` config field, causing startup failure
- Replace deprecated `prometheus_grafana` additional service with separate `prometheus` + `grafana` services
