### PR TITLE
At the fork transition ensure we build ontop of the correct parent block hash

### DIFF
--- a/beacon_node/beacon_chain/src/block_production/gloas.rs
+++ b/beacon_node/beacon_chain/src/block_production/gloas.rs
@@ -164,9 +164,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Extract the parent's execution requests from the envelope (if parent was full).
         // Pre-Gloas blocks have no envelope, so use empty execution requests.
+        let parent_block_slot = state.latest_block_header().slot;
         let parent_slot_gloas = self
             .spec
-            .fork_name_at_slot::<T::EthSpec>(produce_at_slot.saturating_sub(1u64))
+            .fork_name_at_slot::<T::EthSpec>(parent_block_slot)
             .gloas_enabled();
         let parent_execution_requests =
             if parent_payload_status == PayloadStatus::Full && parent_slot_gloas {
@@ -696,9 +697,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let parent_bid = state.latest_execution_payload_bid()?;
 
         // TODO(gloas): need should_extend_payload check here as well
+        let parent_block_slot = state.latest_block_header().slot;
         let parent_is_pre_gloas = !self
             .spec
-            .fork_name_at_slot::<T::EthSpec>(produce_at_slot.saturating_sub(1u64))
+            .fork_name_at_slot::<T::EthSpec>(parent_block_slot)
             .gloas_enabled();
         let parent_block_hash =
             if parent_payload_status == PayloadStatus::Full || parent_is_pre_gloas {

--- a/beacon_node/beacon_chain/src/block_production/gloas.rs
+++ b/beacon_node/beacon_chain/src/block_production/gloas.rs
@@ -163,21 +163,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .map_err(BlockProductionError::TokioJoin)??;
 
         // Extract the parent's execution requests from the envelope (if parent was full).
-        // Pre-Gloas blocks have no envelope, so use empty execution requests.
-        let parent_block_slot = state.latest_block_header().slot;
-        let parent_slot_gloas = self
-            .spec
-            .fork_name_at_slot::<T::EthSpec>(parent_block_slot)
-            .gloas_enabled();
-        let parent_execution_requests =
-            if parent_payload_status == PayloadStatus::Full && parent_slot_gloas {
-                parent_envelope
-                    .as_ref()
-                    .map(|env| env.message.execution_requests.clone())
-                    .ok_or(BlockProductionError::MissingParentExecutionPayload)?
-            } else {
-                ExecutionRequests::default()
-            };
+        let parent_execution_requests = if parent_payload_status == PayloadStatus::Full {
+            parent_envelope
+                .as_ref()
+                .map(|env| env.message.execution_requests.clone())
+                .ok_or(BlockProductionError::MissingParentExecutionPayload)?
+        } else {
+            ExecutionRequests::default()
+        };
 
         // Part 2/3 (async)
         //

--- a/beacon_node/beacon_chain/src/block_production/gloas.rs
+++ b/beacon_node/beacon_chain/src/block_production/gloas.rs
@@ -699,13 +699,21 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let parent_bid = state.latest_execution_payload_bid()?;
 
         // TODO(gloas): need should_extend_payload check here as well
-        let parent_block_hash = if parent_payload_status == PayloadStatus::Full {
-            // Build on parent bid's payload.
-            parent_bid.block_hash
-        } else {
-            // Skip parent bid's payload. For genesis this is the EL genesis hash.
-            parent_bid.parent_block_hash
-        };
+        // At the fork transition the parent is pre-Gloas and always embeds its payload,
+        // so use block_hash directly. Pre-Gloas blocks have Empty status in fork choice
+        // but their payload is always present.
+        let parent_is_pre_gloas = !self
+            .spec
+            .fork_name_at_slot::<T::EthSpec>(produce_at_slot.saturating_sub(1u64))
+            .gloas_enabled();
+        let parent_block_hash =
+            if parent_payload_status == PayloadStatus::Full || parent_is_pre_gloas {
+                // Build on parent bid's payload.
+                parent_bid.block_hash
+            } else {
+                // Skip parent bid's payload. For genesis this is the EL genesis hash.
+                parent_bid.parent_block_hash
+            };
 
         // TODO(gloas) this should be BlockProductionVersion::V4
         // V3 is okay for now as long as we're not connected to a builder

--- a/beacon_node/beacon_chain/src/block_production/gloas.rs
+++ b/beacon_node/beacon_chain/src/block_production/gloas.rs
@@ -163,14 +163,20 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .map_err(BlockProductionError::TokioJoin)??;
 
         // Extract the parent's execution requests from the envelope (if parent was full).
-        let parent_execution_requests = if parent_payload_status == PayloadStatus::Full {
-            parent_envelope
-                .as_ref()
-                .map(|env| env.message.execution_requests.clone())
-                .ok_or(BlockProductionError::MissingParentExecutionPayload)?
-        } else {
-            ExecutionRequests::default()
-        };
+        // Pre-Gloas blocks have no envelope, so use empty execution requests.
+        let parent_slot_gloas = self
+            .spec
+            .fork_name_at_slot::<T::EthSpec>(produce_at_slot.saturating_sub(1u64))
+            .gloas_enabled();
+        let parent_execution_requests =
+            if parent_payload_status == PayloadStatus::Full && parent_slot_gloas {
+                parent_envelope
+                    .as_ref()
+                    .map(|env| env.message.execution_requests.clone())
+                    .ok_or(BlockProductionError::MissingParentExecutionPayload)?
+            } else {
+                ExecutionRequests::default()
+            };
 
         // Part 2/3 (async)
         //

--- a/beacon_node/beacon_chain/src/block_production/gloas.rs
+++ b/beacon_node/beacon_chain/src/block_production/gloas.rs
@@ -696,9 +696,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let parent_bid = state.latest_execution_payload_bid()?;
 
         // TODO(gloas): need should_extend_payload check here as well
-        // At the fork transition the parent is pre-Gloas and always embeds its payload,
-        // so use block_hash directly. Pre-Gloas blocks have Empty status in fork choice
-        // but their payload is always present.
         let parent_is_pre_gloas = !self
             .spec
             .fork_name_at_slot::<T::EthSpec>(produce_at_slot.saturating_sub(1u64))

--- a/beacon_node/beacon_chain/src/block_production/mod.rs
+++ b/beacon_node/beacon_chain/src/block_production/mod.rs
@@ -83,10 +83,21 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     .get_advanced_hot_state(head_block_root, slot, parent_state_root)
                     .map_err(BlockProductionError::FailedToLoadState)?
                     .ok_or(BlockProductionError::UnableToProduceAtSlot(slot))?;
+                // Pre-Gloas blocks always embed their execution payload, so if
+                // the head is pre-Gloas treat its payload as Full.
+                let parent_payload_status = if !self
+                    .spec
+                    .fork_name_at_slot::<T::EthSpec>(head_slot)
+                    .gloas_enabled()
+                {
+                    PayloadStatus::Full
+                } else {
+                    head_payload_status
+                };
                 BlockProductionState {
                     state,
                     state_root: Some(state_root),
-                    parent_payload_status: head_payload_status,
+                    parent_payload_status,
                     parent_envelope: head_envelope,
                 }
             }

--- a/beacon_node/beacon_chain/src/block_production/mod.rs
+++ b/beacon_node/beacon_chain/src/block_production/mod.rs
@@ -83,21 +83,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     .get_advanced_hot_state(head_block_root, slot, parent_state_root)
                     .map_err(BlockProductionError::FailedToLoadState)?
                     .ok_or(BlockProductionError::UnableToProduceAtSlot(slot))?;
-                // Pre-Gloas blocks always embed their execution payload, so if
-                // the head is pre-Gloas treat its payload as Full.
-                let parent_payload_status = if !self
-                    .spec
-                    .fork_name_at_slot::<T::EthSpec>(head_slot)
-                    .gloas_enabled()
-                {
-                    PayloadStatus::Full
-                } else {
-                    head_payload_status
-                };
                 BlockProductionState {
                     state,
                     state_root: Some(state_root),
-                    parent_payload_status,
+                    parent_payload_status: head_payload_status,
                     parent_envelope: head_envelope,
                 }
             }


### PR DESCRIPTION
## Issue Addressed
 
When producing a block at the fork, treat parent payload status as full

I've been testing on kurtosis and this fixes an issue where we cant propose a block at the fork.

This is a screenshot of the fix. The envelope shows missing because we are missing an SSE event, but the envelope is in fact being imported and the chain is progressing just fine
<img width="652" height="748" alt="image" src="https://github.com/user-attachments/assets/7764a68c-33fb-4987-a691-0af71f0bea02" />
