### PR TITLE
ci: require AI assistance disclosure in PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,25 +15,12 @@ or information useful for reviewers.
 
 <!--
 We ask every contributor to disclose AI assistance. This is not a filter — AI-assisted PRs
-are welcome. We just need to know what was generated so reviewers can calibrate, and we need
-you to vouch for the code you're submitting. Please do not delete this section; CI will fail.
+are welcome. We just need to know what was used and you need to vouch for what you submit.
+Please do not delete this section; CI will fail.
 -->
 
-**1. Was AI used to produce any code, tests, or commit messages in this PR?** _(tick exactly one)_
+**Tools used** _(required — write `none` if no AI was used)_: _e.g. none / Claude Code / Copilot / Cursor / ChatGPT_
 
-- [ ] No
-- [ ] Yes, for boilerplate or scaffolding only (renames, trivial refactors, doc edits, generated test fixtures)
-- [ ] Yes, including non-trivial logic (algorithm, control flow, consensus-relevant code, networking, crypto)
+**Attestation** _(required)_:
 
-**2. Author attestation** _(required)_
-
-- [ ] I have read every line of the diff, understand what it does, and can explain it in review.
-
-**3. Tools used** _(required, free-text — write `none` if no AI was used)_
-
-**Tools used**: _e.g. none / Claude Code / Copilot / Cursor / ChatGPT_
-
-<!--
-If you ticked "non-trivial logic", please also note in "Additional Info" which areas were
-AI-assisted and what you did to validate them (tests added, specs cross-checked, etc.).
--->
+- [ ] I have read every line of this diff, understand what it does, and can explain it in review.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,30 @@ Please list or describe the changes introduced by this PR.
 
 Please provide any additional information. For example, future considerations
 or information useful for reviewers.
+
+## AI Assistance Disclosure
+
+<!--
+We ask every contributor to disclose AI assistance. This is not a filter — AI-assisted PRs
+are welcome. We just need to know what was generated so reviewers can calibrate, and we need
+you to vouch for the code you're submitting. Please do not delete this section; CI will fail.
+-->
+
+**1. Was AI used to produce any code, tests, or commit messages in this PR?** _(tick exactly one)_
+
+- [ ] No
+- [ ] Yes, for boilerplate or scaffolding only (renames, trivial refactors, doc edits, generated test fixtures)
+- [ ] Yes, including non-trivial logic (algorithm, control flow, consensus-relevant code, networking, crypto)
+
+**2. Author attestation** _(required)_
+
+- [ ] I have read every line of the diff, understand what it does, and can explain it in review.
+
+**3. Tools used** _(required, free-text — write `none` if no AI was used)_
+
+**Tools used**: _e.g. none / Claude Code / Copilot / Cursor / ChatGPT_
+
+<!--
+If you ticked "non-trivial logic", please also note in "Additional Info" which areas were
+AI-assisted and what you did to validate them (tests added, specs cross-checked, etc.).
+-->

--- a/.github/workflows/pr-ai-disclosure.yml
+++ b/.github/workflows/pr-ai-disclosure.yml
@@ -43,21 +43,16 @@ jobs:
             flag {print}
           ' <<<"$body")"
 
-          # 2. Q1: Was AI used? Exactly one of the three options must be checked.
-          q1_checked=$(grep -cE '^[[:space:]]*-[[:space:]]*\[[xX]\][[:space:]]*(No|Yes, for boilerplate or scaffolding only|Yes, including non-trivial logic)\b' <<<"$section" || true)
-          [ "$q1_checked" -eq 1 ] \
-            || fail "Question 1 (AI usage): tick exactly one of {No | Yes, boilerplate only | Yes, non-trivial logic}. Found $q1_checked."
-
-          # 3. Q2: Reviewed-and-understand attestation must be checked.
-          grep -qE '^[[:space:]]*-[[:space:]]*\[[xX]\][[:space:]]*I have read every line' <<<"$section" \
-            || fail "Question 2: you must tick the 'I have read every line ... and can explain it' attestation."
-
-          # 4. Q3: Tools used — free-text line must be filled (non-placeholder).
-          tools_line="$(grep -E '^[[:space:]]*\*\*Tools used\*\*:' <<<"$section" | head -n1 || true)"
+          # 2. Tools used — free-text line must be filled (non-placeholder).
+          tools_line="$(grep -E '^[[:space:]]*\*\*Tools used\*\*' <<<"$section" | head -n1 || true)"
           tools_value="${tools_line#*:}"
           tools_value="$(echo "$tools_value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
           if [ -z "$tools_value" ] || [ "$tools_value" = "_e.g. none / Claude Code / Copilot / Cursor / ChatGPT_" ]; then
