### PR TITLE
Drop unused EthSpec generic from Stores

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -319,8 +319,8 @@ pub enum StateSkipConfig {
 }
 
 pub trait BeaconChainTypes: Send + Sync + 'static {
-    type HotStore: store::ItemStore<Self::EthSpec>;
-    type ColdStore: store::ItemStore<Self::EthSpec>;
+    type HotStore: store::ItemStore;
+    type ColdStore: store::ItemStore;
     type SlotClock: slot_clock::SlotClock;
     type EthSpec: types::EthSpec;
 }

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -129,8 +129,8 @@ impl BalancesCache {
 /// Implements `fork_choice::ForkChoiceStore` in order to provide a persistent backing to the
 /// `fork_choice::ForkChoice` struct.
 #[derive(Debug, Educe)]
-#[educe(PartialEq(bound(E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>)))]
-pub struct BeaconForkChoiceStore<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+#[educe(PartialEq(bound(E: EthSpec, Hot: ItemStore, Cold: ItemStore)))]
+pub struct BeaconForkChoiceStore<E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     #[educe(PartialEq(ignore))]
     store: Arc<HotColdDB<E, Hot, Cold>>,
     balances_cache: BalancesCache,
@@ -150,8 +150,8 @@ pub struct BeaconForkChoiceStore<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<
 impl<E, Hot, Cold> BeaconForkChoiceStore<E, Hot, Cold>
 where
     E: EthSpec,
-    Hot: ItemStore<E>,
-    Cold: ItemStore<E>,
+    Hot: ItemStore,
+    Cold: ItemStore,
 {
     /// Initialize `Self` from some `anchor` checkpoint which may or may not be the genesis state.
     ///
@@ -267,8 +267,8 @@ where
 impl<E, Hot, Cold> ForkChoiceStore<E> for BeaconForkChoiceStore<E, Hot, Cold>
 where
     E: EthSpec,
-    Hot: ItemStore<E>,
-    Cold: ItemStore<E>,
+    Hot: ItemStore,
+    Cold: ItemStore,
 {
     type Error = Error;
 

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1290,11 +1290,8 @@ mod test {
         let validator_count = 1;
         let genesis_time = 13_371_337;
 
-        let store: HotColdDB<
-            MinimalEthSpec,
-            MemoryStore<MinimalEthSpec>,
-            MemoryStore<MinimalEthSpec>,
-        > = HotColdDB::open_ephemeral(StoreConfig::default(), ChainSpec::minimal().into()).unwrap();
+        let store: HotColdDB<MinimalEthSpec, MemoryStore, MemoryStore> =
+            HotColdDB::open_ephemeral(StoreConfig::default(), ChainSpec::minimal().into()).unwrap();
         let spec = MinimalEthSpec::default_spec();
 
         let genesis_state = interop_genesis_state(

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -59,8 +59,8 @@ pub struct Witness<TSlotClock, E, THotStore, TColdStore>(
 impl<TSlotClock, E, THotStore, TColdStore> BeaconChainTypes
     for Witness<TSlotClock, E, THotStore, TColdStore>
 where
-    THotStore: ItemStore<E> + 'static,
-    TColdStore: ItemStore<E> + 'static,
+    THotStore: ItemStore + 'static,
+    TColdStore: ItemStore + 'static,
     TSlotClock: SlotClock + 'static,
     E: EthSpec + 'static,
 {
@@ -114,8 +114,8 @@ pub struct BeaconChainBuilder<T: BeaconChainTypes> {
 impl<TSlotClock, E, THotStore, TColdStore>
     BeaconChainBuilder<Witness<TSlotClock, E, THotStore, TColdStore>>
 where
-    THotStore: ItemStore<E> + 'static,
-    TColdStore: ItemStore<E> + 'static,
+    THotStore: ItemStore + 'static,
+    TColdStore: ItemStore + 'static,
     TSlotClock: SlotClock + 'static,
     E: EthSpec + 'static,
 {
@@ -1151,8 +1151,8 @@ where
 impl<E, THotStore, TColdStore>
     BeaconChainBuilder<Witness<TestingSlotClock, E, THotStore, TColdStore>>
 where
-    THotStore: ItemStore<E> + 'static,
-    TColdStore: ItemStore<E> + 'static,
+    THotStore: ItemStore + 'static,
+    TColdStore: ItemStore + 'static,
     E: EthSpec + 'static,
 {
     /// Sets the `BeaconChain` slot clock to `TestingSlotClock`.

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -802,7 +802,7 @@ mod test {
     fn get_store_with_spec<E: EthSpec>(
         db_path: &TempDir,
         spec: Arc<ChainSpec>,
-    ) -> Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>> {
+    ) -> Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>> {
         let hot_path = db_path.path().join("hot_db");
         let cold_path = db_path.path().join("cold_db");
         let blobs_path = db_path.path().join("blobs_db");
@@ -946,8 +946,8 @@ mod test {
     where
         E: EthSpec,
         T: BeaconChainTypes<
-                HotStore = BeaconNodeBackend<E>,
-                ColdStore = BeaconNodeBackend<E>,
+                HotStore = BeaconNodeBackend,
+                ColdStore = BeaconNodeBackend,
                 EthSpec = E,
             >,
     {

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -860,8 +860,8 @@ mod test {
     )
     where
         E: EthSpec,
-        Hot: ItemStore<E>,
-        Cold: ItemStore<E>,
+        Hot: ItemStore,
+        Cold: ItemStore,
     {
         let chain = &harness.chain;
         let head = chain.head_snapshot();

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -30,7 +30,7 @@ pub const DEFAULT_EPOCHS_PER_MIGRATION: u64 = 1;
 
 /// The background migrator runs a thread to perform pruning and migrate state from the hot
 /// to the cold database.
-pub struct BackgroundMigrator<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+pub struct BackgroundMigrator<E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     db: Arc<HotColdDB<E, Hot, Cold>>,
     /// Record of when the last migration ran, for enforcing `epochs_per_migration`.
     prev_migration: Arc<Mutex<PrevMigration>>,
@@ -135,7 +135,7 @@ pub struct FinalizationNotification {
     pub prev_migration: Arc<Mutex<PrevMigration>>,
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Hot, Cold> {
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> BackgroundMigrator<E, Hot, Cold> {
     /// Create a new `BackgroundMigrator` and spawn its thread if necessary.
     pub fn new(db: Arc<HotColdDB<E, Hot, Cold>>, config: MigratorConfig) -> Self {
         // Estimate last migration run from DB split slot.

--- a/beacon_node/beacon_chain/src/payload_attestation_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/payload_attestation_verification/tests.rs
@@ -43,7 +43,7 @@ struct TestContext {
     keypairs: Vec<Keypair>,
     spec: ChainSpec,
     genesis_block_root: Hash256,
-    store: Arc<store::HotColdDB<E, store::MemoryStore<E>, store::MemoryStore<E>>>,
+    store: Arc<store::HotColdDB<E, store::MemoryStore, store::MemoryStore>>,
 }
 
 impl TestContext {

--- a/beacon_node/beacon_chain/src/persisted_custody.rs
+++ b/beacon_node/beacon_chain/src/persisted_custody.rs
@@ -9,7 +9,7 @@ pub const CUSTODY_DB_KEY: Hash256 = Hash256::ZERO;
 
 pub struct PersistedCustody(pub CustodyContextSsz);
 
-pub fn load_custody_context<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
+pub fn load_custody_context<E: EthSpec, Hot: ItemStore, Cold: ItemStore>(
     store: Arc<HotColdDB<E, Hot, Cold>>,
 ) -> Option<CustodyContextSsz> {
     let res: Result<Option<PersistedCustody>, _> =
@@ -22,7 +22,7 @@ pub fn load_custody_context<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
 }
 
 /// Attempt to persist the custody context object to `self.store`.
-pub fn persist_custody_context<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
+pub fn persist_custody_context<E: EthSpec, Hot: ItemStore, Cold: ItemStore>(
     store: Arc<HotColdDB<E, Hot, Cold>>,
     custody_context: CustodyContextSsz,
 ) -> Result<(), store::Error> {

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -399,8 +399,8 @@ impl<E: EthSpec> Builder<DiskHarnessType<E>> {
 impl<E, Hot, Cold> Builder<BaseHarnessType<E, Hot, Cold>>
 where
     E: EthSpec,
-    Hot: ItemStore<E>,
-    Cold: ItemStore<E>,
+    Hot: ItemStore,
+    Cold: ItemStore,
 {
     pub fn new(eth_spec_instance: E) -> Self {
         let runtime = TestRuntime::default();
@@ -760,8 +760,8 @@ pub type HarnessSyncContributions<E> = Vec<(
 impl<E, Hot, Cold> BeaconChainHarness<BaseHarnessType<E, Hot, Cold>>
 where
     E: EthSpec,
-    Hot: ItemStore<E>,
-    Cold: ItemStore<E>,
+    Hot: ItemStore,
+    Cold: ItemStore,
 {
     pub fn builder(eth_spec_instance: E) -> Builder<BaseHarnessType<E, Hot, Cold>> {
         create_test_tracing_subscriber();

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -124,8 +124,8 @@ pub fn get_kzg(spec: &ChainSpec) -> Arc<Kzg> {
 pub type BaseHarnessType<E, THotStore, TColdStore> =
     Witness<TestingSlotClock, E, THotStore, TColdStore>;
 
-pub type DiskHarnessType<E> = BaseHarnessType<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>;
-pub type EphemeralHarnessType<E> = BaseHarnessType<E, MemoryStore<E>, MemoryStore<E>>;
+pub type DiskHarnessType<E> = BaseHarnessType<E, BeaconNodeBackend, BeaconNodeBackend>;
+pub type EphemeralHarnessType<E> = BaseHarnessType<E, MemoryStore, MemoryStore>;
 
 pub type BoxedMutator<E, Hot, Cold> = Box<
     dyn FnOnce(
@@ -334,7 +334,7 @@ impl<E: EthSpec> Builder<EphemeralHarnessType<E>> {
     /// Manually restore from a given `MemoryStore`.
     pub fn resumed_ephemeral_store(
         mut self,
-        store: Arc<HotColdDB<E, MemoryStore<E>, MemoryStore<E>>>,
+        store: Arc<HotColdDB<E, MemoryStore, MemoryStore>>,
     ) -> Self {
         let mutator = move |builder: BeaconChainBuilder<_>| {
             builder
@@ -350,7 +350,7 @@ impl<E: EthSpec> Builder<DiskHarnessType<E>> {
     /// Disk store, start from genesis.
     pub fn fresh_disk_store(
         mut self,
-        store: Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>>,
+        store: Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>>,
     ) -> Self {
         let validator_keypairs = self
             .validator_keypairs
@@ -384,7 +384,7 @@ impl<E: EthSpec> Builder<DiskHarnessType<E>> {
     /// Disk store, resume.
     pub fn resumed_disk_store(
         mut self,
-        store: Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>>,
+        store: Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>>,
     ) -> Self {
         let mutator = move |builder: BeaconChainBuilder<_>| {
             builder

--- a/beacon_node/beacon_chain/tests/op_verification.rs
+++ b/beacon_node/beacon_chain/tests/op_verification.rs
@@ -27,7 +27,7 @@ static KEYPAIRS: LazyLock<Vec<Keypair>> =
 
 type E = MinimalEthSpec;
 type TestHarness = BeaconChainHarness<DiskHarnessType<E>>;
-type HotColdDB = store::HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>;
+type HotColdDB = store::HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>;
 
 fn get_store(db_path: &TempDir) -> Arc<HotColdDB> {
     let spec = Arc::new(test_spec::<E>());

--- a/beacon_node/beacon_chain/tests/prepare_payload.rs
+++ b/beacon_node/beacon_chain/tests/prepare_payload.rs
@@ -34,7 +34,7 @@ type TestHarness = BeaconChainHarness<DiskHarnessType<E>>;
 fn get_store(
     db_path: &TempDir,
     spec: Arc<ChainSpec>,
-) -> Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>> {
+) -> Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>> {
     let store_config = StoreConfig {
         prune_payloads: false,
         ..StoreConfig::default()
@@ -46,7 +46,7 @@ fn get_store_generic(
     db_path: &TempDir,
     config: StoreConfig,
     spec: Arc<ChainSpec>,
-) -> Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>> {
+) -> Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>> {
     create_test_tracing_subscriber();
     let hot_path = db_path.path().join("chain_db");
     let cold_path = db_path.path().join("freezer_db");
@@ -64,7 +64,7 @@ fn get_store_generic(
 }
 
 fn get_harness(
-    store: Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>>,
+    store: Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>>,
     validator_count: usize,
 ) -> TestHarness {
     // Most tests expect to retain historic states, so we use this as the default.
@@ -81,7 +81,7 @@ fn get_harness(
 }
 
 fn get_harness_generic(
-    store: Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>>,
+    store: Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>>,
     validator_count: usize,
     chain_config: ChainConfig,
     node_custody_type: NodeCustodyType,

--- a/beacon_node/beacon_chain/tests/schema_stability.rs
+++ b/beacon_node/beacon_chain/tests/schema_stability.rs
@@ -20,7 +20,7 @@ use tempfile::{TempDir, tempdir};
 use types::{ChainSpec, Hash256, MainnetEthSpec, Slot};
 
 type E = MainnetEthSpec;
-type Store<E> = Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>>;
+type Store<E> = Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>>;
 type TestHarness = BeaconChainHarness<DiskHarnessType<E>>;
 
 const VALIDATOR_COUNT: usize = 32;

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -68,7 +68,7 @@ static KEYPAIRS: LazyLock<Vec<Keypair>> =
 type E = MinimalEthSpec;
 type TestHarness = BeaconChainHarness<DiskHarnessType<E>>;
 
-fn get_store(db_path: &TempDir) -> Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>> {
+fn get_store(db_path: &TempDir) -> Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>> {
     let store_config = StoreConfig {
         prune_payloads: false,
         ..StoreConfig::default()
@@ -80,7 +80,7 @@ fn get_store_generic(
     db_path: &TempDir,
     config: StoreConfig,
     spec: ChainSpec,
-) -> Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>> {
+) -> Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>> {
     create_test_tracing_subscriber();
     let hot_path = db_path.path().join("chain_db");
     let cold_path = db_path.path().join("freezer_db");
@@ -98,7 +98,7 @@ fn get_store_generic(
 }
 
 fn get_harness(
-    store: Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>>,
+    store: Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>>,
     validator_count: usize,
 ) -> TestHarness {
     // Most tests expect to retain historic states, so we use this as the default.
@@ -115,7 +115,7 @@ fn get_harness(
 }
 
 fn get_harness_import_all_data_columns(
-    store: Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>>,
+    store: Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>>,
     validator_count: usize,
 ) -> TestHarness {
     // Most tests expect to retain historic states, so we use this as the default.
@@ -133,7 +133,7 @@ fn get_harness_import_all_data_columns(
 }
 
 fn get_harness_generic(
-    store: Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>>,
+    store: Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>>,
     validator_count: usize,
     chain_config: ChainConfig,
     node_custody_type: NodeCustodyType,
@@ -167,7 +167,7 @@ fn check_db_invariants(harness: &TestHarness) {
 }
 
 fn get_states_descendant_of_block(
-    store: &HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>,
+    store: &HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>,
     block_root: Hash256,
 ) -> Vec<(Hash256, Slot)> {
     let summaries = store.load_hot_state_summaries().unwrap();
@@ -5851,7 +5851,7 @@ async fn test_gloas_hot_state_hierarchy() {
 /// Check that the HotColdDB's split_slot is equal to the start slot of the last finalized epoch.
 fn check_split_slot(
     harness: &TestHarness,
-    store: Arc<HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>>,
+    store: Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>>,
 ) {
     let split_slot = store.get_split_slot();
     assert_eq!(

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -842,8 +842,7 @@ where
     }
 }
 
-impl<TSlotClock, E>
-    ClientBuilder<Witness<TSlotClock, E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>>
+impl<TSlotClock, E> ClientBuilder<Witness<TSlotClock, E, BeaconNodeBackend, BeaconNodeBackend>>
 where
     TSlotClock: SlotClock + 'static,
     E: EthSpec + 'static,

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -97,8 +97,8 @@ impl<TSlotClock, E, THotStore, TColdStore>
 where
     TSlotClock: SlotClock + Clone + 'static,
     E: EthSpec + 'static,
-    THotStore: ItemStore<E> + 'static,
-    TColdStore: ItemStore<E> + 'static,
+    THotStore: ItemStore + 'static,
+    TColdStore: ItemStore + 'static,
 {
     /// Instantiates a new, empty builder.
     ///
@@ -810,8 +810,8 @@ impl<TSlotClock, E, THotStore, TColdStore>
 where
     TSlotClock: SlotClock + Clone + 'static,
     E: EthSpec + 'static,
-    THotStore: ItemStore<E> + 'static,
-    TColdStore: ItemStore<E> + 'static,
+    THotStore: ItemStore + 'static,
+    TColdStore: ItemStore + 'static,
 {
     /// Consumes the internal `BeaconChainBuilder`, attaching the resulting `BeaconChain` to self.
     #[instrument(skip_all)]
@@ -884,8 +884,8 @@ where
 impl<E, THotStore, TColdStore> ClientBuilder<Witness<SystemTimeSlotClock, E, THotStore, TColdStore>>
 where
     E: EthSpec + 'static,
-    THotStore: ItemStore<E> + 'static,
-    TColdStore: ItemStore<E> + 'static,
+    THotStore: ItemStore + 'static,
+    TColdStore: ItemStore + 'static,
 {
     /// Specifies that the slot clock should read the time from the computers system clock.
     pub fn system_time_slot_clock(mut self) -> Result<Self, String> {

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -57,7 +57,7 @@ pub struct ApiServer<T: BeaconChainTypes, SFut: Future<Output = ()>> {
 
 type HarnessBuilder<E> = Builder<EphemeralHarnessType<E>>;
 type Initializer<E> = Box<dyn FnOnce(HarnessBuilder<E>) -> HarnessBuilder<E>>;
-type Mutator<E> = BoxedMutator<E, MemoryStore<E>, MemoryStore<E>>;
+type Mutator<E> = BoxedMutator<E, MemoryStore, MemoryStore>;
 
 impl<E: EthSpec> InteractiveTester<E> {
     pub async fn new(spec: Option<ChainSpec>, validator_count: usize) -> Self {

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -1247,8 +1247,7 @@ use {
 };
 
 #[cfg(test)]
-pub(crate) type TestBeaconChainType<E> =
-    Witness<ManualSlotClock, E, MemoryStore<E>, MemoryStore<E>>;
+pub(crate) type TestBeaconChainType<E> = Witness<ManualSlotClock, E, MemoryStore, MemoryStore>;
 
 #[cfg(test)]
 impl<E: EthSpec> NetworkBeaconProcessor<TestBeaconChainType<E>> {

--- a/beacon_node/network/src/persisted_dht.rs
+++ b/beacon_node/network/src/persisted_dht.rs
@@ -75,11 +75,8 @@ mod tests {
     use types::{ChainSpec, MinimalEthSpec};
     #[test]
     fn test_persisted_dht() {
-        let store: HotColdDB<
-            MinimalEthSpec,
-            MemoryStore<MinimalEthSpec>,
-            MemoryStore<MinimalEthSpec>,
-        > = HotColdDB::open_ephemeral(StoreConfig::default(), ChainSpec::minimal().into()).unwrap();
+        let store: HotColdDB<MinimalEthSpec, MemoryStore, MemoryStore> =
+            HotColdDB::open_ephemeral(StoreConfig::default(), ChainSpec::minimal().into()).unwrap();
         let enrs = vec![Enr::from_str("enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8").unwrap()];
         store
             .put_item(&DHT_DB_KEY, &PersistedDht { enrs: enrs.clone() })

--- a/beacon_node/network/src/persisted_dht.rs
+++ b/beacon_node/network/src/persisted_dht.rs
@@ -6,7 +6,7 @@ use types::{EthSpec, Hash256};
 /// 32-byte key for accessing the `DhtEnrs`. All zero because `DhtEnrs` has its own column.
 pub const DHT_DB_KEY: Hash256 = Hash256::ZERO;
 
-pub fn load_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
+pub fn load_dht<E: EthSpec, Hot: ItemStore, Cold: ItemStore>(
     store: Arc<HotColdDB<E, Hot, Cold>>,
 ) -> Vec<Enr> {
     // Load DHT from store
@@ -20,7 +20,7 @@ pub fn load_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
 }
 
 /// Attempt to persist the ENR's in the DHT to `self.store`.
-pub fn persist_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
+pub fn persist_dht<E: EthSpec, Hot: ItemStore, Cold: ItemStore>(
     store: Arc<HotColdDB<E, Hot, Cold>>,
     enrs: Vec<Enr>,
 ) -> Result<(), store::Error> {
@@ -28,7 +28,7 @@ pub fn persist_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
 }
 
 /// Attempts to clear any DHT entries.
-pub fn clear_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
+pub fn clear_dht<E: EthSpec, Hot: ItemStore, Cold: ItemStore>(
     store: Arc<HotColdDB<E, Hot, Cold>>,
 ) -> Result<(), store::Error> {
     store.hot_db.delete::<PersistedDht>(&DHT_DB_KEY)

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -25,12 +25,7 @@ const SLOT_DURATION_MILLIS: u64 = 400;
 
 const TEST_LOG_LEVEL: Option<&str> = None;
 
-type TestBeaconChainType = Witness<
-    SystemTimeSlotClock,
-    MainnetEthSpec,
-    MemoryStore<MainnetEthSpec>,
-    MemoryStore<MainnetEthSpec>,
->;
+type TestBeaconChainType = Witness<SystemTimeSlotClock, MainnetEthSpec, MemoryStore, MemoryStore>;
 
 pub struct TestBeaconChain {
     chain: Arc<BeaconChain<TestBeaconChainType>>,

--- a/beacon_node/network/src/sync/tests/mod.rs
+++ b/beacon_node/network/src/sync/tests/mod.rs
@@ -26,7 +26,7 @@ use types::{ForkName, Hash256, MinimalEthSpec as E, Slot};
 mod lookups;
 mod range;
 
-type T = Witness<ManualSlotClock, E, MemoryStore<E>, MemoryStore<E>>;
+type T = Witness<ManualSlotClock, E, MemoryStore, MemoryStore>;
 
 /// This test utility enables integration testing of Lighthouse sync components.
 ///

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -20,7 +20,7 @@ use types::{ChainSpec, Epoch, EthSpec, ForkName};
 
 /// A type-alias to the tighten the definition of a production-intended `Client`.
 pub type ProductionClient<E> =
-    Client<Witness<SystemTimeSlotClock, E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>>;
+    Client<Witness<SystemTimeSlotClock, E, BeaconNodeBackend, BeaconNodeBackend>>;
 
 /// The beacon node `Client` that is used in production.
 ///

--- a/beacon_node/store/src/database/interface.rs
+++ b/beacon_node/store/src/database/interface.rs
@@ -6,18 +6,17 @@ use crate::{ColumnIter, ColumnKeyIter, DBColumn, Error, ItemStore, Key, KeyValue
 use crate::{KeyValueStoreOp, StoreConfig, config::DatabaseBackend};
 use std::collections::HashSet;
 use std::path::Path;
-use types::EthSpec;
 
-pub enum BeaconNodeBackend<E: EthSpec> {
+pub enum BeaconNodeBackend {
     #[cfg(feature = "leveldb")]
-    LevelDb(leveldb_impl::LevelDB<E>),
+    LevelDb(leveldb_impl::LevelDB),
     #[cfg(feature = "redb")]
-    Redb(redb_impl::Redb<E>),
+    Redb(redb_impl::Redb),
 }
 
-impl<E: EthSpec> ItemStore for BeaconNodeBackend<E> {}
+impl ItemStore for BeaconNodeBackend {}
 
-impl<E: EthSpec> KeyValueStore for BeaconNodeBackend<E> {
+impl KeyValueStore for BeaconNodeBackend {
     fn get_bytes(&self, column: DBColumn, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         match self {
             #[cfg(feature = "leveldb")]
@@ -183,7 +182,7 @@ impl<E: EthSpec> KeyValueStore for BeaconNodeBackend<E> {
     }
 }
 
-impl<E: EthSpec> BeaconNodeBackend<E> {
+impl BeaconNodeBackend {
     pub fn open(config: &StoreConfig, path: &Path) -> Result<Self, Error> {
         metrics::inc_counter_vec(&metrics::DISK_DB_TYPE, &[&config.backend.to_string()]);
         match config.backend {

--- a/beacon_node/store/src/database/interface.rs
+++ b/beacon_node/store/src/database/interface.rs
@@ -15,9 +15,9 @@ pub enum BeaconNodeBackend<E: EthSpec> {
     Redb(redb_impl::Redb<E>),
 }
 
-impl<E: EthSpec> ItemStore<E> for BeaconNodeBackend<E> {}
+impl<E: EthSpec> ItemStore for BeaconNodeBackend<E> {}
 
-impl<E: EthSpec> KeyValueStore<E> for BeaconNodeBackend<E> {
+impl<E: EthSpec> KeyValueStore for BeaconNodeBackend<E> {
     fn get_bytes(&self, column: DBColumn, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         match self {
             #[cfg(feature = "leveldb")]

--- a/beacon_node/store/src/database/leveldb_impl.rs
+++ b/beacon_node/store/src/database/leveldb_impl.rs
@@ -15,15 +15,13 @@ use leveldb::{
     options::{Options, ReadOptions},
 };
 use std::collections::HashSet;
-use std::marker::PhantomData;
 use std::path::Path;
-use types::{EthSpec, Hash256};
+use types::Hash256;
 
 use super::interface::WriteOptions;
 
-pub struct LevelDB<E: EthSpec> {
+pub struct LevelDB {
     db: Database<BytesKey>,
-    _phantom: PhantomData<E>,
 }
 
 impl From<WriteOptions> for leveldb::options::WriteOptions {
@@ -34,7 +32,7 @@ impl From<WriteOptions> for leveldb::options::WriteOptions {
     }
 }
 
-impl<E: EthSpec> LevelDB<E> {
+impl LevelDB {
     pub fn open(path: &Path) -> Result<Self, Error> {
         let mut options = Options::new();
 
@@ -42,10 +40,7 @@ impl<E: EthSpec> LevelDB<E> {
 
         let db = Database::open(path, options)?;
 
-        Ok(Self {
-            db,
-            _phantom: PhantomData,
-        })
+        Ok(Self { db })
     }
 
     pub fn read_options(&self) -> ReadOptions<'_, BytesKey> {

--- a/beacon_node/store/src/database/redb_impl.rs
+++ b/beacon_node/store/src/database/redb_impl.rs
@@ -3,17 +3,15 @@ use crate::{DBColumn, Error, KeyValueStoreOp};
 use parking_lot::RwLock;
 use redb::TableDefinition;
 use std::collections::HashSet;
-use std::{borrow::BorrowMut, marker::PhantomData, path::Path};
+use std::{borrow::BorrowMut, path::Path};
 use strum::IntoEnumIterator;
-use types::EthSpec;
 
 use super::interface::WriteOptions;
 
 pub const DB_FILE_NAME: &str = "database.redb";
 
-pub struct Redb<E: EthSpec> {
+pub struct Redb {
     db: RwLock<redb::Database>,
-    _phantom: PhantomData<E>,
 }
 
 impl From<WriteOptions> for redb::Durability {
@@ -26,19 +24,16 @@ impl From<WriteOptions> for redb::Durability {
     }
 }
 
-impl<E: EthSpec> Redb<E> {
+impl Redb {
     pub fn open(path: &Path) -> Result<Self, Error> {
         let db_file = path.join(DB_FILE_NAME);
         let db = redb::Database::create(db_file)?;
 
         for column in DBColumn::iter() {
-            Redb::<E>::create_table(&db, column.into())?;
+            Self::create_table(&db, column.into())?;
         }
 
-        Ok(Self {
-            db: db.into(),
-            _phantom: PhantomData,
-        })
+        Ok(Self { db: db.into() })
     }
 
     fn create_table(db: &redb::Database, table_name: &str) -> Result<(), Error> {

--- a/beacon_node/store/src/forwards_iter.rs
+++ b/beacon_node/store/src/forwards_iter.rs
@@ -9,7 +9,7 @@ pub type HybridForwardsBlockRootsIterator<'a, E, Hot, Cold> =
 pub type HybridForwardsStateRootsIterator<'a, E, Hot, Cold> =
     HybridForwardsIterator<'a, E, Hot, Cold>;
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> {
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
     fn simple_forwards_iterator(
         &self,
         column: DBColumn,
@@ -116,7 +116,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 }
 
 /// Forwards root iterator that makes use of a slot -> root mapping in the freezer DB.
-pub struct FrozenForwardsIterator<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+pub struct FrozenForwardsIterator<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     inner: ColumnIter<'a, Vec<u8>>,
     column: DBColumn,
     next_slot: Slot,
@@ -124,9 +124,7 @@ pub struct FrozenForwardsIterator<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemS
     _phantom: PhantomData<(E, Hot, Cold)>,
 }
 
-impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
-    FrozenForwardsIterator<'a, E, Hot, Cold>
-{
+impl<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> FrozenForwardsIterator<'a, E, Hot, Cold> {
     /// `end_slot` is EXCLUSIVE here.
     pub fn new(
         store: &'a HotColdDB<E, Hot, Cold>,
@@ -148,7 +146,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
     }
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> Iterator
     for FrozenForwardsIterator<'_, E, Hot, Cold>
 {
     type Item = Result<(Hash256, Slot)>;
@@ -199,7 +197,7 @@ impl Iterator for SimpleForwardsIterator {
 }
 
 /// Fusion of the above two approaches to forwards iteration. Fast and efficient.
-pub enum HybridForwardsIterator<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+pub enum HybridForwardsIterator<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     PreFinalization {
         iter: Box<FrozenForwardsIterator<'a, E, Hot, Cold>>,
         store: &'a HotColdDB<E, Hot, Cold>,
@@ -220,9 +218,7 @@ pub enum HybridForwardsIterator<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemSto
     Finished,
 }
 
-impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
-    HybridForwardsIterator<'a, E, Hot, Cold>
-{
+impl<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> HybridForwardsIterator<'a, E, Hot, Cold> {
     /// Construct a new hybrid iterator.
     ///
     /// The `get_state` closure should return a beacon state and final block/state root to backtrack
@@ -349,7 +345,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
     }
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> Iterator
     for HybridForwardsIterator<'_, E, Hot, Cold>
 {
     type Item = Result<(Hash256, Slot)>;

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -217,11 +217,11 @@ pub enum HotColdDBError {
     Rollback,
 }
 
-impl<E: EthSpec> HotColdDB<E, MemoryStore<E>, MemoryStore<E>> {
+impl<E: EthSpec> HotColdDB<E, MemoryStore, MemoryStore> {
     pub fn open_ephemeral(
         config: StoreConfig,
         spec: Arc<ChainSpec>,
-    ) -> Result<HotColdDB<E, MemoryStore<E>, MemoryStore<E>>, Error> {
+    ) -> Result<HotColdDB<E, MemoryStore, MemoryStore>, Error> {
         config.verify::<E>()?;
 
         let hierarchy = config.hierarchy_config.to_moduli()?;
@@ -258,7 +258,7 @@ impl<E: EthSpec> HotColdDB<E, MemoryStore<E>, MemoryStore<E>> {
     }
 }
 
-impl<E: EthSpec> HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>> {
+impl<E: EthSpec> HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend> {
     /// Open a new or existing database, with the given paths to the hot and cold DBs.
     ///
     /// The `migrate_schema` function is passed in so that the parent `BeaconChain` can provide

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -49,7 +49,7 @@ use zstd::{Decoder, Encoder};
 /// Stores vector fields like the `block_roots` and `state_roots` separately, and only stores
 /// intermittent "restore point" states pre-finalization.
 #[derive(Debug)]
-pub struct HotColdDB<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+pub struct HotColdDB<E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     /// The slot and state root at the point where the database is split between hot and cold.
     ///
     /// States with slots less than `split.slot` are in the cold DB, while states with slots
@@ -451,7 +451,7 @@ impl<E: EthSpec> HotColdDB<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>> {
     }
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> {
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
     fn cold_storage_strategy(&self, slot: Slot) -> Result<StorageStrategy, Error> {
         // The start slot for the freezer HDiff is always 0
         Ok(self.hierarchy.storage_strategy(slot, Slot::new(0))?)
@@ -3575,7 +3575,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 /// This function previously did a combination of freezer migration alongside pruning. Now it is
 /// *just* responsible for copying relevant data to the freezer, while pruning is implemented
 /// in `prune_hot_db`.
-pub fn migrate_database<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
+pub fn migrate_database<E: EthSpec, Hot: ItemStore, Cold: ItemStore>(
     store: Arc<HotColdDB<E, Hot, Cold>>,
     finalized_state_root: Hash256,
     finalized_block_root: Hash256,
@@ -3786,7 +3786,7 @@ pub enum StateSummaryIteratorError {
 
 /// Return the ancestor state root of a state beyond SlotsPerHistoricalRoot using the roots iterator
 /// and the store
-pub fn get_ancestor_state_root<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
+pub fn get_ancestor_state_root<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore>(
     store: &'a HotColdDB<E, Hot, Cold>,
     from_state: &'a BeaconState<E>,
     target_slot: Slot,
@@ -3993,7 +3993,7 @@ impl StoreItem for HotStateSummary {
 
 impl HotStateSummary {
     /// Construct a new summary of the given state.
-    pub fn new<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
+    pub fn new<E: EthSpec, Hot: ItemStore, Cold: ItemStore>(
         store: &HotColdDB<E, Hot, Cold>,
         state_root: Hash256,
         state: &BeaconState<E>,

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -242,7 +242,7 @@ pub enum InvariantViolation {
     ColdStateBaseSummaryMissing { slot: Slot, base_slot: Slot },
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> {
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
     /// Run all database invariant checks.
     ///
     /// The `ctx` parameter provides data from the beacon chain layer (fork choice, state cache,

--- a/beacon_node/store/src/iter.rs
+++ b/beacon_node/store/src/iter.rs
@@ -13,12 +13,12 @@ use types::{
 ///
 /// It is assumed that all ancestors for this object are stored in the database. If this is not the
 /// case, the iterator will start returning `None` prior to genesis.
-pub trait AncestorIter<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>, I: Iterator> {
+pub trait AncestorIter<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore, I: Iterator> {
     /// Returns an iterator over the roots of the ancestors of `self`.
     fn try_iter_ancestor_roots(&self, store: &'a HotColdDB<E, Hot, Cold>) -> Option<I>;
 }
 
-impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
+impl<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore>
     AncestorIter<'a, E, Hot, Cold, BlockRootsIterator<'a, E, Hot, Cold>> for SignedBeaconBlock<E>
 {
     /// Iterates across all available prior block roots of `self`, starting at the most recent and ending
@@ -37,7 +37,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
     }
 }
 
-impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
+impl<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore>
     AncestorIter<'a, E, Hot, Cold, StateRootsIterator<'a, E, Hot, Cold>> for BeaconState<E>
 {
     /// Iterates across all available prior state roots of `self`, starting at the most recent and ending
@@ -51,13 +51,11 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
     }
 }
 
-pub struct StateRootsIterator<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+pub struct StateRootsIterator<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     inner: RootsIterator<'a, E, Hot, Cold>,
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Clone
-    for StateRootsIterator<'_, E, Hot, Cold>
-{
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> Clone for StateRootsIterator<'_, E, Hot, Cold> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -65,7 +63,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Clone
     }
 }
 
-impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> StateRootsIterator<'a, E, Hot, Cold> {
+impl<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> StateRootsIterator<'a, E, Hot, Cold> {
     pub fn new(store: &'a HotColdDB<E, Hot, Cold>, beacon_state: &'a BeaconState<E>) -> Self {
         Self {
             inner: RootsIterator::new(store, beacon_state),
@@ -79,7 +77,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> StateRootsIterator<'
     }
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> Iterator
     for StateRootsIterator<'_, E, Hot, Cold>
 {
     type Item = Result<(Hash256, Slot), Error>;
@@ -99,13 +97,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
 /// exhausted.
 ///
 /// Returns `None` for roots prior to genesis or when there is an error reading from `Store`.
-pub struct BlockRootsIterator<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+pub struct BlockRootsIterator<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     inner: RootsIterator<'a, E, Hot, Cold>,
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Clone
-    for BlockRootsIterator<'_, E, Hot, Cold>
-{
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> Clone for BlockRootsIterator<'_, E, Hot, Cold> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -113,7 +109,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Clone
     }
 }
 
-impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BlockRootsIterator<'a, E, Hot, Cold> {
+impl<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> BlockRootsIterator<'a, E, Hot, Cold> {
     /// Create a new iterator over all block roots in the given `beacon_state` and prior states.
     pub fn new(store: &'a HotColdDB<E, Hot, Cold>, beacon_state: &'a BeaconState<E>) -> Self {
         Self {
@@ -138,7 +134,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BlockRootsIterator<'
     }
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> Iterator
     for BlockRootsIterator<'_, E, Hot, Cold>
 {
     type Item = Result<(Hash256, Slot), Error>;
@@ -151,13 +147,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
 }
 
 /// Iterator over state and block roots that backtracks using the vectors from a `BeaconState`.
-pub struct RootsIterator<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+pub struct RootsIterator<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     store: &'a HotColdDB<E, Hot, Cold>,
     beacon_state: Cow<'a, BeaconState<E>>,
     slot: Slot,
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Clone for RootsIterator<'_, E, Hot, Cold> {
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> Clone for RootsIterator<'_, E, Hot, Cold> {
     fn clone(&self) -> Self {
         Self {
             store: self.store,
@@ -167,7 +163,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Clone for RootsIterator<
     }
 }
 
-impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> RootsIterator<'a, E, Hot, Cold> {
+impl<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> RootsIterator<'a, E, Hot, Cold> {
     pub fn new(store: &'a HotColdDB<E, Hot, Cold>, beacon_state: &'a BeaconState<E>) -> Self {
         Self {
             store,
@@ -234,9 +230,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> RootsIterator<'a, E,
     }
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
-    for RootsIterator<'_, E, Hot, Cold>
-{
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> Iterator for RootsIterator<'_, E, Hot, Cold> {
     /// (block_root, state_root, slot)
     type Item = Result<(Hash256, Hash256, Slot), Error>;
 
@@ -246,15 +240,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
 }
 
 /// Block iterator that uses the `parent_root` of each block to backtrack.
-pub struct ParentRootBlockIterator<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+pub struct ParentRootBlockIterator<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     store: &'a HotColdDB<E, Hot, Cold>,
     next_block_root: Hash256,
     _phantom: PhantomData<E>,
 }
 
-impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
-    ParentRootBlockIterator<'a, E, Hot, Cold>
-{
+impl<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> ParentRootBlockIterator<'a, E, Hot, Cold> {
     pub fn new(store: &'a HotColdDB<E, Hot, Cold>, start_block_root: Hash256) -> Self {
         Self {
             store,
@@ -283,7 +275,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
     }
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> Iterator
     for ParentRootBlockIterator<'_, E, Hot, Cold>
 {
     type Item = Result<(Hash256, SignedBeaconBlock<E, BlindedPayload<E>>), Error>;
@@ -295,11 +287,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
 
 #[derive(Clone)]
 /// Extends `BlockRootsIterator`, returning `SignedBeaconBlock` instances, instead of their roots.
-pub struct BlockIterator<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+pub struct BlockIterator<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     roots: BlockRootsIterator<'a, E, Hot, Cold>,
 }
 
-impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BlockIterator<'a, E, Hot, Cold> {
+impl<'a, E: EthSpec, Hot: ItemStore, Cold: ItemStore> BlockIterator<'a, E, Hot, Cold> {
     /// Create a new iterator over all blocks in the given `beacon_state` and prior states.
     pub fn new(store: &'a HotColdDB<E, Hot, Cold>, beacon_state: &'a BeaconState<E>) -> Self {
         Self {
@@ -324,9 +316,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BlockIterator<'a, E,
     }
 }
 
-impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
-    for BlockIterator<'_, E, Hot, Cold>
-{
+impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> Iterator for BlockIterator<'_, E, Hot, Cold> {
     type Item = Result<SignedBeaconBlock<E, BlindedPayload<E>>, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -338,7 +328,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
 ///
 /// Return `Err(HistoryUnavailable)` in the case where no more backtrack states are available
 /// due to weak subjectivity sync.
-fn next_historical_root_backtrack_state<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
+fn next_historical_root_backtrack_state<E: EthSpec, Hot: ItemStore, Cold: ItemStore>(
     store: &HotColdDB<E, Hot, Cold>,
     current_state: &BeaconState<E>,
 ) -> Result<BeaconState<E>, Error> {

--- a/beacon_node/store/src/iter.rs
+++ b/beacon_node/store/src/iter.rs
@@ -376,7 +376,7 @@ mod test {
         harness.get_current_state()
     }
 
-    fn get_store<E: EthSpec>() -> HotColdDB<E, MemoryStore<E>, MemoryStore<E>> {
+    fn get_store<E: EthSpec>() -> HotColdDB<E, MemoryStore, MemoryStore> {
         let store =
             HotColdDB::open_ephemeral(Config::default(), Arc::new(E::default_spec())).unwrap();
         // Init achor info so anchor slot is set. Use a random block as it is only used for the

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -46,7 +46,7 @@ pub type ColumnKeyIter<'a, K> = Box<dyn Iterator<Item = Result<K, Error>> + 'a>;
 pub type RawEntryIter<'a> =
     Result<Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>), Error>> + 'a>, Error>;
 
-pub trait KeyValueStore<E: EthSpec>: Sync + Send + Sized + 'static {
+pub trait KeyValueStore: Sync + Send + Sized + 'static {
     /// Retrieve some bytes in `column` with `key`.
     fn get_bytes(&self, column: DBColumn, key: &[u8]) -> Result<Option<Vec<u8>>, Error>;
 
@@ -177,7 +177,7 @@ pub enum KeyValueStoreOp {
     DeleteKey(DBColumn, Vec<u8>),
 }
 
-pub trait ItemStore<E: EthSpec>: KeyValueStore<E> + Sync + Send + Sized + 'static {
+pub trait ItemStore: KeyValueStore + Sync + Send + Sized + 'static {
     /// Store an item in `Self`.
     fn put<I: StoreItem>(&self, key: &Hash256, item: &I) -> Result<(), Error> {
         let column = I::db_column();
@@ -493,7 +493,7 @@ mod tests {
         }
     }
 
-    fn test_impl(store: impl ItemStore<MinimalEthSpec>) {
+    fn test_impl(store: impl ItemStore) {
         let key = Hash256::random();
         let item = StorableThing { a: 1, b: 42 };
 
@@ -517,14 +517,15 @@ mod tests {
     fn simplediskdb() {
         let dir = tempdir().unwrap();
         let path = dir.path();
-        let store = BeaconNodeBackend::open(&StoreConfig::default(), path).unwrap();
+        let store =
+            BeaconNodeBackend::<MinimalEthSpec>::open(&StoreConfig::default(), path).unwrap();
 
         test_impl(store);
     }
 
     #[test]
     fn memorydb() {
-        let store = MemoryStore::open();
+        let store = MemoryStore::<MinimalEthSpec>::open();
 
         test_impl(store);
     }

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -517,22 +517,21 @@ mod tests {
     fn simplediskdb() {
         let dir = tempdir().unwrap();
         let path = dir.path();
-        let store =
-            BeaconNodeBackend::<MinimalEthSpec>::open(&StoreConfig::default(), path).unwrap();
+        let store = BeaconNodeBackend::open(&StoreConfig::default(), path).unwrap();
 
         test_impl(store);
     }
 
     #[test]
     fn memorydb() {
-        let store = MemoryStore::<MinimalEthSpec>::open();
+        let store = MemoryStore::open();
 
         test_impl(store);
     }
 
     #[test]
     fn exists() {
-        let store = MemoryStore::<MinimalEthSpec>::open();
+        let store = MemoryStore::open();
         let key = Hash256::random();
         let item = StorableThing { a: 1, b: 42 };
 

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -25,7 +25,7 @@ impl<E: EthSpec> MemoryStore<E> {
     }
 }
 
-impl<E: EthSpec> KeyValueStore<E> for MemoryStore<E> {
+impl<E: EthSpec> KeyValueStore for MemoryStore<E> {
     /// Get the value of some key from the database. Returns `None` if the key does not exist.
     fn get_bytes(&self, col: DBColumn, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         let column_key = BytesKey::from_vec(get_key_for_col(col, key));
@@ -148,4 +148,4 @@ impl<E: EthSpec> KeyValueStore<E> for MemoryStore<E> {
     }
 }
 
-impl<E: EthSpec> ItemStore<E> for MemoryStore<E> {}
+impl<E: EthSpec> ItemStore for MemoryStore<E> {}

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -4,28 +4,24 @@ use crate::{
 };
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
-use std::marker::PhantomData;
-use types::*;
 
 type DBMap = BTreeMap<BytesKey, Vec<u8>>;
 
 /// A thread-safe `BTreeMap` wrapper.
-pub struct MemoryStore<E: EthSpec> {
+pub struct MemoryStore {
     db: RwLock<DBMap>,
-    _phantom: PhantomData<E>,
 }
 
-impl<E: EthSpec> MemoryStore<E> {
+impl MemoryStore {
     /// Create a new, empty database.
     pub fn open() -> Self {
         Self {
             db: RwLock::new(BTreeMap::new()),
-            _phantom: PhantomData,
         }
     }
 }
 
-impl<E: EthSpec> KeyValueStore for MemoryStore<E> {
+impl KeyValueStore for MemoryStore {
     /// Get the value of some key from the database. Returns `None` if the key does not exist.
     fn get_bytes(&self, col: DBColumn, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         let column_key = BytesKey::from_vec(get_key_for_col(col, key));
@@ -148,4 +144,4 @@ impl<E: EthSpec> KeyValueStore for MemoryStore<E> {
     }
 }
 
-impl<E: EthSpec> ItemStore for MemoryStore<E> {}
+impl ItemStore for MemoryStore {}

--- a/beacon_node/store/src/reconstruct.rs
+++ b/beacon_node/store/src/reconstruct.rs
@@ -15,8 +15,8 @@ use types::{EthSpec, Slot};
 impl<E, Hot, Cold> HotColdDB<E, Hot, Cold>
 where
     E: EthSpec,
-    Hot: ItemStore<E>,
-    Cold: ItemStore<E>,
+    Hot: ItemStore,
+    Cold: ItemStore,
 {
     pub fn reconstruct_historic_states(
         self: &Arc<Self>,

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -79,7 +79,7 @@ impl ForkChoiceTest {
     /// Get a value from the `ForkChoice` instantiation.
     fn get<T, U>(&self, func: T) -> U
     where
-        T: Fn(&BeaconForkChoiceStore<E, MemoryStore<E>, MemoryStore<E>>) -> U,
+        T: Fn(&BeaconForkChoiceStore<E, MemoryStore, MemoryStore>) -> U,
     {
         func(
             self.harness

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -55,7 +55,7 @@ pub fn display_db_version<E: EthSpec>(
     let blobs_path = client_config.get_blobs_db_path();
 
     let mut version = CURRENT_SCHEMA_VERSION;
-    HotColdDB::<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>::open(
+    HotColdDB::<E, BeaconNodeBackend, BeaconNodeBackend>::open(
         &hot_path,
         &cold_path,
         &blobs_path,
@@ -143,13 +143,13 @@ pub fn inspect_db<E: EthSpec>(
     let mut num_keys = 0;
 
     let sub_db = if inspect_config.freezer {
-        BeaconNodeBackend::<E>::open(&client_config.store, &cold_path)
+        BeaconNodeBackend::open(&client_config.store, &cold_path)
             .map_err(|e| format!("Unable to open freezer DB: {e:?}"))?
     } else if inspect_config.blobs_db {
-        BeaconNodeBackend::<E>::open(&client_config.store, &blobs_path)
+        BeaconNodeBackend::open(&client_config.store, &blobs_path)
             .map_err(|e| format!("Unable to open blobs DB: {e:?}"))?
     } else {
-        BeaconNodeBackend::<E>::open(&client_config.store, &hot_path)
+        BeaconNodeBackend::open(&client_config.store, &hot_path)
             .map_err(|e| format!("Unable to open hot DB: {e:?}"))?
     };
 
@@ -264,17 +264,17 @@ pub fn compact_db<E: EthSpec>(
 
     let (sub_db, db_name) = if compact_config.freezer {
         (
-            BeaconNodeBackend::<E>::open(&client_config.store, &cold_path)?,
+            BeaconNodeBackend::open(&client_config.store, &cold_path)?,
             "freezer_db",
         )
     } else if compact_config.blobs_db {
         (
-            BeaconNodeBackend::<E>::open(&client_config.store, &blobs_path)?,
+            BeaconNodeBackend::open(&client_config.store, &blobs_path)?,
             "blobs_db",
         )
     } else {
         (
-            BeaconNodeBackend::<E>::open(&client_config.store, &hot_path)?,
+            BeaconNodeBackend::open(&client_config.store, &hot_path)?,
             "hot_db",
         )
     };
@@ -309,7 +309,7 @@ pub fn migrate_db<E: EthSpec>(
 
     let mut from = CURRENT_SCHEMA_VERSION;
     let to = migrate_config.to;
-    let db = HotColdDB::<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>::open(
+    let db = HotColdDB::<E, BeaconNodeBackend, BeaconNodeBackend>::open(
         &hot_path,
         &cold_path,
         &blobs_path,
@@ -339,7 +339,7 @@ pub fn prune_payloads<E: EthSpec>(
     let cold_path = client_config.get_freezer_db_path();
     let blobs_path = client_config.get_blobs_db_path();
 
-    let db = HotColdDB::<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>::open(
+    let db = HotColdDB::<E, BeaconNodeBackend, BeaconNodeBackend>::open(
         &hot_path,
         &cold_path,
         &blobs_path,
@@ -363,7 +363,7 @@ pub fn prune_blobs<E: EthSpec>(
     let cold_path = client_config.get_freezer_db_path();
     let blobs_path = client_config.get_blobs_db_path();
 
-    let db = HotColdDB::<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>::open(
+    let db = HotColdDB::<E, BeaconNodeBackend, BeaconNodeBackend>::open(
         &hot_path,
         &cold_path,
         &blobs_path,
@@ -398,7 +398,7 @@ pub fn prune_states<E: EthSpec>(
     let cold_path = client_config.get_freezer_db_path();
     let blobs_path = client_config.get_blobs_db_path();
 
-    let db = HotColdDB::<E, BeaconNodeBackend<E>, BeaconNodeBackend<E>>::open(
+    let db = HotColdDB::<E, BeaconNodeBackend, BeaconNodeBackend>::open(
         &hot_path,
         &cold_path,
         &blobs_path,


### PR DESCRIPTION
Neither trait used `E` in any method signature, associated type, or where clause — it was a phantom on both. Removing it simplifies the many `Hot: ItemStore<E>, Cold: ItemStore<E>` bounds across the codebase to plain `Hot: ItemStore, Cold: ItemStore`.

### AI disclosure 

Written by claude 4.7 on the prop: remove generic E from ItemStore and co, then reviewed it

