### PR TITLE
Avoid lint and fmt for agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,7 @@ This file provides guidance for AI assistants (Claude Code, Codex, etc.) working
 ## CRITICAL - Always Follow
 
 After completing ANY code changes:
-1. **MUST** run `cargo fmt --all && make lint-fix` to format and fix linting issues
-2. **MUST** run `cargo check` to verify compilation before considering task complete
+1. **MUST** run `cargo check` to verify compilation before considering task complete
 
 Run `make install-hooks` if you have not already to install git hooks. Never skip git hooks. If cargo is not available install the toolchain.
 


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Do not make the AI agent always fmt and lint. This takes way too long and the agents I work with take this too literally sometimes and run lint after incomplete changes just wasting time.

I feel its not a big ask to run fmt and lint yourself and/or run it in some local configs instead of global ones.