### PR TITLE
Gossip reprocessed payload envelopes that are timely

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -3627,6 +3627,23 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self.propagate_if_timely(is_timely, message_id, peer_id)
     }
 
+    /// If a payload envelope is still valid with respect to the current time (i.e., its slot
+    /// matches the current slot), propagate it on gossip. Otherwise, ignore it.
+    fn propagate_envelope_if_timely(
+        &self,
+        envelope_slot: Slot,
+        message_id: MessageId,
+        peer_id: PeerId,
+    ) {
+        let is_timely = self
+            .chain
+            .slot_clock
+            .now()
+            .is_some_and(|current_slot| envelope_slot == current_slot);
+
+        self.propagate_if_timely(is_timely, message_id, peer_id)
+    }
+
     /// If a sync committee signature or sync committee contribution is still valid with respect to
     /// the current time (i.e., timely), propagate it on gossip. Otherwise, ignore it.
     fn propagate_sync_message_if_timely(
@@ -3831,6 +3848,13 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         let process_fn = Box::pin(async move {
                             match chain.verify_envelope_for_gossip(envelope).await {
                                 Ok(verified_envelope) => {
+                                    let envelope_slot =
+                                        verified_envelope.signed_envelope.slot();
+                                    inner_self.propagate_envelope_if_timely(
+                                        envelope_slot,
+                                        message_id,
+                                        peer_id,
+                                    );
                                     inner_self
                                         .process_gossip_verified_execution_payload_envelope(
                                             peer_id,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -3848,8 +3848,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         let process_fn = Box::pin(async move {
                             match chain.verify_envelope_for_gossip(envelope).await {
                                 Ok(verified_envelope) => {
-                                    let envelope_slot =
-                                        verified_envelope.signed_envelope.slot();
+                                    let envelope_slot = verified_envelope.signed_envelope.slot();
                                     inner_self.propagate_envelope_if_timely(
                                         envelope_slot,
                                         message_id,


### PR DESCRIPTION
## Issue Addressed

Payloads from the reprocess queue should be gossiped after import if they are still timely. In devnets this happens frequently since there are many cases where the envelope arrives before the block