### PR TITLE
fix: payload_attestation_data when no block received for slot

### DIFF
--- a/.nvimlog
+++ b/.nvimlog
@@ -1,0 +1,6 @@
+WRN 2026-04-28T10:32:03.304 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0
+WRN 2026-04-28T10:46:43.208 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0
+WRN 2026-04-28T10:50:06.460 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0
+WRN 2026-04-28T10:50:25.315 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0
+WRN 2026-04-28T10:50:25.318 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0
+WRN 2026-04-28T10:54:13.463 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0

--- a/.nvimlog
+++ b/.nvimlog
@@ -1,6 +1,0 @@
-WRN 2026-04-28T10:32:03.304 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0
-WRN 2026-04-28T10:46:43.208 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0
-WRN 2026-04-28T10:50:06.460 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0
-WRN 2026-04-28T10:50:25.315 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0
-WRN 2026-04-28T10:50:25.318 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0
-WRN 2026-04-28T10:54:13.463 ?.2        server_start:199: Failed to start server: operation not permitted: /run/user/1000/nvim.2.0

--- a/beacon_node/http_api/src/validator/mod.rs
+++ b/beacon_node/http_api/src/validator/mod.rs
@@ -329,8 +329,12 @@ pub fn get_validator_payload_attestation_data<T: BeaconChainTypes>(
                     let payload_attestation_data = chain
                         .produce_payload_attestation_data(slot)
                         .map_err(|e| match e {
-                            BeaconChainError::InvalidSlot(_)
-                            | BeaconChainError::NoBlockForSlot(_) => {
+                            BeaconChainError::NoBlockForSlot(_) => {
+                                warp_utils::reject::block_not_found(format!(
+                                    "No block received for slot {slot}"
+                                ))
+                            }
+                            BeaconChainError::InvalidSlot(_) => {
                                 warp_utils::reject::custom_bad_request(format!(
                                     "Unable to produce payload attestation data: {e:?}"
                                 ))

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -8467,7 +8467,7 @@ async fn get_validator_payload_attestation_data_no_block() {
     if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
         return;
     }
-    ApiTester::new()
+    ApiTester::new_with_hard_forks()
         .await
         .test_get_validator_payload_attestation_data_no_block()
         .await;

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -4637,7 +4637,8 @@ impl ApiTester {
             .client
             .get_validator_payload_attestation_data(slot)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("expected payload attestation data for slot with block");
 
         assert_eq!(response.version(), Some(fork_name));
 
@@ -4761,15 +4762,14 @@ impl ApiTester {
         self.harness.advance_slot();
         let slot = self.chain.slot().unwrap();
 
-        // The endpoint should return 404 when no block exists for the slot
-        match self
+        // Should return None when no block exists for the slot
+        let result = self
             .client
             .get_validator_payload_attestation_data(slot)
             .await
-        {
-            Ok(result) => panic!("query for empty slot should fail, got: {result:?}"),
-            Err(e) => assert_eq!(e.status().unwrap(), 404),
-        }
+            .unwrap();
+
+        assert!(result.is_none(), "expected None for empty slot, got: {result:?}");
 
         self
     }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -4667,7 +4667,8 @@ impl ApiTester {
             .client
             .get_validator_payload_attestation_data_ssz(slot)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("expected SSZ payload attestation data for slot with block");
 
         assert_eq!(ssz_result, expected);
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -4761,14 +4761,14 @@ impl ApiTester {
         self.harness.advance_slot();
         let slot = self.chain.slot().unwrap();
 
-        // The endpoint should return 503 when no block exists for the slot
+        // The endpoint should return 404 when no block exists for the slot
         match self
             .client
             .get_validator_payload_attestation_data(slot)
             .await
         {
             Ok(result) => panic!("query for empty slot should fail, got: {result:?}"),
-            Err(e) => assert_eq!(e.status().unwrap(), 503),
+            Err(e) => assert_eq!(e.status().unwrap(), 404),
         }
 
         self

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -4769,7 +4769,10 @@ impl ApiTester {
             .await
             .unwrap();
 
-        assert!(result.is_none(), "expected None for empty slot, got: {result:?}");
+        assert!(
+            result.is_none(),
+            "expected None for empty slot, got: {result:?}"
+        );
 
         self
     }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -4756,6 +4756,24 @@ impl ApiTester {
         self
     }
 
+    pub async fn test_get_validator_payload_attestation_data_no_block(self) -> Self {
+        // Advance the slot clock without producing a block
+        self.harness.advance_slot();
+        let slot = self.chain.slot().unwrap();
+
+        // The endpoint should return 503 when no block exists for the slot
+        match self
+            .client
+            .get_validator_payload_attestation_data(slot)
+            .await
+        {
+            Ok(result) => panic!("query for empty slot should fail, got: {result:?}"),
+            Err(e) => assert_eq!(e.status().unwrap(), 503),
+        }
+
+        self
+    }
+
     #[allow(clippy::await_holding_lock)] // This is a test, so it should be fine.
     pub async fn test_get_validator_aggregate_attestation_v1(self) -> Self {
         let attestation = self
@@ -8426,6 +8444,19 @@ async fn get_validator_payload_attestation_data_pre_gloas() {
     ApiTester::new()
         .await
         .test_get_validator_payload_attestation_data_pre_gloas()
+        .await;
+}
+
+// TODO(EIP-7732): Remove `#[ignore]` once gloas beacon chain harness is implemented
+#[ignore]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_validator_payload_attestation_data_no_block() {
+    if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
+    ApiTester::new()
+        .await
+        .test_get_validator_payload_attestation_data_no_block()
         .await;
 }
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -4725,6 +4725,7 @@ impl ApiTester {
                 .get_validator_payload_attestation_data(slot)
                 .await
                 .unwrap()
+                .expect("expected payload attestation data for slot with block")
                 .into_data();
 
             assert_eq!(pa_data.beacon_block_root, block_root);

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -8447,8 +8447,6 @@ async fn get_validator_payload_attestation_data_pre_gloas() {
         .await;
 }
 
-// TODO(EIP-7732): Remove `#[ignore]` once gloas beacon chain harness is implemented
-#[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_validator_payload_attestation_data_no_block() {
     if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -3004,10 +3004,7 @@ impl BeaconNodeHttpClient {
             .push(&slot.to_string());
 
         let opt_response = self
-            .get_response(
-                path,
-                |b| b.timeout(self.timeouts.payload_attestation),
-            )
+            .get_response(path, |b| b.timeout(self.timeouts.payload_attestation))
             .await
             .optional()?;
 

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -2990,10 +2990,11 @@ impl BeaconNodeHttpClient {
     }
 
     /// `GET validator/payload_attestation_data/{slot}`
+    /// Returns `None` if no block has been received for the requested slot (404).
     pub async fn get_validator_payload_attestation_data(
         &self,
         slot: Slot,
-    ) -> Result<BeaconResponse<PayloadAttestationData>, Error> {
+    ) -> Result<Option<BeaconResponse<PayloadAttestationData>>, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()
@@ -3002,9 +3003,18 @@ impl BeaconNodeHttpClient {
             .push("payload_attestation_data")
             .push(&slot.to_string());
 
-        self.get_with_timeout(path, self.timeouts.payload_attestation)
+        let opt_response = self
+            .get_response(
+                path,
+                |b| b.timeout(self.timeouts.payload_attestation),
+            )
             .await
-            .map(BeaconResponse::ForkVersioned)
+            .optional()?;
+
+        match opt_response {
+            Some(response) => Ok(Some(BeaconResponse::ForkVersioned(response.json().await?))),
+            None => Ok(None),
+        }
     }
 
     /// `GET validator/payload_attestation_data/{slot}` in SSZ format

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -3015,10 +3015,11 @@ impl BeaconNodeHttpClient {
     }
 
     /// `GET validator/payload_attestation_data/{slot}` in SSZ format
+    /// Returns `None` if no block has been received for the requested slot (404).
     pub async fn get_validator_payload_attestation_data_ssz(
         &self,
         slot: Slot,
-    ) -> Result<PayloadAttestationData, Error> {
+    ) -> Result<Option<PayloadAttestationData>, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()
@@ -3031,9 +3032,9 @@ impl BeaconNodeHttpClient {
             .get_bytes_opt_accept_header(path, Accept::Ssz, self.timeouts.payload_attestation)
             .await?;
 
-        let response_bytes = opt_response.ok_or(Error::StatusCode(StatusCode::NOT_FOUND))?;
-
-        PayloadAttestationData::from_ssz_bytes(&response_bytes).map_err(Error::InvalidSsz)
+        opt_response
+            .map(|bytes| PayloadAttestationData::from_ssz_bytes(&bytes).map_err(Error::InvalidSsz))
+            .transpose()
     }
 
     /// `GET v1/validator/aggregate_attestation?slot,attestation_data_root`

--- a/common/warp_utils/src/reject.rs
+++ b/common/warp_utils/src/reject.rs
@@ -121,7 +121,6 @@ pub fn block_not_found(msg: String) -> warp::reject::Rejection {
     warp::reject::custom(BlockNotFound(msg))
 }
 
-
 #[derive(Debug)]
 pub struct InvalidAuthorization(pub String);
 

--- a/common/warp_utils/src/reject.rs
+++ b/common/warp_utils/src/reject.rs
@@ -110,8 +110,8 @@ pub fn not_synced(msg: String) -> warp::reject::Rejection {
     warp::reject::custom(NotSynced(msg))
 }
 
-/// A 503 Service Unavailable response for when no block has been received
-/// for the requested slot.
+/// A 404 Not Found response for when no block has been received for the
+/// requested slot.
 #[derive(Debug)]
 pub struct BlockNotFound(pub String);
 
@@ -211,8 +211,8 @@ pub async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, 
         code = StatusCode::SERVICE_UNAVAILABLE;
         message = format!("SERVICE_UNAVAILABLE: beacon node is syncing: {}", e.0);
     } else if let Some(e) = err.find::<crate::reject::BlockNotFound>() {
-        code = StatusCode::SERVICE_UNAVAILABLE;
-        message = format!("SERVICE_UNAVAILABLE: {}", e.0);
+        code = StatusCode::NOT_FOUND;
+        message = format!("NOT_FOUND: {}", e.0);
     } else if let Some(e) = err.find::<crate::reject::InvalidAuthorization>() {
         code = StatusCode::FORBIDDEN;
         message = format!("FORBIDDEN: Invalid auth token: {}", e.0);

--- a/common/warp_utils/src/reject.rs
+++ b/common/warp_utils/src/reject.rs
@@ -110,6 +110,18 @@ pub fn not_synced(msg: String) -> warp::reject::Rejection {
     warp::reject::custom(NotSynced(msg))
 }
 
+/// A 503 Service Unavailable response for when no block has been received
+/// for the requested slot.
+#[derive(Debug)]
+pub struct BlockNotFound(pub String);
+
+impl Reject for BlockNotFound {}
+
+pub fn block_not_found(msg: String) -> warp::reject::Rejection {
+    warp::reject::custom(BlockNotFound(msg))
+}
+
+
 #[derive(Debug)]
 pub struct InvalidAuthorization(pub String);
 
@@ -199,6 +211,9 @@ pub async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, 
     } else if let Some(e) = err.find::<crate::reject::NotSynced>() {
         code = StatusCode::SERVICE_UNAVAILABLE;
         message = format!("SERVICE_UNAVAILABLE: beacon node is syncing: {}", e.0);
+    } else if let Some(e) = err.find::<crate::reject::BlockNotFound>() {
+        code = StatusCode::SERVICE_UNAVAILABLE;
+        message = format!("SERVICE_UNAVAILABLE: {}", e.0);
     } else if let Some(e) = err.find::<crate::reject::InvalidAuthorization>() {
         code = StatusCode::FORBIDDEN;
         message = format!("FORBIDDEN: Invalid auth token: {}", e.0);

--- a/validator_client/validator_services/src/payload_attestation_service.rs
+++ b/validator_client/validator_services/src/payload_attestation_service.rs
@@ -146,10 +146,9 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
         {
             Ok(data) => data,
             Err(e) => {
-                // A 503 indicates no block was received for this slot. Per the
-                // consensus spec, validators should not submit a payload
-                // attestation when no block has been seen.
-                if e.to_string().contains("SERVICE_UNAVAILABLE") {
+                // Per the consensus spec, validators should not submit a
+                // payload attestation when no block has been seen for the slot.
+                if e.to_string().contains("No block received for slot") {
                     debug!(
                         %slot,
                         "No block received for slot, skipping payload attestation"

--- a/validator_client/validator_services/src/payload_attestation_service.rs
+++ b/validator_client/validator_services/src/payload_attestation_service.rs
@@ -139,7 +139,6 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
                 beacon_node
                     .get_validator_payload_attestation_data(slot)
                     .await
-                    .map_err(|e| format!("Failed to get payload attestation data: {e:?}"))
                     .map(|resp| resp.into_data())
             })
             .await
@@ -148,7 +147,13 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
             Err(e) => {
                 // Per the consensus spec, validators should not submit a
                 // payload attestation when no block has been seen for the slot.
-                if e.to_string().contains("No block received for slot") {
+                // The BN returns 503 in this case.
+                let is_block_not_found = e.0.iter().any(|(_, err)| {
+                    err.request_failure()
+                        .and_then(|e| e.status())
+                        .is_some_and(|s| s == reqwest::StatusCode::SERVICE_UNAVAILABLE)
+                });
+                if is_block_not_found {
                     debug!(
                         %slot,
                         "No block received for slot, skipping payload attestation"

--- a/validator_client/validator_services/src/payload_attestation_service.rs
+++ b/validator_client/validator_services/src/payload_attestation_service.rs
@@ -147,11 +147,11 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
             Err(e) => {
                 // Per the consensus spec, validators should not submit a
                 // payload attestation when no block has been seen for the slot.
-                // The BN returns 503 in this case.
+                // The BN returns 404 in this case.
                 let is_block_not_found = e.0.iter().any(|(_, err)| {
                     err.request_failure()
                         .and_then(|e| e.status())
-                        .is_some_and(|s| s == reqwest::StatusCode::SERVICE_UNAVAILABLE)
+                        .is_some_and(|s| s == reqwest::StatusCode::NOT_FOUND)
                 });
                 if is_block_not_found {
                     debug!(

--- a/validator_client/validator_services/src/payload_attestation_service.rs
+++ b/validator_client/validator_services/src/payload_attestation_service.rs
@@ -139,32 +139,26 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
                 beacon_node
                     .get_validator_payload_attestation_data(slot)
                     .await
-                    .map(|resp| resp.into_data())
+                    .map(|opt| opt.map(|resp| resp.into_data()))
             })
             .await
         {
-            Ok(data) => data,
-            Err(e) => {
+            Ok(Some(data)) => data,
+            Ok(None) => {
                 // Per the consensus spec, validators should not submit a
                 // payload attestation when no block has been seen for the slot.
-                // The BN returns 404 in this case.
-                let is_block_not_found = e.0.iter().any(|(_, err)| {
-                    err.request_failure()
-                        .and_then(|e| e.status())
-                        .is_some_and(|s| s == reqwest::StatusCode::NOT_FOUND)
-                });
-                if is_block_not_found {
-                    debug!(
-                        %slot,
-                        "No block received for slot, skipping payload attestation"
-                    );
-                } else {
-                    error!(
-                        error = %e,
-                        %slot,
-                        "Failed to produce payload attestation data"
-                    );
-                }
+                debug!(
+                    %slot,
+                    "No block received for slot, skipping payload attestation"
+                );
+                return;
+            }
+            Err(e) => {
+                error!(
+                    error = %e,
+                    %slot,
+                    "Failed to produce payload attestation data"
+                );
                 return;
             }
         };

--- a/validator_client/validator_services/src/payload_attestation_service.rs
+++ b/validator_client/validator_services/src/payload_attestation_service.rs
@@ -146,11 +146,21 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> PayloadAttestationServ
         {
             Ok(data) => data,
             Err(e) => {
-                crit!(
-                    error = %e,
-                    %slot,
-                    "Failed to produce payload attestation data"
-                );
+                // A 503 indicates no block was received for this slot. Per the
+                // consensus spec, validators should not submit a payload
+                // attestation when no block has been seen.
+                if e.to_string().contains("SERVICE_UNAVAILABLE") {
+                    debug!(
+                        %slot,
+                        "No block received for slot, skipping payload attestation"
+                    );
+                } else {
+                    error!(
+                        error = %e,
+                        %slot,
+                        "Failed to produce payload attestation data"
+                    );
+                }
                 return;
             }
         };


### PR DESCRIPTION
## Issue Addressed

Addresses issue #9220 

The `payload_attestation_data` endpoint returns 400 when no block has been received for the requested slot. This causes the VC to log at CRIT level for what is expected behaviour per spec: validators should simply not submit a payload attestation when no block has been seen.

## Proposed Changes

- Return 404 (Not Found) instead of 400 from `payload_attestation_data` when no block exists for the slot. This is consistent with other beacon api endpoints. 
- Downgrade the VC log from `crit` to `debug` when a 503 is received, since this is an expected no-op per spec.
- Add `BlockNotFound` rejection type to `warp_utils`.
- Add a test asserting the 404 response for an empty slot.