### PR TITLE
Bump `rustls-webpki` to unblock CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5266,7 +5266,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls 0.23.35",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "thiserror 2.0.17",
  "x509-parser",
  "yasna",
@@ -7678,7 +7678,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -7727,9 +7727,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ install-audit:
 	cargo install --force cargo-audit
 
 audit-CI:
-	cargo audit --ignore RUSTSEC-2026-0049
+	cargo audit --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0098
 
 # Runs cargo deny (check for banned crates, duplicate versions, and source restrictions)
 deny: install-deny deny-CI

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ install-audit:
 	cargo install --force cargo-audit
 
 audit-CI:
-	cargo audit --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0098
+	cargo audit --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099
 
 # Runs cargo deny (check for banned crates, duplicate versions, and source restrictions)
 deny: install-deny deny-CI


### PR DESCRIPTION
## Issue Addressed

New audit failure from `RUSTSEC-2026-0098`

## Proposed Changes

Bump `rustls-webpki` to an unaffected version, add an ignore for the old version used by `warp` 0.3 

## Additional Info

As with `RUSTSEC-2026-0049`, this ignore will also be fixed by the `warp` bump in https://github.com/sigp/lighthouse/pull/9001