### PR TITLE
Add fork choice write lock tracing context

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2318,6 +2318,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         indexed_payload_attestation: &IndexedPayloadAttestation<T::EthSpec>,
         ptc: &PTC<T::EthSpec>,
     ) -> Result<(), Error> {
+        let _fork_choice_span = debug_span!("payload_attestation_fork_choice_update").entered();
         self.canonical_head
             .fork_choice_write_lock()
             .on_payload_attestation(
@@ -2497,6 +2498,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         &self,
         verified: &impl VerifiedAttestation<T>,
     ) -> Result<(), Error> {
+        let _fork_choice_span = debug_span!("attestation_fork_choice_update").entered();
         self.canonical_head
             .fork_choice_write_lock()
             .on_attestation(
@@ -2842,6 +2844,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         attester_slashing: SigVerifiedOp<AttesterSlashing<T::EthSpec>, T::EthSpec>,
     ) {
         // Add to fork choice.
+        let _fork_choice_span = info_span!("attester_slashing_fork_choice_update").entered();
         self.canonical_head
             .fork_choice_write_lock()
             .on_attester_slashing(attester_slashing.as_inner().to_ref());
@@ -4186,6 +4189,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Take an upgradable read lock on fork choice so we can check if this block has already
         // been imported. We don't want to repeat work importing a block that is already imported.
+        let fork_choice_span = info_span!("block_import_fork_choice_update", ?block_root).entered();
         let fork_choice_reader = self.canonical_head.fork_choice_upgradable_read_lock();
         if fork_choice_reader.contains_block(&block_root) {
             return Err(BlockError::DuplicateFullyImported(block_root));
@@ -4383,6 +4387,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // The fork choice write-lock is dropped *after* the on-disk database has been updated.
         // This prevents inconsistency between the two at the expense of concurrency.
         drop(fork_choice);
+        drop(fork_choice_span);
 
         // We're declaring the block "imported" at this point, since fork choice and the DB know
         // about it.
@@ -6147,6 +6152,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let fork_choice_result = self
             .spawn_blocking_handle(
                 move || {
+                    let _fork_choice_span =
+                        info_span!("invalid_payload_fork_choice_update").entered();
                     chain
                         .canonical_head
                         .fork_choice_write_lock()
@@ -6524,6 +6531,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     let fork_choice_update_result = self
                         .spawn_blocking_handle(
                             move || {
+                                let _fork_choice_span =
+                                    info_span!("valid_payload_fork_choice_update").entered();
                                 chain
                                     .canonical_head
                                     .fork_choice_write_lock()

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1648,6 +1648,8 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
          * free real estate.
          */
         let current_slot = chain.slot()?;
+        let _fork_choice_span =
+            info_span!("block_attestations_fork_choice_update", ?block_root).entered();
         let mut fork_choice = chain.canonical_head.fork_choice_write_lock();
 
         // Register each attester slashing in the block with fork choice.

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -58,7 +58,7 @@ use store::{
     Error as StoreError, KeyValueStore, KeyValueStoreOp, StoreConfig, iter::StateRootsIterator,
 };
 use task_executor::{JoinHandle, ShutdownReason};
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, info_span, instrument, warn};
 use types::*;
 
 /// Simple wrapper around `RwLock` that uses private visibility to prevent any other modules from
@@ -629,6 +629,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         };
         let old_payload_status = old_cached_head.head_payload_status();
 
+        let fork_choice_span =
+            info_span!("recompute_head_fork_choice_update", %current_slot).entered();
         let mut fork_choice_write_lock = self.canonical_head.fork_choice_write_lock();
 
         // Recompute the current head via the fork choice algorithm.
@@ -637,6 +639,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // Downgrade the fork choice write-lock to a read lock, without allowing access to any
         // other writers.
         let fork_choice_read_lock = RwLockWriteGuard::downgrade(fork_choice_write_lock);
+        drop(fork_choice_span);
 
         // Read the current head value from the fork choice algorithm.
         let new_view = fork_choice_read_lock.cached_fork_choice_view();
@@ -1059,6 +1062,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         // Take a write-lock on the canonical head and signal for it to prune.
+        let _fork_choice_span = info_span!("finalization_fork_choice_prune").entered();
         self.canonical_head.fork_choice_write_lock().prune()?;
 
         Ok(())

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -236,6 +236,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // Everything in this initial section is on the hot path for processing the envelope.
         // Take an upgradable read lock on fork choice so we can check if this block has already
         // been imported. We don't want to repeat work importing a block that is already imported.
+        let fork_choice_span =
+            info_span!("payload_envelope_import_fork_choice_update", ?block_root).entered();
         let fork_choice_reader = self.canonical_head.fork_choice_upgradable_read_lock();
         if !fork_choice_reader.contains_block(&block_root) {
             return Err(EnvelopeError::BlockRootUnknown { block_root });
@@ -306,6 +308,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // The fork choice write-lock is dropped *after* the on-disk database has been updated.
         // This prevents inconsistency between the two at the expense of concurrency.
         drop(fork_choice);
+        drop(fork_choice_span);
 
         // We're declaring the envelope "imported" at this point, since fork choice and the DB know
         // about it.


### PR DESCRIPTION
## Issue Addressed

Part of #8147.

## Proposed Changes

Adds source-specific tracing spans around production fork-choice write-lock/update paths so lock wait spans have useful parent context in traces.

This is intentionally behavior-neutral:
- does not change fork choice locking semantics
- does not move DB writes outside the lock
- does not introduce a custom lock wrapper
- does not alter fork choice, payload, or block import logic

Covered paths include block import, payload envelope import, attestation/slashing application, recompute-head, finalization prune, and execution payload validity updates.

The instrumentation uses a frequency-aware span level split:
- low-frequency or issue-critical paths use `info_span!` so parent/source context is visible alongside the existing default `#[instrument]` fork-choice write-lock span in info-level tracing configurations
- high-volume attestation application paths use `debug_span!` to avoid adding info-level trace noise on gossip-heavy paths

## Additional Info

This follows the instrumentation-first direction discussed in #8147.

## Verifications Performed

- `cargo fmt --check`
- `cargo check -p beacon_chain`
- `git diff --check`