### PR TITLE
fix: correct hex encoding in as_hex_string

### DIFF
--- a/crypto/bls/src/generic_public_key_bytes.rs
+++ b/crypto/bls/src/generic_public_key_bytes.rs
@@ -67,7 +67,7 @@ impl<Pub> GenericPublicKeyBytes<Pub> {
 
     /// Returns `self.serialize()` as a `0x`-prefixed hex string.
     pub fn as_hex_string(&self) -> String {
-        format!("{:?}", self)
+        hex_encode(&self.bytes)
     }
 
     /// Instantiates `Self` from bytes.


### PR DESCRIPTION
as_hex_string() used Debug formatting instead of explicit hex encoding. Switch to hex_encode(&self.bytes) to ensure correct output.
