### PR TITLE
Gloas data column reprocess queue

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -41,8 +41,8 @@
 pub use crate::scheduler::BeaconProcessorQueueLengths;
 use crate::scheduler::work_queue::WorkQueues;
 use crate::work_reprocessing_queue::{
-    QueuedBackfillBatch, QueuedColumnReconstruction, QueuedGossipBlock, QueuedGossipEnvelope,
-    ReprocessQueueMessage,
+    QueuedBackfillBatch, QueuedColumnReconstruction, QueuedGossipBlock, QueuedGossipDataColumn,
+    QueuedGossipEnvelope, ReprocessQueueMessage,
 };
 use futures::stream::{Stream, StreamExt};
 use futures::task::Poll;
@@ -304,6 +304,10 @@ impl<E: EthSpec> From<ReadyWork> for WorkEvent<E> {
                     work: Work::ColumnReconstruction(process_fn),
                 }
             }
+            ReadyWork::DataColumn(QueuedGossipDataColumn { process_fn, .. }) => Self {
+                drop_during_sync: true,
+                work: Work::UnknownBlockAttestation { process_fn },
+            },
         }
     }
 }

--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -856,6 +856,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             Some(item)
                         } else if let Some(item) = work_queues.gossip_data_column_queue.pop() {
                             Some(item)
+                        } else if let Some(item) = work_queues.unknown_block_data_column_queue.pop()
+                        {
+                            Some(item)
                         } else if let Some(item) =
                             work_queues.gossip_partial_data_column_queue.pop()
                         {
@@ -995,9 +998,6 @@ impl<E: EthSpec> BeaconProcessor<E> {
                         } else if let Some(item) = work_queues.unknown_block_aggregate_queue.pop() {
                             Some(item)
                         } else if let Some(item) = work_queues.unknown_block_attestation_queue.pop()
-                        {
-                            Some(item)
-                        } else if let Some(item) = work_queues.unknown_block_data_column_queue.pop()
                         {
                             Some(item)
                         // Check execution payload bids. Most proposers will request bids directly from builders

--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -306,7 +306,7 @@ impl<E: EthSpec> From<ReadyWork> for WorkEvent<E> {
             }
             ReadyWork::DataColumn(QueuedGossipDataColumn { process_fn, .. }) => Self {
                 drop_during_sync: true,
-                work: Work::UnknownBlockAttestation { process_fn },
+                work: Work::UnknownBlockDataColumn { process_fn },
             },
         }
     }
@@ -371,6 +371,9 @@ pub enum Work<E: EthSpec> {
         process_batch: Box<dyn FnOnce(GossipAttestationBatch) + Send + Sync>,
     },
     UnknownBlockAttestation {
+        process_fn: BlockingFn,
+    },
+    UnknownBlockDataColumn {
         process_fn: BlockingFn,
     },
     GossipAttestationBatch {
@@ -469,6 +472,7 @@ pub enum WorkType {
     GossipAttestation,
     GossipAttestationToConvert,
     UnknownBlockAttestation,
+    UnknownBlockDataColumn,
     GossipAttestationBatch,
     GossipAggregate,
     UnknownBlockAggregate,
@@ -576,6 +580,7 @@ impl<E: EthSpec> Work<E> {
             Work::LightClientFinalityUpdateRequest(_) => WorkType::LightClientFinalityUpdateRequest,
             Work::LightClientUpdatesByRangeRequest(_) => WorkType::LightClientUpdatesByRangeRequest,
             Work::UnknownBlockAttestation { .. } => WorkType::UnknownBlockAttestation,
+            Work::UnknownBlockDataColumn { .. } => WorkType::UnknownBlockDataColumn,
             Work::UnknownBlockAggregate { .. } => WorkType::UnknownBlockAggregate,
             Work::UnknownLightClientOptimisticUpdate { .. } => {
                 WorkType::UnknownLightClientOptimisticUpdate
@@ -992,6 +997,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                         } else if let Some(item) = work_queues.unknown_block_attestation_queue.pop()
                         {
                             Some(item)
+                        } else if let Some(item) = work_queues.unknown_block_data_column_queue.pop()
+                        {
+                            Some(item)
                         // Check execution payload bids. Most proposers will request bids directly from builders
                         // instead of receiving them over gossip.
                         } else if let Some(item) =
@@ -1250,6 +1258,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             Work::UnknownBlockAttestation { .. } => {
                                 work_queues.unknown_block_attestation_queue.push(work)
                             }
+                            Work::UnknownBlockDataColumn { .. } => work_queues
+                                .unknown_block_data_column_queue
+                                .push(work, work_id),
                             Work::UnknownBlockAggregate { .. } => {
                                 work_queues.unknown_block_aggregate_queue.push(work)
                             }
@@ -1299,6 +1310,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
                         }
                         WorkType::UnknownBlockAttestation => {
                             work_queues.unknown_block_attestation_queue.len()
+                        }
+                        WorkType::UnknownBlockDataColumn => {
+                            work_queues.unknown_block_data_column_queue.len()
                         }
                         WorkType::GossipAttestationBatch => 0, // No queue
                         WorkType::GossipAggregate => work_queues.aggregate_queue.len(),
@@ -1517,6 +1531,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
             }),
             Work::UnknownBlockAttestation { process_fn }
             | Work::UnknownBlockAggregate { process_fn }
+            | Work::UnknownBlockDataColumn { process_fn }
             | Work::UnknownLightClientOptimisticUpdate { process_fn, .. } => {
                 task_spawner.spawn_blocking(process_fn)
             }

