### PR TITLE
Advance head state to current slot for proposer_preferences gossip validation

### DIFF
--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/gossip_verified_proposer_preferences.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/gossip_verified_proposer_preferences.rs
@@ -2,10 +2,12 @@ use std::sync::Arc;
 
 use crate::{
     BeaconChain, BeaconChainTypes, CanonicalHead,
+    beacon_proposer_cache::{self, BeaconProposerCache},
     proposer_preferences_verification::{
         ProposerPreferencesError, proposer_preference_cache::GossipVerifiedProposerPreferenceCache,
     },
 };
+use parking_lot::Mutex;
 use slot_clock::SlotClock;
 use state_processing::signature_sets::{get_pubkey_from_state, proposer_preferences_signature_set};
 use tracing::debug;
@@ -42,6 +44,7 @@ pub struct GossipVerificationContext<'a, T: BeaconChainTypes> {
     pub gossip_verified_proposer_preferences_cache: &'a GossipVerifiedProposerPreferenceCache,
     pub slot_clock: &'a T::SlotClock,
     pub spec: &'a ChainSpec,
+    pub beacon_proposer_cache: &'a Mutex<BeaconProposerCache>,
 }
 
 /// A wrapper around `SignedProposerPreferences` that has been verified for gossip propagation.
@@ -91,7 +94,26 @@ impl GossipVerifiedProposerPreferences {
         }
         drop(fork_choice);
 
