### PR TITLE
Fix audit failure for `rustls-webpki`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5266,7 +5266,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls 0.23.35",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "thiserror 2.0.17",
  "x509-parser",
  "yasna",
@@ -7678,7 +7678,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -7727,9 +7727,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ install-audit:
 	cargo install --force cargo-audit
 
 audit-CI:
-	cargo audit --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099
+	cargo audit --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099 --ignore RUSTSEC-2026-0104
 
 # Runs cargo deny (check for banned crates, duplicate versions, and source restrictions)
 deny: install-deny deny-CI


### PR DESCRIPTION
## Issue Addressed

Another `rustls-webpki` audit failure: https://rustsec.org/advisories/RUSTSEC-2026-0104

## Proposed Changes

Bump `rustls-webpki` to the latest (unaffected) version.
As with the previous `rustls-webpki` vulns, we add an ignore for our older version required by warp 0.3.
This ignore will be resolved by https://github.com/sigp/lighthouse/pull/9001

## Additional Info

This is related to cert revocation and we are unaffected.
