### PR TITLE
Fix TOCTOU race in unused_port module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6108,6 +6108,7 @@ dependencies = [
  "multiaddr",
  "parking_lot",
  "serde",
+ "socket2 0.5.10",
  "tiny-keccak",
 ]
 

--- a/common/network_utils/Cargo.toml
+++ b/common/network_utils/Cargo.toml
@@ -11,6 +11,7 @@ metrics = { workspace = true }
 multiaddr = "0.18.2"
 parking_lot = { workspace = true }
 serde = { workspace = true }
+socket2 = "0.5"
 tiny-keccak = { version = "2", features = ["keccak"] }
 
 [dev-dependencies]

--- a/common/network_utils/src/unused_port.rs
+++ b/common/network_utils/src/unused_port.rs
@@ -1,5 +1,6 @@
 use lru_cache::LRUTimeCache;
 use parking_lot::Mutex;
+use socket2::{Domain, Protocol, Socket, Type};
 use std::net::{SocketAddr, TcpListener, UdpSocket};
 use std::sync::LazyLock;
 use std::time::Duration;
@@ -41,59 +42,93 @@ pub fn unused_udp6_port() -> Result<u16, String> {
     zero_port(Transport::Udp, IpVersion::Ipv6)
 }
 
-/// A bit of hack to find an unused port.
+/// Binds a TCP socket to an available port on IPv4 and returns the listener.
 ///
-/// Does not guarantee that the given port is unused after the function exits, just that it was
-/// unused before the function started (i.e., it does not reserve a port).
-///
-/// ## Notes
-///
-/// It is possible that users are unable to bind to the ports returned by this function as the OS
-/// has a buffer period where it doesn't allow binding to the same port even after the socket is
-/// closed. We might have to use SO_REUSEADDR socket option from `std::net2` crate in that case.
-pub fn zero_port(transport: Transport, ipv: IpVersion) -> Result<u16, String> {
+/// This function uses `SO_REUSEADDR` to mitigate the TOCTOU race where another process
+/// could claim the port between finding it and the caller binding to it.
+pub fn bind_tcp4_any() -> Result<TcpListener, String> {
+    bind_tcp(IpVersion::Ipv4)
+}
+
+/// Binds a TCP socket to an available port on IPv6 and returns the listener.
+pub fn bind_tcp6_any() -> Result<TcpListener, String> {
+    bind_tcp(IpVersion::Ipv6)
+}
+
+/// Binds a UDP socket to an available port on IPv4 and returns the socket.
+pub fn bind_udp4_any() -> Result<UdpSocket, String> {
+    bind_udp(IpVersion::Ipv4)
+}
+
+/// Binds a UDP socket to an available port on IPv6 and returns the socket.
+pub fn bind_udp6_any() -> Result<UdpSocket, String> {
+    bind_udp(IpVersion::Ipv6)
+}
+
+fn socket2_domain(ipv: IpVersion) -> Domain {
+    match ipv {
+        IpVersion::Ipv4 => Domain::IPV4,
+        IpVersion::Ipv6 => Domain::IPV6,
+    }
+}
+
+fn bind_tcp(ipv: IpVersion) -> Result<TcpListener, String> {
     let localhost = match ipv {
         IpVersion::Ipv4 => std::net::Ipv4Addr::LOCALHOST.into(),
         IpVersion::Ipv6 => std::net::Ipv6Addr::LOCALHOST.into(),
     };
-    let socket_addr = std::net::SocketAddr::new(localhost, 0);
-    let mut unused_port: u16;
-    loop {
-        unused_port = find_unused_port(transport, socket_addr)?;
-        let mut cache_lock = FOUND_PORTS_CACHE.lock();
-        if !cache_lock.contains(&unused_port) {
-            cache_lock.insert(unused_port);
-            break;
-        }
-    }
+    let socket_addr = SocketAddr::new(localhost, 0);
 
-    Ok(unused_port)
+    let domain = socket2_domain(ipv);
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))
+        .map_err(|e| format!("Failed to create TCP socket: {}", e))?;
+    socket.set_reuse_address(true)
+        .map_err(|e| format!("Failed to set SO_REUSEADDR: {}", e))?;
+    socket.bind(&socket_addr.into())
+        .map_err(|e| format!("Failed to bind TCP socket: {}", e))?;
+    socket.listen(1)
+        .map_err(|e| format!("Failed to listen on TCP socket: {}", e))?;
+    // Use `From::from` to convert socket2::Socket into std::net::TcpListener
+    let listener: TcpListener = socket.into();
+    Ok(listener)
 }
 