-        if !head_state.is_valid_proposal_slot(&signed_preferences.message, ctx.spec)? {
+        // Look up the proposer for `proposal_slot` via the proposer shuffling cache, keyed by
+        // `(proposal_epoch, dependent_root)` per the spec. The cache handles state advances and
+        // state loading on miss, so we avoid using the (potentially stale at an epoch boundary)
+        // cached head state's `proposer_lookahead` directly.
+        let proposal_epoch = proposal_slot.epoch(T::EthSpec::slots_per_epoch());
+        let head_state_root = cached_head.head_state_root();
+        let proposer = beacon_proposer_cache::with_proposer_cache::<
+            T::EthSpec,
+            _,
+            ProposerPreferencesError,
+        >(
+            ctx.beacon_proposer_cache,
+            dependent_root,
+            proposal_epoch,
+            |proposers| proposers.get_slot::<T::EthSpec>(proposal_slot),
+            || Ok((head_state_root, cached_head.snapshot.beacon_state.clone())),
+            ctx.spec,
+        )?;
+
+        if proposer.index as u64 != validator_index {
             return Err(ProposerPreferencesError::InvalidProposalSlot {
                 validator_index,
                 proposal_slot,
@@ -132,6 +154,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .gossip_verified_proposer_preferences_cache,
             slot_clock: &self.slot_clock,
             spec: &self.spec,
+            beacon_proposer_cache: &self.beacon_proposer_cache,
         }
     }
 

--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use bls::Signature;
 use fork_choice::ForkChoice;
 use genesis::{generate_deterministic_keypairs, interop_genesis_state};
+use parking_lot::Mutex;
 use proto_array::PayloadStatus;
 use slot_clock::{SlotClock, TestingSlotClock};
 use store::{HotColdDB, StoreConfig};
@@ -14,6 +15,7 @@ use types::{
 
 use crate::{
     beacon_fork_choice_store::BeaconForkChoiceStore,
+    beacon_proposer_cache::BeaconProposerCache,
     beacon_snapshot::BeaconSnapshot,
     canonical_head::CanonicalHead,
     proposer_preferences_verification::{
@@ -37,6 +39,7 @@ struct TestContext {
     slot_clock: TestingSlotClock,
     spec: ChainSpec,
     genesis_block_root: Hash256,
+    beacon_proposer_cache: Arc<Mutex<BeaconProposerCache>>,
 }
 
 impl TestContext {
@@ -93,6 +96,7 @@ impl TestContext {
             slot_clock,
             spec,
             genesis_block_root: block_root,
+            beacon_proposer_cache: Arc::new(Mutex::new(BeaconProposerCache::default())),
         }
     }
 
@@ -102,6 +106,7 @@ impl TestContext {
             gossip_verified_proposer_preferences_cache: &self.preferences_cache,
             slot_clock: &self.slot_clock,
             spec: &self.spec,
+            beacon_proposer_cache: &self.beacon_proposer_cache,
         }
     }
 


### PR DESCRIPTION
## Summary

Reproduced on a 10-CL Kurtosis enclave (glamsterdam-devnet-4 source on 2026-05-22): at every epoch boundary, both Lighthouse nodes start rejecting `proposer_preferences` messages from Grandine 2.0.4 and Prysm with `InvalidProposalSlot`, applying a `LowToleranceError` penalty each time. The penalties accumulate to the disconnect/ban threshold in ~3 minutes, repeatedly ejecting those peers and producing the visible peer-loss pattern in the `Synced` log (peers: 5 ↔ 7 oscillation).

The publishers are spec-correct. Walking through the slot 23 reject as a concrete example:

- 07:39:45.001 — fork transition `Fulu → Gloas` at slot 8 (start of epoch 1, `SLOTS_PER_EPOCH=8`)
- 07:39:45.119 — `Rejected gossip proposer preferences error: InvalidProposalSlot { validator_index: 405, proposal_slot: Slot(23) }`
- Slot 23 is later proposed and finalized by validator 405 (visible in the explorer), so the publisher's `(validator_index, proposal_slot)` tuple is factually right.

## Root cause

`BeaconState::is_valid_proposal_slot` indexes into `state.proposer_lookahead`, which only covers `[state.current_epoch, state.current_epoch + min_seed_lookahead]`. The gossip verifier passes `cached_head.snapshot.beacon_state` — i.e. the head state at the last imported block. At an epoch boundary the cached head is still the last block of the previous epoch (the new epoch's first block has not yet arrived), so `head_state.current_epoch()` lags `slot_clock.now().epoch()` by one. The lookahead does **not** cover `current_slot.epoch() + min_seed_lookahead`, so `is_valid_proposal_slot` returns `false`, and the inner `InvalidProposalSlot` REJECT fires for every legitimate `current_epoch + 1` message published right at the epoch boundary.

`verify_preferences_consistency` correctly accepts these messages against the slot clock; only the inner check using the lagging head state disagrees.

Spec rule reference (`specs/gloas/p2p-interface.md` → `proposer_preferences`):

```python
def is_valid_proposal_slot(state: BeaconState, preferences: ProposerPreferences) -> bool:
    current_epoch = get_current_epoch(state)
    proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
    ...
    return state.proposer_lookahead[index] == preferences.validator_index
```

> `state` is the checkpoint state at the epoch `compute_epoch_at_slot(preferences.proposal_slot) - MIN_SEED_LOOKAHEAD` and the root `preferences.dependent_root`.

The fully spec-faithful fix is to load that checkpoint state. This PR takes a smaller, pragmatic step that mirrors the existing pattern in `payload_attestation_verification::gossip_verified_payload_attestation`: when the head state's lookahead does not cover the relevant epoch, load an advanced state (and `partial_state_advance` it to `current_slot` if needed) and use that for the lookahead and signature checks. This converges with the spec result in practice for any in-window message and stops the bans.

## Changes

- `gossip_verified_proposer_preferences.rs`: when `current_slot.epoch() > head_state.current_epoch() + min_seed_lookahead`, call `store.get_advanced_hot_state(head_block_root, current_slot, head_state_root)` and `partial_state_advance` it to `current_slot` if still behind. Pass the advanced state to `is_valid_proposal_slot` and the signature set.
- Extend `GossipVerificationContext` with `store: &BeaconStore<T>`; thread `&self.store` through in `proposer_preferences_gossip_verification_context`.
- Update the test harness to hold `store` so `gossip_ctx()` can populate the new field.

## Test plan

- [x] `cargo check -p beacon_chain -p network -p http_api` — clean.
- [x] `FORK_NAME=gloas cargo test -p beacon_chain --lib proposer_preferences_verification` — all 15 existing tests pass (12 verifier + 2 cache + 1 already_seen).
- [ ] A dedicated regression test for the head-state-lag scenario would be welcome; writing one needs to manually `partial_state_advance` a state in the test to compute the actual proposer at `current_epoch + 1`, then drive the slot clock past the head state. Happy to add this in a follow-up if maintainers would like it in-tree.
- [ ] Re-run a multi-client Kurtosis enclave with this patch and confirm Grandine and Prysm peers stop getting banned. (Will edit the PR with results once I rebuild the CL image.)

## Notes

- Bug observed against `Lighthouse/v8.1.3-8ec2936` in the container, which predates commit 1aa28904eb ("min seed lookahead"). That earlier commit fixed the hardcoded `+1` to use `spec.min_seed_lookahead` but did not change which state is used. So even after that commit the lag bug remains, which is what this PR addresses.
- This change does NOT address the wider spec deviation of using `head_state` rather than the `dependent_root` checkpoint state. That would be a larger refactor (state-by-block-root load + reprocess queue for missing dependent_root). This PR fixes the immediate user-visible problem; a follow-up can pursue full spec conformance.