### PR TITLE
Gloas relax epoch aligned checkpoint state requirements

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -172,8 +172,9 @@ where
         let mut anchor_state = anchor.beacon_state;
         let mut anchor_block_header = anchor_state.latest_block_header().clone();
 
-        // The anchor state MUST be on an epoch boundary (it should be advanced by the caller).
-        if !anchor_state
+        // Pre-gloas the anchor state MUST be on an epoch boundary (it should be advanced by the caller).
+        // Post-gloas this requirement is relaxed.
+        if !anchor_state.fork_name_unchecked().gloas_enabled() && !anchor_state
             .slot()
             .as_u64()
             .is_multiple_of(E::slots_per_epoch())

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -174,10 +174,11 @@ where
 
         // Pre-gloas the anchor state MUST be on an epoch boundary (it should be advanced by the caller).
         // Post-gloas this requirement is relaxed.
-        if !anchor_state.fork_name_unchecked().gloas_enabled() && !anchor_state
-            .slot()
-            .as_u64()
-            .is_multiple_of(E::slots_per_epoch())
+        if !anchor_state.fork_name_unchecked().gloas_enabled()
+            && !anchor_state
+                .slot()
+                .as_u64()
+                .is_multiple_of(E::slots_per_epoch())
         {
             return Err(Error::UnalignedCheckpoint {
                 block_slot: anchor_block_header.slot,

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -42,6 +42,7 @@ use store::{Error as StoreError, HotColdDB, ItemStore, KeyValueStoreOp};
 use task_executor::{ShutdownReason, TaskExecutor};
 use tracing::{debug, error, info, warn};
 use tree_hash::TreeHash;
+use types::StatePayloadStatus;
 use types::data::CustodyIndex;
 use types::{
     BeaconBlock, BeaconState, BlobSidecarList, ChainSpec, ColumnIndex, DataColumnSidecarList,
@@ -433,9 +434,15 @@ where
             .clone()
             .ok_or("weak_subjectivity_state requires a store")?;
 
-        // Ensure the state is advanced to an epoch boundary.
+        // Pre-gloas ensure the state is advanced to an epoch boundary.
+        // Post-gloas checkpoint states are always pending (post-block) and cannot
+        // be advanced across epoch boundaries without first checking for a payload
+        // envelope.
         let slots_per_epoch = E::slots_per_epoch();
-        if weak_subj_state.slot() % slots_per_epoch != 0 {
+
+        if !weak_subj_state.fork_name_unchecked().gloas_enabled()
+            && weak_subj_state.slot() % slots_per_epoch != 0
+        {
             debug!(
                 state_slot = %weak_subj_state.slot(),
                 block_slot = %weak_subj_block.slot(),
@@ -568,7 +575,7 @@ where
         // Write the state, block and blobs non-atomically, it doesn't matter if they're forgotten
         // about on a crash restart.
         store
-            .update_finalized_state(
+            .set_initial_finalized_state(
                 weak_subj_state_root,
                 weak_subj_block_root,
                 weak_subj_state.clone(),
@@ -617,7 +624,15 @@ where
                 .map_err(|e| format!("Failed to initialize data column info: {:?}", e))?,
         );
 
-        // TODO(gloas): add check that checkpoint state is Pending
+        if weak_subj_state.fork_name_unchecked().gloas_enabled()
+            && weak_subj_state.payload_status() != StatePayloadStatus::Pending
+        {
+            return Err(format!(
+                "Checkpoint sync state must be Pending (post-block) for Gloas, got {:?}",
+                weak_subj_state.payload_status()
+            ));
+        }
+
         let snapshot = BeaconSnapshot {
             beacon_block_root: weak_subj_block_root,
             execution_envelope: None,

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -5466,12 +5466,12 @@ fn check_finalization(harness: &TestHarness, expected_slot: u64) {
 }
 
 // Verify that post-gloas checkpoint sync accepts a non-epoch aligned state and builds
-// the chain. 
+// the chain.
 //
 // Since post-gloas checkpoint sync states are always the post block state, if the epoch boundary
 // slot is skipped, we'll receive a checkpoint state that is not epoch aligned.
 //
-// Example: slot `n` is the epoch boundary slot and is skipped. We'll receive the post block state for 
+// Example: slot `n` is the epoch boundary slot and is skipped. We'll receive the post block state for
 // slot `n - 1`. This is the state before the payload for slot `n - 1` was processed.
 #[tokio::test]
 async fn weak_subjectivity_sync_gloas_pending_non_aligned() {

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -5465,6 +5465,153 @@ fn check_finalization(harness: &TestHarness, expected_slot: u64) {
     );
 }
 
+// Checkpoint sync with a Gloas Pending state at a non-epoch-boundary slot.
+//
+// Post-Gloas, the finalized state is always the post-block (Pending) state.
+// If the epoch boundary slot is skipped, the checkpoint state will not be
+// epoch-aligned. This test verifies that checkpoint sync accepts such states
+// and builds the chain correctly.
+#[tokio::test]
+async fn weak_subjectivity_sync_gloas_pending_non_aligned() {
+    if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
+
+    let spec = test_spec::<E>();
+
+    // Build a chain with a skipped slot at the epoch boundary.
+    // For MinimalEthSpec (8 slots/epoch), skip slot 8 so the last block before
+    // the epoch boundary is at slot 7 (not epoch-aligned).
+    let epoch_boundary_slot = E::slots_per_epoch();
+    let num_initial_slots = E::slots_per_epoch() * 4;
+    let checkpoint_slot = Slot::new(epoch_boundary_slot);
+
+    let slots = (1..num_initial_slots)
+        .map(Slot::new)
+        .filter(|&slot| {
+            // Skip the epoch boundary slot so the checkpoint resolves to the
+            // block at slot epoch_boundary - 1.
+            slot.as_u64() != epoch_boundary_slot
+        })
+        .collect::<Vec<_>>();
+
+    let temp1 = tempdir().unwrap();
+    let full_store = get_store_generic(&temp1, StoreConfig::default(), spec.clone());
+    let harness = get_harness_import_all_data_columns(full_store.clone(), LOW_VALIDATOR_COUNT);
+    let all_validators = (0..LOW_VALIDATOR_COUNT).collect::<Vec<_>>();
+
+    let (genesis_state, genesis_state_root) = harness.get_current_state_and_root();
+    harness
+        .add_attested_blocks_at_slots(
+            genesis_state.clone(),
+            genesis_state_root,
+            &slots,
+            &all_validators,
+        )
+        .await;
+
+    // Extract the checkpoint block and its Pending (post-block) state.
+    let wss_block_root = harness
+        .chain
+        .block_root_at_slot(checkpoint_slot, WhenSlotSkipped::Prev)
+        .unwrap()
+        .unwrap();
+    let wss_block = harness
+        .chain
+        .store
+        .get_full_block(&wss_block_root)
+        .unwrap()
+        .unwrap();
+
+    // The block's state_root points to the Pending state in Gloas.
+    let wss_state_root = wss_block.state_root();
+    let wss_state = full_store
+        .get_state(&wss_state_root, Some(wss_block.slot()), CACHE_STATE_IN_TESTS)
+        .unwrap()
+        .unwrap();
+
+    // Verify test preconditions: state is Pending and not epoch-aligned.
+    assert_eq!(
+        wss_state.payload_status(),
+        StatePayloadStatus::Pending,
+        "Checkpoint state should be Pending (post-block, pre-payload)"
+    );
+    assert_ne!(
+        wss_state.slot() % E::slots_per_epoch(),
+        0,
+        "Test invalid: checkpoint state is epoch-aligned, expected non-aligned"
+    );
+
+    let wss_blobs_opt = harness
+        .chain
+        .get_or_reconstruct_blobs(&wss_block_root)
+        .unwrap();
+
+    // Build a new chain from the non-aligned Pending checkpoint state.
+    let temp2 = tempdir().unwrap();
+    let store = get_store_generic(&temp2, StoreConfig::default(), spec.clone());
+
+    let slot_clock = TestingSlotClock::new(
+        Slot::new(0),
+        Duration::from_secs(harness.chain.genesis_time),
+        spec.get_slot_duration(),
+    );
+    slot_clock.set_slot(harness.get_current_slot().as_u64());
+
+    let chain_config = ChainConfig {
+        archive: true,
+        ..ChainConfig::default()
+    };
+
+    let trusted_setup = get_kzg(&spec);
+    let (shutdown_tx, _shutdown_rx) = futures::channel::mpsc::channel(1);
+    let mock = mock_execution_layer_from_parts(
+        harness.spec.clone(),
+        harness.runtime.task_executor.clone(),
+    );
+
+    let beacon_chain = BeaconChainBuilder::<DiskHarnessType<E>>::new(MinimalEthSpec, trusted_setup)
+        .chain_config(chain_config)
+        .store(store.clone())
+        .custom_spec(spec.clone().into())
+        .task_executor(harness.chain.task_executor.clone())
+        .weak_subjectivity_state(
+            wss_state,
+            wss_block,
+            wss_blobs_opt,
+            genesis_state,
+        )
+        .unwrap()
+        .store_migrator_config(MigratorConfig::default().blocking())
+        .slot_clock(slot_clock)
+        .shutdown_sender(shutdown_tx)
+        .event_handler(Some(ServerSentEventHandler::new_with_capacity(1)))
+        .execution_layer(Some(mock.el))
+        .ordered_custody_column_indices(generate_data_column_indices_rand_order::<E>())
+        .rng(Box::new(StdRng::seed_from_u64(42)))
+        .build();
+
+    assert!(
+        beacon_chain.is_ok(),
+        "Beacon chain should build from non-aligned Gloas Pending checkpoint state. Error: {:?}",
+        beacon_chain.err()
+    );
+
+    let chain = beacon_chain.unwrap();
+
+    // The head state should be at the block's slot (not advanced to the epoch boundary).
+    assert_eq!(
+        chain.head_snapshot().beacon_state.slot(),
+        Slot::new(epoch_boundary_slot - 1),
+        "Head state should be at the checkpoint block's slot"
+    );
+    assert_eq!(
+        chain.head_snapshot().beacon_state.payload_status(),
+        StatePayloadStatus::Pending,
+        "Head state should be Pending after checkpoint sync"
+    );
+}
+
 // ===================== Gloas Store Tests =====================
 
 /// Test basic Gloas block + envelope storage and retrieval.

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -5465,12 +5465,14 @@ fn check_finalization(harness: &TestHarness, expected_slot: u64) {
     );
 }
 
-// Checkpoint sync with a Gloas Pending state at a non-epoch-boundary slot.
+// Verify that post-gloas checkpoint sync accepts a non-epoch aligned state and builds
+// the chain. 
 //
-// Post-Gloas, the finalized state is always the post-block (Pending) state.
-// If the epoch boundary slot is skipped, the checkpoint state will not be
-// epoch-aligned. This test verifies that checkpoint sync accepts such states
-// and builds the chain correctly.
+// Since post-gloas checkpoint sync states are always the post block state, if the epoch boundary
+// slot is skipped, we'll receive a checkpoint state that is not epoch aligned.
+//
+// Example: slot `n` is the epoch boundary slot and is skipped. We'll receive the post block state for 
+// slot `n - 1`. This is the state before the payload for slot `n - 1` was processed.
 #[tokio::test]
 async fn weak_subjectivity_sync_gloas_pending_non_aligned() {
     if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
@@ -5480,8 +5482,6 @@ async fn weak_subjectivity_sync_gloas_pending_non_aligned() {
     let spec = test_spec::<E>();
 
     // Build a chain with a skipped slot at the epoch boundary.
-    // For MinimalEthSpec (8 slots/epoch), skip slot 8 so the last block before
-    // the epoch boundary is at slot 7 (not epoch-aligned).
     let epoch_boundary_slot = E::slots_per_epoch();
     let num_initial_slots = E::slots_per_epoch() * 4;
     let checkpoint_slot = Slot::new(epoch_boundary_slot);
@@ -5489,8 +5489,7 @@ async fn weak_subjectivity_sync_gloas_pending_non_aligned() {
     let slots = (1..num_initial_slots)
         .map(Slot::new)
         .filter(|&slot| {
-            // Skip the epoch boundary slot so the checkpoint resolves to the
-            // block at slot epoch_boundary - 1.
+            // Skip the epoch boundary slot
             slot.as_u64() != epoch_boundary_slot
         })
         .collect::<Vec<_>>();
@@ -5510,7 +5509,7 @@ async fn weak_subjectivity_sync_gloas_pending_non_aligned() {
         )
         .await;
 
-    // Extract the checkpoint block and its Pending (post-block) state.
+    // Extract the checkpoint block and its Pending state.
     let wss_block_root = harness
         .chain
         .block_root_at_slot(checkpoint_slot, WhenSlotSkipped::Prev)
@@ -5526,20 +5525,23 @@ async fn weak_subjectivity_sync_gloas_pending_non_aligned() {
     // The block's state_root points to the Pending state in Gloas.
     let wss_state_root = wss_block.state_root();
     let wss_state = full_store
-        .get_state(&wss_state_root, Some(wss_block.slot()), CACHE_STATE_IN_TESTS)
+        .get_state(
+            &wss_state_root,
+            Some(wss_block.slot()),
+            CACHE_STATE_IN_TESTS,
+        )
         .unwrap()
         .unwrap();
 
-    // Verify test preconditions: state is Pending and not epoch-aligned.
     assert_eq!(
         wss_state.payload_status(),
         StatePayloadStatus::Pending,
-        "Checkpoint state should be Pending (post-block, pre-payload)"
+        "Checkpoint state should be Pending"
     );
     assert_ne!(
         wss_state.slot() % E::slots_per_epoch(),
         0,
-        "Test invalid: checkpoint state is epoch-aligned, expected non-aligned"
+        "Checkpoint state is epoch-aligned, expected non-aligned"
     );
 
     let wss_blobs_opt = harness
@@ -5575,12 +5577,7 @@ async fn weak_subjectivity_sync_gloas_pending_non_aligned() {
         .store(store.clone())
         .custom_spec(spec.clone().into())
         .task_executor(harness.chain.task_executor.clone())
-        .weak_subjectivity_state(
-            wss_state,
-            wss_block,
-            wss_blobs_opt,
-            genesis_state,
-        )
+        .weak_subjectivity_state(wss_state, wss_block, wss_blobs_opt, genesis_state)
         .unwrap()
         .store_migrator_config(MigratorConfig::default().blocking())
         .slot_clock(slot_clock)
@@ -5599,7 +5596,7 @@ async fn weak_subjectivity_sync_gloas_pending_non_aligned() {
 
     let chain = beacon_chain.unwrap();
 
-    // The head state should be at the block's slot (not advanced to the epoch boundary).
+    // The head state should be at the block's slot
     assert_eq!(
         chain.head_snapshot().beacon_state.slot(),
         Slot::new(epoch_boundary_slot - 1),

--- a/beacon_node/store/src/errors.rs
+++ b/beacon_node/store/src/errors.rs
@@ -101,6 +101,7 @@ pub enum Error {
         from_state_slot: Slot,
         target_slot: Slot,
     },
+    FinalizedStateAlreadySet,
 }
 
 pub trait HandleUnavailable<T> {

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1899,8 +1899,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             return Ok(StatePayloadStatus::Pending);
         }
 
-
-        // If the latest block was at this slot, the state is definitively `Pending`. 
+        // If the latest block was at this slot, the state is definitively `Pending`.
         // Check this before loading the previous summary to avoid errors when the
         // previous state doesn't exist (e.g. checkpoint sync where only one state is stored).
         if summary.slot == summary.latest_block_slot {

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1899,6 +1899,14 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             return Ok(StatePayloadStatus::Pending);
         }
 
+
+        // If the latest block was at this slot, the state is definitively `Pending`. 
+        // Check this before loading the previous summary to avoid errors when the
+        // previous state doesn't exist (e.g. checkpoint sync where only one state is stored).
+        if summary.slot == summary.latest_block_slot {
+            return Ok(StatePayloadStatus::Pending);
+        }
+
         // Load the hot state summary for the previous state.
         //
         // If it has the same slot as this summary then we know this summary is for a `Full` state
@@ -1918,8 +1926,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         if previous_state_summary.slot == summary.slot {
             Ok(StatePayloadStatus::Full)
-        } else if summary.slot == summary.latest_block_slot {
-            Ok(StatePayloadStatus::Pending)
         } else {
             self.get_hot_state_summary_payload_status(&previous_state_summary)
         }

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -474,6 +474,25 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         }
     }
 
+    /// See [`StateCache::set_initial_finalized_state`](crate::state_cache::StateCache::set_initial_finalized_state).  
+    pub fn set_initial_finalized_state(
+        &self,
+        state_root: Hash256,
+        block_root: Hash256,
+        state: BeaconState<E>,
+    ) -> Result<(), Error> {
+        let start_slot = self.get_anchor_info().anchor_slot;
+        let pre_finalized_slots_to_retain = self
+            .hierarchy
+            .closest_layer_points(state.slot(), start_slot);
+        self.state_cache.lock().set_initial_finalized_state(
+            state_root,
+            block_root,
+            state,
+            &pre_finalized_slots_to_retain,
+        )
+    }
+
     pub fn update_finalized_state(
         &self,
         state_root: Hash256,

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -124,6 +124,36 @@ impl<E: EthSpec> StateCache<E> {
         roots
     }
 
+    /// Used by checkpoint sync to initialize the finalized state in the state cache.
+    ///
+    /// Post-gloas the checkpoint state may not be epoch-aligned, e.g when the epoch boundary
+    /// slot is skipped. We relax the epoch-alignment requirement for the initial state only.
+    /// Runtime finalization updates should use [`update_finalized_state`](Self::update_finalized_state),
+    /// which enforces alignment.  
+    pub fn set_initial_finalized_state(
+        &mut self,
+        state_root: Hash256,
+        block_root: Hash256,
+        state: BeaconState<E>,
+        pre_finalized_slots_to_retain: &[Slot],
+    ) -> Result<(), Error> {
+        if self.finalized_state.is_some() {
+            return Err(Error::FinalizedStateAlreadySet);
+        }
+
+        if !state.fork_name_unchecked().gloas_enabled() && state.slot() % E::slots_per_epoch() != 0
+        {
+            return Err(Error::FinalizedStateUnaligned);
+        }
+
+        self.update_finalized_state_inner(
+            state_root,
+            block_root,
+            state,
+            pre_finalized_slots_to_retain,
+        )
+    }
+
     pub fn update_finalized_state(
         &mut self,
         state_root: Hash256,
@@ -135,6 +165,21 @@ impl<E: EthSpec> StateCache<E> {
             return Err(Error::FinalizedStateUnaligned);
         }
 
+        self.update_finalized_state_inner(
+            state_root,
+            block_root,
+            state,
+            pre_finalized_slots_to_retain,
+        )
+    }
+
+    fn update_finalized_state_inner(
+        &mut self,
+        state_root: Hash256,
+        block_root: Hash256,
+        state: BeaconState<E>,
+        pre_finalized_slots_to_retain: &[Slot],
+    ) -> Result<(), Error> {
         if self
             .finalized_state
             .as_ref()

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -127,9 +127,7 @@ impl<E: EthSpec> StateCache<E> {
     /// Used by checkpoint sync to initialize the finalized state in the state cache.
     ///
     /// Post-gloas the checkpoint state may not be epoch-aligned, e.g when the epoch boundary
-    /// slot is skipped. We relax the epoch-alignment requirement for the initial state only.
-    /// Runtime finalization updates should use [`update_finalized_state`](Self::update_finalized_state),
-    /// which enforces alignment.  
+    /// slot is skipped. Regular finalization updates should use `update_finalized_state`.
     pub fn set_initial_finalized_state(
         &mut self,
         state_root: Hash256,

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -396,8 +396,9 @@ where
         current_slot: Option<Slot>,
         spec: &ChainSpec,
     ) -> Result<Self, Error<T::Error>> {
-        // Sanity check: the anchor must lie on an epoch boundary.
-        if anchor_state.slot() % E::slots_per_epoch() != 0 {
+        // Pre-gloas sanity check: the anchor must lie on an epoch boundary.
+        // Post-gloas we relax this requirement
+        if !anchor_state.fork_name_unchecked().gloas_enabled() && anchor_state.slot() % E::slots_per_epoch() != 0 {
             return Err(Error::InvalidAnchor {
                 block_slot: anchor_block.slot(),
                 state_slot: anchor_state.slot(),

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -398,7 +398,9 @@ where
     ) -> Result<Self, Error<T::Error>> {
         // Pre-gloas sanity check: the anchor must lie on an epoch boundary.
         // Post-gloas we relax this requirement
-        if !anchor_state.fork_name_unchecked().gloas_enabled() && anchor_state.slot() % E::slots_per_epoch() != 0 {
+        if !anchor_state.fork_name_unchecked().gloas_enabled()
+            && anchor_state.slot() % E::slots_per_epoch() != 0
+        {
             return Err(Error::InvalidAnchor {
                 block_slot: anchor_block.slot(),
                 state_slot: anchor_state.slot(),


### PR DESCRIPTION
Post-gloas checkpoint sync states are always the post block state. If theres a skipped slot at an epoch boundary, we'll receive a non-epoch aligned state from the checkpointz server. 

Example: slot n is epoch aligned and is skipped. Checkpoint server will serve the post block state for slot n - 1. We cant advance the state to slot n until we process the payload for slot n - 1 (if it exists/is canonical)

This PR loosens the requirement that a checkpoint state must be epoch aligned. This requirement is only loosened for a gloas checkpoint state, subsequent finalized states must be epoch aligned.

Note that the test introduced in this PR doesn't actually do anything until #8998 is merged. I've tested it on top of #8998 and it seems to be working.

When checkpoint syncing, range sync starts at the same epoch as the checkpoint state. So we just need to make sure `filter_chain_segment` doesn't drop the envelope for the checkpoint block (the checkpoint block and columns were already imported) and everything should work I think?

EDIT: I experimented with checkpoint sync and I think the easiest thing would be to make sure checkpointz server is extended to support `GET eth/v1/beacon/payload_envelopes/{block_id}`. This way we fetch the payload (if it exists) and advance the state to the epoch boundary before we hit range sync. 