### PR TITLE
Remove libssl dependency for cargo udeps

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -414,10 +414,6 @@ jobs:
           cache: false
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Fetch libssl1.1
-      run: wget https://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-    - name: Install libssl1.1
-      run: sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
     - name: Create Cargo config dir
       run: mkdir -p .cargo
     - name: Install custom Cargo config


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

libssl download seems to be failing on [CI](https://github.com/sigp/lighthouse/actions/runs/25346412432/job/74316275231?pr=9126). 
This was originally added to unblock CI in https://github.com/sigp/lighthouse/pull/6777, but we may not need this anymore.