### PR TITLE
fix: show Gloas payload status in sync notifier instead of "n/a"

### DIFF
--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -366,7 +366,24 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                 };
 
                 let block_hash = match beacon_chain.canonical_head.head_execution_status() {
-                    Ok(ExecutionStatus::Irrelevant(_)) => "n/a".to_string(),
+                    Ok(ExecutionStatus::Irrelevant(_)) => {
+                        // For Gloas (ePBS), `ExecutionStatus` is always `Irrelevant` because
+                        // the execution payload is delivered via a separate
+                        // `SignedExecutionPayloadEnvelope` rather than embedded in the block body.
+                        // Show "pending" to indicate the slot's payload has not yet been
+                        // committed, rather than implying there is no execution layer.
+                        //
+                        // TODO: distinguish "pending" / "empty" / "full" once the Gloas state
+                        // transition updates `latest_block_hash` to track committed payloads
+                        // per <https://github.com/sigp/lighthouse/issues/9099>.
+                        if cached_head.snapshot.beacon_block.fork_name_unchecked()
+                            == ForkName::Gloas
+                        {
+                            "pending".to_string()
+                        } else {
+                            "n/a".to_string()
+                        }
+                    }
                     Ok(ExecutionStatus::Valid(hash)) => {
                         metrics::set_gauge(&metrics::IS_OPTIMISTIC_SYNC, 0);
                         format!("{} (verified)", hash)


### PR DESCRIPTION
## Description

Fixes #9099.

For Gloas (ePBS), `ExecutionStatus` is always `Irrelevant` because the execution payload is delivered via a separate `SignedExecutionPayloadEnvelope` rather than embedded in the block body. Previously the sync notifier logged `exec_hash: "n/a"` for all Gloas nodes, which implies there is no execution layer — misleading for operators.

This change detects when the head block is on the Gloas fork and displays `"pending"` instead, indicating the slot payload has not yet been committed for the current slot. This maps to the `PAYLOAD_STATUS_PENDING` semantics defined in `types::consts`.

## Changes

- `beacon_node/client/src/notifier.rs`: In the `ExecutionStatus::Irrelevant` branch, check if the head block is Gloas. If so, display `"pending"` rather than `"n/a"`.

## Example log output

**Before:**
```
INFO Synced  peers: 10, exec_hash: n/a, finalized_root: ...
```

**After:**
```
INFO Synced  peers: 10, exec_hash: pending, finalized_root: ...
```

## Future work

A `TODO` is left at the change site to distinguish `pending` / `empty` / `full` once the Gloas state transition updates `latest_block_hash` to track committed payloads (see `BeaconState::is_parent_block_full` and `types::consts::PAYLOAD_STATUS_*`).

## AI Disclosure

This PR was developed with AI assistance (Claude) for code exploration and implementation, per Lighthouse contribution policy.