### PR TITLE
Emit SSE: `execution_payload_gossip`

### DIFF
--- a/beacon_node/beacon_chain/src/payload_envelope_verification/gossip_verified_envelope.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/gossip_verified_envelope.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use educe::Educe;
+use eth2::types::{EventKind, SseExecutionPayloadGossip};
 use parking_lot::{Mutex, RwLock};
 use store::DatabaseBlock;
 use tracing::{Span, debug};
@@ -10,7 +11,7 @@ use types::{
 };
 
 use crate::{
-    BeaconChain, BeaconChainError, BeaconChainTypes, BeaconStore,
+    BeaconChain, BeaconChainError, BeaconChainTypes, BeaconStore, ServerSentEventHandler,
     beacon_proposer_cache::{self, BeaconProposerCache},
     canonical_head::CanonicalHead,
     payload_envelope_verification::{
@@ -28,6 +29,7 @@ pub struct GossipVerificationContext<'a, T: BeaconChainTypes> {
     pub beacon_proposer_cache: &'a Mutex<BeaconProposerCache>,
     pub validator_pubkey_cache: &'a RwLock<ValidatorPubkeyCache<T>>,
     pub genesis_validators_root: Hash256,
+    pub event_handler: &'a Option<ServerSentEventHandler<T::EthSpec>>,
 }
 
 /// Verify that an execution payload envelope is consistent with its beacon block
@@ -213,6 +215,20 @@ impl<T: BeaconChainTypes> GossipVerifiedEnvelope<T> {
             return Err(EnvelopeError::BadSignature);
         }
 
+        if let Some(event_handler) = ctx.event_handler.as_ref()
+            && event_handler.has_execution_payload_gossip_subscribers()
+        {
+            event_handler.register(EventKind::ExecutionPayloadGossip(
+                SseExecutionPayloadGossip {
+                    slot: block.slot(),
+                    builder_index,
+                    block_hash: signed_envelope.message.payload.block_hash,
+                    block_root: beacon_block_root,
+                    state_root: signed_envelope.message.state_root,
+                },
+            ));
+        }
+
         Ok(Self {
             signed_envelope,
             block,
@@ -235,6 +251,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             beacon_proposer_cache: &self.beacon_proposer_cache,
             validator_pubkey_cache: &self.validator_pubkey_cache,
             genesis_validators_root: self.genesis_validators_root,
+            event_handler: &self.event_handler,
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

Emit `execution_payload_gossip` on successful gossip verification of an execution payload. This is done as last step inside the verification function.

## Additional information

This is following the established pattern for other SSEs, e.g.: https://github.com/sigp/lighthouse/blob/95b99ee7247aa966aac48dc5e9bfb3d73db25b39/beacon_node/beacon_chain/src/block_verification.rs#L1024-L1032

Builds upon #9053. 