-            fail "Question 3: fill in '**Tools used**:' with the assistants you used (or 'none')."
+            fail "Fill in '**Tools used**:' with the assistants you used (or 'none')."
           fi
+
+          # 3. Attestation must be checked.
+          grep -qE '^[[:space:]]*-[[:space:]]*\[[xX]\][[:space:]]*I have read every line' <<<"$section" \
+            || fail "You must tick the 'I have read every line ... and can explain it' attestation."
 
           echo "AI disclosure section looks good."

--- a/.github/workflows/pr-ai-disclosure.yml
+++ b/.github/workflows/pr-ai-disclosure.yml
@@ -1,0 +1,63 @@
+name: pr-ai-disclosure
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-disclosure:
+    runs-on: ubuntu-latest
+    name: Check AI disclosure section
+    # Skip for Dependabot / bots and for PRs that opt out via label.
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ai-disclosure')
+    steps:
+      - name: Validate PR body contains AI disclosure
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PR_BODY:-}" ]; then
+            echo "::error::PR description is empty. Please use the PR template, including the 'AI Assistance Disclosure' section."
+            exit 1
+          fi
+
+          # Normalize: drop CRs, strip HTML comments (template hints).
+          body="$(printf '%s' "$PR_BODY" | tr -d '\r' | perl -0777 -pe 's/<!--.*?-->//gs')"
+
+          fail() { echo "::error::$1"; exit 1; }
+
+          # 1. Section header must exist.
+          grep -qE '^##[[:space:]]+AI Assistance Disclosure[[:space:]]*$' <<<"$body" \
+            || fail "Missing '## AI Assistance Disclosure' section. Copy it from .github/PULL_REQUEST_TEMPLATE.md."
+
+          # Extract the section body (until next '## ' or EOF).
+          section="$(awk '
+            /^##[[:space:]]+AI Assistance Disclosure[[:space:]]*$/ {flag=1; next}
+            /^##[[:space:]]+/ {flag=0}
+            flag {print}
+          ' <<<"$body")"
+
+          # 2. Q1: Was AI used? Exactly one of the three options must be checked.
+          q1_checked=$(grep -cE '^[[:space:]]*-[[:space:]]*\[[xX]\][[:space:]]*(No|Yes, for boilerplate or scaffolding only|Yes, including non-trivial logic)\b' <<<"$section" || true)
+          [ "$q1_checked" -eq 1 ] \
+            || fail "Question 1 (AI usage): tick exactly one of {No | Yes, boilerplate only | Yes, non-trivial logic}. Found $q1_checked."
+
+          # 3. Q2: Reviewed-and-understand attestation must be checked.
+          grep -qE '^[[:space:]]*-[[:space:]]*\[[xX]\][[:space:]]*I have read every line' <<<"$section" \
+            || fail "Question 2: you must tick the 'I have read every line ... and can explain it' attestation."
+
+          # 4. Q3: Tools used — free-text line must be filled (non-placeholder).
+          tools_line="$(grep -E '^[[:space:]]*\*\*Tools used\*\*:' <<<"$section" | head -n1 || true)"
+          tools_value="${tools_line#*:}"
+          tools_value="$(echo "$tools_value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+          if [ -z "$tools_value" ] || [ "$tools_value" = "_e.g. none / Claude Code / Copilot / Cursor / ChatGPT_" ]; then
+            fail "Question 3: fill in '**Tools used**:' with the assistants you used (or 'none')."
+          fi
+
+          echo "AI disclosure section looks good."


### PR DESCRIPTION
## Issue Addressed

N/A — process change.

## Proposed Changes

- Add an `## AI Assistance Disclosure` section to `PULL_REQUEST_TEMPLATE.md` with two required fields: tools used (free text; `none` if not used) and an author attestation.
- Add `.github/workflows/pr-ai-disclosure.yml` to validate the section is present and filled in. Runs on `pull_request_target` (read-only, no checkout) so fork PRs are covered. Bots and the `skip-ai-disclosure` label are exempt.

Goal: normalize disclosure rather than discourage AI use, and make contributors explicitly vouch for code they submit. To gate merges, add the check to branch protection on `unstable` after this lands.

Earlier iteration of this PR had a three-tier "trivial / non-trivial" question; dropped because the boundary is fuzzy, unverifiable, and invites underreporting. The attestation is the only item enforceable in review anyway.

## Additional Info

This PR's own description follows the new template — it's the first test of the workflow.

## AI Assistance Disclosure

**Tools used** _(required — write `none` if no AI was used)_: Claude Code (template wording and workflow scaffold; reviewed and edited by author)

**Attestation** _(required)_:

- [x] I have read every line of this diff, understand what it does, and can explain it in review.
