### PR TITLE
Gloas proposer preferences alpha 7

### DIFF
--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/gossip_verified_proposer_preferences.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/gossip_verified_proposer_preferences.rs
@@ -64,7 +64,7 @@ impl GossipVerifiedProposerPreferences {
         ctx: &GossipVerificationContext<'_, T>,
     ) -> Result<Self, ProposerPreferencesError> {
         let proposal_slot = signed_preferences.message.proposal_slot;
-        let checkpoint_root = signed_preferences.message.checkpoint_root;
+        let dependent_root = signed_preferences.message.dependent_root;
         let validator_index = signed_preferences.message.validator_index;
         let cached_head = ctx.canonical_head.cached_head();
         let current_slot = ctx
@@ -75,7 +75,7 @@ impl GossipVerifiedProposerPreferences {
 
         if ctx
             .gossip_verified_proposer_preferences_cache
-            .get_seen_validator(&proposal_slot, checkpoint_root, validator_index)
+            .get_seen_validator(&proposal_slot, dependent_root, validator_index)
         {
             return Err(ProposerPreferencesError::AlreadySeen {
                 validator_index,
@@ -163,7 +163,7 @@ mod tests {
 
     fn make_preferences(proposal_slot: Slot, validator_index: u64) -> ProposerPreferences {
         ProposerPreferences {
-            checkpoint_root: types::Hash256::ZERO,
+            dependent_root: types::Hash256::ZERO,
             proposal_slot,
             validator_index,
             fee_recipient: Address::ZERO,

--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/proposer_preference_cache.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/proposer_preference_cache.rs
@@ -37,24 +37,24 @@ impl GossipVerifiedProposerPreferenceCache {
     pub fn get_seen_validator(
         &self,
         slot: &Slot,
-        checkpoint_root: Hash256,
+        dependent_root: Hash256,
         validator_index: u64,
     ) -> bool {
         self.seen
             .read()
             .get(slot)
-            .is_some_and(|seen| seen.contains(&(checkpoint_root, validator_index)))
+            .is_some_and(|seen| seen.contains(&(dependent_root, validator_index)))
     }
 
     pub fn insert_seen_validator(&self, preferences: &GossipVerifiedProposerPreferences) {
         let slot = preferences.signed_preferences.message.proposal_slot;
-        let checkpoint_root = preferences.signed_preferences.message.checkpoint_root;
+        let dependent_root = preferences.signed_preferences.message.dependent_root;
         let validator_index = preferences.signed_preferences.message.validator_index;
         self.seen
             .write()
             .entry(slot)
             .or_default()
-            .insert((checkpoint_root, validator_index));
+            .insert((dependent_root, validator_index));
     }
 
     pub fn prune(&self, current_slot: Slot) {

--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
@@ -256,6 +256,41 @@ fn validator_index_out_of_bounds() {
     ));
 }
 
+/// Same (slot, validator_index) but different dependent_root should NOT be deduplicated.
+#[test]
+fn same_validator_different_dependent_root_not_deduplicated() {
+    if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
+    let ctx = TestContext::new();
+    let slot = Slot::new(1);
+
+    let verified_a = GossipVerifiedProposerPreferences {
+        signed_preferences: Arc::new(SignedProposerPreferences {
+            message: ProposerPreferences {
+                proposal_slot: slot,
+                validator_index: 42,
+                dependent_root: Hash256::repeat_byte(0xaa),
+                fee_recipient: Address::ZERO,
+                gas_limit: 30_000_000,
+            },
+            signature: Signature::empty(),
+        }),
+    };
+    ctx.preferences_cache.insert_seen_validator(&verified_a);
+
+    // Different dependent_root — should not be seen.
+    assert!(
+        !ctx.preferences_cache
+            .get_seen_validator(&slot, Hash256::repeat_byte(0xbb), 42,)
+    );
+    // Same dependent_root — should be seen.
+    assert!(
+        ctx.preferences_cache
+            .get_seen_validator(&slot, Hash256::repeat_byte(0xaa), 42,)
+    );
+}
+
 // TODO(gloas) add successful proposer preferences check once we have proposer preferences signing logic
 
 #[test]

--- a/consensus/types/src/builder/proposer_preferences.rs
+++ b/consensus/types/src/builder/proposer_preferences.rs
@@ -16,8 +16,7 @@ use tree_hash_derive::TreeHash;
 #[context_deserialize(ForkName)]
 // https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md#new-proposerpreferences
 pub struct ProposerPreferences {
-
-    pub checkpoint_root: Hash256,
+    pub dependent_root: Hash256,
     pub proposal_slot: Slot,
     pub validator_index: u64,
     pub fee_recipient: Address,

--- a/consensus/types/src/builder/proposer_preferences.rs
+++ b/consensus/types/src/builder/proposer_preferences.rs
@@ -16,6 +16,7 @@ use tree_hash_derive::TreeHash;
 #[context_deserialize(ForkName)]
 // https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md#new-proposerpreferences
 pub struct ProposerPreferences {
+
     pub checkpoint_root: Hash256,
     pub proposal_slot: Slot,
     pub validator_index: u64,

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,6 +1,6 @@
 # To download/extract nightly tests, run:
 # CONSENSUS_SPECS_TEST_VERSION=nightly make
-CONSENSUS_SPECS_TEST_VERSION ?= v1.7.0-alpha.6
+CONSENSUS_SPECS_TEST_VERSION ?= v1.7.0-alpha.7
 REPO_NAME := consensus-spec-tests
 OUTPUT_DIR := ./$(REPO_NAME)
 


### PR DESCRIPTION
## Issue Addressed

We yolo'd to alpha 7. We're just changing the proposer preference to include dependent root, instead of checkpoint root. This way we can actually construct it within the VC without needing a view of fork choice.