### PR TITLE
Fix execution integration test CI failure

### DIFF
--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -17,7 +17,7 @@ const NETHERMIND_REPO_URL: &str = "https://github.com/NethermindEth/nethermind";
 fn build_result(repo_dir: &Path) -> Output {
     Command::new("dotnet")
         .arg("build")
-        .arg("src/Nethermind/Nethermind.sln")
+        .arg("src/Nethermind/Nethermind.slnx")
         .arg("-c")
         .arg("Release")
         .current_dir(repo_dir)
@@ -68,8 +68,6 @@ impl NethermindEngine {
         manifest_dir
             .join("execution_clients")
             .join("nethermind")
-            .join("src")
-            .join("Nethermind")
             .join("artifacts")
             .join("bin")
             .join("Nethermind.Runner")

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -20,6 +20,7 @@ fn build_result(repo_dir: &Path) -> Output {
         .arg("src/Nethermind/Nethermind.slnx")
         .arg("-c")
         .arg("Release")
+        .arg("/p:NuGetAudit=false")
         .current_dir(repo_dir)
         .output()
         .expect("failed to make nethermind")

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -11,16 +11,16 @@ use tempfile::TempDir;
 /// We've pinned the Nethermind version since our method of using the `master` branch to
 /// find the latest tag isn't working. It appears Nethermind don't always tag on `master`.
 /// We should fix this so we always pull the latest version of Nethermind.
-const NETHERMIND_BRANCH: &str = "release/1.36.0";
+const NETHERMIND_BRANCH: &str = "release/1.27.0";
 const NETHERMIND_REPO_URL: &str = "https://github.com/NethermindEth/nethermind";
 
 fn build_result(repo_dir: &Path) -> Output {
     Command::new("dotnet")
         .arg("build")
-        .arg("src/Nethermind/Nethermind.slnx")
+        .arg("src/Nethermind/Nethermind.sln")
         .arg("-c")
         .arg("Release")
-        .arg("/p:NuGetAudit=false")
+        .arg("-p:TreatWarningsAsErrors=false")
         .current_dir(repo_dir)
         .output()
         .expect("failed to make nethermind")

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -69,6 +69,8 @@ impl NethermindEngine {
         manifest_dir
             .join("execution_clients")
             .join("nethermind")
+            .join("src")
+            .join("Nethermind")
             .join("artifacts")
             .join("bin")
             .join("Nethermind.Runner")

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -11,7 +11,7 @@ use tempfile::TempDir;
 /// We've pinned the Nethermind version since our method of using the `master` branch to
 /// find the latest tag isn't working. It appears Nethermind don't always tag on `master`.
 /// We should fix this so we always pull the latest version of Nethermind.
-const NETHERMIND_BRANCH: &str = "release/1.27.0";
+const NETHERMIND_BRANCH: &str = "release/1.37.0";
 const NETHERMIND_REPO_URL: &str = "https://github.com/NethermindEth/nethermind";
 
 fn build_result(repo_dir: &Path) -> Output {

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -11,7 +11,7 @@ use tempfile::TempDir;
 /// We've pinned the Nethermind version since our method of using the `master` branch to
 /// find the latest tag isn't working. It appears Nethermind don't always tag on `master`.
 /// We should fix this so we always pull the latest version of Nethermind.
-const NETHERMIND_BRANCH: &str = "release/1.37.0";
+const NETHERMIND_BRANCH: &str = "release/1.36.0";
 const NETHERMIND_REPO_URL: &str = "https://github.com/NethermindEth/nethermind";
 
 fn build_result(repo_dir: &Path) -> Output {


### PR DESCRIPTION
Initially thought of updating the version but it looks a bit more involved with newer versions, so I ended up using the suppressing the warning.  

The failure: https://github.com/sigp/lighthouse/actions/runs/25534071794/job/74946127363?pr=8904 
is about a vulnerability in Nethermind's dependency: https://github.com/advisories/GHSA-pggp-6c3x-2xmx
so it should be ok to suppress the warning for now? 

Using Claude to help to come up with the solution
