### PR TITLE
Revert Gloas API changes from 9092

### DIFF
--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -1,5 +1,5 @@
 use crate::version::inconsistent_fork_rejection;
-use crate::{ExecutionOptimistic, state_id::checkpoint_block_and_execution_optimistic};
+use crate::{ExecutionOptimistic, state_id::checkpoint_slot_and_execution_optimistic};
 use beacon_chain::kzg_utils::reconstruct_blobs;
 use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes, WhenSlotSkipped};
 use eth2::beacon_response::{ExecutionOptimisticFinalizedMetadata, UnversionedResponse};
@@ -60,15 +60,15 @@ impl BlockId {
             CoreBlockId::Finalized => {
                 let finalized_checkpoint =
                     chain.canonical_head.cached_head().finalized_checkpoint();
-                let (_block, execution_optimistic) =
-                    checkpoint_block_and_execution_optimistic(chain, finalized_checkpoint)?;
+                let (_slot, execution_optimistic) =
+                    checkpoint_slot_and_execution_optimistic(chain, finalized_checkpoint)?;
                 Ok((finalized_checkpoint.root, execution_optimistic, true))
             }
             CoreBlockId::Justified => {
                 let justified_checkpoint =
                     chain.canonical_head.cached_head().justified_checkpoint();
-                let (_block, execution_optimistic) =
-                    checkpoint_block_and_execution_optimistic(chain, justified_checkpoint)?;
+                let (_slot, execution_optimistic) =
+                    checkpoint_slot_and_execution_optimistic(chain, justified_checkpoint)?;
                 Ok((justified_checkpoint.root, execution_optimistic, false))
             }
             CoreBlockId::Slot(slot) => {

--- a/beacon_node/http_api/src/state_id.rs
+++ b/beacon_node/http_api/src/state_id.rs
@@ -2,7 +2,6 @@ use crate::ExecutionOptimistic;
 use crate::metrics;
 use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
 use eth2::types::StateId as CoreStateId;
-use proto_array::Block;
 use std::fmt;
 use std::str::FromStr;
 use types::{BeaconState, Checkpoint, EthSpec, Fork, Hash256, Slot};
@@ -20,8 +19,6 @@ impl StateId {
         Self(CoreStateId::Slot(slot))
     }
 
-    // TODO(gloas) add tests for finalized and justified checkpoint states to ensure
-    // we return the post block state for gloas
     /// Return the state root identified by `self`.
     pub fn root<T: BeaconChainTypes>(
         &self,
@@ -44,41 +41,15 @@ impl StateId {
             CoreStateId::Finalized => {
                 let finalized_checkpoint =
                     chain.canonical_head.cached_head().finalized_checkpoint();
-
-                let slot = finalized_checkpoint
-                    .epoch
-                    .start_slot(T::EthSpec::slots_per_epoch());
-                let (block, execution_optimistic) =
-                    checkpoint_block_and_execution_optimistic(chain, finalized_checkpoint)?;
-
-                if chain
-                    .spec
-                    .fork_name_at_slot::<T::EthSpec>(block.slot)
-                    .gloas_enabled()
-                {
-                    return Ok((block.state_root, execution_optimistic, true));
-                }
-
+                let (slot, execution_optimistic) =
+                    checkpoint_slot_and_execution_optimistic(chain, finalized_checkpoint)?;
                 (slot, execution_optimistic, true)
             }
             CoreStateId::Justified => {
                 let justified_checkpoint =
                     chain.canonical_head.cached_head().justified_checkpoint();
-
-                let slot = justified_checkpoint
-                    .epoch
-                    .start_slot(T::EthSpec::slots_per_epoch());
-                let (block, execution_optimistic) =
-                    checkpoint_block_and_execution_optimistic(chain, justified_checkpoint)?;
-
-                if chain
-                    .spec
-                    .fork_name_at_slot::<T::EthSpec>(block.slot)
-                    .gloas_enabled()
-                {
-                    return Ok((block.state_root, execution_optimistic, false));
-                }
-
+                let (slot, execution_optimistic) =
+                    checkpoint_slot_and_execution_optimistic(chain, justified_checkpoint)?;
                 (slot, execution_optimistic, false)
             }
             CoreStateId::Slot(slot) => (
@@ -283,11 +254,13 @@ impl fmt::Display for StateId {
     }
 }
 
-/// Returns checkpoint block and the execution status of the checkpoint's `root`.
-pub fn checkpoint_block_and_execution_optimistic<T: BeaconChainTypes>(
+/// Returns the first slot of the checkpoint's `epoch` and the execution status of the checkpoint's
+/// `root`.
+pub fn checkpoint_slot_and_execution_optimistic<T: BeaconChainTypes>(
     chain: &BeaconChain<T>,
     checkpoint: Checkpoint,
-) -> Result<(Block, ExecutionOptimistic), warp::reject::Rejection> {
+) -> Result<(Slot, ExecutionOptimistic), warp::reject::Rejection> {
+    let slot = checkpoint.epoch.start_slot(T::EthSpec::slots_per_epoch());
     let fork_choice = chain.canonical_head.fork_choice_read_lock();
     let finalized_checkpoint = fork_choice.cached_fork_choice_view().finalized_checkpoint;
 
@@ -304,9 +277,5 @@ pub fn checkpoint_block_and_execution_optimistic<T: BeaconChainTypes>(
         .map_err(BeaconChainError::ForkChoiceError)
         .map_err(warp_utils::reject::unhandled_error)?;
 
-    let block = fork_choice.get_block(&checkpoint.root).ok_or_else(|| {
-        warp_utils::reject::custom_not_found(format!("Block {:?} not found", checkpoint.root))
-    })?;
-
-    Ok((block, execution_optimistic))
+    Ok((slot, execution_optimistic))
 }

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -125,15 +125,7 @@ impl fmt::Display for BlockId {
 pub enum StateId {
     Head,
     Genesis,
-    /// Pre-gloas the finalized state is the checkpoint block state
-    /// advanced to the epoch boundary.
-    /// Post-gloas this state is always the checkpoint post-block state and is not advanced
-    /// to the epoch boundary.
     Finalized,
-    /// Pre-gloas the justified state is the checkpoint block state
-    /// advanced to the epoch boundary.
-    /// Post-gloas this state is always the checkpoint post-block state and is not advanced
-    /// to the epoch boundary.
     Justified,
     Slot(Slot),
     Root(Hash256),


### PR DESCRIPTION
## Issue Addressed

This reverts commit 2749e18d0e35e6f148642623327acac5a7066658, from:

- #9092

We no longer need those changes since the abolition of pending/full states.

## Additional Info

HTTP API tests will be enabled in another PR. Keeping this one as just a straight revert.

(There are many failing HTTP API tests currently)
