### PR TITLE
cli: make --validator-dir flag global

### DIFF
--- a/account_manager/src/validator/mod.rs
+++ b/account_manager/src/validator/mod.rs
@@ -29,7 +29,8 @@ pub fn cli_app() -> Command {
                     Defaults to ~/.lighthouse/{network}/validators",
                 )
                 .action(ArgAction::Set)
-                .conflicts_with("datadir"),
+                .conflicts_with("datadir")
+                .global(true),
         )
         .subcommand(create::cli_app())
         .subcommand(modify::cli_app())

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2774,9 +2774,10 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("health"))
         .and(warp::path::end())
         .and(task_spawner_filter.clone())
-        .then(|task_spawner: TaskSpawner<T::EthSpec>| {
+        .and(data_dir_filter.clone())
+        .then(|task_spawner: TaskSpawner<T::EthSpec>, data_dir: PathBuf| {
             task_spawner.blocking_json_task(Priority::P0, move || {
-                eth2::lighthouse::Health::observe()
+                eth2::lighthouse::Health::observe(Some(&data_dir))
                     .map(api_types::GenericResponse::from)
                     .map_err(warp_utils::reject::custom_bad_request)
             })

--- a/common/health_metrics/src/metrics.rs
+++ b/common/health_metrics/src/metrics.rs
@@ -130,7 +130,7 @@ pub fn scrape_health_metrics() {
 pub fn scrape_process_health_metrics() {
     // This will silently fail if we are unable to observe the health. This is desired behaviour
     // since we don't support `Health` for all platforms.
-    if let Ok(health) = ProcessHealth::observe() {
+    if let Ok(health) = ProcessHealth::observe(None) {
         set_gauge(&PROCESS_NUM_THREADS, health.pid_num_threads);
         set_gauge(&PROCESS_RES_MEM, health.pid_mem_resident_set_size as i64);
         set_gauge(&PROCESS_VIRT_MEM, health.pid_mem_virtual_memory_size as i64);
@@ -142,7 +142,7 @@ pub fn scrape_process_health_metrics() {
 pub fn scrape_system_health_metrics() {
     // This will silently fail if we are unable to observe the health. This is desired behaviour
     // since we don't support `Health` for all platforms.
-    if let Ok(health) = SystemHealth::observe() {
+    if let Ok(health) = SystemHealth::observe(None) {
         set_gauge(&SYSTEM_VIRT_MEM_TOTAL, health.sys_virt_mem_total as i64);
         set_gauge(
             &SYSTEM_VIRT_MEM_AVAILABLE,

--- a/common/health_metrics/src/observe.rs
+++ b/common/health_metrics/src/observe.rs
@@ -1,4 +1,5 @@
 use eth2::lighthouse::{Health, ProcessHealth, SystemHealth};
+use std::path::Path;
 
 #[cfg(target_os = "linux")]
 use {
@@ -7,32 +8,32 @@ use {
 };
 
 pub trait Observe: Sized {
-    fn observe() -> Result<Self, String>;
+    fn observe(data_dir: Option<&Path>) -> Result<Self, String>;
 }
 
 impl Observe for Health {
     #[cfg(not(target_os = "linux"))]
-    fn observe() -> Result<Self, String> {
+    fn observe(_data_dir: Option<&Path>) -> Result<Self, String> {
         Err("Health is only available on Linux".into())
     }
 
     #[cfg(target_os = "linux")]
-    fn observe() -> Result<Self, String> {
+    fn observe(data_dir: Option<&Path>) -> Result<Self, String> {
         Ok(Self {
-            process: ProcessHealth::observe()?,
-            system: SystemHealth::observe()?,
+            process: ProcessHealth::observe(data_dir)?,
+            system: SystemHealth::observe(data_dir)?,
         })
     }
 }
 
 impl Observe for SystemHealth {
     #[cfg(not(target_os = "linux"))]
-    fn observe() -> Result<Self, String> {
+    fn observe(_data_dir: Option<&Path>) -> Result<Self, String> {
         Err("Health is only available on Linux".into())
     }
 
     #[cfg(target_os = "linux")]
-    fn observe() -> Result<Self, String> {
+    fn observe(data_dir: Option<&Path>) -> Result<Self, String> {
         let vm = psutil::memory::virtual_memory()
             .map_err(|e| format!("Unable to get virtual memory: {:?}", e))?;
         let loadavg =
@@ -41,7 +42,8 @@ impl Observe for SystemHealth {
         let cpu =
             psutil::cpu::cpu_times().map_err(|e| format!("Unable to get cpu times: {:?}", e))?;
 
-        let disk_usage = psutil::disk::disk_usage("/")
+        let disk_path = data_dir.unwrap_or_else(|| Path::new("/"));
+        let disk_usage = psutil::disk::disk_usage(disk_path)
             .map_err(|e| format!("Unable to disk usage info: {:?}", e))?;
 
         let disk = psutil::disk::DiskIoCountersCollector::default()
@@ -90,12 +92,12 @@ impl Observe for SystemHealth {
 
 impl Observe for ProcessHealth {
     #[cfg(not(target_os = "linux"))]
-    fn observe() -> Result<Self, String> {
+    fn observe(_data_dir: Option<&Path>) -> Result<Self, String> {
         Err("Health is only available on Linux".into())
     }
 
     #[cfg(target_os = "linux")]
-    fn observe() -> Result<Self, String> {
+    fn observe(_data_dir: Option<&Path>) -> Result<Self, String> {
         let process =
             Process::current().map_err(|e| format!("Unable to get current process: {:?}", e))?;
 

--- a/common/monitoring_api/src/gather.rs
+++ b/common/monitoring_api/src/gather.rs
@@ -190,7 +190,7 @@ pub fn gather_beacon_metrics(
 
     let beacon_metrics = gather_metrics(&BEACON_METRICS_MAP)
         .ok_or_else(|| "Failed to gather beacon metrics".to_string())?;
-    let process = eth2::lighthouse::ProcessHealth::observe()?.into();
+    let process = eth2::lighthouse::ProcessHealth::observe(None)?.into();
 
     Ok(BeaconProcessMetrics {
         beacon: beacon_metrics,
@@ -203,7 +203,7 @@ pub fn gather_validator_metrics() -> Result<ValidatorProcessMetrics, String> {
     let validator_metrics = gather_metrics(&VALIDATOR_METRICS_MAP)
         .ok_or_else(|| "Failed to gather validator metrics".to_string())?;
 
-    let process = eth2::lighthouse::ProcessHealth::observe()?.into();
+    let process = eth2::lighthouse::ProcessHealth::observe(None)?.into();
     Ok(ValidatorProcessMetrics {
         validator: validator_metrics,
         common: process,

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -159,7 +159,8 @@ impl MonitoringHttpClient {
 
     /// Gets system metrics by observing capturing the SystemHealth metrics.
     pub fn get_system_metrics(&self) -> Result<MonitoringMetrics, Error> {
-        let system_health = SystemHealth::observe().map_err(Error::SystemMetricsFailed)?;
+        let system_health =
+            SystemHealth::observe(self.db_path.as_deref()).map_err(Error::SystemMetricsFailed)?;
         Ok(MonitoringMetrics {
             metadata: Metadata::new(ProcessType::System),
             process_metrics: Process::System(system_health.into()),

--- a/validator_client/http_api/src/lib.rs
+++ b/validator_client/http_api/src/lib.rs
@@ -303,9 +303,10 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
     let get_lighthouse_health = warp::path("lighthouse")
         .and(warp::path("health"))
         .and(warp::path::end())
-        .then(|| {
+        .and(validator_dir_filter.clone())
+        .then(|validator_dir: PathBuf| {
             blocking_json_task(move || {
-                eth2::lighthouse::Health::observe()
+                eth2::lighthouse::Health::observe(Some(&validator_dir))
                     .map(api_types::GenericResponse::from)
                     .map_err(warp_utils::reject::custom_bad_request)
             })


### PR DESCRIPTION
Resolves #3768.

This PR marks the --validator-dir (and its alias --validators-dir) flag as global within the validator subcommand of the account manager.

Currently, clap requires flags to be placed either before or after a subcommand based on where they are defined. For node operators, this is often unintuitive (e.g. they might expect validator create --validator-dir /dir) to work). 

By marking this flag as global in the parent validator command, it can now be placed:
- Immediately after validator: lighthouse am validator --validator-dir /foo create
- - After a subcommand: lighthouse am validator create --validator-dir /foo
This follows the consistency of the datadir flag used across the binary.

**Changes:**
- Modified account_manager/src/validator/mod.rs to set .global(true) on the VALIDATOR_DIR_FLAG argument.