### PR TITLE
Gloas proposer pref gossip validation bug

### DIFF
--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/gossip_verified_proposer_preferences.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/gossip_verified_proposer_preferences.rs
@@ -9,22 +9,21 @@ use crate::{
 use slot_clock::SlotClock;
 use state_processing::signature_sets::{get_pubkey_from_state, proposer_preferences_signature_set};
 use tracing::debug;
-use types::{
-    BeaconState, ChainSpec, EthSpec, ProposerPreferences, SignedProposerPreferences, Slot,
-};
+use types::{ChainSpec, EthSpec, ProposerPreferences, SignedProposerPreferences, Slot};
 
-/// Verify that proposer preferences are consistent with the current chain state
+/// Verify cheap consistency checks on proposer preferences (epoch range and slot).
 pub(crate) fn verify_preferences_consistency<E: EthSpec>(
     preferences: &ProposerPreferences,
     current_slot: Slot,
-    head_state: &BeaconState<E>,
+    spec: &ChainSpec,
 ) -> Result<(), ProposerPreferencesError> {
     let proposal_slot = preferences.proposal_slot;
-    let validator_index = preferences.validator_index;
     let current_epoch = current_slot.epoch(E::slots_per_epoch());
     let proposal_epoch = proposal_slot.epoch(E::slots_per_epoch());
 
-    if proposal_epoch < current_epoch || proposal_epoch > current_epoch.saturating_add(1u64) {
+    if proposal_epoch < current_epoch
+        || proposal_epoch > current_epoch.saturating_add(spec.min_seed_lookahead)
+    {
         return Err(ProposerPreferencesError::InvalidProposalEpoch { proposal_epoch });
     }
 
@@ -32,13 +31,6 @@ pub(crate) fn verify_preferences_consistency<E: EthSpec>(
         return Err(ProposerPreferencesError::ProposalSlotAlreadyPassed {
             proposal_slot,
             current_slot,
-        });
-    }
-
-    if !head_state.is_valid_proposal_slot(preferences)? {
-        return Err(ProposerPreferencesError::InvalidProposalSlot {
-            validator_index,
-            proposal_slot,
         });
     }
 
@@ -83,7 +75,28 @@ impl GossipVerifiedProposerPreferences {
             });
         }
 
-        verify_preferences_consistency(&signed_preferences.message, current_slot, head_state)?;
+        verify_preferences_consistency::<T::EthSpec>(
+            &signed_preferences.message,
+            current_slot,
+            ctx.spec,
+        )?;
+
+        let fork_choice = ctx.canonical_head.fork_choice_read_lock();
+        if !fork_choice.contains_block(&dependent_root) {
+            return Err(ProposerPreferencesError::DependentRootUnknown { dependent_root });
+        }
+        let head_root = cached_head.head_block_root();
+        if !fork_choice.is_descendant(dependent_root, head_root) {
+            return Err(ProposerPreferencesError::DependentRootNotCanonical { dependent_root });
+        }
+        drop(fork_choice);
+
+        if !head_state.is_valid_proposal_slot(&signed_preferences.message)? {
+            return Err(ProposerPreferencesError::InvalidProposalSlot {
+                validator_index,
+                proposal_slot,
+            });
+        }
 
         // Verify signature
         proposer_preferences_signature_set(
@@ -154,9 +167,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
 #[cfg(test)]
 mod tests {
-    use types::{
-        Address, BeaconState, EthSpec, Hash256, MinimalEthSpec, ProposerPreferences, Slot,
-    };
+    use types::{Address, ChainSpec, EthSpec, Hash256, MinimalEthSpec, ProposerPreferences, Slot};
 
     use super::verify_preferences_consistency;
     use crate::proposer_preferences_verification::ProposerPreferencesError;
@@ -173,8 +184,8 @@ mod tests {
         }
     }
 
-    fn state() -> BeaconState<E> {
-        BeaconState::new(0, <_>::default(), &E::default_spec())
+    fn spec() -> ChainSpec {
+        E::default_spec()
     }
 
     #[test]
@@ -182,7 +193,7 @@ mod tests {
         let current_slot = Slot::new(2 * E::slots_per_epoch());
         let prefs = make_preferences(Slot::new(3), 0);
 
-        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &state());
+        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &spec());
         assert!(matches!(
             result,
             Err(ProposerPreferencesError::InvalidProposalEpoch { .. })
@@ -194,7 +205,7 @@ mod tests {
         let current_slot = Slot::new(E::slots_per_epoch());
         let prefs = make_preferences(Slot::new(3 * E::slots_per_epoch() + 1), 0);
 
-        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &state());
+        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &spec());
         assert!(matches!(
             result,
             Err(ProposerPreferencesError::InvalidProposalEpoch { .. })
@@ -206,7 +217,7 @@ mod tests {
         let current_slot = Slot::new(10);
         let prefs = make_preferences(Slot::new(9), 0);
 
-        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &state());
+        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &spec());
         assert!(matches!(
             result,
             Err(ProposerPreferencesError::ProposalSlotAlreadyPassed { .. })
@@ -218,7 +229,7 @@ mod tests {
         let current_slot = Slot::new(10);
         let prefs = make_preferences(Slot::new(10), 0);
 
-        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &state());
+        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &spec());
         assert!(matches!(
             result,
             Err(ProposerPreferencesError::ProposalSlotAlreadyPassed { .. })

--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/mod.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-use types::{BeaconStateError, Epoch, Slot};
+use types::{BeaconStateError, Epoch, Hash256, Slot};
 
 use crate::BeaconChainError;
 
@@ -38,6 +38,10 @@ pub enum ProposerPreferencesError {
     },
     /// The slot clock cannot be read.
     UnableToReadSlot,
+    /// The block with root `dependent_root` has not been seen.
+    DependentRootUnknown { dependent_root: Hash256 },
+    /// The block with root `dependent_root` is not canonical.
+    DependentRootNotCanonical { dependent_root: Hash256 },
     /// A valid message from this validator for this slot has already been seen.
     AlreadySeen {
         validator_index: u64,

--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
@@ -36,6 +36,7 @@ struct TestContext {
     preferences_cache: GossipVerifiedProposerPreferenceCache,
     slot_clock: TestingSlotClock,
     spec: ChainSpec,
+    genesis_block_root: Hash256,
 }
 
 impl TestContext {
@@ -91,6 +92,7 @@ impl TestContext {
             preferences_cache: GossipVerifiedProposerPreferenceCache::default(),
             slot_clock,
             spec,
+            genesis_block_root: block_root,
         }
     }
 
@@ -124,10 +126,11 @@ impl TestContext {
 fn make_signed_preferences(
     proposal_slot: Slot,
     validator_index: u64,
+    dependent_root: Hash256,
 ) -> Arc<SignedProposerPreferences> {
     Arc::new(SignedProposerPreferences {
         message: ProposerPreferences {
-            dependent_root: Hash256::ZERO,
+            dependent_root,
             proposal_slot,
             validator_index,
             fee_recipient: Address::ZERO,
@@ -145,13 +148,14 @@ fn already_seen_validator() {
     let ctx = TestContext::new();
     let gossip = ctx.gossip_ctx();
     let slot = Slot::new(1);
+    let root = ctx.genesis_block_root;
 
     let verified = GossipVerifiedProposerPreferences {
-        signed_preferences: make_signed_preferences(slot, 42),
+        signed_preferences: make_signed_preferences(slot, 42, root),
     };
     ctx.preferences_cache.insert_seen_validator(&verified);
 
-    let prefs = make_signed_preferences(slot, 42);
+    let prefs = make_signed_preferences(slot, 42, root);
     let result = GossipVerifiedProposerPreferences::new(prefs, &gossip);
     assert!(matches!(
         result,
@@ -171,7 +175,7 @@ fn invalid_epoch_too_far_ahead() {
     let gossip = ctx.gossip_ctx();
 
     let far_slot = Slot::new(3 * E::slots_per_epoch());
-    let prefs = make_signed_preferences(far_slot, 0);
+    let prefs = make_signed_preferences(far_slot, 0, ctx.genesis_block_root);
     let result = GossipVerifiedProposerPreferences::new(prefs, &gossip);
     assert!(matches!(
         result,
@@ -187,7 +191,7 @@ fn proposal_slot_already_passed() {
     let ctx = TestContext::new();
     let gossip = ctx.gossip_ctx();
 
-    let prefs = make_signed_preferences(Slot::new(0), 0);
+    let prefs = make_signed_preferences(Slot::new(0), 0, ctx.genesis_block_root);
     let result = GossipVerifiedProposerPreferences::new(prefs, &gossip);
     assert!(matches!(
         result,
@@ -207,7 +211,7 @@ fn wrong_proposer_for_slot() {
     let actual_proposer = ctx.proposer_at_slot(slot);
     let wrong_validator = if actual_proposer == 0 { 1 } else { 0 };
 
-    let prefs = make_signed_preferences(slot, wrong_validator);
+    let prefs = make_signed_preferences(slot, wrong_validator, ctx.genesis_block_root);
     let result = GossipVerifiedProposerPreferences::new(prefs, &gossip);
     assert!(matches!(
         result,
@@ -223,9 +227,10 @@ fn correct_proposer_bad_signature() {
     let ctx = TestContext::new();
     let gossip = ctx.gossip_ctx();
     let slot = Slot::new(1);
+    let root = ctx.genesis_block_root;
 
     let actual_proposer = ctx.proposer_at_slot(slot);
-    let prefs = make_signed_preferences(slot, actual_proposer);
+    let prefs = make_signed_preferences(slot, actual_proposer, root);
     let result = GossipVerifiedProposerPreferences::new(prefs, &gossip);
     assert!(matches!(
         result,
@@ -233,7 +238,7 @@ fn correct_proposer_bad_signature() {
     ));
     assert!(
         !ctx.preferences_cache
-            .get_seen_validator(&slot, Hash256::ZERO, actual_proposer)
+            .get_seen_validator(&slot, root, actual_proposer)
     );
     assert!(ctx.preferences_cache.get_preferences(&slot).is_none());
 }
@@ -247,11 +252,28 @@ fn validator_index_out_of_bounds() {
     let gossip = ctx.gossip_ctx();
     let slot = Slot::new(1);
 
-    let prefs = make_signed_preferences(slot, u64::MAX);
+    let prefs = make_signed_preferences(slot, u64::MAX, ctx.genesis_block_root);
     let result = GossipVerifiedProposerPreferences::new(prefs, &gossip);
     assert!(matches!(
         result,
         Err(ProposerPreferencesError::InvalidProposalSlot { .. })
+    ));
+}
+
+#[test]
+fn dependent_root_unknown() {
+    if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
+    let ctx = TestContext::new();
+    let gossip = ctx.gossip_ctx();
+    let slot = Slot::new(1);
+
+    let prefs = make_signed_preferences(slot, 0, Hash256::repeat_byte(0xff));
+    let result = GossipVerifiedProposerPreferences::new(prefs, &gossip);
+    assert!(matches!(
+        result,
+        Err(ProposerPreferencesError::DependentRootUnknown { .. })
     ));
 }
 

--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
@@ -326,7 +326,7 @@ fn preferences_for_next_epoch_slot() {
     let next_epoch_slot = Slot::new(E::slots_per_epoch() + 1);
     let actual_proposer = ctx.proposer_at_slot(next_epoch_slot);
 
-    let prefs = make_signed_preferences(next_epoch_slot, actual_proposer);
+    let prefs = make_signed_preferences(next_epoch_slot, actual_proposer, ctx.genesis_block_root);
     let result = GossipVerifiedProposerPreferences::new(prefs, &gossip);
     // Should pass consistency checks but fail on signature (empty sig).
     assert!(

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -4111,6 +4111,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 ProposerPreferencesError::AlreadySeen { .. }
                 | ProposerPreferencesError::InvalidProposalEpoch { .. }
                 | ProposerPreferencesError::ProposalSlotAlreadyPassed { .. }
+                | ProposerPreferencesError::DependentRootUnknown { .. }
+                | ProposerPreferencesError::DependentRootNotCanonical { .. }
                 | ProposerPreferencesError::BeaconChainError(_)
                 | ProposerPreferencesError::BeaconStateError(_)
                 | ProposerPreferencesError::UnableToReadSlot,

--- a/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
@@ -601,17 +601,18 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
                         exceeded_retries: _,
                     } = coupling_error
                 {
-                    for (column_index, faulty_peer) in faulty_peers {
+                    let unique_faulty_peers: HashSet<PeerId> =
+                        faulty_peers.iter().map(|(_, peer)| *peer).collect();
+                    for faulty_peer in unique_faulty_peers {
                         debug!(
                             ?error,
-                            ?column_index,
                             ?faulty_peer,
                             "Custody backfill sync penalizing peer"
                         );
                         network.report_peer(
                             faulty_peer,
                             PeerAction::LowToleranceError,
-                            "Peer failed to serve column",
+                            "Peer failed to serve columns",
                         );
                     }
                 }


### PR DESCRIPTION
## Issue Addressed

Fix issues with gossip proposer preference verification 

I also snuck in another change to the way we penalize peers when we custody backfill. Before this fix we would iterate over faulty peers and applie a low tolerance error for each column a peer failed to serve. For peers appearing multiple times, they would be penalized multiple times for a single batch failure. Now with this PR we only penalize a peer at most once per batch. 