### PR TITLE
Fix graffiti calculator test mock commit fallback

### DIFF
--- a/beacon_node/beacon_chain/src/graffiti_calculator.rs
+++ b/beacon_node/beacon_chain/src/graffiti_calculator.rs
@@ -446,7 +446,7 @@ mod tests {
                     DEFAULT_CLIENT_VERSION.code,
                     mock_commit
                         .strip_prefix("0x")
-                        .unwrap_or("&mock_commit")
+                        .unwrap_or(&mock_commit)
                         .get(0..4)
                         .expect("should get first 2 bytes in hex"),
                     "LH",
@@ -459,7 +459,7 @@ mod tests {
                     DEFAULT_CLIENT_VERSION.code,
                     mock_commit
                         .strip_prefix("0x")
-                        .unwrap_or("&mock_commit")
+                        .unwrap_or(&mock_commit)
                         .get(0..2)
                         .expect("should get first 2 bytes in hex"),
                     "LH",


### PR DESCRIPTION
## Summary

Corrects the `unwrap_or` fallback in `graffiti_calculator` unit tests: use `&mock_commit` instead of the literal string `"&mock_commit"` when `strip_prefix("0x")` does not match, so the hex slice is derived from the actual mock value.

## Notes

- Test-only change; no runtime behavior change.