### PR TITLE
Gloas fork choice fixes

### DIFF
--- a/beacon_node/beacon_chain/src/payload_envelope_verification/execution_pending_envelope.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/execution_pending_envelope.rs
@@ -12,7 +12,7 @@ use crate::{
     PayloadVerificationOutcome,
     block_verification::PayloadVerificationHandle,
     payload_envelope_verification::{
-        EnvelopeError, EnvelopeImportData, MaybeAvailableEnvelope,
+        AvailableEnvelope, EnvelopeError, EnvelopeImportData, MaybeAvailableEnvelope,
         gossip_verified_envelope::GossipVerifiedEnvelope, load_snapshot_from_state_root,
         payload_notifier::PayloadNotifier,
     },
@@ -32,7 +32,6 @@ impl<T: BeaconChainTypes> GossipVerifiedEnvelope<T> {
     ) -> Result<ExecutionPendingEnvelope<T::EthSpec>, EnvelopeError> {
         let signed_envelope = self.signed_envelope;
         let envelope = &signed_envelope.message;
-        let payload = &envelope.payload;
 
         // Define a future that will verify the execution payload with an execution engine.
         //
@@ -91,10 +90,13 @@ impl<T: BeaconChainTypes> GossipVerifiedEnvelope<T> {
         )?;
 
         Ok(ExecutionPendingEnvelope {
-            signed_envelope: MaybeAvailableEnvelope::AvailabilityPending {
-                block_hash: payload.block_hash,
-                envelope: signed_envelope,
-            },
+            signed_envelope: MaybeAvailableEnvelope::Available(AvailableEnvelope::new(
+                signed_envelope.block_hash(),
+                signed_envelope.clone(),
+                vec![],
+                None,
+                chain.spec.clone(),
+            )),
             import_data: EnvelopeImportData {
                 block_root,
                 post_state: Box::new(state),

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
@@ -59,6 +59,22 @@ pub struct AvailableEnvelope<E: EthSpec> {
 }
 
 impl<E: EthSpec> AvailableEnvelope<E> {
+    pub fn new(
+        execution_block_hash: ExecutionBlockHash,
+        envelope: Arc<SignedExecutionPayloadEnvelope<E>>,
+        columns: DataColumnSidecarList<E>,
+        columns_available_timestamp: Option<std::time::Duration>,
+        spec: Arc<ChainSpec>,
+    ) -> Self {
+        Self {
+            execution_block_hash,
+            envelope,
+            columns,
+            columns_available_timestamp,
+            spec,
+        }
+    }
+
     pub fn message(&self) -> &ExecutionPayloadEnvelope<E> {
         &self.envelope.message
     }

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -1431,7 +1431,30 @@ impl ProtoArray {
                 .nodes
                 .get(node.proto_node_index)
                 .ok_or(Error::InvalidNodeIndex(node.proto_node_index))?;
-            
+
+            // V17 (pre-GLOAS) nodes don't have payload_received or parent_payload_status.
+            // Skip the virtual Empty/Full split and return real children directly.
+            if proto_node.as_v17().is_ok() {
+                let child_indices = children_index
+                    .get(node.proto_node_index)
+                    .map(|c| c.as_slice())
+                    .unwrap_or(&[]);
+                return Ok(child_indices
+                    .iter()
+                    .filter_map(|&child_index| {
+                        let child_node = self.nodes.get(child_index)?;
+                        Some((
+                            IndexedForkChoiceNode {
+                                root: child_node.root(),
+                                proto_node_index: child_index,
+                                payload_status: PayloadStatus::Pending,
+                            },
+                            child_node.clone(),
+                        ))
+                    })
+                    .collect());
+            }
+
             // TODO(gloas) this is the actual change we want to keep once PTC is implemented
             // let mut children = vec![(node.with_status(PayloadStatus::Empty), proto_node.clone())];
             // // The FULL virtual child only exists if the payload has been received.
@@ -1448,7 +1471,7 @@ impl ProtoArray {
                 vec![(node.with_status(PayloadStatus::Empty), proto_node.clone())]
             };
             // TODO(gloas) delete up to here
-            
+
             Ok(children)
         } else {
             let child_indices = children_index
@@ -1459,7 +1482,10 @@ impl ProtoArray {
                 .iter()
                 .filter_map(|&child_index| {
                     let child_node = self.nodes.get(child_index)?;
-                    if child_node.get_parent_payload_status() != node.payload_status {
+                    // Skip parent_payload_status filter for V17 children (they don't have it)
+                    if child_node.as_v17().is_err()
+                        && child_node.get_parent_payload_status() != node.payload_status
+                    {
                         return None;
                     }
                     Some((

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -1431,7 +1431,6 @@ impl ProtoArray {
                 .nodes
                 .get(node.proto_node_index)
                 .ok_or(Error::InvalidNodeIndex(node.proto_node_index))?;
-
             let mut children = vec![(node.with_status(PayloadStatus::Empty), proto_node.clone())];
             // The FULL virtual child only exists if the payload has been received.
             if proto_node.payload_received().is_ok_and(|received| received) {
@@ -1464,7 +1463,6 @@ impl ProtoArray {
                 .iter()
                 .filter_map(|&child_index| {
                     let child_node = self.nodes.get(child_index)?;
-                    // Skip parent_payload_status filter for V17 children (they don't have it)
                     if child_node.get_parent_payload_status() != node.payload_status {
                         return None;
                     }

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -1431,11 +1431,24 @@ impl ProtoArray {
                 .nodes
                 .get(node.proto_node_index)
                 .ok_or(Error::InvalidNodeIndex(node.proto_node_index))?;
-            let mut children = vec![(node.with_status(PayloadStatus::Empty), proto_node.clone())];
-            // The FULL virtual child only exists if the payload has been received.
-            if proto_node.payload_received().is_ok_and(|received| received) {
-                children.push((node.with_status(PayloadStatus::Full), proto_node.clone()));
-            }
+            
+            // TODO(gloas) this is the actual change we want to keep once PTC is implemented
+            // let mut children = vec![(node.with_status(PayloadStatus::Empty), proto_node.clone())];
+            // // The FULL virtual child only exists if the payload has been received.
+            // if proto_node.payload_received().is_ok_and(|received| received) {
+            //     children.push((node.with_status(PayloadStatus::Full), proto_node.clone()));
+            // }
+
+            // TODO(gloas) remove this and uncomment the code above once we implement PTC
+            // Skip Empty/Full split: go straight to Full when payload received,
+            // giving full payload weight 100% without PTC votes.
+            let children = if proto_node.payload_received().is_ok_and(|received| received) {
+                vec![(node.with_status(PayloadStatus::Full), proto_node.clone())]
+            } else {
+                vec![(node.with_status(PayloadStatus::Empty), proto_node.clone())]
+            };
+            // TODO(gloas) delete up to here
+            
             Ok(children)
         } else {
             let child_indices = children_index

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -1483,9 +1483,7 @@ impl ProtoArray {
                 .filter_map(|&child_index| {
                     let child_node = self.nodes.get(child_index)?;
                     // Skip parent_payload_status filter for V17 children (they don't have it)
-                    if child_node.as_v17().is_err()
-                        && child_node.get_parent_payload_status() != node.payload_status
-                    {
+                    if child_node.get_parent_payload_status() != node.payload_status {
                         return None;
                     }
                     Some((

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -1432,29 +1432,11 @@ impl ProtoArray {
                 .get(node.proto_node_index)
                 .ok_or(Error::InvalidNodeIndex(node.proto_node_index))?;
 
-            // V17 (pre-GLOAS) nodes don't have payload_received or parent_payload_status.
-            // Skip the virtual Empty/Full split and return real children directly.
-            if proto_node.as_v17().is_ok() {
-                let child_indices = children_index
-                    .get(node.proto_node_index)
-                    .map(|c| c.as_slice())
-                    .unwrap_or(&[]);
-                return Ok(child_indices
-                    .iter()
-                    .filter_map(|&child_index| {
-                        let child_node = self.nodes.get(child_index)?;
-                        Some((
-                            IndexedForkChoiceNode {
-                                root: child_node.root(),
-                                proto_node_index: child_index,
-                                payload_status: PayloadStatus::Pending,
-                            },
-                            child_node.clone(),
-                        ))
-                    })
-                    .collect());
+            let mut children = vec![(node.with_status(PayloadStatus::Empty), proto_node.clone())];
+            // The FULL virtual child only exists if the payload has been received.
+            if proto_node.payload_received().is_ok_and(|received| received) {
+                children.push((node.with_status(PayloadStatus::Full), proto_node.clone()));
             }
-
             // TODO(gloas) this is the actual change we want to keep once PTC is implemented
             // let mut children = vec![(node.with_status(PayloadStatus::Empty), proto_node.clone())];
             // // The FULL virtual child only exists if the payload has been received.

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -997,11 +997,7 @@ impl ProtoArrayForkChoice {
     /// Returns the `block.execution_status` field, if the block is present.
     pub fn get_block_execution_status(&self, block_root: &Hash256) -> Option<ExecutionStatus> {
         let block = self.get_proto_node(block_root)?;
-        Some(
-            block
-                .execution_status()
-                .unwrap_or_else(|_| ExecutionStatus::irrelevant()),
-        )
+        block.execution_status().ok()
     }
 
     /// Returns whether the execution payload for a block has been received.

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -997,7 +997,11 @@ impl ProtoArrayForkChoice {
     /// Returns the `block.execution_status` field, if the block is present.
     pub fn get_block_execution_status(&self, block_root: &Hash256) -> Option<ExecutionStatus> {
         let block = self.get_proto_node(block_root)?;
-        block.execution_status().ok()
+        Some(
+            block
+                .execution_status()
+                .unwrap_or_else(|_| ExecutionStatus::irrelevant()),
+        )
     }
 
     /// Returns whether the execution payload for a block has been received.


### PR DESCRIPTION
These are some hacks I had to implement to get fork choice to work for devnet-1

- Default payload FULL weight to 100%. Since we aren't including PTC votes in devnet-1 we need this to build on top of payloads
- Always available envelope. There are no DA checks in devnet-1, so we just immediately make the envelope available for import
- fix `get_block_execution_status` for gloas nodes, we just return `Irrelevant`. 
- Hack to `get_node_children`

I need to spend a bit more time debugging, but I have a working epbs-devnet-1 branch that requires at least a subset of these changes.

I've opened this PR mostly for visibility, not sure we'll actually want to merge any of this. 