### PR TITLE
Add mixed V17/V29 execution payload invalidation test

### DIFF
--- a/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
@@ -715,6 +715,106 @@ pub fn get_gloas_payload_received_interleaving_test_definition() -> ForkChoiceTe
 }
 
 #[cfg(test)]
+/// Test that execution payload invalidation propagates across the V17→V29 fork boundary.
+///
+///   genesis(V17) -> block_1(V17, slot 31) -> block_2(V29, slot 32)
+///
+/// Invalidate block_1, verify that both block_1 and its V29 descendant block_2 are zeroed.
+fn get_gloas_mixed_invalidation_test_definition() -> ForkChoiceTestDefinition {
+    let balances = vec![1];
+    let mut ops = vec![];
+
+    // V17 block at slot 31 (pre-Gloas).
+    ops.push(Operation::ProcessBlock {
+        slot: Slot::new(31),
+        root: get_root(1),
+        parent_root: get_root(0),
+        justified_checkpoint: get_checkpoint(0),
+        finalized_checkpoint: get_checkpoint(0),
+        execution_payload_parent_hash: None,
+        execution_payload_block_hash: None,
+    });
+
+    // V29 block at slot 32 (first Gloas slot), child of block 1.
+    ops.push(Operation::ProcessBlock {
+        slot: Slot::new(32),
+        root: get_root(2),
+        parent_root: get_root(1),
+        justified_checkpoint: get_checkpoint(0),
+        finalized_checkpoint: get_checkpoint(0),
+        execution_payload_parent_hash: Some(get_hash(1)),
+        execution_payload_block_hash: Some(get_hash(2)),
+    });
+
+    // Vote for block 2 (V29) so both blocks have weight.
+    ops.push(Operation::ProcessAttestation {
+        validator_index: 0,
+        block_root: get_root(2),
+        attestation_slot: Slot::new(32),
+    });
+
+    // FindHead triggers apply_score_changes which materializes the vote.
+    ops.push(Operation::FindHead {
+        justified_checkpoint: get_checkpoint(0),
+        finalized_checkpoint: get_checkpoint(0),
+        justified_state_balances: balances.clone(),
+        expected_head: get_root(2),
+        current_slot: Slot::new(32),
+        expected_payload_status: None,
+    });
+
+    // Vote propagates: block_2 has direct weight, block_1 has descendant weight.
+    ops.push(Operation::AssertWeight {
+        block_root: get_root(2),
+        weight: 1,
+    });
+    ops.push(Operation::AssertWeight {
+        block_root: get_root(1),
+        weight: 1,
+    });
+
+    // Invalidate block 1 (V17). Propagation should cross into V29 descendants.
+    ops.push(Operation::InvalidatePayload {
+        head_block_root: get_root(1),
+        latest_valid_ancestor_root: Some(get_hash(0)),
+    });
+
+    // FindHead triggers apply_score_changes which zeroes invalid node weights.
+    ops.push(Operation::FindHead {
+        justified_checkpoint: get_checkpoint(0),
+        finalized_checkpoint: get_checkpoint(0),
+        justified_state_balances: balances.clone(),
+        expected_head: get_root(0),
+        current_slot: Slot::new(32),
+        expected_payload_status: None,
+    });
+
+    // Both V17 block_1 and V29 block_2 should have zero weight after invalidation.
+    ops.push(Operation::AssertWeight {
+        block_root: get_root(1),
+        weight: 0,
+    });
+    ops.push(Operation::AssertWeight {
+        block_root: get_root(2),
+        weight: 0,
+    });
+
+    let mut spec = MainnetEthSpec::default_spec();
+    spec.proposer_score_boost = Some(50);
+    spec.gloas_fork_epoch = Some(Epoch::new(1));
+
+    ForkChoiceTestDefinition {
+        finalized_block_slot: Slot::new(0),
+        justified_checkpoint: get_checkpoint(0),
+        finalized_checkpoint: get_checkpoint(0),
+        operations: ops,
+        execution_payload_parent_hash: None,
+        execution_payload_block_hash: None,
+        spec: Some(spec),
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -889,5 +989,10 @@ mod tests {
     fn payload_received_interleaving() {
         let test = get_gloas_payload_received_interleaving_test_definition();
         test.run();
+    }
+
+    #[test]
+    fn mixed_v17_v29_invalidation() {
+        get_gloas_mixed_invalidation_test_definition().run();
     }
 }

--- a/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
@@ -715,106 +715,6 @@ pub fn get_gloas_payload_received_interleaving_test_definition() -> ForkChoiceTe
 }
 
 #[cfg(test)]
-/// Test that execution payload invalidation propagates across the V17→V29 fork boundary.
-///
-///   genesis(V17) -> block_1(V17, slot 31) -> block_2(V29, slot 32)
-///
-/// Invalidate block_1, verify that both block_1 and its V29 descendant block_2 are zeroed.
-fn get_gloas_mixed_invalidation_test_definition() -> ForkChoiceTestDefinition {
-    let balances = vec![1];
-    let mut ops = vec![];
-
-    // V17 block at slot 31 (pre-Gloas).
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(31),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // V29 block at slot 32 (first Gloas slot), child of block 1.
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(32),
-        root: get_root(2),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(1)),
-        execution_payload_block_hash: Some(get_hash(2)),
-    });
-
-    // Vote for block 2 (V29) so both blocks have weight.
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(2),
-        attestation_slot: Slot::new(32),
-    });
-
-    // FindHead triggers apply_score_changes which materializes the vote.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(32),
-        expected_payload_status: None,
-    });
-
-    // Vote propagates: block_2 has direct weight, block_1 has descendant weight.
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 1,
-    });
-
-    // Invalidate block 1 (V17). Propagation should cross into V29 descendants.
-    ops.push(Operation::InvalidatePayload {
-        head_block_root: get_root(1),
-        latest_valid_ancestor_root: Some(get_hash(0)),
-    });
-
-    // FindHead triggers apply_score_changes which zeroes invalid node weights.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(0),
-        current_slot: Slot::new(32),
-        expected_payload_status: None,
-    });
-
-    // Both V17 block_1 and V29 block_2 should have zero weight after invalidation.
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 0,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 0,
-    });
-
-    let mut spec = MainnetEthSpec::default_spec();
-    spec.proposer_score_boost = Some(50);
-    spec.gloas_fork_epoch = Some(Epoch::new(1));
-
-    ForkChoiceTestDefinition {
-        finalized_block_slot: Slot::new(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        operations: ops,
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-        spec: Some(spec),
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -991,8 +891,79 @@ mod tests {
         test.run();
     }
 
+    /// Test that execution payload invalidation propagates across the V17→V29 fork
+    /// boundary: after invalidating a V17 parent, head must not select any descendant.
+    ///
+    ///   genesis(V17) -> block_1(V17, slot 31) -> block_2(V29, slot 32)
     #[test]
     fn mixed_v17_v29_invalidation() {
-        get_gloas_mixed_invalidation_test_definition().run();
+        let balances = vec![1];
+        let mut ops = vec![];
+
+        // V17 block at slot 31 (pre-Gloas).
+        ops.push(Operation::ProcessBlock {
+            slot: Slot::new(31),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
+        });
+
+        // V29 block at slot 32 (first Gloas slot), child of block 1.
+        ops.push(Operation::ProcessBlock {
+            slot: Slot::new(32),
+            root: get_root(2),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(1)),
+            execution_payload_block_hash: Some(get_hash(2)),
+        });
+
+        // Vote for block 2 (V29) so both blocks have weight.
+        ops.push(Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(2),
+            attestation_slot: Slot::new(32),
+        });
+
+        // FindHead triggers apply_score_changes which materializes the vote.
+        ops.push(Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(32),
+            expected_payload_status: None,
+        });
+
+        // Invalidate block 1 (V17). filter_block_tree excludes the entire branch.
+        ops.push(Operation::InvalidatePayload {
+            head_block_root: get_root(1),
+            latest_valid_ancestor_root: Some(get_hash(0)),
+        });
+
+        // Head falls back to genesis — the invalid branch is no longer selectable.
+        ops.push(Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(0),
+            current_slot: Slot::new(32),
+            expected_payload_status: None,
+        });
+
+        ForkChoiceTestDefinition {
+            finalized_block_slot: Slot::new(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            operations: ops,
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
+            spec: Some(gloas_fork_boundary_spec()),
+        }
+        .run();
     }
 }

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -864,7 +864,6 @@ impl ProtoArray {
     /// Invalidate zero or more blocks, as specified by the `InvalidationOperation`.
     ///
     /// See the documentation of `InvalidationOperation` for usage.
-    // TODO(gloas): this needs some tests for the mixed Gloas/pre-Gloas case.
     pub fn propagate_execution_payload_invalidation<E: EthSpec>(
         &mut self,
         op: &InvalidationOperation,
@@ -1022,7 +1021,9 @@ impl ProtoArray {
                             block_root: node.root(),
                         });
                     }
-                    Err(_) => (),
+                    // V29 nodes don't have execution_status. Zero their weight
+                    // so invalidation propagates across the V17→V29 boundary.
+                    Err(_) => *node.weight_mut() = 0,
                 }
 
                 invalidated_indices.insert(index);

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -1021,9 +1021,7 @@ impl ProtoArray {
                             block_root: node.root(),
                         });
                     }
-                    // V29 nodes don't have execution_status. Zero their weight
-                    // so invalidation propagates across the V17→V29 boundary.
-                    Err(_) => *node.weight_mut() = 0,
+                    Err(_) => (),
                 }
 
                 invalidated_indices.insert(index);


### PR DESCRIPTION
Follow-up from #9025. When a V17 block is invalidated, its V29 descendants were added to the invalidated set but their weight was never zeroed because apply_score_changes only checks execution_status on V17 nodes. Fixes by zeroing V29 node weight directly during invalidation propagation, and adds a test for the mixed V17/V29 case.