### PR TITLE
Enable partial data columns by default on Hoodi and Sepolia

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -674,8 +674,19 @@ pub fn cli_app() -> Command {
             Arg::new("enable-partial-columns")
                 .long("enable-partial-columns")
                 .help("Enable partial messages for data columns. This can reduce the amount of \
-                data sent over the network.")
+                data sent over the network. Enabled by default on Hoodi and Sepolia; use \
+                --disable-partial-columns to opt out.")
                 .action(ArgAction::SetTrue)
+                .help_heading(FLAG_HEADER)
+                .display_order(0)
+        )
+        .arg(
+            Arg::new("disable-partial-columns")
+                .long("disable-partial-columns")
+                .help("Disable partial messages for data columns. Use this on Hoodi or Sepolia \
+                to opt out of the default-enabled behavior.")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("enable-partial-columns")
                 .help_heading(FLAG_HEADER)
                 .display_order(0)
         )

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -110,7 +110,16 @@ pub fn get_config<E: EthSpec>(
 
     set_network_config(&mut client_config.network, cli_args, &data_dir_ref)?;
 
-    if parse_flag(cli_args, "enable-partial-columns") {
+    let default_partial_columns_enabled = spec
+        .config_name
+        .as_ref()
+        .is_some_and(|name| matches!(name.as_str(), "hoodi" | "sepolia"));
+    let user_disable_partial_columns = parse_flag(cli_args, "disable-partial-columns");
+    let user_enable_partial_columns = parse_flag(cli_args, "enable-partial-columns");
+    let enable_partial_columns = !user_disable_partial_columns
+        && (user_enable_partial_columns || default_partial_columns_enabled);
+
+    if enable_partial_columns {
         // Partial messages assume that each subnet maps to exactly one column.
         // Check this here to avoid weird issues on networks where this is not the case.
         if spec.data_column_sidecar_subnet_count == E::number_of_columns() as u64 {

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -482,6 +482,9 @@ Flags:
       --disable-packet-filter
           Disables the discovery packet filter. Useful for testing in smaller
           networks
+      --disable-partial-columns
+          Disable partial messages for data columns. Use this on Hoodi or
+          Sepolia to opt out of the default-enabled behavior.
       --disable-proposer-reorgs
           Do not attempt to reorg late blocks from other validators when
           proposing.
@@ -499,7 +502,8 @@ Flags:
           --listen-address and the UDP port will be --discovery-port.
       --enable-partial-columns
           Enable partial messages for data columns. This can reduce the amount
-          of data sent over the network.
+          of data sent over the network. Enabled by default on Hoodi and
+          Sepolia; use --disable-partial-columns to opt out.
       --enable-private-discovery
           Lighthouse by default does not discover private IP addresses. Set this
           flag to enable connection attempts to local addresses.

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2874,11 +2874,68 @@ fn partial_columns() {
             assert!(config.network.enable_partial_columns);
             assert!(config.chain.enable_partial_columns);
         });
-    // And disabled by default:
+    // And disabled by default on mainnet:
     CommandLineTest::new()
         .run_with_zero_port()
         .with_config(|config| {
             assert!(!config.network.enable_partial_columns);
             assert!(!config.chain.enable_partial_columns);
         })
+}
+
+#[test]
+fn partial_columns_default_hoodi() {
+    CommandLineTest::new()
+        .flag("network", Some("hoodi"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(config.network.enable_partial_columns);
+            assert!(config.chain.enable_partial_columns);
+        });
+}
+
+#[test]
+fn partial_columns_default_sepolia() {
+    CommandLineTest::new()
+        .flag("network", Some("sepolia"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(config.network.enable_partial_columns);
+            assert!(config.chain.enable_partial_columns);
+        });
+}
+
+#[test]
+fn partial_columns_disable_overrides_hoodi_default() {
+    CommandLineTest::new()
+        .flag("network", Some("hoodi"))
+        .flag("disable-partial-columns", None)
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(!config.network.enable_partial_columns);
+            assert!(!config.chain.enable_partial_columns);
+        });
+}
+
+#[test]
+fn partial_columns_disable_on_mainnet_no_op() {
+    CommandLineTest::new()
+        .flag("disable-partial-columns", None)
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(!config.network.enable_partial_columns);
+            assert!(!config.chain.enable_partial_columns);
+        });
+}
+
+#[test]
+fn partial_columns_enable_disable_conflict() {
+    let mut cmd = base_cmd();
+    cmd.arg("--enable-partial-columns")
+        .arg("--disable-partial-columns");
+    let output = cmd.output().expect("should run command");
+    assert!(
+        !output.status.success(),
+        "expected clap to reject --enable-partial-columns and --disable-partial-columns together",
+    );
 }


### PR DESCRIPTION
## Proposed Changes

Enable partial data columns by default on Hoodi and Sepolia.

## Additional Info

Notably, custom testnets are still disabled by default.

with help of Claude
