### PR TITLE
Prefix VC root spans with `lh_` so they get exported to tracing backend

### DIFF
--- a/validator_client/validator_services/src/attestation_service.rs
+++ b/validator_client/validator_services/src/attestation_service.rs
@@ -439,7 +439,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
     }
 
     #[instrument(
-        name = "handle_aggregates",
+        name = "lh_handle_aggregates",
         skip_all,
         fields(%slot, %committee_index)
     )]
@@ -494,7 +494,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
     ///
     /// The given `validator_duties` should already be filtered to only contain those that match
     /// `slot`. Critical errors will be logged if this is not the case.
-    #[instrument(skip_all, fields(%slot, %attestation_data.beacon_block_root))]
+    #[instrument(name = "lh_sign_and_publish_attestations", skip_all, fields(%slot, %attestation_data.beacon_block_root))]
     async fn sign_and_publish_attestations(
         &self,
         slot: Slot,

--- a/validator_client/validator_services/src/block_service.rs
+++ b/validator_client/validator_services/src/block_service.rs
@@ -404,7 +404,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
     }
 
     #[instrument(
-        name = "block_proposal_duty_cycle",
+        name = "lh_block_proposal_duty_cycle",
         skip_all,
         fields(%slot, ?validator_pubkey)
     )]

--- a/validator_client/validator_services/src/sync_committee_service.rs
+++ b/validator_client/validator_services/src/sync_committee_service.rs
@@ -214,7 +214,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
                     .map(|_| ())
                     .await
             }
-            .instrument(info_span!("sync_committee_signature_publish", %slot)),
+            .instrument(info_span!("lh_sync_committee_signature_publish", %slot)),
             "sync_committee_signature_publish",
         );
 
@@ -232,7 +232,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
                     .map(|_| ())
                     .await
             }
-            .instrument(info_span!("sync_committee_aggregate_publish", %slot)),
+            .instrument(info_span!("lh_sync_committee_aggregate_publish", %slot)),
             "sync_committee_aggregate_publish",
         );
 
@@ -324,7 +324,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
                         .map(|_| ())
                         .await
                 }
-                .instrument(info_span!("publish_sync_committee_aggregate_for_subnet", %slot, ?beacon_block_root, %subnet_id)),
+                .instrument(info_span!("lh_publish_sync_committee_aggregate_for_subnet", %slot, ?beacon_block_root, %subnet_id)),
                 "sync_committee_aggregate_publish_subnet",
             );
         }


### PR DESCRIPTION
## Issue Addressed

The tracing exporter uses a `PrefixBasedSampler` that only samples root spans whose name starts with `lh_`. Rename the VC root spans to include the prefix so their traces are exported.

Thanks @lmnzx for pointing this out!