### PR TITLE
Remove outdated SPRP hint

### DIFF
--- a/beacon_node/http_api/src/beacon/states.rs
+++ b/beacon_node/http_api/src/beacon/states.rs
@@ -390,54 +390,34 @@ pub fn get_beacon_state_committees<T: BeaconChainTypes>(
                                     if let Some(shuffling) = maybe_cached_shuffling {
                                         shuffling
                                     } else {
-                                        let possibly_built_cache =
-                                            match RelativeEpoch::from_epoch(current_epoch, epoch) {
-                                                Ok(relative_epoch)
-                                                    if state.committee_cache_is_initialized(
-                                                        relative_epoch,
-                                                    ) =>
-                                                {
-                                                    state.committee_cache(relative_epoch).cloned()
-                                                }
-                                                _ => CommitteeCache::initialized(
-                                                    state,
-                                                    epoch,
-                                                    &chain.spec,
-                                                ),
+                                        let possibly_built_cache = match RelativeEpoch::from_epoch(
+                                            current_epoch,
+                                            epoch,
+                                        ) {
+                                            Ok(relative_epoch)
+                                                if state.committee_cache_is_initialized(
+                                                    relative_epoch,
+                                                ) =>
+                                            {
+                                                state.committee_cache(relative_epoch).cloned()
                                             }
-                                            .map_err(
-                                                |e| match e {
-                                                    BeaconStateError::EpochOutOfBounds => {
-                                                        let max_sprp =
-                                                            T::EthSpec::slots_per_historical_root()
-                                                                as u64;
-                                                        let first_subsequent_restore_point_slot =
-                                                            ((epoch.start_slot(
-                                                                T::EthSpec::slots_per_epoch(),
-                                                            ) / max_sprp)
-                                                                + 1)
-                                                                * max_sprp;
-                                                        if epoch < current_epoch {
-                                                            warp_utils::reject::custom_bad_request(
-                                                                format!(
-                                                        "epoch out of bounds, \
-                                                                 try state at slot {}",
-                                                        first_subsequent_restore_point_slot,
-                                                    ),
-                                                            )
-                                                        } else {
-                                                            warp_utils::reject::custom_bad_request(
-                                                                "epoch out of bounds, \
-                                                             too far in future"
-                                                                    .into(),
-                                                            )
-                                                        }
-                                                    }
-                                                    _ => warp_utils::reject::unhandled_error(
-                                                        BeaconChainError::from(e),
-                                                    ),
-                                                },
-                                            )?;
+                                            _ => CommitteeCache::initialized(
+                                                state,
+                                                epoch,
+                                                &chain.spec,
+                                            ),
+                                        }
+                                        .map_err(|e| match e {
+                                            BeaconStateError::EpochOutOfBounds => {
+                                                warp_utils::reject::custom_bad_request(format!(
+                                                    "epoch {} out of bounds for state at {}",
+                                                    epoch, current_epoch
+                                                ))
+                                            }
+                                            _ => warp_utils::reject::unhandled_error(
+                                                BeaconChainError::from(e),
+                                            ),
+                                        })?;
 
                                         // Attempt to write to the beacon cache (only if the cache
                                         // size is not the default value).


### PR DESCRIPTION
## Proposed Changes

While working on this code in another branch I noticed we had this messy, complicated and incorrect code about SPRP (slots-per-restore-point), which is no longer a relevant concept since the introduction of hot state diffs.

In the name of simplicity, I've removed any kind of hinting here in favour of a simple out of bounds error. The benefit of adding complex hinting code (which is not tested) to such a function is not worth it IMO. Users will work it out (or ask) if we just tell them their request is out of bounds.

## Additional Info

There's a bit of churn from `rustfmt`, which flip flops a bit with these deeply nested blocks and long format strings.
