### PR TITLE
Dont penalize payload envelope peers after gossip verification

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -3956,7 +3956,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
     async fn process_gossip_verified_execution_payload_envelope(
         self: Arc<Self>,
-        peer_id: PeerId,
+        _peer_id: PeerId,
         verified_envelope: GossipVerifiedEnvelope<T>,
     ) {
         let _processing_start_time = Instant::now();
@@ -3977,44 +3977,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         // TODO(gloas) metrics
         // register_process_result_metrics(&result, metrics::BlockSource::Gossip, "envelope");
 
-        match &result {
-            Ok(AvailabilityProcessingStatus::Imported(_))
-            | Ok(AvailabilityProcessingStatus::MissingComponents(_, _)) => {
-                // Nothing to do
-            }
-            Err(e) => match e {
-                EnvelopeError::ExecutionPayloadError(epe) if !epe.penalize_peer() => {}
-                EnvelopeError::BadSignature
-                | EnvelopeError::BuilderIndexMismatch { .. }
-                | EnvelopeError::SlotMismatch { .. }
-                | EnvelopeError::BlockHashMismatch { .. }
-                | EnvelopeError::UnknownValidator { .. }
-                | EnvelopeError::IncorrectBlockProposer { .. }
-                | EnvelopeError::ExecutionPayloadError(_) => {
-                    self.gossip_penalize_peer(
-                        peer_id,
-                        PeerAction::LowToleranceError,
-                        "gossip_envelope_processing_low",
-                    );
-                }
-
-                EnvelopeError::EnvelopeProcessingError(_)
-                | EnvelopeError::BlockError(_)
-                | EnvelopeError::BlockRootUnknown { .. } => {
-                    self.gossip_penalize_peer(
-                        peer_id,
-                        PeerAction::LowToleranceError,
-                        "gossip_envelope_processing_error",
-                    );
-                }
-
-                EnvelopeError::PriorToFinalization { .. }
-                | EnvelopeError::OptimisticSyncNotSupported { .. }
-                | EnvelopeError::BeaconChainError(_)
-                | EnvelopeError::BeaconStateError(_)
-                | EnvelopeError::BlockProcessingError(_)
-                | EnvelopeError::InternalError(_) => {}
-            },
+        if let Err(e) = &result {
+            warn!(
+                ?beacon_block_root,
+                error = ?e,
+                "Execution payload envelope rejected"
+            );
         }
     }
 

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -3956,7 +3956,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
     async fn process_gossip_verified_execution_payload_envelope(
         self: Arc<Self>,
-        _peer_id: PeerId,
+        peer_id: PeerId,
         verified_envelope: GossipVerifiedEnvelope<T>,
     ) {
         let _processing_start_time = Instant::now();
@@ -3978,10 +3978,11 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         // register_process_result_metrics(&result, metrics::BlockSource::Gossip, "envelope");
 
         if let Err(e) = &result {
-            warn!(
+            debug!(
                 ?beacon_block_root,
+                %peer_id,
                 error = ?e,
-                "Execution payload envelope rejected"
+                "Execution payload envelope processing failed"
             );
         }
     }


### PR DESCRIPTION
## Issue Addressed

We got in a little bit of trouble in devnet-3. After gossip verifying an envelope and before importing it, we got the following error 

```
May 07 08:04:24.383 WARN  Execution payload envelope rejected           reason: "EnvelopeProcessingError(WithdrawalsRootMismatch { state: 0x852d38aaecc9f4e2e309919f74020c7bbcf050fea4a20edf3304f171e44ee9d5, payload: 
```

The envelope had already passed gossip verification checks and was correctly propagated to the network, we should not penalize peers for doing this. This caused our node to isolate itself from the rest of the network. This PR removes peer penalties for any envelope that passes gossip validation
