### PR TITLE
Unblock CI by temporarily ignoring `hickory-proto` audit failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ install-audit:
 	cargo install --force cargo-audit
 
 audit-CI:
-	cargo audit --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099 --ignore RUSTSEC-2026-0104
+	cargo audit --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099 --ignore RUSTSEC-2026-0104 --ignore RUSTSEC-2026-0118 --ignore RUSTSEC-2026-0119
 
 # Runs cargo deny (check for banned crates, duplicate versions, and source restrictions)
 deny: install-deny deny-CI


### PR DESCRIPTION
## Issue Addressed

Two audit failures for `hickory-proto` which is used upstream in `libp2p-dns` and `libp2p-mdns`

- https://rustsec.org/advisories/RUSTSEC-2026-0118.html
- https://rustsec.org/advisories/RUSTSEC-2026-0119.html

Tracking Issue: https://github.com/sigp/lighthouse/issues/9258

## Proposed Changes

Since RUSTSEC-2026-0118 does not even have any non-patched versions available and RUSTSEC-2026-0119 requires a major version bump I think we would need to wait on a release from libp2p in both cases.
So for now, add an ignore for each so we can at least unblock CI

## Additional Info

I did not check if Lighthouse specifically is affected
