### PR TITLE
Add missing beacon API config/spec values

### DIFF
--- a/consensus/types/presets/gnosis/gloas.yaml
+++ b/consensus/types/presets/gnosis/gloas.yaml
@@ -1,1 +1,23 @@
 # Gnosis preset - Gloas
+
+# Misc
+# ---------------------------------------------------------------
+# 2**9 (= 512) validators
+PTC_SIZE: 512
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**1 (= 2) attestations
+MAX_PAYLOAD_ATTESTATIONS: 2
+
+# State list lengths
+# ---------------------------------------------------------------
+# 2**40 (= 1,099,511,627,776) builder spots
+BUILDER_REGISTRY_LIMIT: 1099511627776
+# 2**20 (= 1,048,576) builder pending withdrawals
+BUILDER_PENDING_WITHDRAWALS_LIMIT: 1048576
+
+# Withdrawals processing
+# ---------------------------------------------------------------
+# 2**14 (= 16,384) builders
+MAX_BUILDERS_PER_WITHDRAWALS_SWEEP: 16384

--- a/consensus/types/src/core/chain_spec.rs
+++ b/consensus/types/src/core/chain_spec.rs
@@ -152,6 +152,7 @@ pub struct ChainSpec {
     pub proposer_score_boost: Option<u64>,
     pub reorg_head_weight_threshold: Option<u64>,
     pub reorg_parent_weight_threshold: Option<u64>,
+    pub reorg_max_epochs_since_finalization: Option<u64>,
 
     /*
      * Eth1
@@ -1149,6 +1150,7 @@ impl ChainSpec {
             proposer_score_boost: Some(40),
             reorg_head_weight_threshold: Some(20),
             reorg_parent_weight_threshold: Some(160),
+            reorg_max_epochs_since_finalization: Some(2),
 
             /*
              * Eth1
@@ -1554,6 +1556,7 @@ impl ChainSpec {
             proposer_score_boost: Some(40),
             reorg_head_weight_threshold: Some(20),
             reorg_parent_weight_threshold: Some(160),
+            reorg_max_epochs_since_finalization: Some(2),
 
             /*
              * Eth1
@@ -1982,6 +1985,13 @@ pub struct Config {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     proposer_score_boost: Option<MaybeQuoted<u64>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reorg_head_weight_threshold: Option<MaybeQuoted<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reorg_parent_weight_threshold: Option<MaybeQuoted<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reorg_max_epochs_since_finalization: Option<MaybeQuoted<u64>>,
 
     #[serde(with = "serde_utils::quoted_u64")]
     deposit_chain_id: u64,
@@ -2545,6 +2555,15 @@ impl Config {
             max_per_epoch_activation_churn_limit: spec.max_per_epoch_activation_churn_limit,
 
             proposer_score_boost: spec.proposer_score_boost.map(|value| MaybeQuoted { value }),
+            reorg_head_weight_threshold: spec
+                .reorg_head_weight_threshold
+                .map(|value| MaybeQuoted { value }),
+            reorg_parent_weight_threshold: spec
+                .reorg_parent_weight_threshold
+                .map(|value| MaybeQuoted { value }),
+            reorg_max_epochs_since_finalization: spec
+                .reorg_max_epochs_since_finalization
+                .map(|value| MaybeQuoted { value }),
 
             deposit_chain_id: spec.deposit_chain_id,
             deposit_network_id: spec.deposit_network_id,
@@ -2647,6 +2666,9 @@ impl Config {
             max_per_epoch_activation_churn_limit,
             churn_limit_quotient,
             proposer_score_boost,
+            reorg_head_weight_threshold,
+            reorg_parent_weight_threshold,
+            reorg_max_epochs_since_finalization,
             deposit_chain_id,
             deposit_network_id,
             deposit_contract_address,
@@ -2743,6 +2765,10 @@ impl Config {
             max_per_epoch_activation_churn_limit,
             churn_limit_quotient,
             proposer_score_boost: proposer_score_boost.map(|q| q.value),
+            reorg_head_weight_threshold: reorg_head_weight_threshold.map(|q| q.value),
+            reorg_parent_weight_threshold: reorg_parent_weight_threshold.map(|q| q.value),
+            reorg_max_epochs_since_finalization: reorg_max_epochs_since_finalization
+                .map(|q| q.value),
             deposit_chain_id,
             deposit_network_id,
             deposit_contract_address,
@@ -3692,10 +3718,6 @@ mod yaml_tests {
         "SYNC_MESSAGE_DUE_BPS_GLOAS",
         "CONTRIBUTION_DUE_BPS_GLOAS",
         "MAX_REQUEST_PAYLOADS",
-        // Gloas fork choice params not yet in Config
-        "REORG_HEAD_WEIGHT_THRESHOLD",
-        "REORG_PARENT_WEIGHT_THRESHOLD",
-        "REORG_MAX_EPOCHS_SINCE_FINALIZATION",
         // Heze networking
         "VIEW_FREEZE_CUTOFF_BPS",
         "INCLUSION_LIST_SUBMISSION_DUE_BPS",

--- a/consensus/types/src/core/config_and_preset.rs
+++ b/consensus/types/src/core/config_and_preset.rs
@@ -133,6 +133,9 @@ pub fn get_extra_fields(spec: &ChainSpec) -> HashMap<String, Value> {
         "domain_sync_committee_selection_proof".to_uppercase() =>
             u32_hex(spec.domain_sync_committee_selection_proof),
         "domain_bls_to_execution_change".to_uppercase() => u32_hex(spec.domain_bls_to_execution_change),
+        "domain_beacon_builder".to_uppercase() => u32_hex(spec.domain_beacon_builder),
+        "domain_ptc_attester".to_uppercase() => u32_hex(spec.domain_ptc_attester),
+        "domain_proposer_preferences".to_uppercase() => u32_hex(spec.domain_proposer_preferences),
         "sync_committee_subnet_count".to_uppercase() =>
             consts::altair::SYNC_COMMITTEE_SUBNET_COUNT.to_string().into(),
         "target_aggregators_per_sync_subcommittee".to_uppercase() =>

--- a/consensus/types/src/core/preset.rs
+++ b/consensus/types/src/core/preset.rs
@@ -331,11 +331,28 @@ impl FuluPreset {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
-pub struct GloasPreset {}
+pub struct GloasPreset {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub ptc_size: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub max_payload_attestations: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub builder_registry_limit: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub builder_pending_withdrawals_limit: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub max_builders_per_withdrawals_sweep: u64,
+}
 
 impl GloasPreset {
     pub fn from_chain_spec<E: EthSpec>(_spec: &ChainSpec) -> Self {
-        Self {}
+        Self {
+            ptc_size: E::ptc_size() as u64,
+            max_payload_attestations: E::max_payload_attestations() as u64,
+            builder_registry_limit: E::BuilderRegistryLimit::to_u64(),
+            builder_pending_withdrawals_limit: E::builder_pending_withdrawals_limit() as u64,
+            max_builders_per_withdrawals_sweep: E::max_builders_per_withdrawals_sweep() as u64,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Populate `GloasPreset` with `PTC_SIZE`, `MAX_PAYLOAD_ATTESTATIONS`, `BUILDER_REGISTRY_LIMIT`, `BUILDER_PENDING_WITHDRAWALS_LIMIT`, and `MAX_BUILDERS_PER_WITHDRAWALS_SWEEP`
- Add `DOMAIN_BEACON_BUILDER`, `DOMAIN_PTC_ATTESTER`, and `DOMAIN_PROPOSER_PREFERENCES` to the config/spec extra fields
- Add `REORG_HEAD_WEIGHT_THRESHOLD`, `REORG_PARENT_WEIGHT_THRESHOLD`, and `REORG_MAX_EPOCHS_SINCE_FINALIZATION` to the `Config` struct
- Populate gnosis Gloas preset YAML with matching values

## Test plan

- [x] All `types` crate tests pass (preset consistency for mainnet, minimal, gnosis + config round-trip)
- [x] `cargo check` and `make lint-fix` pass cleanly
- [x] Verified via kurtosis (mainnet preset) that `eth/v1/config/spec` now returns all previously missing fields with correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)