### PR TITLE
Update CI: warp runnner to use snapshot and use warm

### DIFF
--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   dockerfile-ubuntu:
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x;snapshot.key=lighthouse-ubuntu-latest-v1' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -31,7 +31,7 @@ jobs:
           retention-days: 3
 
   run-local-testnet:
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x;snapshot.key=lighthouse-ubuntu-latest-v1' || 'ubuntu-latest' }}
     needs: dockerfile-ubuntu
     steps:
       - uses: actions/checkout@v5
@@ -173,7 +173,7 @@ jobs:
   # Tests checkpoint syncing to a live network (current fork) and a running devnet (usually next scheduled fork)
   checkpoint-sync-test:
     name: checkpoint-sync-test-${{ matrix.network }}
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x;snapshot.key=lighthouse-ubuntu-latest-v1' || 'ubuntu-latest' }}
     needs: dockerfile-ubuntu
     if: contains(github.event.pull_request.labels.*.name, 'syncing')
     continue-on-error: true
@@ -216,7 +216,7 @@ jobs:
   # Test syncing from genesis on a local testnet. Aims to cover forward syncing both short and long distances.
   genesis-sync-test:
     name: genesis-sync-test-${{ matrix.fork }}-${{ matrix.offline_secs }}s
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x;snapshot.key=lighthouse-ubuntu-latest-v1' || 'ubuntu-latest' }}
     needs: dockerfile-ubuntu
     strategy:
       matrix:
@@ -259,7 +259,7 @@ jobs:
   # a PR is safe to merge. New jobs should be added here.
   local-testnet-success:
     name: local-testnet-success
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x;snapshot.key=lighthouse-ubuntu-latest-v1' || 'ubuntu-latest' }}
     needs: [
       'dockerfile-ubuntu',
       'run-local-testnet',

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -97,15 +97,18 @@ jobs:
     name: release-tests-ubuntu
     needs: [check-labels]
     if: needs.check-labels.outputs.skip_ci != 'true'
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x;snapshot.key=lighthouse-ubuntu-latest-v1' || 'ubuntu-latest' }}
     steps:
     - uses: actions/checkout@v5
     # Set Java version to 21. (required since Web3Signer 24.12.0).
-    - uses: actions/setup-java@v4
+    # On sigp/lighthouse, Java 21 is baked into the snapshot.
+    - if: github.repository != 'sigp/lighthouse'
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '21'
-    - name: Get latest version of stable Rust
+    - if: github.repository != 'sigp/lighthouse'
+      name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
           channel: stable
@@ -113,6 +116,10 @@ jobs:
           bins: cargo-nextest
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - if: github.repository == 'sigp/lighthouse'
+      uses: Swatinem/rust-cache@v2
+      with:
+          cache-provider: warpbuild
     - name: Run tests in release
       run: make test-release
     - name: Show cache stats
@@ -123,34 +130,44 @@ jobs:
     name: beacon-chain-tests
     needs: [check-labels]
     if: needs.check-labels.outputs.skip_ci != 'true'
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x;snapshot.key=lighthouse-ubuntu-latest-v1' || 'ubuntu-latest' }}
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v5
-    - name: Get latest version of stable Rust
+    - if: github.repository != 'sigp/lighthouse'
+      name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
           channel: stable
           cache-target: release
           bins: cargo-nextest
+    - if: github.repository == 'sigp/lighthouse'
+      uses: Swatinem/rust-cache@v2
+      with:
+          cache-provider: warpbuild
     - name: Run beacon_chain tests for all known forks
       run: make test-beacon-chain
   http-api-tests:
     name: http-api-tests
     needs: [check-labels]
     if: needs.check-labels.outputs.skip_ci != 'true'
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x;snapshot.key=lighthouse-ubuntu-latest-v1' || 'ubuntu-latest' }}
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v5
-    - name: Get latest version of stable Rust
+    - if: github.repository != 'sigp/lighthouse'
+      name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
           channel: stable
           cache-target: release
           bins: cargo-nextest
+    - if: github.repository == 'sigp/lighthouse'
+      uses: Swatinem/rust-cache@v2
+      with:
+          cache-provider: warpbuild
     - name: Run http_api tests for all recent forks
       run: make test-http-api
   op-pool-tests:
@@ -220,16 +237,21 @@ jobs:
     name: debug-tests-ubuntu
     needs: [check-labels]
     if: needs.check-labels.outputs.skip_ci != 'true'
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x;snapshot.key=lighthouse-ubuntu-latest-v1' || 'ubuntu-latest' }}
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v5
-    - name: Get latest version of stable Rust
+    - if: github.repository != 'sigp/lighthouse'
+      name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
           channel: stable
           bins: cargo-nextest
+    - if: github.repository == 'sigp/lighthouse'
+      uses: Swatinem/rust-cache@v2
+      with:
+          cache-provider: warpbuild
     - name: Run tests in debug
       run: make test-debug
   state-transition-vectors-ubuntu:
@@ -250,17 +272,22 @@ jobs:
     name: ef-tests-ubuntu
     needs: [check-labels]
     if: needs.check-labels.outputs.skip_ci != 'true'
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x;snapshot.key=lighthouse-ubuntu-latest-v1' || 'ubuntu-latest' }}
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v5
-    - name: Get latest version of stable Rust
+    - if: github.repository != 'sigp/lighthouse'
+      name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
           channel: stable
           cache-target: release
           bins: cargo-nextest
+    - if: github.repository == 'sigp/lighthouse'
+      uses: Swatinem/rust-cache@v2
+      with:
+          cache-provider: warpbuild
     - name: Run consensus-spec-tests with blst and fake_crypto
       run: make test-ef
   basic-simulator-ubuntu:
@@ -311,14 +338,14 @@ jobs:
     name: execution-engine-integration-ubuntu
     needs: [check-labels]
     if: needs.check-labels.outputs.skip_ci != 'true'
-    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'sigp/lighthouse' && 'warp-ubuntu-latest-x64-8x;snapshot.key=lighthouse-ubuntu-latest-v1' || 'ubuntu-latest' }}
     steps:
     - uses: actions/checkout@v5
