### PR TITLE
Fix validator manager compilation

### DIFF
--- a/validator_manager/Cargo.toml
+++ b/validator_manager/Cargo.toml
@@ -11,7 +11,7 @@ clap = { workspace = true }
 clap_utils = { workspace = true }
 educe = { workspace = true }
 environment = { workspace = true }
-eth2 = { workspace = true }
+eth2 = { workspace = true, features = ["lighthouse"] }
 eth2_network_config = { workspace = true }
 eth2_wallet = { workspace = true }
 ethereum_serde_utils = { workspace = true }


### PR DESCRIPTION
## Issue Addressed

Currently, running `cargo check -p validator_manager` fails due to missing features. Although the `validator_manager` will almost always be called through the Lighthouse binary which will enable the required features, it is still good hygiene to ensure all workspace crates can compile standalone.

## Proposed Changes

Add the `lighthouse` feature to the `eth2` dependency in `validator_manager`
