### PR TITLE
fix: gloas from genesis

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -942,12 +942,14 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
 
         // Check that we've received the parent envelope. If not, issue a single envelope
         // lookup for the parent and queue this block in the reprocess queue.
+        // Skip this check for the genesis block — it's a synthetic anchor with no envelope.
         let parent_is_gloas = chain
             .spec
             .fork_name_at_slot::<T::EthSpec>(parent_block.slot)
             .gloas_enabled();
 
         if parent_is_gloas
+            && parent_block.slot != chain.spec.genesis_slot
             && !fork_choice_read_lock.is_payload_received(&block.message().parent_root())
         {
             return Err(BlockError::ParentEnvelopeUnknown {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -416,12 +416,28 @@ where
 
         let (execution_status, execution_payload_parent_hash, execution_payload_block_hash) =
             if let Ok(signed_bid) = anchor_block.message().body().signed_execution_payload_bid() {
-                // Gloas: execution status is irrelevant post-Gloas; payload validation
-                // is decoupled from beacon blocks.
+                let parent_block_hash = signed_bid.message.parent_block_hash;
+                let block_hash = signed_bid.message.block_hash;
+
+                // At Gloas genesis the block bid is empty (all zeros) per spec, but the
+                // state holds the EL genesis hash in `latest_block_hash`. Use it so the
+                // first forkchoice update sends a valid head to the EL.
+                let parent_hash = if anchor_block.slot() == spec.genesis_slot
+                    && anchor_state.slot() == spec.genesis_slot
+                    && parent_block_hash.into_root().is_zero()
+                    && block_hash.into_root().is_zero()
+                {
+                    *anchor_state
+                        .latest_block_hash()
+                        .map_err(Error::BeaconStateError)?
+                } else {
+                    parent_block_hash
+                };
+
                 (
                     ExecutionStatus::irrelevant(),
-                    Some(signed_bid.message.parent_block_hash),
-                    Some(signed_bid.message.block_hash),
+                    Some(parent_hash),
+                    Some(block_hash),
                 )
             } else if let Ok(execution_payload) = anchor_block.message().execution_payload() {
                 // Pre-Gloas forks: do not set payload hashes, they are only used post-Gloas.

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -416,28 +416,25 @@ where
 
         let (execution_status, execution_payload_parent_hash, execution_payload_block_hash) =
             if let Ok(signed_bid) = anchor_block.message().body().signed_execution_payload_bid() {
-                let parent_block_hash = signed_bid.message.parent_block_hash;
-                let block_hash = signed_bid.message.block_hash;
-
                 // At Gloas genesis the block bid is empty (all zeros) per spec, but the
                 // state holds the EL genesis hash in `latest_block_hash`. Use it so the
                 // first forkchoice update sends a valid head to the EL.
                 let parent_hash = if anchor_block.slot() == spec.genesis_slot
                     && anchor_state.slot() == spec.genesis_slot
-                    && parent_block_hash.into_root().is_zero()
-                    && block_hash.into_root().is_zero()
+                    && signed_bid.message.parent_block_hash.into_root().is_zero()
+                    && signed_bid.message.block_hash.into_root().is_zero()
                 {
                     *anchor_state
                         .latest_block_hash()
                         .map_err(Error::BeaconStateError)?
                 } else {
-                    parent_block_hash
+                    signed_bid.message.parent_block_hash
                 };
 
                 (
                     ExecutionStatus::irrelevant(),
                     Some(parent_hash),
-                    Some(block_hash),
+                    Some(signed_bid.message.block_hash),
                 )
             } else if let Ok(execution_payload) = anchor_block.message().execution_payload() {
                 // Pre-Gloas forks: do not set payload hashes, they are only used post-Gloas.

--- a/consensus/state_processing/src/genesis.rs
+++ b/consensus/state_processing/src/genesis.rs
@@ -167,21 +167,12 @@ pub fn initialize_beacon_state_from_eth1<E: EthSpec>(
         // Remove intermediate Fulu fork from `state.fork`.
         state.fork_mut().previous_version = spec.gloas_fork_version;
 
-        // The genesis block's bid must have block_hash = 0x00 per spec (empty payload).
         // Retain the EL genesis hash in latest_block_hash and parent_block_hash so the
         // first post-genesis proposer can build on the correct EL head.
         let el_genesis_hash = state.latest_execution_payload_bid()?.block_hash;
         let bid = state.latest_execution_payload_bid_mut()?;
         bid.parent_block_hash = el_genesis_hash;
         bid.block_hash = ExecutionBlockHash::default();
-
-        // Update latest_block_header to reflect the Gloas genesis block body which contains
-        // the EL genesis hash in the signed_execution_payload_bid. This is needed because
-        // BeaconState::new() created the header from BeaconBlock::empty() which has zero bid
-        // fields, but the spec requires the genesis block's bid to contain the EL block hash
-        // and the tree hash root of empty ExecutionRequests.
-        let block = genesis_block(&state, spec)?;
-        state.latest_block_header_mut().body_root = block.body_root();
     }
 
     // Now that we have our validators, initialize the caches (including the committees)
@@ -193,26 +184,16 @@ pub fn initialize_beacon_state_from_eth1<E: EthSpec>(
     Ok(state)
 }
 
-/// Create an unsigned genesis `BeaconBlock` whose body matches the genesis state.
+/// Create an unsigned genesis `BeaconBlock` matching the genesis state.
 ///
-/// For Gloas, the block's `signed_execution_payload_bid` is populated from the state's
-/// `latest_execution_payload_bid` so that the body root is consistent with
-/// `state.latest_block_header.body_root`.
-///
-/// The returned block has `state_root == Hash256::ZERO`; callers that need the real
-/// state root should set it themselves.
+/// Per spec, the genesis block body is empty (all default fields).
+/// `state.latest_block_header.body_root` is set from `BeaconBlock::empty()`,
+/// so this function must return the same empty block to keep roots consistent.
 pub fn genesis_block<E: EthSpec>(
-    genesis_state: &BeaconState<E>,
+    _genesis_state: &BeaconState<E>,
     spec: &ChainSpec,
 ) -> Result<BeaconBlock<E>, BeaconStateError> {
-    let mut block = BeaconBlock::empty(spec);
-    if let Ok(block) = block.as_gloas_mut() {
-        let state_bid = genesis_state.latest_execution_payload_bid()?;
-        let bid = &mut block.body.signed_execution_payload_bid.message;
-        bid.block_hash = state_bid.block_hash;
-        bid.execution_requests_root = state_bid.execution_requests_root;
-    }
-    Ok(block)
+    Ok(BeaconBlock::empty(spec))
 }
 
 /// Determine whether a candidate genesis state is suitable for starting the chain.

--- a/validator_client/validator_services/src/payload_attestation_service.rs
+++ b/validator_client/validator_services/src/payload_attestation_service.rs
@@ -7,8 +7,7 @@ use std::sync::Arc;
 use task_executor::TaskExecutor;
 use tokio::time::sleep;
 use tracing::{debug, error, info};
-<<<<<<< HEAD
-use types::ChainSpec;
+use types::{ChainSpec, EthSpec};
 use validator_store::ValidatorStore;
 
 pub struct PayloadAttestationServiceBuilder<S: ValidatorStore, T: SlotClock + 'static> {
@@ -96,11 +95,6 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
     }
 }
 
-=======
-use types::{ChainSpec, EthSpec};
-use validator_store::ValidatorStore;
-
->>>>>>> 028b5a42a9715c31f416d45db70add39d9934b12
 pub struct Inner<S, T> {
     duties_service: Arc<DutiesService<S, T>>,
     validator_store: Arc<S>,
@@ -131,29 +125,6 @@ impl<S, T> Deref for PayloadAttestationService<S, T> {
 }
 
 impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationService<S, T> {
-<<<<<<< HEAD
-=======
-    pub fn new(
-        duties_service: Arc<DutiesService<S, T>>,
-        validator_store: Arc<S>,
-        slot_clock: T,
-        beacon_nodes: Arc<BeaconNodeFallback<T>>,
-        executor: TaskExecutor,
-        chain_spec: Arc<ChainSpec>,
-    ) -> Self {
-        Self {
-            inner: Arc::new(Inner {
-                duties_service,
-                validator_store,
-                slot_clock,
-                beacon_nodes,
-                executor,
-                chain_spec,
-            }),
-        }
-    }
-
->>>>>>> 028b5a42a9715c31f416d45db70add39d9934b12
     pub fn start_update_service(self) -> Result<(), String> {
         let slot_duration = self.chain_spec.get_slot_duration();
         let payload_attestation_due = self.chain_spec.get_payload_attestation_due();
@@ -173,11 +144,8 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
                     continue;
                 };
 
-<<<<<<< HEAD
                 sleep(duration_to_next_slot + payload_attestation_due).await;
 
-=======
->>>>>>> 028b5a42a9715c31f416d45db70add39d9934b12
                 let Some(current_slot) = self.slot_clock.now() else {
                     error!("Failed to read slot clock after trigger");
                     continue;
@@ -188,7 +156,6 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
                     .fork_name_at_slot::<S::E>(current_slot)
                     .gloas_enabled()
                 {
-<<<<<<< HEAD
                     continue;
                 }
 
@@ -202,19 +169,6 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
                     duty_count = duties.len(),
                     "Producing payload attestations"
                 );
-=======
-                    let duration_to_next_epoch = self
-                        .slot_clock
-                        .duration_to_next_epoch(S::E::slots_per_epoch())
-                        .unwrap_or_else(|| {
-                            self.chain_spec.get_slot_duration() * S::E::slots_per_epoch() as u32
-                        });
-                    sleep(duration_to_next_epoch).await;
-                    continue;
-                }
-
-                sleep(duration_to_next_slot + payload_attestation_due).await;
->>>>>>> 028b5a42a9715c31f416d45db70add39d9934b12
 
                 let service = self.clone();
                 self.executor.spawn(
@@ -232,23 +186,10 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
 
     async fn produce_and_publish(&self, slot: types::Slot) {
         let duties = self.duties_service.get_ptc_duties_for_slot(slot);
-<<<<<<< HEAD
-=======
-
->>>>>>> 028b5a42a9715c31f416d45db70add39d9934b12
         if duties.is_empty() {
             return;
         }
 
-<<<<<<< HEAD
-=======
-        debug!(
-            %slot,
-            duty_count = duties.len(),
-            "Producing payload attestations"
-        );
-
->>>>>>> 028b5a42a9715c31f416d45db70add39d9934b12
         let attestation_data = match self
             .beacon_nodes
             .first_success(|beacon_node| async move {
@@ -305,21 +246,13 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
         }
 
         let count = messages.len();
-<<<<<<< HEAD
-=======
-        let fork_name = self.chain_spec.fork_name_at_slot::<S::E>(slot);
->>>>>>> 028b5a42a9715c31f416d45db70add39d9934b12
         let result = self
             .beacon_nodes
             .first_success(|beacon_node| {
                 let messages = messages.clone();
                 async move {
                     beacon_node
-<<<<<<< HEAD
                         .post_beacon_pool_payload_attestations_ssz(&messages)
-=======
-                        .post_beacon_pool_payload_attestations_ssz(&messages, fork_name)
->>>>>>> 028b5a42a9715c31f416d45db70add39d9934b12
                         .await
                         .map_err(|e| format!("Failed to publish payload attestations (SSZ): {e:?}"))
                 }
@@ -335,11 +268,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
                         let messages = messages.clone();
                         async move {
                             beacon_node
-<<<<<<< HEAD
                                 .post_beacon_pool_payload_attestations(&messages)
-=======
-                                .post_beacon_pool_payload_attestations(&messages, fork_name)
->>>>>>> 028b5a42a9715c31f416d45db70add39d9934b12
                                 .await
                                 .map_err(|e| {
                                     format!("Failed to publish payload attestations (JSON): {e:?}")


### PR DESCRIPTION
  - Fix forkchoice update sending zero-hash head to EL at genesis by reading latest_block_hash
  from state when the genesis bid hashes are all zeros
  - Simplify genesis block construction — the genesis block body is empty per spec, remove the
  incorrect bid-copying logic and body root override in initialize_beacon_state_from_eth1
  - Skip parent envelope received check in gossip verification when the parent is the genesis
  block