### PR TITLE
Add support for jemalloc memory profiling

### DIFF
--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -37,6 +37,8 @@ beacon-node-redb = ["store/redb"]
 console-subscriber = ["console-subscriber/default"]
 # Force the use of the system memory allocator rather than jemalloc.
 sysmalloc = ["malloc_utils/sysmalloc"]
+# Enable jemalloc heap profiling support.
+jemalloc-profiling = ["malloc_utils/jemalloc-profiling"]
 
 [dependencies]
 account_manager = { "path" = "../account_manager" }


### PR DESCRIPTION
## Proposed Changes

Add a new feature flag to `lighthouse` which adds jemalloc profiling support.
We could manually add this during memory profiling but it is a nice QoL to have this built-in imo 
