### PR TITLE
Refactor `timestamp_now`

### DIFF
--- a/beacon_node/beacon_chain/src/data_column_verification.rs
+++ b/beacon_node/beacon_chain/src/data_column_verification.rs
@@ -5,13 +5,12 @@ use crate::kzg_utils::{reconstruct_data_columns, validate_data_columns};
 use crate::observed_data_sidecars::{
     Error as ObservedDataSidecarsError, ObservationKey, ObservationStrategy, Observe,
 };
-use crate::validator_monitor::timestamp_now;
 use crate::{BeaconChain, BeaconChainError, BeaconChainTypes, metrics};
 use educe::Educe;
 use fork_choice::ProtoBlock;
 use kzg::{Error as KzgError, Kzg};
 use proto_array::Block;
-use slot_clock::SlotClock;
+use slot_clock::{SlotClock, timestamp_now};
 use ssz_derive::Encode;
 use ssz_types::VariableList;
 use std::iter;
@@ -570,8 +569,9 @@ pub fn validate_data_column_sidecar_for_gossip_fulu<T: BeaconChainTypes, O: Obse
     verify_slot_higher_than_parent(&parent_block, column_slot)?;
     verify_proposer_and_signature(data_column_fulu, &parent_block, chain)?;
     let kzg = &chain.kzg;
+    let seen_timestamp = chain.slot_clock.now_duration().unwrap_or_default();
     let kzg_verified_data_column =
-        verify_kzg_for_data_column(data_column.clone(), kzg, timestamp_now())
+        verify_kzg_for_data_column(data_column.clone(), kzg, seen_timestamp)
             .map_err(|(_, e)| GossipDataColumnError::InvalidKzgProof(e))?;
 
     chain

