### PR TITLE
Rust 1.95 lints

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_rewards.rs
+++ b/beacon_node/beacon_chain/src/attestation_rewards.rs
@@ -320,7 +320,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             )
             .into_values()
             .collect::<Vec<IdealAttestationRewards>>();
-        ideal_rewards.sort_by(|a, b| a.effective_balance.cmp(&b.effective_balance));
+        ideal_rewards.sort_by_key(|a| a.effective_balance);
 
         Ok(StandardAttestationRewards {
             ideal_rewards,

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -3694,11 +3694,8 @@ pub fn generate_rand_block_and_blobs<E: EthSpec>(
         blobs,
     } = bundle;
 
-    for (index, ((blob, kzg_commitment), kzg_proof)) in blobs
-        .into_iter()
-        .zip(commitments.into_iter())
-        .zip(proofs.into_iter())
-        .enumerate()
+    for (index, ((blob, kzg_commitment), kzg_proof)) in
+        blobs.into_iter().zip(commitments).zip(proofs).enumerate()
     {
         blob_sidecars.push(BlobSidecar {
             index: index as u64,

--- a/beacon_node/http_api/src/ui.rs
+++ b/beacon_node/http_api/src/ui.rs
@@ -215,24 +215,22 @@ pub fn post_validator_monitor_metrics<T: BeaconChainTypes>(
             drop(val_metrics);
 
             let attestations = attestation_hits + attestation_misses;
-            let attestation_hit_percentage: f64 = if attestations == 0 {
-                0.0
-            } else {
-                (100 * attestation_hits / attestations) as f64
-            };
+            let attestation_hit_percentage: f64 = (100 * attestation_hits)
+                .checked_div(attestations)
+                .map(|f| f as f64)
+                .unwrap_or(0.0);
+
             let head_attestations = attestation_head_hits + attestation_head_misses;
-            let attestation_head_hit_percentage: f64 = if head_attestations == 0 {
-                0.0
-            } else {
-                (100 * attestation_head_hits / head_attestations) as f64
-            };
+            let attestation_head_hit_percentage: f64 = (100 * attestation_head_hits)
+                .checked_div(head_attestations)
+                .map(|f| f as f64)
+                .unwrap_or(0.0);
 
             let target_attestations = attestation_target_hits + attestation_target_misses;
-            let attestation_target_hit_percentage: f64 = if target_attestations == 0 {
-                0.0
-            } else {
-                (100 * attestation_target_hits / target_attestations) as f64
-            };
+            let attestation_target_hit_percentage: f64 = (100 * attestation_target_hits)
+                .checked_div(target_attestations)
+                .map(|f| f as f64)
+                .unwrap_or(0.0);
 
             let metrics = ValidatorMetrics {
                 attestation_hits,

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -4746,7 +4746,7 @@ impl ApiTester {
             .beacon_state
             .validators()
             .into_iter()
-            .zip(fee_recipients.into_iter())
+            .zip(fee_recipients)
             .enumerate()
         {
             let actual_fee_recipient = self
@@ -4803,7 +4803,7 @@ impl ApiTester {
             .beacon_state
             .validators()
             .into_iter()
-            .zip(fee_recipients.into_iter())
+            .zip(fee_recipients)
             .enumerate()
         {
             let actual = self
@@ -4842,7 +4842,7 @@ impl ApiTester {
             .beacon_state
             .validators()
             .into_iter()
-            .zip(fee_recipients.into_iter())
+            .zip(fee_recipients)
             .enumerate()
         {
             let actual_fee_recipient = self

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -139,16 +139,10 @@ fn test_tcp_status_rpc() {
                         peer_id,
                         inbound_request_id,
                         request_type,
-                    } => {
-                        if request_type == rpc_request {
-                            // send the response
-                            debug!("Receiver Received");
-                            receiver.send_response(
-                                peer_id,
-                                inbound_request_id,
-                                rpc_response.clone(),
-                            );
-                        }
+                    } if request_type == rpc_request => {
+                        // send the response
+                        debug!("Receiver Received");
+                        receiver.send_response(peer_id, inbound_request_id, rpc_response.clone());
                     }
                     _ => {} // Ignore other events
                 }
@@ -269,34 +263,33 @@ fn test_tcp_blocks_by_range_chunked_rpc() {
                         peer_id,
                         inbound_request_id,
                         request_type,
-                    } => {
-                        if request_type == rpc_request {
-                            // send the response
-                            warn!("Receiver got request");
-                            for i in 0..messages_to_send {
-                                // Send first third of responses as base blocks,
-                                // second as altair and third as bellatrix.
-                                let rpc_response = if i < 2 {
-                                    rpc_response_base.clone()
-                                } else if i < 4 {
-                                    rpc_response_altair.clone()
-                                } else {
-                                    rpc_response_bellatrix_small.clone()
-                                };
-                                receiver.send_response(
-                                    peer_id,
-                                    inbound_request_id,
-                                    rpc_response.clone(),
-                                );
-                            }
-                            // send the stream termination
+                    } if request_type == rpc_request => {
+                        // send the response
+                        warn!("Receiver got request");
+                        for i in 0..messages_to_send {
+                            // Send first third of responses as base blocks,
+                            // second as altair and third as bellatrix.
+                            let rpc_response = if i < 2 {
+                                rpc_response_base.clone()
+                            } else if i < 4 {
+                                rpc_response_altair.clone()
+                            } else {
+                                rpc_response_bellatrix_small.clone()
+                            };
                             receiver.send_response(
                                 peer_id,
                                 inbound_request_id,
-                                Response::BlocksByRange(None),
+                                rpc_response.clone(),
                             );
                         }
+                        // send the stream termination
+                        receiver.send_response(
+                            peer_id,
+                            inbound_request_id,
+                            Response::BlocksByRange(None),
+                        );
                     }
+
                     _ => {} // Ignore other events
                 }
             }
@@ -404,26 +397,24 @@ fn test_blobs_by_range_chunked_rpc() {
                         peer_id,
                         inbound_request_id,
                         request_type,
-                    } => {
-                        if request_type == rpc_request {
-                            // send the response
-                            warn!("Receiver got request");
-                            for _ in 0..messages_to_send {
-                                // Send first third of responses as base blocks,
-                                // second as altair and third as bellatrix.
-                                receiver.send_response(
-                                    peer_id,
-                                    inbound_request_id,
-                                    rpc_response.clone(),
-                                );
-                            }
-                            // send the stream termination
+                    } if request_type == rpc_request => {
+                        // send the response
+                        warn!("Receiver got request");
+                        for _ in 0..messages_to_send {
+                            // Send first third of responses as base blocks,
+                            // second as altair and third as bellatrix.
                             receiver.send_response(
                                 peer_id,
                                 inbound_request_id,
-                                Response::BlobsByRange(None),
+                                rpc_response.clone(),
                             );
                         }
+                        // send the stream termination
+                        receiver.send_response(
+                            peer_id,
+                            inbound_request_id,
+                            Response::BlobsByRange(None),
+                        );
                     }
                     _ => {} // Ignore other events
                 }
@@ -512,25 +503,23 @@ fn test_tcp_blocks_by_range_over_limit() {
                         peer_id,
                         inbound_request_id,
                         request_type,
-                    } => {
-                        if request_type == rpc_request {
-                            // send the response
-                            warn!("Receiver got request");
-                            for _ in 0..messages_to_send {
-                                let rpc_response = rpc_response_bellatrix_large.clone();
-                                receiver.send_response(
-                                    peer_id,
-                                    inbound_request_id,
-                                    rpc_response.clone(),
-                                );
-                            }
-                            // send the stream termination
+                    } if request_type == rpc_request => {
+                        // send the response
+                        warn!("Receiver got request");
+                        for _ in 0..messages_to_send {
+                            let rpc_response = rpc_response_bellatrix_large.clone();
                             receiver.send_response(
                                 peer_id,
                                 inbound_request_id,
-                                Response::BlocksByRange(None),
+                                rpc_response.clone(),
                             );
                         }
+                        // send the stream termination
+                        receiver.send_response(
+                            peer_id,
+                            inbound_request_id,
+                            Response::BlocksByRange(None),
+                        );
                     }
                     _ => {} // Ignore other events
                 }
@@ -650,12 +639,10 @@ fn test_tcp_blocks_by_range_chunked_rpc_terminates_correctly() {
                             request_type,
                         },
                         _,
-                    )) => {
-                        if request_type == rpc_request {
-                            // send the response
-                            warn!("Receiver got request");
-                            message_info = Some((peer_id, inbound_request_id));
-                        }
+                    )) if request_type == rpc_request => {
+                        // send the response
+                        warn!("Receiver got request");
+                        message_info = Some((peer_id, inbound_request_id));
                     }
                     futures::future::Either::Right((_, _)) => {} // The timeout hit, send messages if required
                     _ => continue,
@@ -770,25 +757,23 @@ fn test_tcp_blocks_by_range_single_empty_rpc() {
                         peer_id,
                         inbound_request_id,
                         request_type,
-                    } => {
-                        if request_type == rpc_request {
-                            // send the response
-                            warn!("Receiver got request");
+                    } if request_type == rpc_request => {
+                        // send the response
+                        warn!("Receiver got request");
 
-                            for _ in 1..=messages_to_send {
-                                receiver.send_response(
-                                    peer_id,
-                                    inbound_request_id,
-                                    rpc_response.clone(),
-                                );
-                            }
-                            // send the stream termination
+                        for _ in 1..=messages_to_send {
                             receiver.send_response(
                                 peer_id,
                                 inbound_request_id,
-                                Response::BlocksByRange(None),
+                                rpc_response.clone(),
                             );
                         }
+                        // send the stream termination
+                        receiver.send_response(
+                            peer_id,
+                            inbound_request_id,
+                            Response::BlocksByRange(None),
+                        );
                     }
                     _ => {} // Ignore other events
                 }
@@ -917,31 +902,29 @@ fn test_tcp_blocks_by_root_chunked_rpc() {
                         peer_id,
                         inbound_request_id,
                         request_type,
-                    } => {
-                        if request_type == rpc_request {
-                            // send the response
-                            debug!("Receiver got request");
+                    } if request_type == rpc_request => {
+                        // send the response
+                        debug!("Receiver got request");
 
-                            for i in 0..messages_to_send {
-                                // Send equal base, altair and bellatrix blocks
-                                let rpc_response = if i < 2 {
-                                    rpc_response_base.clone()
-                                } else if i < 4 {
-                                    rpc_response_altair.clone()
-                                } else {
-                                    rpc_response_bellatrix_small.clone()
-                                };
-                                receiver.send_response(peer_id, inbound_request_id, rpc_response);
-                                debug!("Sending message");
-                            }
-                            // send the stream termination
-                            receiver.send_response(
-                                peer_id,
-                                inbound_request_id,
-                                Response::BlocksByRange(None),
-                            );
-                            debug!("Send stream term");
+                        for i in 0..messages_to_send {
+                            // Send equal base, altair and bellatrix blocks
+                            let rpc_response = if i < 2 {
+                                rpc_response_base.clone()
+                            } else if i < 4 {
+                                rpc_response_altair.clone()
+                            } else {
+                                rpc_response_bellatrix_small.clone()
+                            };
+                            receiver.send_response(peer_id, inbound_request_id, rpc_response);
+                            debug!("Sending message");
                         }
+                        // send the stream termination
+                        receiver.send_response(
+                            peer_id,
+                            inbound_request_id,
+                            Response::BlocksByRange(None),
+                        );
+                        debug!("Send stream term");
                     }
                     _ => {} // Ignore other events
                 }
@@ -1099,27 +1082,25 @@ fn test_tcp_columns_by_root_chunked_rpc_for_fork(fork_name: ForkName) {
                         peer_id,
                         inbound_request_id,
                         request_type,
-                    } => {
-                        if request_type == rpc_request {
-                            // send the response
-                            info!("Receiver got request");
+                    } if request_type == rpc_request => {
+                        // send the response
+                        info!("Receiver got request");
 
-                            for _ in 0..messages_to_send {
-                                receiver.send_response(
-                                    peer_id,
-                                    inbound_request_id,
-                                    rpc_response.clone(),
-                                );
-                                info!("Sending message");
-                            }
-                            // send the stream termination
+                        for _ in 0..messages_to_send {
                             receiver.send_response(
                                 peer_id,
                                 inbound_request_id,
-                                Response::DataColumnsByRoot(None),
+                                rpc_response.clone(),
                             );
-                            info!("Send stream term");
+                            info!("Sending message");
                         }
+                        // send the stream termination
+                        receiver.send_response(
+                            peer_id,
+                            inbound_request_id,
+                            Response::DataColumnsByRoot(None),
+                        );
+                        info!("Send stream term");
                     }
                     e => {
                         info!(?e, "Got event");
@@ -1425,12 +1406,10 @@ fn test_tcp_blocks_by_root_chunked_rpc_terminates_correctly() {
                             request_type,
                         },
                         _,
-                    )) => {
-                        if request_type == rpc_request {
-                            // send the response
-                            warn!("Receiver got request");
-                            message_info = Some((peer_id, inbound_request_id));
-                        }
+                    )) if request_type == rpc_request => {
+                        // send the response
+                        warn!("Receiver got request");
+                        message_info = Some((peer_id, inbound_request_id));
                     }
                     futures::future::Either::Right((_, _)) => {} // The timeout hit, send messages if required
                     _ => continue,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -289,7 +289,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             })
             .collect::<Vec<_>>();
 
-        for (result, package) in results.into_iter().zip(packages.into_iter()) {
+        for (result, package) in results.into_iter().zip(packages) {
             let result = match result {
                 Ok((indexed_attestation, attestation)) => Ok(VerifiedUnaggregate {
                     indexed_attestation,
@@ -495,7 +495,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             .map(|result| result.map(|verified| verified.into_indexed_attestation()))
             .collect::<Vec<_>>();
 
-        for (result, package) in results.into_iter().zip(packages.into_iter()) {
+        for (result, package) in results.into_iter().zip(packages) {
             let result = match result {
                 Ok(indexed_attestation) => Ok(VerifiedAggregate {
                     indexed_attestation,

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -1702,8 +1702,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         };
 
         let result = columns_by_range_peers_to_request
-            .iter()
-            .filter_map(|(peer_id, _)| {
+            .keys()
+            .filter_map(|peer_id| {
                 self.send_data_columns_by_range_request(
                     *peer_id,
                     request.clone(),

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -1148,7 +1148,7 @@ mod release_tests {
                 })
                 .collect::<Vec<_>>();
 
-            for att in aggs1.into_iter().chain(aggs2.into_iter()) {
+            for att in aggs1.into_iter().chain(aggs2) {
                 let attesting_indices =
                     get_attesting_indices_from_state(&state, att.to_ref()).unwrap();
                 op_pool.insert_attestation(att, attesting_indices).unwrap();

--- a/consensus/types/src/core/chain_spec.rs
+++ b/consensus/types/src/core/chain_spec.rs
@@ -1789,7 +1789,7 @@ impl<'de> Deserialize<'de> for BlobSchedule {
 impl BlobSchedule {
     pub fn new(mut vec: Vec<BlobParameters>) -> Self {
         // reverse sort by epoch
-        vec.sort_by(|a, b| b.epoch.cmp(&a.epoch));
+        vec.sort_by_key(|b| std::cmp::Reverse(b.epoch));
         Self {
             schedule: vec,
             skip_serializing: false,

--- a/consensus/types/src/test_utils/generate_random_block_and_blobs.rs
+++ b/consensus/types/src/test_utils/generate_random_block_and_blobs.rs
@@ -34,11 +34,8 @@ pub fn generate_rand_block_and_blobs<E: EthSpec>(
         .blob_kzg_commitments_mut()
         .expect("kzg commitment expected from Deneb") = commitments.clone();
 
-    for (index, ((blob, kzg_commitment), kzg_proof)) in blobs
-        .into_iter()
-        .zip(commitments.into_iter())
-        .zip(proofs.into_iter())
-        .enumerate()
+    for (index, ((blob, kzg_commitment), kzg_proof)) in
+        blobs.into_iter().zip(commitments).zip(proofs).enumerate()
     {
         blob_sidecars.push(BlobSidecar {
             index: index as u64,

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -388,7 +388,7 @@ impl<E: EthSpec> Environment<E> {
                 Err(e) => error!(error = ?e, "Could not register SIGHUP handler"),
             }
 
-            future::select(inner_shutdown, future::select_all(handles.into_iter())).await
+            future::select(inner_shutdown, future::select_all(handles)).await
         };
 
         match self.runtime().block_on(register_handlers) {

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -660,11 +660,8 @@ impl<E: EthSpec> Tester<E> {
             // Zipping will stop when any of the zipped lists runs out, which is what we want. Some
             // of the tests don't provide enough proofs/blobs, and should fail the availability
             // check.
-            for (i, ((blob, kzg_proof), kzg_commitment)) in blobs
-                .into_iter()
-                .zip(proofs)
-                .zip(commitments.into_iter())
-                .enumerate()
+            for (i, ((blob, kzg_proof), kzg_commitment)) in
+                blobs.into_iter().zip(proofs).zip(commitments).enumerate()
             {
                 let blob_sidecar = Arc::new(BlobSidecar {
                     index: i as u64,

--- a/validator_client/http_api/src/keystores.rs
+++ b/validator_client/http_api/src/keystores.rs
@@ -102,10 +102,8 @@ pub fn import<T: SlotClock + 'static, E: EthSpec>(
     // Import each keystore. Some keystores may fail to be imported, so we record a status for each.
     let mut statuses = Vec::with_capacity(request.keystores.len());
 
-    for (KeystoreJsonStr(keystore), password) in request
-        .keystores
-        .into_iter()
-        .zip(request.passwords.into_iter())
+    for (KeystoreJsonStr(keystore), password) in
+        request.keystores.into_iter().zip(request.passwords)
     {
         let pubkey_str = keystore.pubkey().to_string();
 

--- a/validator_client/lighthouse_validator_store/src/lib.rs
+++ b/validator_client/lighthouse_validator_store/src/lib.rs
@@ -1030,7 +1030,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore for LighthouseValidatorS
 
             // Collect successfully signed attestations and log errors.
             let mut signed_attestations = Vec::with_capacity(attestations.len());
-            for (result, att) in results.into_iter().zip(attestations.into_iter()) {
+            for (result, att) in results.into_iter().zip(attestations) {
                 match result {
                     Ok(()) => {
                         signed_attestations.push((

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -471,8 +471,8 @@ impl<S: ValidatorStore, T: SlotClock + 'static> DutiesService<S, T> {
             .voting_pubkeys(DoppelgangerStatus::only_safe);
         self.attesters
             .read()
-            .iter()
-            .filter_map(|(_, map)| map.get(&epoch))
+            .values()
+            .filter_map(|map| map.get(&epoch))
             .map(|(_, duty_and_proof)| duty_and_proof)
             .filter(|duty_and_proof| signing_pubkeys.contains(&duty_and_proof.duty.pubkey))
             .count()
@@ -533,8 +533,8 @@ impl<S: ValidatorStore, T: SlotClock + 'static> DutiesService<S, T> {
 
         self.attesters
             .read()
-            .iter()
-            .filter_map(|(_, map)| map.get(&epoch))
+            .values()
+            .filter_map(|map| map.get(&epoch))
             .map(|(_, duty_and_proof)| duty_and_proof)
             .filter(|duty_and_proof| {
                 duty_and_proof.duty.slot == slot
@@ -983,8 +983,8 @@ async fn poll_beacon_attesters<S: ValidatorStore + 'static, T: SlotClock + 'stat
         duties_service
             .attesters
             .read()
-            .iter()
-            .filter_map(|(_, map)| map.get(epoch))
+            .values()
+            .filter_map(|map| map.get(epoch))
             .filter(|(_, duty_and_proof)| {
                 duty_and_proof
                     .subscription_slots


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Adds lints for rust 1.95. Mostly cosmetic. 
1. .zip(a.into_iter()) -> .zip(a) . Also a few more places where into_iter is not required
2. replace sort_by with sort_by_key
3. move if statements inside match block. 
4. use checked_div instead of if statements. I think this is debatable in terms of being better, happy to remove it if others also feel its unnecessary


