### PR TITLE
Remove `test_logger` feature

### DIFF
--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -10,7 +10,6 @@ disable-backfill = []
 fork_from_env = ["beacon_chain/fork_from_env"]
 fake_crypto = ["bls/fake_crypto", "kzg/fake_crypto"]
 portable = ["beacon_chain/portable"]
-test_logger = []
 
 [dependencies]
 alloy-primitives = { workspace = true }

--- a/beacon_node/network/src/sync/tests/mod.rs
+++ b/beacon_node/network/src/sync/tests/mod.rs
@@ -148,13 +148,13 @@ pub fn init_tracing() {
     INIT_TRACING.call_once(|| {
         if std::env::var(CI_LOGGER_DIR_ENV_VAR).is_ok() {
             // Enable logging to log files for each test and each fork.
-            tracing_subscriber::registry()
+            let _ = tracing_subscriber::registry()
                 .with(
                     tracing_subscriber::fmt::layer()
                         .with_ansi(false)
                         .with_writer(CILogWriter),
                 )
-                .init();
+                .try_init();
         }
     });
 }

--- a/book/src/contributing_setup.md
+++ b/book/src/contributing_setup.md
@@ -109,6 +109,32 @@ For VSCode users, this is already configured in the repository's `.vscode/settin
 }
 ```
 
+### Logging in tests
+
+By default, when running tests, the logs will not be printed if the tests passed. For example, to run the tests for the `beacon_chain` package:
+
+```bash
+cargo test --release  -p beacon_chain
+```
+
+To always show the logs, run the tests with `-- --nocapture`.
+
+```bash
+cargo test --release  -p beacon_chain -- --nocapture
+```
+
+By default, the log shown is `DEBUG` level. This can be overridden using the environment variable `RUST_LOG`. For example, to only show logs with `INFO` level and above:
+
+```bash
+RUST_LOG=info cargo test --release  -p beacon_chain -- --nocapture
+```
+
+To only show logs from the `beacon_chain` crate and with `INFO` level and above:
+
+```bash
+RUST_LOG=beacon_chain=info cargo test --release  -p beacon_chain -- --nocapture
+```
+
 ### Consensus Spec Tests
 
 The

--- a/book/src/contributing_setup.md
+++ b/book/src/contributing_setup.md
@@ -109,33 +109,6 @@ For VSCode users, this is already configured in the repository's `.vscode/settin
 }
 ```
 
-### test_logger
-
-The test_logger, located in `/common/logging/` can be used to create a `Logger` that by
-default returns a NullLogger. But if `--features 'logging/test_logger'` is passed while
-testing the logs are displayed. This can be very helpful while debugging tests.
-
-Example:
-
-```
-$ cargo nextest run -p beacon_chain -E 'test(validator_pubkey_cache::test::basic_operation)' --features 'logging/test_logger'
-    Finished test [unoptimized + debuginfo] target(s) in 0.20s
-     Running unittests (target/debug/deps/beacon_chain-975363824f1143bc)
-
-running 1 test
-Sep 19 19:23:25.192 INFO Beacon chain initialized, head_slot: 0, head_block: 0x2353…dcf4, head_state: 0xef4b…4615, module: beacon_chain::builder:649
-Sep 19 19:23:25.192 INFO Saved beacon chain to disk, module: beacon_chain::beacon_chain:3608
-Sep 19 19:23:26.798 INFO Beacon chain initialized, head_slot: 0, head_block: 0x2353…dcf4, head_state: 0xef4b…4615, module: beacon_chain::builder:649
-Sep 19 19:23:26.798 INFO Saved beacon chain to disk, module: beacon_chain::beacon_chain:3608
-Sep 19 19:23:28.407 INFO Beacon chain initialized, head_slot: 0, head_block: 0xdcdd…501f, head_state: 0x3055…032c, module: beacon_chain::builder:649
-Sep 19 19:23:28.408 INFO Saved beacon chain to disk, module: beacon_chain::beacon_chain:3608
-Sep 19 19:23:30.069 INFO Beacon chain initialized, head_slot: 0, head_block: 0xa739…1b22, head_state: 0xac1c…eab6, module: beacon_chain::builder:649
-Sep 19 19:23:30.069 INFO Saved beacon chain to disk, module: beacon_chain::beacon_chain:3608
-test validator_pubkey_cache::test::basic_operation ... ok
-
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 51 filtered out; finished in 6.46s
-```
-
 ### Consensus Spec Tests
 
 The

--- a/common/logging/Cargo.toml
+++ b/common/logging/Cargo.toml
@@ -4,12 +4,11 @@ version = "0.2.0"
 authors = ["blacktemplar <blacktemplar@a1.net>"]
 edition = { workspace = true }
 
-[features]
-# Print log output to stderr when running tests instead of dropping it.
-test_logger = []
-
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "std",
+] }
 logroller = { workspace = true }
 metrics = { workspace = true }
 serde = { workspace = true }

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -50,6 +50,8 @@ impl TimeLatch {
 pub fn create_test_tracing_subscriber() {
     let _ = tracing_subscriber::fmt()
         .with_test_writer()
-        .with_env_filter(EnvFilter::try_new("debug").unwrap())
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug")),
+        )
         .try_init();
 }

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -42,16 +42,14 @@ impl TimeLatch {
 
 /// Return a tracing subscriber suitable for test usage.
 ///
-/// By default no logs will be printed, but they can be enabled via
-/// the `test_logger` feature.  This feature can be enabled for any
-/// dependent crate by passing `--features logging/test_logger`, e.g.
+/// By default no logs will be printed, logs will be printed by using --nocapture. Example:
 /// ```bash
-/// cargo test -p beacon_chain --features logging/test_logger
-/// ```
+/// cargo test --release  -p beacon_chain -- --nocapture
+/// ```bash
+/// (typically when --nocapture is used with cargo test).
 pub fn create_test_tracing_subscriber() {
-    if cfg!(feature = "test_logger") {
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(EnvFilter::try_new("debug").unwrap())
-            .try_init();
-    }
+    let _ = tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter(EnvFilter::try_new("debug").unwrap())
+        .try_init();
 }

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -45,8 +45,7 @@ impl TimeLatch {
 /// By default no logs will be printed, logs will be printed by using --nocapture. Example:
 /// ```bash
 /// cargo test --release  -p beacon_chain -- --nocapture
-/// ```bash
-/// (typically when --nocapture is used with cargo test).
+/// ```
 pub fn create_test_tracing_subscriber() {
     let _ = tracing_subscriber::fmt()
         .with_test_writer()


### PR DESCRIPTION
## Issue Addressed

- #9107

## Proposed Changes

Remove all instances of `test_logger` in the code

## Additional Info

Running with, e.g.: 
`cargo test --release  -p beacon_chain` - no beacon node logs are printed
`cargo test --release  -p beacon_chain -- --nocapture` - beacon node logs are printed
