### PR TITLE
Emit SSE: `execution_payload`

### DIFF
--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -5,7 +5,8 @@ use fork_choice::PayloadVerificationStatus;
 use slot_clock::SlotClock;
 use store::StoreOp;
 use tracing::{debug, error, info, info_span, instrument, warn};
-use types::{BeaconState, BlockImportSource, Hash256, Slot};
+use eth2::types::{EventKind, SseExecutionPayload};
+use types::{BeaconState, BlockImportSource, Hash256, SignedExecutionPayloadEnvelope};
 
 use super::{
     AvailableEnvelope, AvailableExecutedEnvelope, EnvelopeError, EnvelopeImportData,
@@ -225,7 +226,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         signed_envelope: AvailableEnvelope<T::EthSpec>,
         block_root: Hash256,
         state: BeaconState<T::EthSpec>,
-        _payload_verification_status: PayloadVerificationStatus,
+        payload_verification_status: PayloadVerificationStatus,
     ) -> Result<Hash256, EnvelopeError> {
         // Everything in this initial section is on the hot path for processing the envelope.
         // Take an upgradable read lock on fork choice so we can check if this block has already
@@ -317,8 +318,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         metrics::stop_timer(db_write_timer);
 
         self.import_envelope_update_metrics_and_events(
+            signed_envelope,
             block_root,
-            signed_envelope.slot(),
+            payload_verification_status,
             envelope_time_imported,
         );
 
@@ -327,10 +329,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     fn import_envelope_update_metrics_and_events(
         &self,
+        signed_envelope: Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>,
         block_root: Hash256,
-        envelope_slot: Slot,
+        payload_verification_status: PayloadVerificationStatus,
         envelope_time_imported: Duration,
     ) {
+        let envelope_slot = signed_envelope.slot();
         let envelope_delay_total =
             get_slot_delay_ms(envelope_time_imported, envelope_slot, &self.slot_clock);
 
@@ -349,6 +353,19 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             );
         }
 
-        // TODO(gloas) emit SSE event for envelope import (similar to SseBlock for blocks).
+        if let Some(event_handler) = self.event_handler.as_ref()
+            && event_handler.has_execution_payload_subscribers()
+        {
+            event_handler.register(EventKind::ExecutionPayload(
+                SseExecutionPayload {
+                    slot: envelope_slot,
+                    builder_index: signed_envelope.message.builder_index,
+                    block_hash: signed_envelope.block_hash(),
+                    block_root,
+                    state_root: signed_envelope.message.state_root,
+                    execution_optimistic: payload_verification_status.is_optimistic(),
+                },
+            ));
+        }
     }
 }

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use eth2::types::{EventKind, SseExecutionPayload};
 use fork_choice::PayloadVerificationStatus;
 use slot_clock::SlotClock;
 use store::StoreOp;
 use tracing::{debug, error, info, info_span, instrument, warn};
-use eth2::types::{EventKind, SseExecutionPayload};
 use types::{BeaconState, BlockImportSource, Hash256, SignedExecutionPayloadEnvelope};
 
 use super::{
@@ -356,16 +356,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         if let Some(event_handler) = self.event_handler.as_ref()
             && event_handler.has_execution_payload_subscribers()
         {
-            event_handler.register(EventKind::ExecutionPayload(
-                SseExecutionPayload {
-                    slot: envelope_slot,
-                    builder_index: signed_envelope.message.builder_index,
-                    block_hash: signed_envelope.block_hash(),
-                    block_root,
-                    state_root: signed_envelope.message.state_root,
-                    execution_optimistic: payload_verification_status.is_optimistic(),
-                },
-            ));
+            event_handler.register(EventKind::ExecutionPayload(SseExecutionPayload {
+                slot: envelope_slot,
+                builder_index: signed_envelope.message.builder_index,
+                block_hash: signed_envelope.block_hash(),
+                block_root,
+                state_root: signed_envelope.message.state_root,
+                execution_optimistic: payload_verification_status.is_optimistic(),
+            }));
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Emit `execution_payload` on successful import of an execution payload.

## Additional information

Builds upon #9053. 

Eitan's PR #9038 previously emitted `execution_payload_available` here, but https://github.com/ethereum/beacon-APIs/pull/588 specifies that `execution_payload` is to be emitted on import - matching the `block` event nomenclature. A PR for `execution_payload_available` will follow.