### PR TITLE
Gloas dont enforce peer column custody on block import

### DIFF
--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -310,11 +310,7 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                     // have the block but not yet imported the envelope and data columns.
                     // Don't enforce max_responses in this case.
                     lookup_peers.contains(&peer_id)
-                        && !cx
-                            .chain
-                            .spec
-                            .fork_name_at_epoch(cx.chain.epoch().unwrap_or_default())
-                            .gloas_enabled(),
+                        && !cx.fork_context.current_fork_name().gloas_enabled(),
                 )
                 .map_err(Error::SendFailed)?;
 

--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -305,7 +305,16 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                     // must have its columns in custody. In that case, set `true = enforce max_requests`
                     // and downscore if data_columns_by_root does not return the expected custody
                     // columns. For the rest of peers, don't downscore if columns are missing.
-                    lookup_peers.contains(&peer_id),
+                    //
+                    // Post-Gloas, blocks and payload envelopes are decoupled. A peer may
+                    // have the block but not yet imported the envelope and data columns.
+                    // Don't enforce max_responses in this case.
+                    lookup_peers.contains(&peer_id)
+                        && !cx
+                            .chain
+                            .spec
+                            .fork_name_at_epoch(cx.chain.epoch().unwrap_or_default())
+                            .gloas_enabled(),
                 )
                 .map_err(Error::SendFailed)?;
 


### PR DESCRIPTION
## Issue Addressed

Peers that advertise that they have imported a block may not have the columns for that slot available post-Gloas. Ensure that we dont penalize them.