### PR TITLE
Gloas add spans for deposit signature verification

### DIFF
--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -901,6 +901,11 @@ pub fn process_deposit_requests_pre_gloas<E: EthSpec>(
     Ok(())
 }
 
+#[instrument(
+    name = "lh_process_deposit_requests_post_gloas",
+    skip_all,
+    level = "debug"
+)]
 pub fn process_deposit_requests_post_gloas<E: EthSpec>(
     state: &mut BeaconState<E>,
     deposit_requests: &[DepositRequest],
@@ -916,6 +921,7 @@ pub fn process_deposit_requests_post_gloas<E: EthSpec>(
 /// Check if there is a pending deposit for a new validator with the given pubkey.
 // TODO(gloas): cache the deposit signature validation or remove this loop entirely if possible,
 // it is `O(n * m)` where `n` is max 8192 and `m` is max 128M.
+#[instrument(name = "lh_is_pending_validator", skip_all, level = "debug")]
 fn is_pending_validator<E: EthSpec>(
     state: &BeaconState<E>,
     pubkey: &PublicKeyBytes,
@@ -994,6 +1000,7 @@ pub fn process_deposit_request_post_gloas<E: EthSpec>(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[instrument(name = "lh_apply_deposit_for_builder", skip_all, level = "debug")]
 pub fn apply_deposit_for_builder<E: EthSpec>(
     state: &mut BeaconState<E>,
     builder_index_opt: Option<BuilderIndex>,


### PR DESCRIPTION
## Issue Addressed

We want to be able to measure the time it takes to sig verify deposits. We'll probably have to make optimizations to this code path (maybe a pre-processing cache?) so it'll be nice to have metrics we can look at.

• lh_process_deposit_requests_post_gloas — total time for all deposits in the block
• lh_is_pending_validator — sig verification per validator deposit
• lh_apply_deposit_for_builder — sig verification for builder deposit

