### PR TITLE
Fix spurious re-org logs on ePBS payload status changes

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -796,7 +796,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let new_snapshot = &new_cached_head.snapshot;
         let old_snapshot = &old_cached_head.snapshot;
 
-        // If the head changed, perform some updates.
+        // Only run on head *block* changes - payload status changes only need the
+        // `cached_head` update above, not re-org detection or event emission.
         if new_snapshot.beacon_block_root != old_snapshot.beacon_block_root
             && let Err(e) =
                 self.after_new_head(&old_cached_head, &new_cached_head, new_head_proto_block)

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -797,8 +797,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let old_snapshot = &old_cached_head.snapshot;
 
         // If the head changed, perform some updates.
-        if (new_snapshot.beacon_block_root != old_snapshot.beacon_block_root
-            || new_payload_status != old_payload_status)
+        if new_snapshot.beacon_block_root != old_snapshot.beacon_block_root
             && let Err(e) =
                 self.after_new_head(&old_cached_head, &new_cached_head, new_head_proto_block)
         {


### PR DESCRIPTION
`after_new_head` fired on every payload status change (Empty→Full on envelope import), even when the head block root was unchanged. This caused spurious "Beacon chain re-org" logs with reorg_distance: 0 on every block, false reorg metrics/SSE events, and unnecessary fork choice persistence.