--- a/beacon_node/beacon_processor/src/scheduler/work_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_queue.rs
@@ -111,6 +111,7 @@ pub struct BeaconProcessorQueueLengths {
     attestation_queue: usize,
     unknown_block_aggregate_queue: usize,
     unknown_block_attestation_queue: usize,
+    unknown_block_data_column_queue: usize,
     sync_message_queue: usize,
     sync_contribution_queue: usize,
     gossip_voluntary_exit_queue: usize,
@@ -175,6 +176,8 @@ impl BeaconProcessorQueueLengths {
         Ok(Self {
             aggregate_queue: 4096,
             unknown_block_aggregate_queue: 1024,
+            // Capacity for two slot's worth of data columns for a supernode.
+            unknown_block_data_column_queue: 256,
             // Capacity for a full slot's worth of attestations if subscribed to all subnets
             attestation_queue: std::cmp::max(
                 active_validator_count / slots_per_epoch,
@@ -247,6 +250,7 @@ pub struct WorkQueues<E: EthSpec> {
     pub attestation_debounce: TimeLatch,
     pub unknown_block_aggregate_queue: LifoQueue<Work<E>>,
     pub unknown_block_attestation_queue: LifoQueue<Work<E>>,
+    pub unknown_block_data_column_queue: FifoQueue<Work<E>>,
     pub sync_message_queue: LifoQueue<Work<E>>,
     pub sync_contribution_queue: LifoQueue<Work<E>>,
     pub gossip_voluntary_exit_queue: FifoQueue<Work<E>>,
@@ -305,6 +309,8 @@ impl<E: EthSpec> WorkQueues<E> {
             LifoQueue::new(queue_lengths.unknown_block_aggregate_queue);
         let unknown_block_attestation_queue =
             LifoQueue::new(queue_lengths.unknown_block_attestation_queue);
+        let unknown_block_data_column_queue =
+            FifoQueue::new(queue_lengths.unknown_block_data_column_queue);
 
         let sync_message_queue = LifoQueue::new(queue_lengths.sync_message_queue);
         let sync_contribution_queue = LifoQueue::new(queue_lengths.sync_contribution_queue);
@@ -387,6 +393,7 @@ impl<E: EthSpec> WorkQueues<E> {
             attestation_debounce,
             unknown_block_aggregate_queue,
             unknown_block_attestation_queue,
+            unknown_block_data_column_queue,
             sync_message_queue,
             sync_contribution_queue,
             gossip_voluntary_exit_queue,

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -252,7 +252,7 @@ enum InboundEvent {
     ReadyBackfillSync(QueuedBackfillBatch),
     /// A column reconstruction that was queued is ready for processing.
     ReadyColumnReconstruction(QueuedColumnReconstruction),
-    /// A gossip data column that timed out waiting for its block.
+    /// A gossip data column that is ready for re-processing.
     ReadyDataColumn(Hash256),
     /// A message sent to the `ReprocessQueue`
     Msg(ReprocessQueueMessage),

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -301,7 +301,7 @@ struct ReprocessQueue<S> {
     /// Queued backfill batches
     queued_backfill_batches: Vec<QueuedBackfillBatch>,
     /// Queued gossip data columns awaiting their block, keyed by block root.
-    queued_gossip_data_columns: HashMap<Hash256, (Vec<QueuedGossipDataColumn>, DelayKey)>,
+    awaiting_data_columns_per_root: HashMap<Hash256, (Vec<QueuedGossipDataColumn>, DelayKey)>,
 
     /* Aux */
     /// Next attestation id, used for both aggregated and unaggregated attestations
@@ -490,7 +490,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
             awaiting_lc_updates_per_parent_root: HashMap::new(),
             queued_backfill_batches: Vec::new(),
             queued_column_reconstructions: HashMap::new(),
-            queued_gossip_data_columns: HashMap::new(),
+            awaiting_data_columns_per_root: HashMap::new(),
             next_attestation: 0,
             next_lc_update: 0,
             early_block_debounce: TimeLatch::default(),
@@ -719,12 +719,12 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 let block_root = queued_data_column.beacon_block_root;
 
                 if let Some((columns, _delay_key)) =
-                    self.queued_gossip_data_columns.get_mut(&block_root)
+                    self.awaiting_data_columns_per_root.get_mut(&block_root)
                 {
                     // Append to existing entry; the timer for this root is already running.
                     columns.push(queued_data_column);
                 } else {
-                    if self.queued_gossip_data_columns.len() >= MAXIMUM_QUEUED_DATA_COLUMNS {
+                    if self.awaiting_data_columns_per_root.len() >= MAXIMUM_QUEUED_DATA_COLUMNS {
                         return;
                     }
 
@@ -732,7 +732,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
                         .data_columns_delay_queue
                         .insert(block_root, QUEUED_ATTESTATION_DELAY);
 
-                    self.queued_gossip_data_columns
+                    self.awaiting_data_columns_per_root
                         .insert(block_root, (vec![queued_data_column], delay_key));
                 }
             }
@@ -851,7 +851,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
 
                 // Unqueue the data columns we have for this root, if any.
                 if let Some((data_columns, delay_key)) =
-                    self.queued_gossip_data_columns.remove(&block_root)
+                    self.awaiting_data_columns_per_root.remove(&block_root)
                 {
                     self.data_columns_delay_queue.remove(&delay_key);
                     for data_column in data_columns {
@@ -1118,7 +1118,8 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 }
             }
             InboundEvent::ReadyDataColumn(block_root) => {
-                if let Some((data_columns, _)) = self.queued_gossip_data_columns.remove(&block_root)
+                if let Some((data_columns, _)) =
+                    self.awaiting_data_columns_per_root.remove(&block_root)
                 {
                     for data_column in data_columns {
                         if self
@@ -1731,7 +1732,11 @@ mod tests {
         queue.handle_message(InboundEvent::Msg(msg));
 
         assert_eq!(queue.awaiting_data_columns_per_root.len(), 1);
-        assert_eq!(queue.queued_gossip_data_columns.len(), 1);
+        assert!(
+            queue
+                .awaiting_data_columns_per_root
+                .contains_key(&beacon_block_root)
+        );
         assert_eq!(queue.data_columns_delay_queue.len(), 1);
 
         // Simulate block import.
@@ -1742,7 +1747,6 @@ mod tests {
 
         // Internal state should be cleaned up.
         assert!(queue.awaiting_data_columns_per_root.is_empty());
-        assert!(queue.queued_gossip_data_columns.is_empty());
         assert_eq!(queue.data_columns_delay_queue.len(), 0);
 
         // The column should have been sent to the ready_work channel.
@@ -1782,6 +1786,5 @@ mod tests {
 
         // All internal state should be cleaned up.
         assert!(queue.awaiting_data_columns_per_root.is_empty());
-        assert!(queue.queued_gossip_data_columns.is_empty());
     }
 }

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -52,6 +52,9 @@ pub const QUEUED_ATTESTATION_DELAY: Duration = Duration::from_secs(12);
 /// For how long to queue light client updates for re-processing.
 pub const QUEUED_LIGHT_CLIENT_UPDATE_DELAY: Duration = Duration::from_secs(12);
 
+/// For how long to queue gossip data columns awaiting their block for re-processing.
+pub const QUEUED_GOSSIP_DATA_COLUMN_DELAY: Duration = Duration::from_secs(12);
+
 /// Envelope timeout as a multiplier of slot duration. Envelopes waiting for their block will be
 /// sent for processing after this many slots worth of time, even if the block hasn't arrived.
 const QUEUED_ENVELOPE_DELAY_SLOTS: u32 = 1;
@@ -302,6 +305,8 @@ struct ReprocessQueue<S> {
     queued_backfill_batches: Vec<QueuedBackfillBatch>,
     /// Queued gossip data columns awaiting their block, keyed by block root.
     awaiting_data_columns_per_root: HashMap<Hash256, (Vec<QueuedGossipDataColumn>, DelayKey)>,
+    /// Total number of queued gossip data columns across all roots.
+    queued_data_columns_count: usize,
 
     /* Aux */
     /// Next attestation id, used for both aggregated and unaggregated attestations
@@ -312,6 +317,7 @@ struct ReprocessQueue<S> {
     rpc_block_debounce: TimeLatch,
     attestation_delay_debounce: TimeLatch,
     lc_update_delay_debounce: TimeLatch,
+    data_column_delay_debounce: TimeLatch,
     next_backfill_batch_event: Option<Pin<Box<tokio::time::Sleep>>>,
     slot_clock: Arc<S>,
 }
@@ -491,6 +497,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
             queued_backfill_batches: Vec::new(),
             queued_column_reconstructions: HashMap::new(),
             awaiting_data_columns_per_root: HashMap::new(),
+            queued_data_columns_count: 0,
             next_attestation: 0,
             next_lc_update: 0,
             early_block_debounce: TimeLatch::default(),
@@ -498,6 +505,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
             rpc_block_debounce: TimeLatch::default(),
             attestation_delay_debounce: TimeLatch::default(),
             lc_update_delay_debounce: TimeLatch::default(),
+            data_column_delay_debounce: TimeLatch::default(),
             next_backfill_batch_event: None,
             slot_clock,
         }
@@ -718,23 +726,32 @@ impl<S: SlotClock> ReprocessQueue<S> {
             InboundEvent::Msg(UnknownBlockDataColumn(queued_data_column)) => {
                 let block_root = queued_data_column.beacon_block_root;
 
+                if self.queued_data_columns_count >= MAXIMUM_QUEUED_DATA_COLUMNS {
+                    if self.data_column_delay_debounce.elapsed() {
+                        warn!(
+                            queue_size = MAXIMUM_QUEUED_DATA_COLUMNS,
+                            msg = "system resources may be saturated",
+                            "Data column delay queue is full, dropping column"
+                        );
+                    }
+                    return;
+                }
+
                 if let Some((columns, _delay_key)) =
                     self.awaiting_data_columns_per_root.get_mut(&block_root)
                 {
                     // Append to existing entry; the timer for this root is already running.
                     columns.push(queued_data_column);
                 } else {
-                    if self.awaiting_data_columns_per_root.len() >= MAXIMUM_QUEUED_DATA_COLUMNS {
-                        return;
-                    }
-
                     let delay_key = self
                         .data_columns_delay_queue
-                        .insert(block_root, QUEUED_ATTESTATION_DELAY);
+                        .insert(block_root, QUEUED_GOSSIP_DATA_COLUMN_DELAY);
 
                     self.awaiting_data_columns_per_root
                         .insert(block_root, (vec![queued_data_column], delay_key));
                 }
+
+                self.queued_data_columns_count += 1;
             }
             InboundEvent::Msg(UnknownLightClientOptimisticUpdate(
                 queued_light_client_optimistic_update,
@@ -854,6 +871,9 @@ impl<S: SlotClock> ReprocessQueue<S> {
                     self.awaiting_data_columns_per_root.remove(&block_root)
                 {
                     self.data_columns_delay_queue.remove(&delay_key);
+                    self.queued_data_columns_count = self
+                        .queued_data_columns_count
+                        .saturating_sub(data_columns.len());
                     for data_column in data_columns {
                         if self
                             .ready_work_tx
@@ -1121,6 +1141,9 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 if let Some((data_columns, _)) =
                     self.awaiting_data_columns_per_root.remove(&block_root)
                 {
+                    self.queued_data_columns_count = self
+                        .queued_data_columns_count
+                        .saturating_sub(data_columns.len());
                     for data_column in data_columns {
                         if self
                             .ready_work_tx
@@ -1779,7 +1802,7 @@ mod tests {
         );
 
         // Advance time past the delay so the entry expires.
-        advance_time(&queue.slot_clock, 2 * QUEUED_ATTESTATION_DELAY).await;
+        advance_time(&queue.slot_clock, 2 * QUEUED_GOSSIP_DATA_COLUMN_DELAY).await;
         let ready_msg = queue.next().await.unwrap();
         assert!(matches!(ready_msg, InboundEvent::ReadyDataColumn(_)));
         queue.handle_message(ready_msg);

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -253,7 +253,7 @@ enum InboundEvent {
     /// A column reconstruction that was queued is ready for processing.
     ReadyColumnReconstruction(QueuedColumnReconstruction),
     /// A gossip data column that timed out waiting for its block.
-    ReadyDataColumn(usize),
+    ReadyDataColumn(Hash256),
     /// A message sent to the `ReprocessQueue`
     Msg(ReprocessQueueMessage),
 }
@@ -278,7 +278,8 @@ struct ReprocessQueue<S> {
     lc_updates_delay_queue: DelayQueue<QueuedLightClientUpdateId>,
     /// Queue to manage scheduled column reconstructions.
     column_reconstructions_delay_queue: DelayQueue<QueuedColumnReconstruction>,
-    data_columns_delay_queue: DelayQueue<usize>,
+    /// Queue to manage gossip data column timeouts.
+    data_columns_delay_queue: DelayQueue<Hash256>,
 
     /* Queued items */
     /// Queued blocks.
@@ -299,15 +300,12 @@ struct ReprocessQueue<S> {
     queued_column_reconstructions: HashMap<Hash256, Option<DelayKey>>,
     /// Queued backfill batches
     queued_backfill_batches: Vec<QueuedBackfillBatch>,
-    /// Queued gossip data columns awaiting their block.
-    queued_gossip_data_columns: FnvHashMap<usize, (QueuedGossipDataColumn, DelayKey)>,
-    /// Data columns per block root.
-    awaiting_data_columns_per_root: HashMap<Hash256, Vec<usize>>,
+    /// Queued gossip data columns awaiting their block, keyed by block root.
+    queued_gossip_data_columns: HashMap<Hash256, (Vec<QueuedGossipDataColumn>, DelayKey)>,
 
     /* Aux */
     /// Next attestation id, used for both aggregated and unaggregated attestations
     next_attestation: usize,
-    next_data_column: usize,
     next_lc_update: usize,
     early_block_debounce: TimeLatch,
     envelope_delay_debounce: TimeLatch,
@@ -408,8 +406,8 @@ impl<S: SlotClock> Stream for ReprocessQueue<S> {
         }
 
         match self.data_columns_delay_queue.poll_expired(cx) {
-            Poll::Ready(Some(col_id)) => {
-                return Poll::Ready(Some(InboundEvent::ReadyDataColumn(col_id.into_inner())));
+            Poll::Ready(Some(block_root)) => {
+                return Poll::Ready(Some(InboundEvent::ReadyDataColumn(block_root.into_inner())));
             }
             Poll::Ready(None) | Poll::Pending => (),
         }
@@ -492,10 +490,8 @@ impl<S: SlotClock> ReprocessQueue<S> {
             awaiting_lc_updates_per_parent_root: HashMap::new(),
             queued_backfill_batches: Vec::new(),
             queued_column_reconstructions: HashMap::new(),
-            queued_gossip_data_columns: FnvHashMap::default(),
-            awaiting_data_columns_per_root: HashMap::new(),
+            queued_gossip_data_columns: HashMap::new(),
             next_attestation: 0,
-            next_data_column: 0,
             next_lc_update: 0,
             early_block_debounce: TimeLatch::default(),
             envelope_delay_debounce: TimeLatch::default(),
@@ -720,27 +716,25 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 self.next_attestation += 1;
             }
             InboundEvent::Msg(UnknownBlockDataColumn(queued_data_column)) => {
-                if self.queued_gossip_data_columns.len() >= MAXIMUM_QUEUED_DATA_COLUMNS {
-                    return;
+                let block_root = queued_data_column.beacon_block_root;
+
+                if let Some((columns, _delay_key)) =
+                    self.queued_gossip_data_columns.get_mut(&block_root)
+                {
+                    // Append to existing entry; the timer for this root is already running.
+                    columns.push(queued_data_column);
+                } else {
+                    if self.queued_gossip_data_columns.len() >= MAXIMUM_QUEUED_DATA_COLUMNS {
+                        return;
+                    }
+
+                    let delay_key = self
+                        .data_columns_delay_queue
+                        .insert(block_root, QUEUED_ATTESTATION_DELAY);
+
+                    self.queued_gossip_data_columns
+                        .insert(block_root, (vec![queued_data_column], delay_key));
                 }
-
-                let col_id = self.next_data_column;
-
-                let delay_key = self
-                    .data_columns_delay_queue
-                    .insert(col_id, QUEUED_ATTESTATION_DELAY);
-
-                // Register this column for the corresponding block root.
-                self.awaiting_data_columns_per_root
-                    .entry(queued_data_column.beacon_block_root)
-                    .or_default()
-                    .push(col_id);
-
-                // Store the column and its info.
-                self.queued_gossip_data_columns
-                    .insert(col_id, (queued_data_column, delay_key));
-
-                self.next_data_column += 1;
             }
             InboundEvent::Msg(UnknownLightClientOptimisticUpdate(
                 queued_light_client_optimistic_update,
@@ -856,19 +850,17 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 }
 
                 // Unqueue the data columns we have for this root, if any.
-                if let Some(queued_ids) = self.awaiting_data_columns_per_root.remove(&block_root) {
-                    for col_id in queued_ids {
-                        if let Some((data_column, delay_key)) =
-                            self.queued_gossip_data_columns.remove(&col_id)
+                if let Some((data_columns, delay_key)) =
+                    self.queued_gossip_data_columns.remove(&block_root)
+                {
+                    self.data_columns_delay_queue.remove(&delay_key);
+                    for data_column in data_columns {
+                        if self
+                            .ready_work_tx
+                            .try_send(ReadyWork::DataColumn(data_column))
+                            .is_err()
                         {
-                            self.data_columns_delay_queue.remove(&delay_key);
-                            if self
-                                .ready_work_tx
-                                .try_send(ReadyWork::DataColumn(data_column))
-                                .is_err()
-                            {
-                                error!(?block_root, "Failed to send data column for reprocessing");
-                            }
+                            error!(?block_root, "Failed to send data column for reprocessing");
                         }
                     }
                 }
@@ -1125,28 +1117,20 @@ impl<S: SlotClock> ReprocessQueue<S> {
                     );
                 }
             }
-            InboundEvent::ReadyDataColumn(col_id) => {
-                if let Some((data_column, _)) = self.queued_gossip_data_columns.remove(&col_id) {
-                    // Clean up the per-root index.
-                    let root = data_column.beacon_block_root;
-                    if let Entry::Occupied(mut entry) =
-                        self.awaiting_data_columns_per_root.entry(root)
-                    {
-                        let ids = entry.get_mut();
-                        ids.retain(|&id| id != col_id);
-                        if ids.is_empty() {
-                            entry.remove_entry();
+            InboundEvent::ReadyDataColumn(block_root) => {
+                if let Some((data_columns, _)) = self.queued_gossip_data_columns.remove(&block_root)
+                {
+                    for data_column in data_columns {
+                        if self
+                            .ready_work_tx
+                            .try_send(ReadyWork::DataColumn(data_column))
+                            .is_err()
+                        {
+                            error!(
+                                hint = "system may be overloaded",
+                                "Ignored expired gossip data column"
+                            );
                         }
-                    }
-                    if self
-                        .ready_work_tx
-                        .try_send(ReadyWork::DataColumn(data_column))
-                        .is_err()
-                    {
-                        error!(
-                            hint = "system may be overloaded",
-                            "Ignored expired gossip data column"
-                        );
                     }
                 }
             }

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -123,6 +123,8 @@ pub enum ReprocessQueueMessage {
     UnknownLightClientOptimisticUpdate(QueuedLightClientUpdate),
     /// A new backfill batch that needs to be scheduled for processing.
     BackfillSync(QueuedBackfillBatch),
+    /// A gossip data column that references an unknown block.
+    UnknownBlockDataColumn(QueuedGossipDataColumn),
     /// A delayed column reconstruction that needs checking
     DelayColumnReconstruction(QueuedColumnReconstruction),
 }
@@ -138,6 +140,7 @@ pub enum ReadyWork {
     LightClientUpdate(QueuedLightClientUpdate),
     BackfillSync(QueuedBackfillBatch),
     ColumnReconstruction(QueuedColumnReconstruction),
+    DataColumn(QueuedGossipDataColumn),
 }
 
 /// An Attestation for which the corresponding block was not seen while processing, queued for
@@ -200,6 +203,12 @@ pub struct QueuedColumnReconstruction {
     pub process_fn: AsyncFn,
 }
 
+/// A gossip data column that references an unknown block, queued for later reprocessing.
+pub struct QueuedGossipDataColumn {
+    pub beacon_block_root: Hash256,
+    pub process_fn: BlockingFn,
+}
+
 impl<E: EthSpec> TryFrom<WorkEvent<E>> for QueuedBackfillBatch {
     type Error = WorkEvent<E>;
 
@@ -240,6 +249,8 @@ enum InboundEvent {
     ReadyBackfillSync(QueuedBackfillBatch),
     /// A column reconstruction that was queued is ready for processing.
     ReadyColumnReconstruction(QueuedColumnReconstruction),
+    /// A gossip data column that timed out waiting for its block.
+    ReadyDataColumn(usize),
     /// A message sent to the `ReprocessQueue`
     Msg(ReprocessQueueMessage),
 }
@@ -264,6 +275,7 @@ struct ReprocessQueue<S> {
     lc_updates_delay_queue: DelayQueue<QueuedLightClientUpdateId>,
     /// Queue to manage scheduled column reconstructions.
     column_reconstructions_delay_queue: DelayQueue<QueuedColumnReconstruction>,
+    data_columns_delay_queue: DelayQueue<usize>,
 
     /* Queued items */
     /// Queued blocks.
@@ -284,10 +296,15 @@ struct ReprocessQueue<S> {
     queued_column_reconstructions: HashMap<Hash256, Option<DelayKey>>,
     /// Queued backfill batches
     queued_backfill_batches: Vec<QueuedBackfillBatch>,
+    /// Queued gossip data columns awaiting their block.
+    queued_gossip_data_columns: FnvHashMap<usize, (QueuedGossipDataColumn, DelayKey)>,
+    /// Data columns per block root.
+    awaiting_data_columns_per_root: HashMap<Hash256, Vec<usize>>,
 
     /* Aux */
     /// Next attestation id, used for both aggregated and unaggregated attestations
     next_attestation: usize,
+    next_data_column: usize,
     next_lc_update: usize,
     early_block_debounce: TimeLatch,
     envelope_delay_debounce: TimeLatch,
@@ -387,6 +404,13 @@ impl<S: SlotClock> Stream for ReprocessQueue<S> {
             Poll::Ready(None) | Poll::Pending => (),
         }
 
+        match self.data_columns_delay_queue.poll_expired(cx) {
+            Poll::Ready(Some(col_id)) => {
+                return Poll::Ready(Some(InboundEvent::ReadyDataColumn(col_id.into_inner())));
+            }
+            Poll::Ready(None) | Poll::Pending => (),
+        }
+
         if let Some(next_backfill_batch_event) = self.next_backfill_batch_event.as_mut() {
             match next_backfill_batch_event.as_mut().poll(cx) {
                 Poll::Ready(_) => {
@@ -455,6 +479,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
             attestations_delay_queue: DelayQueue::new(),
             lc_updates_delay_queue: DelayQueue::new(),
             column_reconstructions_delay_queue: DelayQueue::new(),
+            data_columns_delay_queue: DelayQueue::new(),
             queued_gossip_block_roots: HashSet::new(),
             awaiting_envelopes_per_root: HashMap::new(),
             queued_lc_updates: FnvHashMap::default(),
@@ -464,7 +489,10 @@ impl<S: SlotClock> ReprocessQueue<S> {
             awaiting_lc_updates_per_parent_root: HashMap::new(),
             queued_backfill_batches: Vec::new(),
             queued_column_reconstructions: HashMap::new(),
+            queued_gossip_data_columns: FnvHashMap::default(),
+            awaiting_data_columns_per_root: HashMap::new(),
             next_attestation: 0,
+            next_data_column: 0,
             next_lc_update: 0,
             early_block_debounce: TimeLatch::default(),
             envelope_delay_debounce: TimeLatch::default(),
@@ -688,6 +716,29 @@ impl<S: SlotClock> ReprocessQueue<S> {
 
                 self.next_attestation += 1;
             }
+            InboundEvent::Msg(UnknownBlockDataColumn(queued_data_column)) => {
+                if self.queued_gossip_data_columns.len() >= MAXIMUM_QUEUED_ATTESTATIONS {
+                    return;
+                }
+
+                let col_id = self.next_data_column;
+
+                let delay_key = self
+                    .data_columns_delay_queue
+                    .insert(col_id, QUEUED_ATTESTATION_DELAY);
+
+                // Register this column for the corresponding block root.
+                self.awaiting_data_columns_per_root
+                    .entry(queued_data_column.beacon_block_root)
+                    .or_default()
+                    .push(col_id);
+
+                // Store the column and its info.
+                self.queued_gossip_data_columns
+                    .insert(col_id, (queued_data_column, delay_key));
+
+                self.next_data_column += 1;
+            }
             InboundEvent::Msg(UnknownLightClientOptimisticUpdate(
                 queued_light_client_optimistic_update,
             )) => {
@@ -798,6 +849,29 @@ impl<S: SlotClock> ReprocessQueue<S> {
                             sent_count,
                             "Ignored scheduled attestation(s) for block"
                         );
+                    }
+                }
+
+                // Unqueue the data columns we have for this root, if any.
+                if let Some(queued_ids) =
+                    self.awaiting_data_columns_per_root.remove(&block_root)
+                {
+                    for col_id in queued_ids {
+                        if let Some((data_column, delay_key)) =
+                            self.queued_gossip_data_columns.remove(&col_id)
+                        {
+                            self.data_columns_delay_queue.remove(&delay_key);
+                            if self
+                                .ready_work_tx
+                                .try_send(ReadyWork::DataColumn(data_column))
+                                .is_err()
+                            {
+                                error!(
+                                    ?block_root,
+                                    "Failed to send data column for reprocessing"
+                                );
+                            }
+                        }
                     }
                 }
             }
@@ -1051,6 +1125,31 @@ impl<S: SlotClock> ReprocessQueue<S> {
                         hint = "system may be overloaded",
                         "Ignored scheduled column reconstruction"
                     );
+                }
+            }
+            InboundEvent::ReadyDataColumn(col_id) => {
+                if let Some((data_column, _)) = self.queued_gossip_data_columns.remove(&col_id) {
+                    // Clean up the per-root index.
+                    let root = data_column.beacon_block_root;
+                    if let Entry::Occupied(mut entry) =
+                        self.awaiting_data_columns_per_root.entry(root)
+                    {
+                        let ids = entry.get_mut();
+                        ids.retain(|&id| id != col_id);
+                        if ids.is_empty() {
+                            entry.remove_entry();
+                        }
+                    }
+                    if self
+                        .ready_work_tx
+                        .try_send(ReadyWork::DataColumn(data_column))
+                        .is_err()
+                    {
+                        error!(
+                            hint = "system may be overloaded",
+                            "Ignored expired gossip data column"
+                        );
+                    }
                 }
             }
         }

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -1682,51 +1682,6 @@ mod tests {
         assert_eq!(queue.envelope_delay_queue.len(), 1);
     }
 
-    #[tokio::test]
-    async fn envelope_capacity_evicts_oldest() {
-        create_test_tracing_subscriber();
-
-        let mut queue = test_queue();
-
-        // Pause time so it only advances manually
-        tokio::time::pause();
-
-        // Fill the queue to capacity.
-        for i in 0..MAXIMUM_QUEUED_ENVELOPES {
-            let block_root = Hash256::repeat_byte(i as u8);
-            let msg = ReprocessQueueMessage::UnknownBlockForEnvelope(QueuedGossipEnvelope {
-                beacon_block_slot: Slot::new(1),
-                beacon_block_root: block_root,
-                process_fn: Box::pin(async {}),
-            });
-            queue.handle_message(InboundEvent::Msg(msg));
-        }
-        assert_eq!(
-            queue.awaiting_envelopes_per_root.len(),
-            MAXIMUM_QUEUED_ENVELOPES
-        );
-
-        // One more should evict the oldest and insert the new one.
-        let overflow_root = Hash256::repeat_byte(0xff);
-        let msg = ReprocessQueueMessage::UnknownBlockForEnvelope(QueuedGossipEnvelope {
-            beacon_block_slot: Slot::new(1),
-            beacon_block_root: overflow_root,
-            process_fn: Box::pin(async {}),
-        });
-        queue.handle_message(InboundEvent::Msg(msg));
-
-        // Queue should still be at capacity, with the new root present.
-        assert_eq!(
-            queue.awaiting_envelopes_per_root.len(),
-            MAXIMUM_QUEUED_ENVELOPES
-        );
-        assert!(
-            queue
-                .awaiting_envelopes_per_root
-                .contains_key(&overflow_root)
-        );
-    }
-
     /// Tests that a queued gossip data column is released when its block is imported.
     #[tokio::test]
     async fn data_column_released_on_block_imported() {

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -76,6 +76,9 @@ const MAXIMUM_QUEUED_ENVELOPES: usize = 16;
 /// How many attestations we keep before new ones get dropped.
 const MAXIMUM_QUEUED_ATTESTATIONS: usize = 16_384;
 
+/// How many columns we keep before new ones get dropped.
+const MAXIMUM_QUEUED_DATA_COLUMNS: usize = 256;
+
 /// How many light client updates we keep before new ones get dropped.
 const MAXIMUM_QUEUED_LIGHT_CLIENT_UPDATES: usize = 128;
 
@@ -717,7 +720,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 self.next_attestation += 1;
             }
             InboundEvent::Msg(UnknownBlockDataColumn(queued_data_column)) => {
-                if self.queued_gossip_data_columns.len() >= MAXIMUM_QUEUED_ATTESTATIONS {
+                if self.queued_gossip_data_columns.len() >= MAXIMUM_QUEUED_DATA_COLUMNS {
                     return;
                 }
 

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -586,22 +586,16 @@ impl<S: SlotClock> ReprocessQueue<S> {
                     return;
                 }
 
-                // When the queue is full, evict the oldest entry to make room for newer envelopes.
+                // When the queue is full, drop the new envelope.
                 if self.awaiting_envelopes_per_root.len() >= MAXIMUM_QUEUED_ENVELOPES {
                     if self.envelope_delay_debounce.elapsed() {
                         warn!(
                             queue_size = MAXIMUM_QUEUED_ENVELOPES,
                             msg = "system resources may be saturated",
-                            "Envelope delay queue is full, evicting oldest entry"
+                            "Envelope delay queue is full, dropping envelope"
                         );
                     }
-                    if let Some(oldest_root) =
-                        self.awaiting_envelopes_per_root.keys().next().copied()
-                        && let Some((_envelope, delay_key)) =
-                            self.awaiting_envelopes_per_root.remove(&oldest_root)
-                    {
-                        self.envelope_delay_queue.remove(&delay_key);
-                    }
+                    return;
                 }
 
                 // Register the timeout.

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -52,8 +52,9 @@ pub const QUEUED_ATTESTATION_DELAY: Duration = Duration::from_secs(12);
 /// For how long to queue light client updates for re-processing.
 pub const QUEUED_LIGHT_CLIENT_UPDATE_DELAY: Duration = Duration::from_secs(12);
 
-/// For how long to queue gossip data columns awaiting their block for re-processing.
-pub const QUEUED_GOSSIP_DATA_COLUMN_DELAY: Duration = Duration::from_secs(12);
+/// Data column timeout as a multiplier of slot duration. Columns waiting for their block will be
+/// sent for processing after this many slots worth of time, even if the block hasn't arrived.
+const QUEUED_DATA_COLUMN_DELAY_SLOTS: u32 = 1;
 
 /// Envelope timeout as a multiplier of slot duration. Envelopes waiting for their block will be
 /// sent for processing after this many slots worth of time, even if the block hasn't arrived.
@@ -737,9 +738,10 @@ impl<S: SlotClock> ReprocessQueue<S> {
                     // Append to existing entry; the timer for this root is already running.
                     columns.push(queued_data_column);
                 } else {
-                    let delay_key = self
-                        .data_columns_delay_queue
-                        .insert(block_root, QUEUED_GOSSIP_DATA_COLUMN_DELAY);
+                    let delay_key = self.data_columns_delay_queue.insert(
+                        block_root,
+                        self.slot_clock.slot_duration() * QUEUED_DATA_COLUMN_DELAY_SLOTS,
+                    );
 
                     self.awaiting_data_columns_per_root
                         .insert(block_root, (vec![queued_data_column], delay_key));
@@ -1796,7 +1798,11 @@ mod tests {
         );
 
         // Advance time past the delay so the entry expires.
-        advance_time(&queue.slot_clock, 2 * QUEUED_GOSSIP_DATA_COLUMN_DELAY).await;
+        advance_time(
+            &queue.slot_clock,
+            2 * queue.slot_clock.slot_duration() * QUEUED_DATA_COLUMN_DELAY_SLOTS,
+        )
+        .await;
         let ready_msg = queue.next().await.unwrap();
         assert!(matches!(ready_msg, InboundEvent::ReadyDataColumn(_)));
         queue.handle_message(ready_msg);

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -853,9 +853,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 }
 
                 // Unqueue the data columns we have for this root, if any.
-                if let Some(queued_ids) =
-                    self.awaiting_data_columns_per_root.remove(&block_root)
-                {
+                if let Some(queued_ids) = self.awaiting_data_columns_per_root.remove(&block_root) {
                     for col_id in queued_ids {
                         if let Some((data_column, delay_key)) =
                             self.queued_gossip_data_columns.remove(&col_id)
@@ -866,10 +864,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
                                 .try_send(ReadyWork::DataColumn(data_column))
                                 .is_err()
                             {
-                                error!(
-                                    ?block_root,
-                                    "Failed to send data column for reprocessing"
-                                );
+                                error!(?block_root, "Failed to send data column for reprocessing");
                             }
                         }
                     }
@@ -1723,5 +1718,83 @@ mod tests {
                 .awaiting_envelopes_per_root
                 .contains_key(&overflow_root)
         );
+    }
+
+    /// Tests that a queued gossip data column is released when its block is imported.
+    #[tokio::test]
+    async fn data_column_released_on_block_imported() {
+        create_test_tracing_subscriber();
+
+        let config = BeaconProcessorConfig::default();
+        let (ready_work_tx, mut ready_work_rx) =
+            mpsc::channel::<ReadyWork>(config.max_scheduled_work_queue_len);
+        let (_, reprocess_work_rx) =
+            mpsc::channel::<ReprocessQueueMessage>(config.max_scheduled_work_queue_len);
+        let slot_clock = Arc::new(testing_slot_clock(12));
+        let mut queue = ReprocessQueue::new(ready_work_tx, reprocess_work_rx, slot_clock);
+
+        tokio::time::pause();
+
+        let beacon_block_root = Hash256::repeat_byte(0xbb);
+
+        let msg = ReprocessQueueMessage::UnknownBlockDataColumn(QueuedGossipDataColumn {
+            beacon_block_root,
+            process_fn: Box::new(|| {}),
+        });
+        queue.handle_message(InboundEvent::Msg(msg));
+
+        assert_eq!(queue.awaiting_data_columns_per_root.len(), 1);
+        assert_eq!(queue.queued_gossip_data_columns.len(), 1);
+        assert_eq!(queue.data_columns_delay_queue.len(), 1);
+
+        // Simulate block import.
+        queue.handle_message(InboundEvent::Msg(ReprocessQueueMessage::BlockImported {
+            block_root: beacon_block_root,
+            parent_root: Hash256::repeat_byte(0x00),
+        }));
+
+        // Internal state should be cleaned up.
+        assert!(queue.awaiting_data_columns_per_root.is_empty());
+        assert!(queue.queued_gossip_data_columns.is_empty());
+        assert_eq!(queue.data_columns_delay_queue.len(), 0);
+
+        // The column should have been sent to the ready_work channel.
+        let ready = ready_work_rx.try_recv().expect("column should be ready");
+        assert!(matches!(ready, ReadyWork::DataColumn(_)));
+    }
+
+    /// Tests that an expired gossip data column is pruned cleanly from all internal state.
+    #[tokio::test]
+    async fn prune_awaiting_data_columns_per_root() {
+        create_test_tracing_subscriber();
+
+        let mut queue = test_queue();
+
+        tokio::time::pause();
+
+        let beacon_block_root = Hash256::repeat_byte(0xcd);
+
+        let msg = ReprocessQueueMessage::UnknownBlockDataColumn(QueuedGossipDataColumn {
+            beacon_block_root,
+            process_fn: Box::new(|| {}),
+        });
+        queue.handle_message(InboundEvent::Msg(msg));
+
+        assert_eq!(queue.awaiting_data_columns_per_root.len(), 1);
+        assert!(
+            queue
+                .awaiting_data_columns_per_root
+                .contains_key(&beacon_block_root)
+        );
+
+        // Advance time past the delay so the entry expires.
+        advance_time(&queue.slot_clock, 2 * QUEUED_ATTESTATION_DELAY).await;
+        let ready_msg = queue.next().await.unwrap();
+        assert!(matches!(ready_msg, InboundEvent::ReadyDataColumn(_)));
+        queue.handle_message(ready_msg);
+
+        // All internal state should be cleaned up.
+        assert!(queue.awaiting_data_columns_per_root.is_empty());
+        assert!(queue.queued_gossip_data_columns.is_empty());
     }
 }

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -64,8 +64,8 @@ use beacon_processor::work_reprocessing_queue::QueuedColumnReconstruction;
 use beacon_processor::{
     DuplicateCache, GossipAggregatePackage, GossipAttestationBatch,
     work_reprocessing_queue::{
-        QueuedAggregate, QueuedGossipBlock, QueuedGossipEnvelope, QueuedLightClientUpdate,
-        QueuedUnaggregate, ReprocessQueueMessage,
+        QueuedAggregate, QueuedGossipBlock, QueuedGossipDataColumn, QueuedGossipEnvelope,
+        QueuedLightClientUpdate, QueuedUnaggregate, ReprocessQueueMessage,
     },
 };
 
@@ -728,19 +728,46 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         ..
                     } => {
                         debug!(
-                            action = "ignoring",
+                            action = "queuing for reprocessing",
                             %unknown_block_root,
                             "Unknown block root for column"
                         );
-                        // TODO(gloas): wire this into proper lookup sync. Sending
-                        // `UnknownBlockHashFromAttestation` here is a Fulu-shaped fallback that
-                        // mixes column processing with the attestation lookup path and is not
-                        // the right primitive for Gloas column lookups.
                         self.propagate_validation_result(
-                            message_id,
+                            message_id.clone(),
                             peer_id,
                             MessageAcceptance::Ignore,
                         );
+
+                        // Queue the column for reprocessing when the block arrives.
+                        let processor = self.clone();
+                        let reprocess_msg = ReprocessQueueMessage::UnknownBlockDataColumn(
+                            QueuedGossipDataColumn {
+                                beacon_block_root: unknown_block_root,
+                                process_fn: Box::new(move || {
+                                    // Re-dispatch through the normal gossip column processing path.
+                                    let _ = processor.send_gossip_data_column_sidecar(
+                                        message_id,
+                                        peer_id,
+                                        subnet_id,
+                                        column_sidecar,
+                                        seen_duration,
+                                    );
+                                }),
+                            },
+                        );
+                        if self
+                            .beacon_processor_send
+                            .try_send(WorkEvent {
+                                drop_during_sync: false,
+                                work: Work::Reprocess(reprocess_msg),
+                            })
+                            .is_err()
+                        {
+                            debug!(
+                                %unknown_block_root,
+                                "Failed to queue data column for reprocessing"
+                            );
+                        }
                     }
                     GossipDataColumnError::InvalidVariant
                     | GossipDataColumnError::PubkeyCacheTimeout

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -740,8 +740,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
                         // Queue the column for reprocessing when the block arrives.
                         let processor = self.clone();
-                        let reprocess_msg = ReprocessQueueMessage::UnknownBlockDataColumn(
-                            QueuedGossipDataColumn {
+                        let reprocess_msg =
+                            ReprocessQueueMessage::UnknownBlockDataColumn(QueuedGossipDataColumn {
                                 beacon_block_root: unknown_block_root,
                                 process_fn: Box::new(move || {
                                     // Re-dispatch through the normal gossip column processing path.
@@ -753,8 +753,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                                         seen_duration,
                                     );
                                 }),
-                            },
-                        );
+                            });
                         if self
                             .beacon_processor_send
                             .try_send(WorkEvent {

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -649,6 +649,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         subnet_id: DataColumnSubnetId,
         column_sidecar: Arc<DataColumnSidecar<T::EthSpec>>,
         seen_duration: Duration,
+        allow_reprocess: bool,
     ) {
         let slot = column_sidecar.slot();
         let block_root = column_sidecar.block_root();
@@ -738,33 +739,37 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             MessageAcceptance::Ignore,
                         );
 
-                        // Queue the column for reprocessing when the block arrives.
-                        let processor = self.clone();
-                        let reprocess_msg =
-                            ReprocessQueueMessage::UnknownBlockDataColumn(QueuedGossipDataColumn {
-                                beacon_block_root: unknown_block_root,
-                                process_fn: Box::new(move || {
-                                    let _ = processor.send_gossip_data_column_sidecar(
-                                        message_id,
-                                        peer_id,
-                                        subnet_id,
-                                        column_sidecar,
-                                        seen_duration,
-                                    );
-                                }),
-                            });
-                        if self
-                            .beacon_processor_send
-                            .try_send(WorkEvent {
-                                drop_during_sync: false,
-                                work: Work::Reprocess(reprocess_msg),
-                            })
-                            .is_err()
-                        {
-                            debug!(
-                                %unknown_block_root,
-                                "Failed to queue data column for reprocessing"
+                        if allow_reprocess {
+                            // Queue the column for reprocessing when the block arrives.
+                            let processor = self.clone();
+                            let reprocess_msg = ReprocessQueueMessage::UnknownBlockDataColumn(
+                                QueuedGossipDataColumn {
+                                    beacon_block_root: unknown_block_root,
+                                    process_fn: Box::new(move || {
+                                        let _ = processor.send_gossip_data_column_sidecar(
+                                            message_id,
+                                            peer_id,
+                                            subnet_id,
+                                            column_sidecar,
+                                            seen_duration,
+                                            false, // Do not reprocess this message again.
+                                        );
+                                    }),
+                                },
                             );
+                            if self
+                                .beacon_processor_send
+                                .try_send(WorkEvent {
+                                    drop_during_sync: false,
+                                    work: Work::Reprocess(reprocess_msg),
+                                })
+                                .is_err()
+                            {
+                                debug!(
+                                    %unknown_block_root,
+                                    "Failed to queue data column for reprocessing"
+                                );
+                            }
                         }
                     }
                     GossipDataColumnError::InvalidVariant

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -744,7 +744,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             ReprocessQueueMessage::UnknownBlockDataColumn(QueuedGossipDataColumn {
                                 beacon_block_root: unknown_block_root,
                                 process_fn: Box::new(move || {
-                                    // Re-dispatch through the normal gossip column processing path.
                                     let _ = processor.send_gossip_data_column_sidecar(
                                         message_id,
                                         peer_id,

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -231,6 +231,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         subnet_id: DataColumnSubnetId,
         column_sidecar: Arc<DataColumnSidecar<T::EthSpec>>,
         seen_timestamp: Duration,
+        allow_reprocess: bool,
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
         let process_fn = async move {
@@ -241,6 +242,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     subnet_id,
                     column_sidecar,
                     seen_timestamp,
+                    allow_reprocess,
                 )
                 .await
         };

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -435,6 +435,7 @@ impl TestRig {
                     DataColumnSubnetId::from_column_index(*data_column.index(), &self.chain.spec),
                     data_column.clone(),
                     Duration::from_secs(0),
+                    true,
                 )
                 .unwrap();
         }

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -435,6 +435,7 @@ impl<T: BeaconChainTypes> Router<T> {
                             subnet_id,
                             column_sidecar,
                             seen_timestamp,
+                            true,
                         ),
                 )
             }


### PR DESCRIPTION
## Issue Addressed

When debugging ePBS with columns, we noticed that columns arriving before their block dont pass gossip verification checks and are dropped. This PR ensures that columns arriving before the block are sent to the reprocess queue. Once their block arrives, they are reprocessed. 

This isn't an issue pre-gloas because we don't make block root checks for fulu data columns. This allows us to gossip verify the column and send it to the DA cache before the block arrives. 

I think we also need to handle this edge case for partial data columns. Theres an existing TODO for that already.