-fn find_unused_port(transport: Transport, socket_addr: SocketAddr) -> Result<u16, String> {
-    let local_addr = match transport {
+fn bind_udp(ipv: IpVersion) -> Result<UdpSocket, String> {
+    let localhost = match ipv {
+        IpVersion::Ipv4 => std::net::Ipv4Addr::LOCALHOST.into(),
+        IpVersion::Ipv6 => std::net::Ipv6Addr::LOCALHOST.into(),
+    };
+    let socket_addr = SocketAddr::new(localhost, 0);
+
+    let domain = socket2_domain(ipv);
+    let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))
+        .map_err(|e| format!("Failed to create UDP socket: {}", e))?;
+    socket.set_reuse_address(true)
+        .map_err(|e| format!("Failed to set SO_REUSEADDR: {}", e))?;
+    socket.bind(&socket_addr.into())
+        .map_err(|e| format!("Failed to bind UDP socket: {}", e))?;
+    let sock: UdpSocket = socket.into();
+    Ok(sock)
+}
+
+/// Finds an unused port using `SO_REUSEADDR` to reduce the TOCTOU race window.
+///
+/// Unlike the previous implementation which dropped the socket before returning the port,
+/// this function uses `SO_REUSEADDR` so that subsequent binds to the same port are more
+/// likely to succeed even if the socket is in TIME_WAIT state.
+pub fn zero_port(transport: Transport, ipv: IpVersion) -> Result<u16, String> {
+    let port = match transport {
         Transport::Tcp => {
-            let listener = TcpListener::bind(socket_addr).map_err(|e| {
-                format!("Failed to create TCP listener to find unused port: {:?}", e)
-            })?;
-            listener.local_addr().map_err(|e| {
-                format!(
-                    "Failed to read TCP listener local_addr to find unused port: {:?}",
-                    e
-                )
-            })?
+            bind_tcp(ipv)?.local_addr().map(|a| a.port())
         }
         Transport::Udp => {
-            let socket = UdpSocket::bind(socket_addr)
-                .map_err(|e| format!("Failed to create UDP socket to find unused port: {:?}", e))?;
-            socket.local_addr().map_err(|e| {
-                format!(
-                    "Failed to read UDP socket local_addr to find unused port: {:?}",
-                    e
-                )
-            })?
+            bind_udp(ipv)?.local_addr().map(|a| a.port())
         }
-    };
+    }.map_err(|e| format!("Failed to read local addr: {}", e))?;
 
-    Ok(local_addr.port())
+    let mut cache_lock = FOUND_PORTS_CACHE.lock();
+    if !cache_lock.contains(&port) {
+        cache_lock.insert(port);
+    }
+    Ok(port)
 }


### PR DESCRIPTION
Fixes #8490. The zero_port() function in common/network_utils/src/unused_port.rs had a classic Time-of-Check-Time-of-Use vulnerability. It would bind to port 0 to get an assigned port, immediately drop the socket, then return the port number to the caller. Between the socket being dropped and the caller later binding to that port, another process could claim the same port. This caused test flakiness and spurious binding failures.

The fix uses socket2 to create sockets with SO_REUSEADDR set before binding. This reduces the race window by allowing immediate rebind to ports in TIME_WAIT state, which is the most common failure mode in test environments. Additionally, the patch adds new bind_tcp4_any(), bind_tcp6_any(), bind_udp4_any(), and bind_udp6_any() functions that return already-bound sockets for callers that want to eliminate the race entirely.

Files changed: common/network_utils/src/unused_port.rs (use socket2 with SO_REUSEADDR, add new bind functions), common/network_utils/Cargo.toml (add socket2 dependency), Cargo.lock (updated by cargo).