### PR TITLE
Send correct payload hashes for safe/finalized in fcU

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -942,12 +942,18 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
 
         // Check that we've received the parent envelope. If not, issue a single envelope
         // lookup for the parent and queue this block in the reprocess queue.
+        //
+        // The anchor block (proto-array root) is implicitly considered to have its payload
+        // received: there is no envelope to fetch for the anchor (per spec, the anchor is
+        // never added to `store.payloads`), and the anchor is trusted by definition.
         let parent_is_gloas = chain
             .spec
             .fork_name_at_slot::<T::EthSpec>(parent_block.slot)
             .gloas_enabled();
+        let parent_is_anchor = parent_block.parent_root.is_none();
 
         if parent_is_gloas
+            && !parent_is_anchor
             && !fork_choice_read_lock.is_payload_received(&block.message().parent_root())
         {
             return Err(BlockError::ParentEnvelopeUnknown {

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -69,6 +69,13 @@ impl<E: EthSpec> Block<E> {
         }
     }
 
+    pub fn timestamp(&self) -> u64 {
+        match self {
+            Block::PoW(block) => block.timestamp,
+            Block::PoS(payload) => payload.timestamp(),
+        }
+    }
+
     pub fn total_difficulty(&self) -> Option<Uint256> {
         match self {
             Block::PoW(block) => Some(block.total_difficulty),
@@ -556,6 +563,23 @@ impl<E: EthSpec> ExecutionBlockGenerator<E> {
 
         if let Some(payload) = self.pending_payloads.remove(&head_block_hash) {
             self.insert_block(Block::PoS(payload))?;
+        }
+
+        // Post-Gloas, the justified and finalized block hashes must be non-zero, since the
+        // CL always has a known parent_block_hash to reference.
+        if let Some(head_block) = self.blocks.get(&head_block_hash)
+            && self
+                .get_fork_at_timestamp(head_block.timestamp())
+                .gloas_enabled()
+        {
+            assert!(
+                forkchoice_state.safe_block_hash != ExecutionBlockHash::zero(),
+                "post-Gloas safe_block_hash must not be zero"
+            );
+            assert!(
+                forkchoice_state.finalized_block_hash != ExecutionBlockHash::zero(),
+                "post-Gloas finalized_block_hash must not be zero"
+            );
         }
 
         let unknown_head_block_hash = !self.blocks.contains_key(&head_block_hash);

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -577,9 +577,8 @@ where
         // For Gloas blocks, `execution_status` is Irrelevant (no embedded payload).
         // If the payload envelope was received (Full), use the bid's block_hash as the
         // execution chain head. Otherwise fall back to the parent hash (Pending) or None.
-        // TODO(gloas): this is a bit messy, and we probably need a similar treatment for
-        // justified/finalized
-        // Can fix as part of: https://github.com/sigp/lighthouse/issues/8957
+        // For justified/finalized hashes we always use the bid's parent_block_hash, since it
+        // references an EL block already known to the EL (the previous block_hash).
         let head_hash = self.get_block(&head_root).and_then(|b| {
             b.execution_status
                 .block_hash()
@@ -592,12 +591,16 @@ where
         });
         let justified_root = self.justified_checkpoint().root;
         let finalized_root = self.finalized_checkpoint().root;
-        let justified_hash = self
-            .get_block(&justified_root)
-            .and_then(|b| b.execution_status.block_hash());
-        let finalized_hash = self
-            .get_block(&finalized_root)
-            .and_then(|b| b.execution_status.block_hash());
+        let justified_hash = self.get_block(&justified_root).and_then(|b| {
+            b.execution_status
+                .block_hash()
+                .or(b.execution_payload_parent_hash)
+        });
+        let finalized_hash = self.get_block(&finalized_root).and_then(|b| {
+            b.execution_status
+                .block_hash()
+                .or(b.execution_payload_parent_hash)
+        });
         self.forkchoice_update_parameters = ForkchoiceUpdateParameters {
             head_root,
             head_hash,


### PR DESCRIPTION
## Proposed Changes

Send the right payload hashes in `forkchoiceUpdated` post-Gloas for the safe and finalized blocks.

## Additional Info

`make lint-full` seems to be failing due to some stuff with `GossipVerifiedDataColumn::new_for_block_publishing`. This seems to be from the `glamsterdam-devnet-0` branch