--- a/beacon_node/beacon_chain/src/fetch_blobs/mod.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs/mod.rs
@@ -19,7 +19,6 @@ use crate::data_column_verification::{KzgVerifiedCustodyDataColumn, KzgVerifiedD
 use crate::fetch_blobs::fetch_blobs_beacon_adapter::FetchBlobsBeaconAdapter;
 use crate::kzg_utils::blobs_to_data_column_sidecars;
 use crate::observed_data_sidecars::ObservationKey;
-use crate::validator_monitor::timestamp_now;
 use crate::{
     AvailabilityProcessingStatus, BeaconChain, BeaconChainError, BeaconChainTypes, BlockError,
     metrics,
@@ -29,6 +28,7 @@ use execution_layer::json_structures::{BlobAndProofV1, BlobAndProofV2};
 use metrics::{TryExt, inc_counter};
 #[cfg(test)]
 use mockall_double::double;
+use slot_clock::timestamp_now;
 use ssz_types::FixedVector;
 use state_processing::per_block_processing::deneb::kzg_commitment_to_versioned_hash;
 use std::sync::Arc;

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -20,7 +20,7 @@ use std::io;
 use std::marker::PhantomData;
 use std::str::Utf8Error;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 use store::AbstractExecPayload;
 use tracing::{debug, error, info, warn};
 use types::consts::altair::{
@@ -2083,13 +2083,6 @@ fn register_simulated_attestation(
         head_hit,
         "Simulated attestation evaluated"
     );
-}
-
-/// Returns the duration since the unix epoch.
-pub fn timestamp_now() -> Duration {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_else(|_| Duration::from_secs(0))
 }
 
 fn u64_to_i64(n: impl Into<u64>) -> i64 {

--- a/beacon_node/http_api/src/publish_attestations.rs
+++ b/beacon_node/http_api/src/publish_attestations.rs
@@ -35,15 +35,13 @@
 //! appears that this validator is capable of producing valid
 //! attestations and there's no immediate cause for concern.
 use crate::task_spawner::{Priority, TaskSpawner};
-use beacon_chain::{
-    AttestationError, BeaconChain, BeaconChainError, BeaconChainTypes,
-    validator_monitor::timestamp_now,
-};
+use beacon_chain::{AttestationError, BeaconChain, BeaconChainError, BeaconChainTypes};
 use beacon_processor::work_reprocessing_queue::{QueuedUnaggregate, ReprocessQueueMessage};
 use beacon_processor::{Work, WorkEvent};
 use eth2::types::Failure;
 use lighthouse_network::PubsubMessage;
 use network::NetworkMessage;
+use slot_clock::SlotClock;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
@@ -138,7 +136,7 @@ pub async fn publish_attestations<T: BeaconChainTypes>(
         .collect::<Vec<_>>();
 
     // Gossip validate and publish attestations that can be immediately processed.
-    let seen_timestamp = timestamp_now();
+    let seen_timestamp = chain.slot_clock.now_duration().unwrap_or_default();
     let mut prelim_results = task_spawner
         .clone()
         .blocking_task(Priority::P0, move || {

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 use beacon_chain::blob_verification::{GossipBlobError, GossipVerifiedBlob};
 use beacon_chain::block_verification_types::{AsBlock, LookupBlock};
 use beacon_chain::data_column_verification::GossipVerifiedDataColumn;
-use beacon_chain::validator_monitor::{get_block_delay_ms, timestamp_now};
+use beacon_chain::validator_monitor::get_block_delay_ms;
 use beacon_chain::{
     AvailabilityProcessingStatus, BeaconChain, BeaconChainError, BeaconChainTypes, BlockError,
     IntoGossipVerifiedBlock, NotifyExecutionLayer, build_blob_data_column_sidecars,
@@ -19,6 +19,7 @@ use lighthouse_network::PubsubMessage;
 use network::NetworkMessage;
 use rand::prelude::SliceRandom;
 use reqwest::StatusCode;
+use slot_clock::SlotClock;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -88,7 +89,7 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlock<T>>(
     validation_level: BroadcastValidation,
     duplicate_status_code: StatusCode,
 ) -> Result<Response, Rejection> {
-    let seen_timestamp = timestamp_now();
+    let seen_timestamp = chain.slot_clock.now_duration().unwrap_or_default();
     let block_publishing_delay_for_testing = chain.config.block_publishing_delay;
     let data_column_publishing_delay_for_testing = chain.config.data_column_publishing_delay;
 
@@ -113,11 +114,12 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlock<T>>(
     debug!("Signed block received in HTTP API");
 
     /* actually publish a block */
+    let publish_chain = chain.clone();
     let publish_block_p2p = move |block: Arc<SignedBeaconBlock<T::EthSpec>>,
                                   sender,
                                   seen_timestamp|
           -> Result<(), BlockError> {
-        let publish_timestamp = timestamp_now();
+        let publish_timestamp = publish_chain.slot_clock.now_duration().unwrap_or_default();
         let publish_delay = publish_timestamp
             .checked_sub(seen_timestamp)
             .unwrap_or_else(|| Duration::from_secs(0));
@@ -676,7 +678,7 @@ pub async fn reconstruct_block<T: BeaconChainTypes>(
             // us.
             late_block_logging(
                 &chain,
-                timestamp_now(),
+                chain.slot_clock.now_duration().unwrap_or_default(),
                 block.message(),
                 block_root,
                 "builder",

--- a/beacon_node/http_api/src/sync_committees.rs
+++ b/beacon_node/http_api/src/sync_committees.rs
@@ -4,10 +4,7 @@ use crate::utils::publish_pubsub_message;
 use beacon_chain::sync_committee_verification::{
     Error as SyncVerificationError, VerifiedSyncCommitteeMessage,
 };
-use beacon_chain::{
-    BeaconChain, BeaconChainError, BeaconChainTypes, StateSkipConfig,
-    validator_monitor::timestamp_now,
-};
+use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes, StateSkipConfig};
 use eth2::types::{self as api_types};
 use lighthouse_network::PubsubMessage;
 use network::NetworkMessage;
@@ -188,7 +185,7 @@ pub fn process_sync_committee_signatures<T: BeaconChainTypes>(
 ) -> Result<(), warp::reject::Rejection> {
     let mut failures = vec![];
 
-    let seen_timestamp = timestamp_now();
+    let seen_timestamp = chain.slot_clock.now_duration().unwrap_or_default();
 
     for (i, sync_committee_signature) in sync_committee_signatures.iter().enumerate() {
         let subnet_positions = match get_subnet_positions_for_sync_committee_message(
@@ -319,7 +316,7 @@ pub fn process_signed_contribution_and_proofs<T: BeaconChainTypes>(
     let mut verified_contributions = Vec::with_capacity(signed_contribution_and_proofs.len());
     let mut failures = vec![];
 
-    let seen_timestamp = timestamp_now();
+    let seen_timestamp = chain.slot_clock.now_duration().unwrap_or_default();
 
     if let Some(latest_optimistic_update) = chain
         .light_client_server_cache

--- a/beacon_node/http_api/src/validator/mod.rs
+++ b/beacon_node/http_api/src/validator/mod.rs
@@ -9,7 +9,6 @@ use crate::utils::{
 use crate::version::{V1, V2, V3, unsupported_version_rejection};
 use crate::{StateId, attester_duties, proposer_duties, sync_committees};
 use beacon_chain::attestation_verification::VerifiedAttestation;
-use beacon_chain::validator_monitor::timestamp_now;
 use beacon_chain::{AttestationError, BeaconChain, BeaconChainError, BeaconChainTypes};
 use bls::PublicKeyBytes;
 use eth2::types::{
@@ -871,7 +870,7 @@ pub fn post_validator_aggregate_and_proofs<T: BeaconChainTypes>(
              network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>| {
                 task_spawner.blocking_json_task(Priority::P0, move || {
                     not_synced_filter?;
-                    let seen_timestamp = timestamp_now();
+                    let seen_timestamp = chain.slot_clock.now_duration().unwrap_or_default();
                     let mut verified_aggregates = Vec::with_capacity(aggregates.len());
                     let mut messages = Vec::with_capacity(aggregates.len());
                     let mut failures = Vec::new();

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -19,8 +19,8 @@ use lighthouse_network::{
 };
 use logging::TimeLatch;
 use logging::crit;
+use slot_clock::SlotClock;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, trace, warn};
@@ -351,6 +351,7 @@ impl<T: BeaconChainTypes> Router<T> {
         gossip_message: PubsubMessage<T::EthSpec>,
         should_process: bool,
     ) {
+        let seen_timestamp = self.chain.slot_clock.now_duration().unwrap_or_default();
         match gossip_message {
             PubsubMessage::AggregateAndProofAttestation(aggregate_and_proof) => self
                 .handle_beacon_processor_send_result(
@@ -358,7 +359,7 @@ impl<T: BeaconChainTypes> Router<T> {
                         message_id,
                         peer_id,
                         *aggregate_and_proof,
-                        timestamp_now(),
+                        seen_timestamp,
                     ),
                 ),
             PubsubMessage::Attestation(subnet_attestation) => self
@@ -369,7 +370,7 @@ impl<T: BeaconChainTypes> Router<T> {
                         subnet_attestation.1,
                         subnet_attestation.0,
                         should_process,
-                        timestamp_now(),
+                        seen_timestamp,
                     ),
                 ),
             PubsubMessage::BeaconBlock(block) => self.handle_beacon_processor_send_result(
@@ -378,7 +379,7 @@ impl<T: BeaconChainTypes> Router<T> {
                     peer_id,
                     self.network_globals.client(&peer_id),
                     block,
-                    timestamp_now(),
+                    seen_timestamp,
                 ),
             ),
             PubsubMessage::BlobSidecar(data) => {
@@ -390,7 +391,7 @@ impl<T: BeaconChainTypes> Router<T> {
                         self.network_globals.client(&peer_id),
                         blob_index,
                         blob_sidecar,
-                        timestamp_now(),
+                        seen_timestamp,
                     ),
                 )
             }
@@ -403,7 +404,7 @@ impl<T: BeaconChainTypes> Router<T> {
                             peer_id,
                             subnet_id,
                             column_sidecar,
-                            timestamp_now(),
+                            seen_timestamp,
                         ),
                 )
             }
@@ -450,7 +451,7 @@ impl<T: BeaconChainTypes> Router<T> {
                         message_id,
                         peer_id,
                         *contribution_and_proof,
-                        timestamp_now(),
+                        seen_timestamp,
                     ),
                 )
             }
@@ -465,7 +466,7 @@ impl<T: BeaconChainTypes> Router<T> {
                         peer_id,
                         sync_committtee_msg.1,
                         sync_committtee_msg.0,
-                        timestamp_now(),
+                        seen_timestamp,
                     ),
                 )
             }
@@ -480,7 +481,7 @@ impl<T: BeaconChainTypes> Router<T> {
                             message_id,
                             peer_id,
                             *light_client_finality_update,
-                            timestamp_now(),
+                            seen_timestamp,
                         ),
                 )
             }
@@ -496,7 +497,7 @@ impl<T: BeaconChainTypes> Router<T> {
                             message_id,
                             peer_id,
                             *light_client_optimistic_update,
-                            timestamp_now(),
+                            seen_timestamp,
                         ),
                 )
             }
@@ -516,7 +517,7 @@ impl<T: BeaconChainTypes> Router<T> {
                         message_id,
                         peer_id,
                         signed_execution_payload_envelope,
-                        timestamp_now(),
+                        seen_timestamp,
                     ),
                 )
             }
@@ -642,7 +643,7 @@ impl<T: BeaconChainTypes> Router<T> {
             peer_id,
             sync_request_id,
             beacon_block,
-            seen_timestamp: timestamp_now(),
+            seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
         });
     }
 
@@ -662,7 +663,7 @@ impl<T: BeaconChainTypes> Router<T> {
                 peer_id,
                 sync_request_id,
                 blob_sidecar,
-                seen_timestamp: timestamp_now(),
+                seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
             });
         } else {
             crit!("All blobs by range responses should belong to sync");
@@ -699,7 +700,7 @@ impl<T: BeaconChainTypes> Router<T> {
             peer_id,
             sync_request_id,
             beacon_block,
-            seen_timestamp: timestamp_now(),
+            seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
         });
     }
 
@@ -733,7 +734,7 @@ impl<T: BeaconChainTypes> Router<T> {
             sync_request_id,
             peer_id,
             blob_sidecar,
-            seen_timestamp: timestamp_now(),
+            seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
         });
     }
 
@@ -767,7 +768,7 @@ impl<T: BeaconChainTypes> Router<T> {
             sync_request_id,
             peer_id,
             data_column,
-            seen_timestamp: timestamp_now(),
+            seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
         });
     }
 
