### PR TITLE
Default envelope to always avail

### DIFF
--- a/beacon_node/beacon_chain/src/payload_envelope_verification/execution_pending_envelope.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/execution_pending_envelope.rs
@@ -9,9 +9,7 @@ use crate::{
     PayloadVerificationOutcome,
     block_verification::PayloadVerificationHandle,
     payload_envelope_verification::{
-        EnvelopeError, EnvelopeImportData, MaybeAvailableEnvelope,
-        gossip_verified_envelope::GossipVerifiedEnvelope, load_snapshot_from_state_root,
-        payload_notifier::PayloadNotifier,
+        AvailableEnvelope, EnvelopeError, EnvelopeImportData, MaybeAvailableEnvelope, gossip_verified_envelope::GossipVerifiedEnvelope, load_snapshot_from_state_root, payload_notifier::PayloadNotifier
     },
 };
 
@@ -86,11 +84,17 @@ impl<T: BeaconChainTypes> GossipVerifiedEnvelope<T> {
             &chain.spec,
         )?;
 
+        // TODO(gloas) Since we dont have a DA cache we are always constructing an available envelope.
+        // once the da cache is implemented we should set this envelope to pending and let the da cache
+        // handle the availability logic.
         Ok(ExecutionPendingEnvelope {
-            signed_envelope: MaybeAvailableEnvelope::AvailabilityPending {
-                block_hash: payload.block_hash,
+            signed_envelope: MaybeAvailableEnvelope::Available(AvailableEnvelope {
+                execution_block_hash: payload.block_hash,
                 envelope: signed_envelope,
-            },
+                columns: vec![].into(),
+                columns_available_timestamp: None,
+                spec: chain.spec.clone(),
+            }),
             import_data: EnvelopeImportData {
                 block_root,
                 _phantom: Default::default(),

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/execution_pending_envelope.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/execution_pending_envelope.rs
@@ -9,7 +9,9 @@ use crate::{
     PayloadVerificationOutcome,
     block_verification::PayloadVerificationHandle,
     payload_envelope_verification::{
-        AvailableEnvelope, EnvelopeError, EnvelopeImportData, MaybeAvailableEnvelope, gossip_verified_envelope::GossipVerifiedEnvelope, load_snapshot_from_state_root, payload_notifier::PayloadNotifier
+        AvailableEnvelope, EnvelopeError, EnvelopeImportData, MaybeAvailableEnvelope,
+        gossip_verified_envelope::GossipVerifiedEnvelope, load_snapshot_from_state_root,
+        payload_notifier::PayloadNotifier,
     },
 };
 
@@ -88,13 +90,12 @@ impl<T: BeaconChainTypes> GossipVerifiedEnvelope<T> {
         // once the da cache is implemented we should set this envelope to pending and let the da cache
         // handle the availability logic.
         Ok(ExecutionPendingEnvelope {
-            signed_envelope: MaybeAvailableEnvelope::Available(AvailableEnvelope {
-                execution_block_hash: payload.block_hash,
-                envelope: signed_envelope,
-                columns: vec![].into(),
-                columns_available_timestamp: None,
-                spec: chain.spec.clone(),
-            }),
+            signed_envelope: MaybeAvailableEnvelope::Available(AvailableEnvelope::new(
+                payload.block_hash,
+                signed_envelope,
+                vec![].into(),
+                chain.spec.clone(),
+            )),
             import_data: EnvelopeImportData {
                 block_root,
                 _phantom: Default::default(),

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
@@ -50,14 +50,29 @@ pub struct EnvelopeImportData<E: EthSpec> {
 
 #[derive(Debug)]
 pub struct AvailableEnvelope<E: EthSpec> {
-    pub execution_block_hash: ExecutionBlockHash,
-    pub envelope: Arc<SignedExecutionPayloadEnvelope<E>>,
-    pub columns: DataColumnSidecarList<E>,
-    pub columns_available_timestamp: Option<std::time::Duration>,
+    execution_block_hash: ExecutionBlockHash,
+    envelope: Arc<SignedExecutionPayloadEnvelope<E>>,
+    columns: DataColumnSidecarList<E>,
+    columns_available_timestamp: Option<std::time::Duration>,
     pub spec: Arc<ChainSpec>,
 }
 
 impl<E: EthSpec> AvailableEnvelope<E> {
+    pub fn new(
+        execution_block_hash: ExecutionBlockHash,
+        envelope: Arc<SignedExecutionPayloadEnvelope<E>>,
+        columns: DataColumnSidecarList<E>,
+        spec: Arc<ChainSpec>,
+    ) -> Self {
+        Self {
+            execution_block_hash,
+            envelope,
+            columns,
+            columns_available_timestamp: None,
+            spec,
+        }
+    }
+
     pub fn message(&self) -> &ExecutionPayloadEnvelope<E> {
         &self.envelope.message
     }

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
@@ -49,13 +49,11 @@ pub struct EnvelopeImportData<E: EthSpec> {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct AvailableEnvelope<E: EthSpec> {
-    execution_block_hash: ExecutionBlockHash,
-    envelope: Arc<SignedExecutionPayloadEnvelope<E>>,
-    columns: DataColumnSidecarList<E>,
-    /// Timestamp at which this envelope first became available (UNIX timestamp, time since 1970).
-    columns_available_timestamp: Option<std::time::Duration>,
+    pub execution_block_hash: ExecutionBlockHash,
+    pub envelope: Arc<SignedExecutionPayloadEnvelope<E>>,
+    pub columns: DataColumnSidecarList<E>,
+    pub columns_available_timestamp: Option<std::time::Duration>,
     pub spec: Arc<ChainSpec>,
 }
 


### PR DESCRIPTION
## Issue Addressed

We default to pending envelope status because we haven't merged the gloas da checker in yet. For devnets we are ignoring the availability check. This. sets the envelope to availabel by default so that we can interop with other clients for upcoming devnets. Seems easier to merge this into unstable than creating a special branch just for devnets.