-    - name: Get latest version of stable Rust
+    - if: github.repository != 'sigp/lighthouse'
+      name: Get latest version of stable Rust
       uses: moonrepo/setup-rust@v1
       with:
           channel: stable
-          cache-target: release
           cache: false
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/warpbuild-ubuntu-latest-snapshot.yml
+++ b/.github/workflows/warpbuild-ubuntu-latest-snapshot.yml
@@ -1,0 +1,63 @@
+name: Bake warpbuild snapshot (lighthouse-ubuntu-latest)
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every week (Sunday at 00:00 UTC)
+    - cron: "0 0 * * 0"
+  pull_request:
+    branches: [stable, unstable]
+    paths:
+      - '.github/workflows/warpbuild-ubuntu-latest-snapshot.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bake:
+    runs-on: warp-ubuntu-latest-x64-8x
+    steps:
+      - name: Install system deps
+        run: |
+          set -euxo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config \
+            libssl-dev \
+            build-essential \
+            cmake \
+            clang \
+            llvm-dev \
+            libclang-dev \
+            protobuf-compiler \
+            git \
+            gcc \
+            g++ \
+            make
+
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt,clippy
+
+      - name: Install cargo bins
+        run: |
+          cargo install --locked cargo-nextest
+          cargo install --locked cargo-audit
+          cargo install --locked cargo-deny
+          cargo install --locked cargo-sort
+          cargo install --locked cargo-hack
+
+      - name: Install Java (Temurin 21)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Save snapshot
+        uses: WarpBuilds/snapshot-save@v1
+        with:
+          alias: 'lighthouse-ubuntu-latest-v1'
+          fail-on-error: true
+          wait-timeout-minutes: 60


### PR DESCRIPTION
## Issue Addressed

Update the ci workflow to use warpbuild snapshot image and test suit uses `Swatinew/rust-cache` to utilize warpbuild cache