@@ -787,7 +788,7 @@ impl<T: BeaconChainTypes> Router<T> {
                 peer_id,
                 sync_request_id,
                 data_column,
-                seen_timestamp: timestamp_now(),
+                seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
             });
         } else {
             crit!("All data columns by range responses should belong to sync");
@@ -854,10 +855,4 @@ impl<E: EthSpec> HandlerNetworkContext<E> {
             response,
         })
     }
-}
-
-fn timestamp_now() -> Duration {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_else(|_| Duration::from_secs(0))
 }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -49,7 +49,6 @@ use crate::sync::block_lookups::{
 use crate::sync::custody_backfill_sync::CustodyBackFillSync;
 use crate::sync::network_context::{PeerGroup, RpcResponseResult};
 use beacon_chain::block_verification_types::AsBlock;
-use beacon_chain::validator_monitor::timestamp_now;
 use beacon_chain::{
     AvailabilityProcessingStatus, BeaconChain, BeaconChainTypes, BlockError, EngineState,
 };
@@ -851,7 +850,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     BlockComponent::Block(DownloadResult {
                         value: block.block_cloned(),
                         block_root,
-                        seen_timestamp: timestamp_now(),
+                        seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
                         peer_group: PeerGroup::from_single(peer_id),
                     }),
                 );
