### PR TITLE
Use spec constants for PTC thresholds in fork choice

### DIFF
--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -211,7 +211,7 @@ impl ProtoNode {
             return false;
         }
 
-        node.payload_timeliness_votes.num_set_bits() > E::ptc_size() / 2
+        node.payload_timeliness_votes.num_set_bits() > E::payload_timely_threshold()
     }
 
     pub fn is_payload_data_available<E: EthSpec>(&self) -> bool {
@@ -224,8 +224,8 @@ impl ProtoNode {
             return false;
         }
 
-        // TODO(gloas): add function on EthSpec for DATA_AVAILABILITY_TIMELY_THRESHOLD
-        node.payload_data_availability_votes.num_set_bits() > E::ptc_size() / 2
+        node.payload_data_availability_votes.num_set_bits()
+            > E::data_availability_timely_threshold()
     }
 }
 

--- a/consensus/types/src/core/eth_spec.rs
+++ b/consensus/types/src/core/eth_spec.rs
@@ -448,6 +448,11 @@ pub trait EthSpec: 'static + Default + Sync + Send + Clone + Debug + PartialEq +
     fn payload_timely_threshold() -> usize {
         Self::PTCSize::to_usize() / 2
     }
+
+    /// Returns the `DATA_AVAILABILITY_TIMELY_THRESHOLD` constant (PTC_SIZE / 2).
+    fn data_availability_timely_threshold() -> usize {
+        Self::PTCSize::to_usize() / 2
+    }
 }
 
 /// Macro to inherit some type values from another EthSpec.


### PR DESCRIPTION
Follow-up from #9025. The `is_payload_timely` and `is_payload_data_available` functions were using inline `ptc_size() / 2` instead of the spec constant functions. This adds `data_availability_timely_threshold()` to `EthSpec` and uses both it and the existing `payload_timely_threshold()` in proto_array.