### PR TITLE
Use fork-choice finality for block slot checks

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1729,7 +1729,7 @@ fn check_block_against_finalized_slot<T: BeaconChainTypes>(
     // block which conflicts with the fork-choice view of finalization.
     let finalized_slot = chain
         .canonical_head
-        .cached_head()
+        .fork_choice_read_lock()
         .finalized_checkpoint()
         .epoch
         .start_slot(T::EthSpec::slots_per_epoch());


### PR DESCRIPTION
## Issue Addressed

Found while wiring the EF gossip-validation handler in #9256.

`check_block_against_finalized_slot` already documents that it should use fork choice's finality view rather than the cached head, because fork choice can be ahead of the cached head after block import / fork-choice processing. The implementation still read `canonical_head.cached_head()`, so a block at or before the fork-choice finalized slot could be checked against stale cached-head finality.

## Changes

- Read the finalized checkpoint from `canonical_head.fork_choice_read_lock()` in `check_block_against_finalized_slot`.
- Leave the existing rejection behavior unchanged once the finalized slot is computed.

## Testing

- `cargo check -p beacon_chain`
- `cargo fmt --check --package beacon_chain`
- `git diff --check`