@@ -869,7 +868,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     BlockComponent::Blob(DownloadResult {
                         value: blob,
                         block_root,
-                        seen_timestamp: timestamp_now(),
+                        seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
                         peer_group: PeerGroup::from_single(peer_id),
                     }),
                 );
@@ -889,7 +888,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                             BlockComponent::DataColumn(DownloadResult {
                                 value: data_column,
                                 block_root,
-                                seen_timestamp: timestamp_now(),
+                                seen_timestamp: self
+                                    .chain
+                                    .slot_clock
+                                    .now_duration()
+                                    .unwrap_or_default(),
                                 peer_group: PeerGroup::from_single(peer_id),
                             }),
                         );

--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -2,11 +2,11 @@ use crate::sync::network_context::{
     DataColumnsByRootRequestId, DataColumnsByRootSingleBlockRequest,
 };
 use beacon_chain::BeaconChainTypes;
-use beacon_chain::validator_monitor::timestamp_now;
 use fnv::FnvHashMap;
 use lighthouse_network::PeerId;
 use lighthouse_network::service::api_types::{CustodyId, DataColumnsByRootRequester};
 use parking_lot::RwLock;
+use slot_clock::SlotClock;
 use std::collections::HashSet;
 use std::hash::{BuildHasher, RandomState};
 use std::time::{Duration, Instant};
