### PR TITLE
Fix stale `beacon_state_root` in test helpers

### DIFF
--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -325,7 +325,7 @@ mod test {
             .deterministic_keypairs(8)
             .fresh_ephemeral_store()
             .build();
-        let (mut state, _) = harness.get_current_state_and_root();
+        let mut state = harness.get_current_state();
         state
             .build_committee_cache(RelativeEpoch::Current, &harness.chain.spec)
             .unwrap();

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -3365,14 +3365,8 @@ where
         for epoch in min_epoch.as_u64()..=max_epoch.as_u64() {
             let mut new_chains = vec![];
 
-            for (
-                head_state,
-                slots,
-                validators,
-                mut block_hashes,
-                mut state_hashes,
-                head_block,
-            ) in chains
+            for (head_state, slots, validators, mut block_hashes, mut state_hashes, head_block) in
+                chains
             {
                 let epoch_slots = slots
                     .iter()

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -1570,6 +1570,15 @@ where
         mut state: Cow<BeaconState<E>>,
         state_root: Hash256,
     ) -> Result<Attestation<E>, BeaconChainError> {
+        assert_eq!(
+            state.get_latest_block_root(state_root),
+            beacon_block_root,
+            "State must match beacon block root, state slot {:?} attestation slot {:?} state root {:?}",
+            state.latest_block_header().slot,
+            slot,
+            state_root,
+        );
+
         let epoch = slot.epoch(E::slots_per_epoch());
 
         if state.slot() > slot {
@@ -1594,6 +1603,13 @@ where
             *state.get_block_root(target_slot)?
         };
 
+        let payload_present = state.fork_name_unchecked().gloas_enabled()
+            && state.latest_block_header().slot != slot
+            && self
+                .chain
+                .canonical_head
+                .block_has_canonical_payload(&beacon_block_root, &self.spec)?;
+
         Ok(Attestation::empty_for_signing(
             index,
             committee_len,
@@ -1604,7 +1620,7 @@ where
                 epoch,
                 root: target_root,
             },
-            false,
+            payload_present,
             &self.spec,
         )?)
     }
@@ -3111,13 +3127,11 @@ where
         &self,
         slot: Slot,
         state: BeaconState<E>,
-        state_root: Hash256,
         validators: &[usize],
     ) -> Result<(SignedBeaconBlockHash, BeaconState<E>), BlockError> {
         self.add_attested_block_at_slot_with_sync(
             slot,
             state,
-            state_root,
             validators,
             SyncCommitteeStrategy::NoValidators,
         )
@@ -3128,18 +3142,18 @@ where
         &self,
         slot: Slot,
         state: BeaconState<E>,
-        state_root: Hash256,
         validators: &[usize],
         sync_committee_strategy: SyncCommitteeStrategy,
     ) -> Result<(SignedBeaconBlockHash, BeaconState<E>), BlockError> {
-        let (block_hash, block, state) = self.add_block_at_slot(slot, state).await?;
-        self.attest_block(&state, state_root, block_hash, &block.0, validators);
+        let (block_hash, block, mut new_state) = self.add_block_at_slot(slot, state).await?;
+        let new_state_root = new_state.canonical_root().unwrap();
+        self.attest_block(&new_state, new_state_root, block_hash, &block.0, validators);
 
         if sync_committee_strategy == SyncCommitteeStrategy::AllValidators
-            && state.current_sync_committee().is_ok()
+            && new_state.current_sync_committee().is_ok()
         {
             self.sync_committee_sign_block(
-                &state,
+                &new_state,
                 block_hash.into(),
                 slot,
                 if (slot + 1).epoch(E::slots_per_epoch())
@@ -3153,19 +3167,17 @@ where
             );
         }
 
-        Ok((block_hash, state))
+        Ok((block_hash, new_state))
     }
 
     pub async fn add_attested_blocks_at_slots(
         &self,
         state: BeaconState<E>,
-        state_root: Hash256,
         slots: &[Slot],
         validators: &[usize],
     ) -> AddBlocksResult<E> {
         self.add_attested_blocks_at_slots_with_sync(
             state,
-            state_root,
             slots,
             validators,
             SyncCommitteeStrategy::NoValidators,
@@ -3176,7 +3188,6 @@ where
     pub async fn add_attested_blocks_at_slots_with_sync(
         &self,
         state: BeaconState<E>,
-        state_root: Hash256,
         slots: &[Slot],
         validators: &[usize],
         sync_committee_strategy: SyncCommitteeStrategy,
@@ -3184,7 +3195,6 @@ where
         assert!(!slots.is_empty());
         self.add_attested_blocks_at_slots_given_lbh(
             state,
-            state_root,
             slots,
             validators,
             None,
@@ -3241,7 +3251,6 @@ where
     pub async fn add_attested_blocks_at_slots_with_lc_data(
         &self,
         mut state: BeaconState<E>,
-        state_root: Hash256,
         slots: &[Slot],
         validators: &[usize],
         mut latest_block_hash: Option<SignedBeaconBlockHash>,
@@ -3255,7 +3264,6 @@ where
                 .add_attested_block_at_slot_with_sync(
                     *slot,
                     state,
-                    state_root,
                     validators,
                     sync_committee_strategy,
                 )
@@ -3281,7 +3289,6 @@ where
     async fn add_attested_blocks_at_slots_given_lbh(
         &self,
         mut state: BeaconState<E>,
-        state_root: Hash256,
         slots: &[Slot],
         validators: &[usize],
         mut latest_block_hash: Option<SignedBeaconBlockHash>,
@@ -3295,7 +3302,6 @@ where
             let (block_hash, new_state) = Box::pin(self.add_attested_block_at_slot_with_sync(
                 *slot,
                 state,
-                state_root,
                 validators,
                 sync_committee_strategy,
             ))
@@ -3360,7 +3366,7 @@ where
             let mut new_chains = vec![];
 
             for (
-                mut head_state,
+                head_state,
                 slots,
                 validators,
                 mut block_hashes,
@@ -3374,11 +3380,9 @@ where
                     .copied()
                     .collect::<Vec<_>>();
 
-                let head_state_root = head_state.update_tree_hash_cache().unwrap();
                 let (new_block_hashes, new_state_hashes, new_head_block, new_head_state) = self
                     .add_attested_blocks_at_slots_given_lbh(
                         head_state,
-                        head_state_root,
                         &epoch_slots,
                         &validators,
                         Some(head_block),
@@ -3540,7 +3544,7 @@ where
         sync_committee_strategy: SyncCommitteeStrategy,
         light_client_strategy: LightClientStrategy,
     ) -> Hash256 {
-        let (mut state, slots) = match block_strategy {
+        let (state, slots) = match block_strategy {
             BlockStrategy::OnCanonicalHead => {
                 let current_slot: u64 = self.get_current_slot().into();
                 let slots: Vec<Slot> = (current_slot..(current_slot + (num_blocks as u64)))
@@ -3569,12 +3573,10 @@ where
             AttestationStrategy::SomeValidators(vals) => vals,
         };
 
-        let state_root = state.update_tree_hash_cache().unwrap();
         let (_, _, last_produced_block_hash, _) = match light_client_strategy {
             LightClientStrategy::Enabled => {
                 self.add_attested_blocks_at_slots_with_lc_data(
                     state,
-                    state_root,
                     &slots,
                     &validators,
                     None,
@@ -3585,7 +3587,6 @@ where
             LightClientStrategy::Disabled => {
                 self.add_attested_blocks_at_slots_with_sync(
                     state,
-                    state_root,
                     &slots,
                     &validators,
                     sync_committee_strategy,

--- a/beacon_node/beacon_chain/tests/rewards.rs
+++ b/beacon_node/beacon_chain/tests/rewards.rs
@@ -105,7 +105,7 @@ async fn test_sync_committee_rewards() {
 
     // Add block
     let chain = &harness.chain;
-    let (head_state, _) = harness.get_current_state_and_root();
+    let head_state = harness.get_current_state();
     let target_slot = harness.get_current_slot() + 1;
 
     let (block_root, mut state) = harness

--- a/beacon_node/beacon_chain/tests/rewards.rs
+++ b/beacon_node/beacon_chain/tests/rewards.rs
@@ -105,11 +105,11 @@ async fn test_sync_committee_rewards() {
 
     // Add block
     let chain = &harness.chain;
-    let (head_state, head_state_root) = harness.get_current_state_and_root();
+    let (head_state, _) = harness.get_current_state_and_root();
     let target_slot = harness.get_current_slot() + 1;
 
     let (block_root, mut state) = harness
-        .add_attested_block_at_slot(target_slot, head_state, head_state_root, &[])
+        .add_attested_block_at_slot(target_slot, head_state, &[])
         .await
         .unwrap();
 

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -5630,7 +5630,7 @@ async fn test_gloas_block_replay_with_envelopes() {
     let harness = get_harness(store.clone(), LOW_VALIDATOR_COUNT);
 
     let num_blocks = 16u64;
-    let (genesis_state, _genesis_state_root) = harness.get_current_state_and_root();
+    let genesis_state = harness.get_current_state();
     let mut state = genesis_state.clone();
 
     let mut last_block_root = Hash256::zero();
@@ -5706,7 +5706,7 @@ async fn test_gloas_hot_state_hierarchy() {
     let num_blocks = E::slots_per_epoch() * 5;
     let all_validators = (0..LOW_VALIDATOR_COUNT).collect::<Vec<_>>();
 
-    let (genesis_state, _genesis_state_root) = harness.get_current_state_and_root();
+    let genesis_state = harness.get_current_state();
 
     // Use manual block building with envelopes for the first few blocks,
     // then use the standard attested-blocks path once we've verified envelope handling.
@@ -5746,7 +5746,7 @@ async fn test_gloas_hot_state_hierarchy() {
 
         last_block_root = block_root;
         state = block_state;
-    }
+
 
     // Head should be the block at slot 40 with full payload.
     let head = harness.chain.canonical_head.cached_head();

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -198,11 +198,10 @@ async fn light_client_bootstrap_test() {
     let num_initial_slots = E::slots_per_epoch() * 7;
     let slots: Vec<Slot> = (1..num_initial_slots).map(Slot::new).collect();
 
-    let (genesis_state, genesis_state_root) = harness.get_current_state_and_root();
+    let genesis_state = harness.get_current_state();
     harness
         .add_attested_blocks_at_slots_with_lc_data(
             genesis_state.clone(),
-            genesis_state_root,
             &slots,
             &all_validators,
             None,
@@ -258,14 +257,9 @@ async fn light_client_updates_test() {
     let num_initial_slots = E::slots_per_epoch() * 10;
     let slots: Vec<Slot> = (1..num_initial_slots).map(Slot::new).collect();
 
-    let (genesis_state, genesis_state_root) = harness.get_current_state_and_root();
+    let genesis_state = harness.get_current_state();
     harness
-        .add_attested_blocks_at_slots(
-            genesis_state.clone(),
-            genesis_state_root,
-            &slots,
-            &all_validators,
-        )
+        .add_attested_blocks_at_slots(genesis_state.clone(), &slots, &all_validators)
         .await;
 
     harness.advance_slot();
@@ -639,7 +633,7 @@ async fn forwards_iter_block_and_state_roots_until() {
 
     for slot in (1..=num_blocks_produced).map(Slot::from) {
         let (block_root, mut state) = harness
-            .add_attested_block_at_slot(slot, head_state, head_state_root, all_validators)
+            .add_attested_block_at_slot(slot, head_state, all_validators)
             .await
             .unwrap();
         head_state_root = state.update_tree_hash_cache().unwrap();
@@ -714,10 +708,10 @@ async fn block_replayer_hooks() {
     let max_slot = *block_slots.last().unwrap();
     let all_slots = (0..=max_slot.as_u64()).map(Slot::new).collect::<Vec<_>>();
 
-    let (state, state_root) = harness.get_current_state_and_root();
+    let state = harness.get_current_state();
     let all_validators = harness.get_all_validators();
     let (_, _, end_block_root, mut end_state) = harness
-        .add_attested_blocks_at_slots(state.clone(), state_root, &block_slots, &all_validators)
+        .add_attested_blocks_at_slots(state.clone(), &block_slots, &all_validators)
         .await;
 
     let blocks = store
@@ -786,10 +780,10 @@ async fn delete_blocks_and_states() {
 
     // Finalize an initial portion of the chain.
     let initial_slots: Vec<Slot> = (1..=unforked_blocks).map(Into::into).collect();
-    let (state, state_root) = harness.get_current_state_and_root();
+    let state = harness.get_current_state();
     let all_validators = harness.get_all_validators();
     harness
-        .add_attested_blocks_at_slots(state, state_root, &initial_slots, &all_validators)
+        .add_attested_blocks_at_slots(state, &initial_slots, &all_validators)
         .await;
 
     // Create a fork post-finalization.
@@ -924,10 +918,10 @@ async fn multi_epoch_fork_valid_blocks_test(
     // Create the initial portion of the chain
     if initial_blocks > 0 {
         let initial_slots: Vec<Slot> = (1..=initial_blocks).map(Into::into).collect();
-        let (state, state_root) = harness.get_current_state_and_root();
+        let state = harness.get_current_state();
         let all_validators = harness.get_all_validators();
         harness
-            .add_attested_blocks_at_slots(state, state_root, &initial_slots, &all_validators)
+            .add_attested_blocks_at_slots(state, &initial_slots, &all_validators)
             .await;
     }
 
@@ -1269,17 +1263,17 @@ async fn proposer_shuffling_root_consistency_test(
 
     // Build chain out to parent block.
     let initial_slots: Vec<Slot> = (1..=parent_slot).map(Into::into).collect();
-    let (state, state_root) = harness.get_current_state_and_root();
+    let state = harness.get_current_state();
     let all_validators = harness.get_all_validators();
     let (_, _, parent_root, _) = harness
-        .add_attested_blocks_at_slots(state, state_root, &initial_slots, &all_validators)
+        .add_attested_blocks_at_slots(state, &initial_slots, &all_validators)
         .await;
 
     // Add the child block.
-    let (state, state_root) = harness.get_current_state_and_root();
+    let state = harness.get_current_state();
     let all_validators = harness.get_all_validators();
     let (_, _, child_root, child_block_state) = harness
-        .add_attested_blocks_at_slots(state, state_root, &[child_slot], &all_validators)
+        .add_attested_blocks_at_slots(state, &[child_slot], &all_validators)
         .await;
 
     let child_block_epoch = child_slot.epoch(E::slots_per_epoch());
@@ -1591,10 +1585,10 @@ async fn proposer_duties_from_head_fulu() {
 
     // Build chain out to parent block.
     let initial_slots: Vec<Slot> = (1..=initial_blocks).map(Into::into).collect();
-    let (state, state_root) = harness.get_current_state_and_root();
+    let state = harness.get_current_state();
     let all_validators = harness.get_all_validators();
     let (_, _, head_block_root, head_state) = harness
-        .add_attested_blocks_at_slots(state, state_root, &initial_slots, &all_validators)
+        .add_attested_blocks_at_slots(state, &initial_slots, &all_validators)
         .await;
 
     // Compute the proposer duties at the next epoch from the head
@@ -1642,10 +1636,10 @@ async fn proposer_lookahead_gloas_fork_epoch() {
 
     // Build chain out to parent block.
     let initial_slots: Vec<Slot> = (1..=initial_blocks).map(Into::into).collect();
-    let (state, state_root) = harness.get_current_state_and_root();
+    let state = harness.get_current_state();
     let all_validators = harness.get_all_validators();
     let (_, _, head_block_root, mut head_state) = harness
-        .add_attested_blocks_at_slots(state, state_root, &initial_slots, &all_validators)
+        .add_attested_blocks_at_slots(state, &initial_slots, &all_validators)
         .await;
     let head_state_root = head_state.canonical_root().unwrap();
 
@@ -1681,7 +1675,7 @@ async fn proposer_lookahead_gloas_fork_epoch() {
     // Build a block in the Gloas fork epoch and assert that the shuffling does not change.
     let gloas_slots = vec![gloas_fork_epoch.start_slot(E::slots_per_epoch())];
     let (_, _, _, _) = harness
-        .add_attested_blocks_at_slots(head_state, head_state_root, &gloas_slots, &all_validators)
+        .add_attested_blocks_at_slots(head_state, &gloas_slots, &all_validators)
         .await;
 
     let (no_lookahead_indices, no_lookahead_dependent_root, _, _, no_lookahead_fork) =
@@ -1704,16 +1698,11 @@ async fn prunes_abandoned_fork_between_two_finalized_checkpoints() {
     let store = get_store(&db_path);
     let rig = get_harness(store.clone(), VALIDATOR_COUNT);
     let slots_per_epoch = rig.slots_per_epoch();
-    let (mut state, state_root) = rig.get_current_state_and_root();
+    let mut state = rig.get_current_state();
 
     let canonical_chain_slots: Vec<Slot> = (1..=rig.epoch_start_slot(1)).map(Slot::new).collect();
     let (canonical_chain_blocks_pre_finalization, _, _, new_state) = rig
-        .add_attested_blocks_at_slots(
-            state,
-            state_root,
-            &canonical_chain_slots,
-            &honest_validators,
-        )
+        .add_attested_blocks_at_slots(state, &canonical_chain_slots, &honest_validators)
         .await;
     state = new_state;
     let canonical_chain_slot: u64 = rig.get_current_slot().into();
@@ -1721,14 +1710,9 @@ async fn prunes_abandoned_fork_between_two_finalized_checkpoints() {
     let stray_slots: Vec<Slot> = (canonical_chain_slot + 1..rig.epoch_start_slot(2))
         .map(Slot::new)
         .collect();
-    let (current_state, current_state_root) = rig.get_current_state_and_root();
+    let current_state = rig.get_current_state();
     let (stray_blocks, stray_states, stray_head, _) = rig
-        .add_attested_blocks_at_slots(
-            current_state,
-            current_state_root,
-            &stray_slots,
-            &adversarial_validators,
-        )
+        .add_attested_blocks_at_slots(current_state, &stray_slots, &adversarial_validators)
         .await;
 
     // Precondition: Ensure all stray_blocks blocks are still known
@@ -1758,9 +1742,8 @@ async fn prunes_abandoned_fork_between_two_finalized_checkpoints() {
         ..=(canonical_chain_slot + slots_per_epoch * 5))
         .map(Slot::new)
         .collect();
-    let state_root = state.update_tree_hash_cache().unwrap();
     let (canonical_chain_blocks_post_finalization, _, _, _) = rig
-        .add_attested_blocks_at_slots(state, state_root, &finalization_slots, &honest_validators)
+        .add_attested_blocks_at_slots(state, &finalization_slots, &honest_validators)
         .await;
 
     // Postcondition: New blocks got finalized
@@ -1815,15 +1798,14 @@ async fn pruning_does_not_touch_abandoned_block_shared_with_canonical_chain() {
     let store = get_store(&db_path);
     let rig = get_harness(store.clone(), VALIDATOR_COUNT);
     let slots_per_epoch = rig.slots_per_epoch();
-    let (state, state_root) = rig.get_current_state_and_root();
+    let state = rig.get_current_state();
 
     // Fill up 0th epoch
     let canonical_chain_slots_zeroth_epoch: Vec<Slot> =
         (1..rig.epoch_start_slot(1)).map(Slot::new).collect();
-    let (_, _, _, mut state) = rig
+    let (_, _, _, state) = rig
         .add_attested_blocks_at_slots(
             state,
-            state_root,
             &canonical_chain_slots_zeroth_epoch,
             &honest_validators,
         )
@@ -1834,11 +1816,9 @@ async fn pruning_does_not_touch_abandoned_block_shared_with_canonical_chain() {
         ..=rig.epoch_start_slot(1) + 1)
         .map(Slot::new)
         .collect();
-    let state_root = state.update_tree_hash_cache().unwrap();
-    let (canonical_chain_blocks_first_epoch, _, shared_head, mut state) = rig
+    let (canonical_chain_blocks_first_epoch, _, shared_head, state) = rig
         .add_attested_blocks_at_slots(
             state.clone(),
-            state_root,
             &canonical_chain_slots_first_epoch,
             &honest_validators,
         )
@@ -1849,11 +1829,9 @@ async fn pruning_does_not_touch_abandoned_block_shared_with_canonical_chain() {
         ..=rig.epoch_start_slot(1) + 2)
         .map(Slot::new)
         .collect();
-    let state_root = state.update_tree_hash_cache().unwrap();
     let (stray_blocks, stray_states, stray_head, _) = rig
         .add_attested_blocks_at_slots(
             state.clone(),
-            state_root,
             &stray_chain_slots_first_epoch,
             &adversarial_validators,
         )
@@ -1890,9 +1868,8 @@ async fn pruning_does_not_touch_abandoned_block_shared_with_canonical_chain() {
         ..=(canonical_chain_slot + slots_per_epoch * 5))
         .map(Slot::new)
         .collect();
-    let state_root = state.update_tree_hash_cache().unwrap();
     let (canonical_chain_blocks, _, _, _) = rig
-        .add_attested_blocks_at_slots(state, state_root, &finalization_slots, &honest_validators)
+        .add_attested_blocks_at_slots(state, &finalization_slots, &honest_validators)
         .await;
 
     // Postconditions
@@ -1945,12 +1922,12 @@ async fn pruning_does_not_touch_blocks_prior_to_finalization() {
     let store = get_store(&db_path);
     let rig = get_harness(store.clone(), VALIDATOR_COUNT);
     let slots_per_epoch = rig.slots_per_epoch();
-    let (mut state, state_root) = rig.get_current_state_and_root();
+    let mut state = rig.get_current_state();
 
     // Fill up 0th epoch with canonical chain blocks
     let zeroth_epoch_slots: Vec<Slot> = (1..=rig.epoch_start_slot(1)).map(Slot::new).collect();
     let (canonical_chain_blocks, _, _, new_state) = rig
-        .add_attested_blocks_at_slots(state, state_root, &zeroth_epoch_slots, &honest_validators)
+        .add_attested_blocks_at_slots(state, &zeroth_epoch_slots, &honest_validators)
         .await;
     state = new_state;
     let canonical_chain_slot: u64 = rig.get_current_slot().into();
@@ -1959,14 +1936,8 @@ async fn pruning_does_not_touch_blocks_prior_to_finalization() {
     let first_epoch_slots: Vec<Slot> = ((rig.epoch_start_slot(1) + 1)..(rig.epoch_start_slot(2)))
         .map(Slot::new)
         .collect();
-    let state_root = state.update_tree_hash_cache().unwrap();
     let (stray_blocks, stray_states, stray_head, _) = rig
-        .add_attested_blocks_at_slots(
-            state.clone(),
-            state_root,
-            &first_epoch_slots,
-            &adversarial_validators,
-        )
+        .add_attested_blocks_at_slots(state.clone(), &first_epoch_slots, &adversarial_validators)
         .await;
 
     // Preconditions
@@ -1994,9 +1965,8 @@ async fn pruning_does_not_touch_blocks_prior_to_finalization() {
         ..=(canonical_chain_slot + slots_per_epoch * 4))
         .map(Slot::new)
         .collect();
-    let state_root = state.update_tree_hash_cache().unwrap();
     let (_, _, _, _) = rig
-        .add_attested_blocks_at_slots(state, state_root, &slots, &honest_validators)
+        .add_attested_blocks_at_slots(state, &slots, &honest_validators)
         .await;
 
     // Postconditions
@@ -2037,29 +2007,23 @@ async fn prunes_fork_growing_past_youngest_finalized_checkpoint() {
     let db_path = tempdir().unwrap();
     let store = get_store(&db_path);
     let rig = get_harness(store.clone(), VALIDATOR_COUNT);
-    let (state, state_root) = rig.get_current_state_and_root();
+    let state = rig.get_current_state();
 
     // Fill up 0th epoch with canonical chain blocks
     let zeroth_epoch_slots: Vec<Slot> = (1..=rig.epoch_start_slot(1)).map(Slot::new).collect();
-    let (canonical_blocks_zeroth_epoch, _, _, mut state) = rig
-        .add_attested_blocks_at_slots(state, state_root, &zeroth_epoch_slots, &honest_validators)
+    let (canonical_blocks_zeroth_epoch, _, _, state) = rig
+        .add_attested_blocks_at_slots(state, &zeroth_epoch_slots, &honest_validators)
         .await;
 
     // Fill up 1st epoch.  Contains a fork.
     let slots_first_epoch: Vec<Slot> = (rig.epoch_start_slot(1) + 1..rig.epoch_start_slot(2))
         .map(Into::into)
         .collect();
-    let state_root = state.update_tree_hash_cache().unwrap();
-    let (stray_blocks_first_epoch, stray_states_first_epoch, _, mut stray_state) = rig
-        .add_attested_blocks_at_slots(
-            state.clone(),
-            state_root,
-            &slots_first_epoch,
-            &adversarial_validators,
-        )
+    let (stray_blocks_first_epoch, stray_states_first_epoch, _, stray_state) = rig
+        .add_attested_blocks_at_slots(state.clone(), &slots_first_epoch, &adversarial_validators)
         .await;
-    let (canonical_blocks_first_epoch, _, _, mut canonical_state) = rig
-        .add_attested_blocks_at_slots(state, state_root, &slots_first_epoch, &honest_validators)
+    let (canonical_blocks_first_epoch, _, _, canonical_state) = rig
+        .add_attested_blocks_at_slots(state, &slots_first_epoch, &honest_validators)
         .await;
 
     // Fill up 2nd epoch.  Extends both the canonical chain and the fork.
@@ -2067,11 +2031,9 @@ async fn prunes_fork_growing_past_youngest_finalized_checkpoint() {
         ..=rig.epoch_start_slot(2) + 1)
         .map(Into::into)
         .collect();
-    let stray_state_root = stray_state.update_tree_hash_cache().unwrap();
     let (stray_blocks_second_epoch, stray_states_second_epoch, stray_head, _) = rig
         .add_attested_blocks_at_slots(
             stray_state,
-            stray_state_root,
             &stray_slots_second_epoch,
             &adversarial_validators,
         )
@@ -2114,10 +2076,8 @@ async fn prunes_fork_growing_past_youngest_finalized_checkpoint() {
     let canonical_slots: Vec<Slot> = (rig.epoch_start_slot(2)..=rig.epoch_start_slot(6))
         .map(Into::into)
         .collect();
-    let canonical_state_root = canonical_state.update_tree_hash_cache().unwrap();
     let (canonical_blocks, _, _, _) = Box::pin(rig.add_attested_blocks_at_slots(
         canonical_state,
-        canonical_state_root,
         &canonical_slots,
         &honest_validators,
     ))
@@ -2179,14 +2139,13 @@ async fn prunes_skipped_slots_states() {
     let db_path = tempdir().unwrap();
     let store = get_store(&db_path);
     let rig = get_harness(store.clone(), VALIDATOR_COUNT);
-    let (state, state_root) = rig.get_current_state_and_root();
+    let state = rig.get_current_state();
 
     let canonical_slots_zeroth_epoch: Vec<Slot> =
         (1..=rig.epoch_start_slot(1)).map(Into::into).collect();
-    let (canonical_blocks_zeroth_epoch, _, _, mut canonical_state) = rig
+    let (canonical_blocks_zeroth_epoch, _, _, canonical_state) = rig
         .add_attested_blocks_at_slots(
             state.clone(),
-            state_root,
             &canonical_slots_zeroth_epoch,
             &honest_validators,
         )
@@ -2197,11 +2156,9 @@ async fn prunes_skipped_slots_states() {
     let stray_slots: Vec<Slot> = ((skipped_slot + 1).into()..rig.epoch_start_slot(2))
         .map(Into::into)
         .collect();
-    let canonical_state_root = canonical_state.update_tree_hash_cache().unwrap();
     let (stray_blocks, stray_states, _, stray_state) = rig
         .add_attested_blocks_at_slots(
             canonical_state.clone(),
-            canonical_state_root,
             &stray_slots,
             &adversarial_validators,
         )
@@ -2242,14 +2199,8 @@ async fn prunes_skipped_slots_states() {
     let canonical_slots: Vec<Slot> = ((skipped_slot + 1).into()..rig.epoch_start_slot(7))
         .map(Into::into)
         .collect();
-    let canonical_state_root = canonical_state.update_tree_hash_cache().unwrap();
     let (canonical_blocks_post_finalization, _, _, _) = rig
-        .add_attested_blocks_at_slots(
-            canonical_state,
-            canonical_state_root,
-            &canonical_slots,
-            &honest_validators,
-        )
+        .add_attested_blocks_at_slots(canonical_state, &canonical_slots, &honest_validators)
         .await;
 
     // Postconditions
@@ -2304,14 +2255,13 @@ async fn finalizes_non_epoch_start_slot() {
     let db_path = tempdir().unwrap();
     let store = get_store(&db_path);
     let rig = get_harness(store.clone(), VALIDATOR_COUNT);
-    let (state, state_root) = rig.get_current_state_and_root();
+    let state = rig.get_current_state();
 
     let canonical_slots_zeroth_epoch: Vec<Slot> =
         (1..rig.epoch_start_slot(1)).map(Into::into).collect();
-    let (canonical_blocks_zeroth_epoch, _, _, mut canonical_state) = rig
+    let (canonical_blocks_zeroth_epoch, _, _, canonical_state) = rig
         .add_attested_blocks_at_slots(
             state.clone(),
-            state_root,
             &canonical_slots_zeroth_epoch,
             &honest_validators,
         )
@@ -2322,11 +2272,9 @@ async fn finalizes_non_epoch_start_slot() {
     let stray_slots: Vec<Slot> = ((skipped_slot + 1).into()..rig.epoch_start_slot(2))
         .map(Into::into)
         .collect();
-    let canonical_state_root = canonical_state.update_tree_hash_cache().unwrap();
     let (stray_blocks, stray_states, _, stray_state) = rig
         .add_attested_blocks_at_slots(
             canonical_state.clone(),
-            canonical_state_root,
             &stray_slots,
             &adversarial_validators,
         )
@@ -2367,14 +2315,8 @@ async fn finalizes_non_epoch_start_slot() {
     let canonical_slots: Vec<Slot> = ((skipped_slot + 1).into()..rig.epoch_start_slot(7))
         .map(Into::into)
         .collect();
-    let canonical_state_root = canonical_state.update_tree_hash_cache().unwrap();
     let (canonical_blocks_post_finalization, _, _, _) = rig
-        .add_attested_blocks_at_slots(
-            canonical_state,
-            canonical_state_root,
-            &canonical_slots,
-            &honest_validators,
-        )
+        .add_attested_blocks_at_slots(canonical_state, &canonical_slots, &honest_validators)
         .await;
 
     // Postconditions
@@ -2597,11 +2539,10 @@ async fn pruning_test(
 
     let start_slot = Slot::new(1);
     let divergence_slot = start_slot + num_initial_blocks;
-    let (state, state_root) = harness.get_current_state_and_root();
+    let state = harness.get_current_state();
     let (_, _, _, divergence_state) = harness
         .add_attested_blocks_at_slots(
             state,
-            state_root,
             &slots(start_slot, num_initial_blocks)[..],
             &honest_validators,
         )
@@ -2626,7 +2567,7 @@ async fn pruning_test(
             ),
         ])
         .await;
-    let (_, _, _, mut canonical_state) = chains.remove(0);
+    let (_, _, _, canonical_state) = chains.remove(0);
     let (stray_blocks, stray_states, _, stray_head_state) = chains.remove(0);
 
     let stray_head_slot = divergence_slot + num_fork_skips + num_fork_blocks - 1;
@@ -2650,11 +2591,9 @@ async fn pruning_test(
     // Trigger finalization
     let num_finalization_blocks = 4 * E::slots_per_epoch();
     let canonical_slot = divergence_slot + num_canonical_skips + num_canonical_middle_blocks;
-    let canonical_state_root = canonical_state.update_tree_hash_cache().unwrap();
     harness
         .add_attested_blocks_at_slots(
             canonical_state,
-            canonical_state_root,
             &slots(canonical_slot, num_finalization_blocks),
             &honest_validators,
         )
@@ -2862,14 +2801,9 @@ async fn reproduction_unaligned_checkpoint_sync_pruned_payload() {
     let harness = get_harness_import_all_data_columns(full_store.clone(), LOW_VALIDATOR_COUNT);
     let all_validators = (0..LOW_VALIDATOR_COUNT).collect::<Vec<_>>();
 
-    let (genesis_state, genesis_state_root) = harness.get_current_state_and_root();
+    let genesis_state = harness.get_current_state();
     harness
-        .add_attested_blocks_at_slots(
-            genesis_state.clone(),
-            genesis_state_root,
-            &slots,
-            &all_validators,
-        )
+        .add_attested_blocks_at_slots(genesis_state.clone(), &slots, &all_validators)
         .await;
 
     // Extract snapshot data from the harness.
@@ -3016,14 +2950,9 @@ async fn weak_subjectivity_sync_test(
 
     let all_validators = (0..LOW_VALIDATOR_COUNT).collect::<Vec<_>>();
 
-    let (genesis_state, genesis_state_root) = harness.get_current_state_and_root();
+    let genesis_state = harness.get_current_state();
     harness
-        .add_attested_blocks_at_slots(
-            genesis_state.clone(),
-            genesis_state_root,
-            &slots,
-            &all_validators,
-        )
+        .add_attested_blocks_at_slots(genesis_state.clone(), &slots, &all_validators)
         .await;
 
     let wss_block_root = harness
@@ -3831,14 +3760,9 @@ async fn process_blocks_and_attestations_for_unaligned_checkpoint() {
         .map(Slot::new)
         .collect::<Vec<_>>();
 
-    let (genesis_state, genesis_state_root) = harness.get_current_state_and_root();
+    let genesis_state = harness.get_current_state();
     harness
-        .add_attested_blocks_at_slots(
-            genesis_state.clone(),
-            genesis_state_root,
-            &slots,
-            &all_validators,
-        )
+        .add_attested_blocks_at_slots(genesis_state.clone(), &slots, &all_validators)
         .await;
 
     // Before the split slot becomes finalized, create two forking blocks that build on the split

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -5746,7 +5746,7 @@ async fn test_gloas_hot_state_hierarchy() {
 
         last_block_root = block_root;
         state = block_state;
-
+    }
 
     // Head should be the block at slot 40 with full payload.
     let head = harness.chain.canonical_head.cached_head();

--- a/beacon_node/beacon_chain/tests/sync_committee_verification.rs
+++ b/beacon_node/beacon_chain/tests/sync_committee_verification.rs
@@ -185,7 +185,6 @@ async fn aggregated_gossip_verification() {
     harness
         .add_attested_blocks_at_slots(
             state,
-            Hash256::zero(),
             &[Slot::new(1), Slot::new(2)],
             (0..VALIDATOR_COUNT).collect::<Vec<_>>().as_slice(),
         )
@@ -495,7 +494,7 @@ async fn aggregated_gossip_verification() {
     );
 
     harness
-        .add_attested_block_at_slot(target_slot, state, Hash256::zero(), &[])
+        .add_attested_block_at_slot(target_slot, state, &[])
         .await
         .expect("should add block");
 
@@ -519,7 +518,6 @@ async fn unaggregated_gossip_verification() {
     harness
         .add_attested_blocks_at_slots(
             state,
-            Hash256::zero(),
             &[Slot::new(1), Slot::new(2)],
             (0..VALIDATOR_COUNT).collect::<Vec<_>>().as_slice(),
         )
@@ -801,7 +799,7 @@ async fn unaggregated_gossip_verification() {
     );
 
     harness
-        .add_attested_block_at_slot(target_slot, state, Hash256::zero(), &[])
+        .add_attested_block_at_slot(target_slot, state, &[])
         .await
         .expect("should add block");
 

--- a/beacon_node/beacon_chain/tests/validator_monitor.rs
+++ b/beacon_node/beacon_chain/tests/validator_monitor.rs
@@ -47,7 +47,6 @@ async fn missed_blocks_across_epochs() {
     let harness = get_harness(VALIDATOR_COUNT, vec![]);
     let validator_monitor = &harness.chain.validator_monitor;
     let mut genesis_state = harness.get_current_state();
-    let genesis_state_root = genesis_state.update_tree_hash_cache().unwrap();
     let genesis_block_root = harness.head_block_root();
 
     // Skip a slot in the first epoch (to prime the cache inside the missed block function) and then
@@ -64,7 +63,7 @@ async fn missed_blocks_across_epochs() {
         .collect::<Vec<_>>();
 
     let (block_roots_by_slot, state_roots_by_slot, _, head_state) = harness
-        .add_attested_blocks_at_slots(genesis_state, genesis_state_root, &slots, &all_validators)
+        .add_attested_blocks_at_slots(genesis_state, &slots, &all_validators)
         .await;
 
     // Prime the proposer shuffling cache.

--- a/beacon_node/beacon_chain/tests/validator_monitor.rs
+++ b/beacon_node/beacon_chain/tests/validator_monitor.rs
@@ -46,7 +46,7 @@ async fn missed_blocks_across_epochs() {
 
     let harness = get_harness(VALIDATOR_COUNT, vec![]);
     let validator_monitor = &harness.chain.validator_monitor;
-    let mut genesis_state = harness.get_current_state();
+    let genesis_state = harness.get_current_state();
     let genesis_block_root = harness.head_block_root();
 
     // Skip a slot in the first epoch (to prime the cache inside the missed block function) and then

--- a/beacon_node/http_api/tests/fork_tests.rs
+++ b/beacon_node/http_api/tests/fork_tests.rs
@@ -58,12 +58,8 @@ async fn sync_committee_duties_across_fork() {
     // though the head state hasn't transitioned yet.
     let fork_slot = fork_epoch.start_slot(E::slots_per_epoch());
     let (genesis_state, _) = harness.get_current_state_and_root();
-    let (_, mut state) = harness
-        .add_attested_block_at_slot(
-            fork_slot - 1,
-            genesis_state,
-            &all_validators,
-        )
+    let (_, state) = harness
+        .add_attested_block_at_slot(fork_slot - 1, genesis_state, &all_validators)
         .await
         .unwrap();
 
@@ -78,7 +74,6 @@ async fn sync_committee_duties_across_fork() {
     assert_eq!(sync_duties.len(), E::sync_committee_size());
 
     // After applying a block at the fork slot the duties should remain unchanged.
-    let state_root = state.canonical_root().unwrap();
     harness
         .add_attested_block_at_slot(fork_slot, state, &all_validators)
         .await
@@ -295,12 +290,8 @@ async fn sync_committee_indices_across_fork() {
     // applied.
     let fork_slot = fork_epoch.start_slot(E::slots_per_epoch());
     let (genesis_state, _) = harness.get_current_state_and_root();
-    let (_, mut state) = harness
-        .add_attested_block_at_slot(
-            fork_slot - 1,
-            genesis_state,
-            &all_validators,
-        )
+    let (_, state) = harness
+        .add_attested_block_at_slot(fork_slot - 1, genesis_state, &all_validators)
         .await
         .unwrap();
 
@@ -332,7 +323,6 @@ async fn sync_committee_indices_across_fork() {
 
     // Once the head is updated it should be useable for requests, including in the next sync
     // committee period.
-    let state_root = state.canonical_root().unwrap();
     harness
         .add_attested_block_at_slot(fork_slot + 1, state, &all_validators)
         .await

--- a/beacon_node/http_api/tests/fork_tests.rs
+++ b/beacon_node/http_api/tests/fork_tests.rs
@@ -57,7 +57,7 @@ async fn sync_committee_duties_across_fork() {
     // If there's a skip slot at the fork slot, the endpoint should return duties, even
     // though the head state hasn't transitioned yet.
     let fork_slot = fork_epoch.start_slot(E::slots_per_epoch());
-    let (genesis_state, _) = harness.get_current_state_and_root();
+    let genesis_state = harness.get_current_state();
     let (_, state) = harness
         .add_attested_block_at_slot(fork_slot - 1, genesis_state, &all_validators)
         .await
@@ -289,7 +289,7 @@ async fn sync_committee_indices_across_fork() {
     // If there's a skip slot at the fork slot, the endpoint will return a 400 until a block is
     // applied.
     let fork_slot = fork_epoch.start_slot(E::slots_per_epoch());
-    let (genesis_state, _) = harness.get_current_state_and_root();
+    let genesis_state = harness.get_current_state();
     let (_, state) = harness
         .add_attested_block_at_slot(fork_slot - 1, genesis_state, &all_validators)
         .await

--- a/beacon_node/http_api/tests/fork_tests.rs
+++ b/beacon_node/http_api/tests/fork_tests.rs
@@ -57,12 +57,11 @@ async fn sync_committee_duties_across_fork() {
     // If there's a skip slot at the fork slot, the endpoint should return duties, even
     // though the head state hasn't transitioned yet.
     let fork_slot = fork_epoch.start_slot(E::slots_per_epoch());
-    let (genesis_state, genesis_state_root) = harness.get_current_state_and_root();
+    let (genesis_state, _) = harness.get_current_state_and_root();
     let (_, mut state) = harness
         .add_attested_block_at_slot(
             fork_slot - 1,
             genesis_state,
-            genesis_state_root,
             &all_validators,
         )
         .await
@@ -81,7 +80,7 @@ async fn sync_committee_duties_across_fork() {
     // After applying a block at the fork slot the duties should remain unchanged.
     let state_root = state.canonical_root().unwrap();
     harness
-        .add_attested_block_at_slot(fork_slot, state, state_root, &all_validators)
+        .add_attested_block_at_slot(fork_slot, state, &all_validators)
         .await
         .unwrap();
 
@@ -295,12 +294,11 @@ async fn sync_committee_indices_across_fork() {
     // If there's a skip slot at the fork slot, the endpoint will return a 400 until a block is
     // applied.
     let fork_slot = fork_epoch.start_slot(E::slots_per_epoch());
-    let (genesis_state, genesis_state_root) = harness.get_current_state_and_root();
+    let (genesis_state, _) = harness.get_current_state_and_root();
     let (_, mut state) = harness
         .add_attested_block_at_slot(
             fork_slot - 1,
             genesis_state,
-            genesis_state_root,
             &all_validators,
         )
         .await
@@ -336,7 +334,7 @@ async fn sync_committee_indices_across_fork() {
     // committee period.
     let state_root = state.canonical_root().unwrap();
     harness
-        .add_attested_block_at_slot(fork_slot + 1, state, state_root, &all_validators)
+        .add_attested_block_at_slot(fork_slot + 1, state, &all_validators)
         .await
         .unwrap();
 

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -944,10 +944,10 @@ mod release_tests {
     fn get_current_state_initialize_epoch_cache<E: EthSpec>(
         harness: &BeaconChainHarness<EphemeralHarnessType<E>>,
         spec: &ChainSpec,
-    ) -> BeaconState<E> {
-        let mut state = harness.get_current_state();
+    ) -> (BeaconState<E>, Hash256) {
+        let (mut state, state_root) = harness.get_current_state_and_root();
         initialize_epoch_cache(&mut state, spec).unwrap();
-        state
+        (state, state_root)
     }
 
     /// Test state for sync contribution-related tests.
@@ -965,7 +965,6 @@ mod release_tests {
         harness
             .add_attested_blocks_at_slots(
                 state,
-                Hash256::zero(),
                 &[Slot::new(1)],
                 (0..num_validators).collect::<Vec<_>>().as_slice(),
             )
@@ -983,7 +982,7 @@ mod release_tests {
             return;
         }
 
-        let mut state = get_current_state_initialize_epoch_cache(&harness, spec);
+        let (mut state, state_root) = get_current_state_initialize_epoch_cache(&harness, spec);
         let slot = state.slot();
         let committees = state
             .get_beacon_committees_at_slot(slot)
@@ -998,8 +997,8 @@ mod release_tests {
         let attestations = harness.make_attestations(
             (0..num_validators).collect::<Vec<_>>().as_slice(),
             &state,
-            Hash256::zero(),
-            SignedBeaconBlockHash::from(Hash256::zero()),
+            state_root,
+            harness.head_block_root().into(),
             slot,
         );
 
@@ -1065,7 +1064,7 @@ mod release_tests {
         let (harness, ref spec) = attestation_test_state::<MainnetEthSpec>(1);
 
         let op_pool = OperationPool::<MainnetEthSpec>::new();
-        let mut state = get_current_state_initialize_epoch_cache(&harness, spec);
+        let (mut state, state_root) = get_current_state_initialize_epoch_cache(&harness, spec);
 
         let slot = state.slot();
         let committees = state
@@ -1087,8 +1086,8 @@ mod release_tests {
         let attestations = harness.make_attestations(
             (0..num_validators).collect::<Vec<_>>().as_slice(),
             &state,
-            Hash256::zero(),
-            SignedBeaconBlockHash::from(Hash256::zero()),
+            state_root,
+            harness.head_block_root().into(),
             slot,
         );
 
@@ -1141,7 +1140,7 @@ mod release_tests {
     fn attestation_duplicate() {
         let (harness, ref spec) = attestation_test_state::<MainnetEthSpec>(1);
 
-        let state = get_current_state_initialize_epoch_cache(&harness, spec);
+        let (state, state_root) = get_current_state_initialize_epoch_cache(&harness, spec);
 
         let op_pool = OperationPool::<MainnetEthSpec>::new();
 
@@ -1158,8 +1157,8 @@ mod release_tests {
         let attestations = harness.make_attestations(
             (0..num_validators).collect::<Vec<_>>().as_slice(),
             &state,
-            Hash256::zero(),
-            SignedBeaconBlockHash::from(Hash256::zero()),
+            state_root,
+            harness.head_block_root().into(),
             slot,
         );
 
@@ -1184,7 +1183,7 @@ mod release_tests {
     fn attestation_pairwise_overlapping() {
         let (harness, ref spec) = attestation_test_state::<MainnetEthSpec>(1);
 
-        let state = get_current_state_initialize_epoch_cache(&harness, spec);
+        let (state, state_root) = get_current_state_initialize_epoch_cache(&harness, spec);
 
         let op_pool = OperationPool::<MainnetEthSpec>::new();
 
@@ -1202,8 +1201,8 @@ mod release_tests {
         let attestations = harness.make_attestations(
             (0..num_validators).collect::<Vec<_>>().as_slice(),
             &state,
-            Hash256::zero(),
-            SignedBeaconBlockHash::from(Hash256::zero()),
+            state_root,
+            harness.head_block_root().into(),
             slot,
         );
 
@@ -1279,7 +1278,7 @@ mod release_tests {
 
         let (harness, ref spec) = attestation_test_state::<MainnetEthSpec>(num_committees);
 
-        let mut state = get_current_state_initialize_epoch_cache(&harness, spec);
+        let (mut state, state_root) = get_current_state_initialize_epoch_cache(&harness, spec);
 
         let op_pool = OperationPool::<MainnetEthSpec>::new();
 
@@ -1300,8 +1299,8 @@ mod release_tests {
         let attestations = harness.make_attestations(
             (0..num_validators).collect::<Vec<_>>().as_slice(),
             &state,
-            Hash256::zero(),
-            SignedBeaconBlockHash::from(Hash256::zero()),
+            state_root,
+            harness.head_block_root().into(),
             slot,
         );
 
@@ -1385,7 +1384,7 @@ mod release_tests {
 
         let (harness, ref spec) = attestation_test_state::<MainnetEthSpec>(num_committees);
 
-        let mut state = get_current_state_initialize_epoch_cache(&harness, spec);
+        let (mut state, state_root) = get_current_state_initialize_epoch_cache(&harness, spec);
         let op_pool = OperationPool::<MainnetEthSpec>::new();
 
         let slot = state.slot();
@@ -1411,8 +1410,8 @@ mod release_tests {
         let attestations = harness.make_attestations(
             (0..num_validators).collect::<Vec<_>>().as_slice(),
             &state,
-            Hash256::zero(),
-            SignedBeaconBlockHash::from(Hash256::zero()),
+            state_root,
+            harness.head_block_root().into(),
             slot,
         );
 
@@ -2275,7 +2274,6 @@ mod release_tests {
         harness
             .add_attested_blocks_at_slots(
                 harness.get_current_state(),
-                Hash256::zero(),
                 &[Slot::new(1)],
                 (0..num_validators).collect::<Vec<_>>().as_slice(),
             )
@@ -2332,7 +2330,6 @@ mod release_tests {
         harness
             .add_attested_blocks_at_slots(
                 harness.get_current_state(),
-                Hash256::zero(),
                 &[Slot::new(1)],
                 (0..num_validators).collect::<Vec<_>>().as_slice(),
             )

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -897,7 +897,6 @@ mod release_tests {
         BeaconChainHarness, EphemeralHarnessType, RelativeSyncCommittee, test_spec,
     };
     use bls::Keypair;
-    use fixed_bytes::FixedBytesExtended;
     use maplit::hashset;
     use state_processing::epoch_cache::initialize_epoch_cache;
     use state_processing::{VerifyOperation, common::get_attesting_indices_from_state};

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -52,7 +52,6 @@ async fn get_harness<E: EthSpec>(
         harness
             .add_attested_blocks_at_slots(
                 state,
-                Hash256::zero(),
                 (1..last_slot_of_epoch.as_u64())
                     .map(Slot::new)
                     .collect::<Vec<_>>()

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType};
 use bls::{AggregateSignature, Keypair, PublicKeyBytes, Signature, SignatureBytes};
-use fixed_bytes::FixedBytesExtended;
 use ssz_types::Bitfield;
 use ssz_types::VariableList;
 use std::sync::{Arc, LazyLock};

--- a/consensus/state_processing/src/per_epoch_processing/tests.rs
+++ b/consensus/state_processing/src/per_epoch_processing/tests.rs
@@ -2,7 +2,6 @@
 use crate::per_epoch_processing::process_epoch;
 use beacon_chain::test_utils::BeaconChainHarness;
 use beacon_chain::types::{EthSpec, MinimalEthSpec};
-use bls::{FixedBytesExtended, Hash256};
 use types::Slot;
 
 #[tokio::test]
@@ -22,7 +21,6 @@ async fn runs_without_error() {
     harness
         .add_attested_blocks_at_slots(
             state,
-            Hash256::zero(),
             (1..target_slot.as_u64())
                 .map(Slot::new)
                 .collect::<Vec<_>>()

--- a/consensus/types/tests/committee_cache.rs
+++ b/consensus/types/tests/committee_cache.rs
@@ -47,7 +47,6 @@ async fn new_state<E: EthSpec>(validator_count: usize, slot: Slot) -> BeaconStat
         harness
             .add_attested_blocks_at_slots(
                 head_state,
-                Hash256::zero(),
                 (1..=slot.as_u64())
                     .map(Slot::new)
                     .collect::<Vec<_>>()

--- a/consensus/types/tests/state.rs
+++ b/consensus/types/tests/state.rs
@@ -39,7 +39,6 @@ async fn get_harness<E: EthSpec>(
         harness
             .add_attested_blocks_at_slots(
                 state,
-                Hash256::zero(),
                 slots.as_slice(),
                 (0..validator_count).collect::<Vec<_>>().as_slice(),
             )

--- a/testing/state_transition_vectors/src/main.rs
+++ b/testing/state_transition_vectors/src/main.rs
@@ -4,7 +4,6 @@ mod exit;
 
 use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType};
 use bls::Keypair;
-use fixed_bytes::FixedBytesExtended;
 use ssz::Encode;
 use std::env;
 use std::fs::{self, File};
@@ -13,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::sync::LazyLock;
 use types::{BeaconState, EthSpec, SignedBeaconBlock, test_utils::generate_deterministic_keypairs};
-use types::{Hash256, MainnetEthSpec, Slot};
+use types::{MainnetEthSpec, Slot};
 
 type E = MainnetEthSpec;
 
@@ -65,7 +64,6 @@ async fn get_harness<E: EthSpec>(
         harness
             .add_attested_blocks_at_slots(
                 state,
-                Hash256::zero(),
                 (skip_to_slot.as_u64()..slot.as_u64())
                     .map(Slot::new)
                     .collect::<Vec<_>>()


### PR DESCRIPTION
## Issue Addressed

Test helpers `add_attested_block_at_slot` and `add_attested_blocks_at_slot` accepted `state_root` argument which was computed before applying the block. 


