### PR TITLE
Ensure we use the right fork when calculating payload attestation sig domain

### DIFF
--- a/consensus/state_processing/src/per_block_processing/signature_sets.rs
+++ b/consensus/state_processing/src/per_block_processing/signature_sets.rs
@@ -378,10 +378,11 @@ where
         .data
         .slot
         .epoch(E::slots_per_epoch());
+    let fork = spec.fork_at_epoch(epoch);
     let domain = spec.get_domain(
         epoch,
         Domain::PTCAttester,
-        &state.fork(),
+        &fork,
         state.genesis_validators_root(),
     );
 


### PR DESCRIPTION
## Issue Addressed

Using `state.fork` is a bit sketchy at the fork boundary. It's safer to just use the payload attestations slot 