@@ -223,7 +223,10 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                 .collect::<Result<Vec<_>, _>>()?;
 
             let peer_group = PeerGroup::from_set(peers);
-            let max_seen_timestamp = seen_timestamps.into_iter().max().unwrap_or(timestamp_now());
+            let max_seen_timestamp = seen_timestamps
+                .into_iter()
+                .max()
+                .unwrap_or_else(|| cx.chain.slot_clock.now_duration().unwrap_or_default());
             return Ok(Some((columns, peer_group, max_seen_timestamp)));
         }
 

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -1,9 +1,9 @@
 use std::time::Instant;
 use std::{collections::hash_map::Entry, hash::Hash};
 
-use beacon_chain::validator_monitor::timestamp_now;
 use fnv::FnvHashMap;
 use lighthouse_network::PeerId;
+use slot_clock::timestamp_now;
 use strum::IntoStaticStr;
 use tracing::{Span, debug};
 use types::{Hash256, Slot};

--- a/common/slot_clock/src/lib.rs
+++ b/common/slot_clock/src/lib.rs
@@ -2,7 +2,7 @@ mod manual_slot_clock;
 mod metrics;
 mod system_time_slot_clock;
 
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 pub use crate::manual_slot_clock::ManualSlotClock as TestingSlotClock;
 pub use crate::manual_slot_clock::ManualSlotClock;
@@ -109,4 +109,14 @@ pub trait SlotClock: Send + Sync + Sized + Clone {
         slot_clock.set_current_time(freeze_at);
         slot_clock
     }
+}
+
+/// Returns the current system time as a duration since the UNIX epoch.
+///
+/// This is a convenience function for recording timestamps when `SlotClock` is not available.
+/// Prefer `SlotClock::now_duration` if available.
+pub fn timestamp_now() -> Duration {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
 }


### PR DESCRIPTION
## Issue Addressed
#9077 

## Proposed Changes

Where possible replaces all instances of `validator_monitor::timestamp_now` with `chain.slot_clock.now_duration().unwrap_or_default()`.
Where chain/slot_clock is not available, instead replace it with a convenience function `slot_clock::timestamp_now`.
Remove the `validator_monitor::timestamp_now` function.

## Additional Info

We could remove `timestamp_now` completely by threading either the slot clock, or the timestamp itself, through the necessary functions. I tried this and it wasn't extremely invasive but it still felt out of scope and I'm not convinced it is worth it