### PR TITLE
added builder pubkey bidirectional cache

### DIFF
--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -944,14 +944,7 @@ pub fn process_deposit_request_post_gloas<E: EthSpec>(
     // [New in Gloas:EIP7732]
     // Regardless of the withdrawal credentials prefix, if a builder/validator
     // already exists with this pubkey, apply the deposit to their balance
-    // TODO(gloas): this could be more efficient in the builder case, see:
-    // https://github.com/sigp/lighthouse/issues/8783
-    let builder_index = state
-        .builders()?
-        .iter()
-        .enumerate()
-        .find(|(_, builder)| builder.pubkey == deposit_request.pubkey)
-        .map(|(i, _)| i as u64);
+    let builder_index = state.get_builder_index(&deposit_request.pubkey)?;
     let is_builder = builder_index.is_some();
 
     let validator_index = state.get_validator_index(&deposit_request.pubkey)?;

--- a/consensus/state_processing/src/upgrade/gloas.rs
+++ b/consensus/state_processing/src/upgrade/gloas.rs
@@ -9,8 +9,9 @@ use std::mem;
 use tree_hash::TreeHash;
 use typenum::Unsigned;
 use types::{
-    BeaconState, BeaconStateError as Error, BeaconStateGloas, BuilderPendingPayment, ChainSpec,
-    EthSpec, ExecutionPayloadBid, ExecutionRequests, Fork, is_builder_withdrawal_credential,
+    BeaconState, BeaconStateError as Error, BeaconStateGloas, BuilderPendingPayment,
+    BuilderPubkeyCache, ChainSpec, EthSpec, ExecutionPayloadBid, ExecutionRequests, Fork,
+    is_builder_withdrawal_credential,
 };
 
 /// Transform a `Fulu` state into a `Gloas` state.
@@ -116,6 +117,7 @@ pub fn upgrade_state_to_gloas<E: EthSpec>(
         progressive_balances_cache: mem::take(&mut pre.progressive_balances_cache),
         committee_caches: mem::take(&mut pre.committee_caches),
         pubkey_cache: mem::take(&mut pre.pubkey_cache),
+        builder_pubkey_cache: BuilderPubkeyCache::default(),
         exit_cache: mem::take(&mut pre.exit_cache),
         slashings_cache: mem::take(&mut pre.slashings_cache),
         epoch_cache: mem::take(&mut pre.epoch_cache),

--- a/consensus/types/src/state/beacon_state.rs
+++ b/consensus/types/src/state/beacon_state.rs
@@ -44,8 +44,8 @@ use crate::{
         FINALIZED_ROOT_INDEX_ELECTRA, NEXT_SYNC_COMMITTEE_INDEX, NEXT_SYNC_COMMITTEE_INDEX_ELECTRA,
     },
     state::{
-        BlockRootsIter, CommitteeCache, EpochCache, EpochCacheError, ExitCache, HistoricalBatch,
-        HistoricalSummary, ProgressiveBalancesCache, PubkeyCache, SlashingsCache,
+        BlockRootsIter, BuilderPubkeyCache, CommitteeCache, EpochCache, EpochCacheError, ExitCache,
+        HistoricalBatch, HistoricalSummary, ProgressiveBalancesCache, PubkeyCache, SlashingsCache,
         get_active_validator_indices,
     },
     sync_committee::{SyncCommittee, SyncDuty},
@@ -118,6 +118,7 @@ pub enum BeaconStateError {
         cache_len: usize,
         registry_len: usize,
     },
+    BuilderPubkeyCacheInconsistent,
     PreviousCommitteeCacheUninitialized,
     CurrentCommitteeCacheUninitialized,
     TotalActiveBalanceCacheUninitialized,
@@ -695,6 +696,13 @@ where
     #[cfg_attr(feature = "arbitrary", arbitrary(default))]
     #[metastruct(exclude)]
     pub pubkey_cache: PubkeyCache,
+    #[serde(skip_serializing, skip_deserializing)]
+    #[ssz(skip_serializing, skip_deserializing)]
+    #[tree_hash(skip_hashing)]
+    #[cfg_attr(feature = "arbitrary", arbitrary(default))]
+    #[metastruct(exclude)]
+    #[superstruct(only(Gloas))]
+    pub builder_pubkey_cache: BuilderPubkeyCache,
     #[serde(skip_serializing, skip_deserializing)]
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]
@@ -2050,6 +2058,7 @@ impl<E: EthSpec> BeaconState<E> {
         // up elsewhere. It has been retconned into the spec to support index reuse but so far
         // index reuse is only relevant for builders.
         let builder_index = self.get_index_for_new_builder()?;
+        self.update_builder_pubkey_cache()?;
         let builders = self.builders_mut()?;
 
         let version = *withdrawal_credentials
@@ -2078,6 +2087,11 @@ impl<E: EthSpec> BeaconState<E> {
                 .get_mut(builder_index as usize)
                 .ok_or(BeaconStateError::UnknownBuilder(builder_index))? = builder;
         }
+
+        if !self.builder_pubkey_cache_mut()?.set(builder_index, pubkey) {
+            return Err(BeaconStateError::BuilderPubkeyCacheInconsistent);
+        }
+
         Ok(builder_index)
     }
 
@@ -2390,6 +2404,7 @@ impl<E: EthSpec> BeaconState<E> {
         self.drop_committee_cache(RelativeEpoch::Current)?;
         self.drop_committee_cache(RelativeEpoch::Next)?;
         self.drop_pubkey_cache();
+        self.drop_builder_pubkey_cache();
         self.drop_progressive_balances_cache();
         *self.exit_cache_mut() = ExitCache::default();
         *self.slashings_cache_mut() = SlashingsCache::default();
@@ -2582,6 +2597,51 @@ impl<E: EthSpec> BeaconState<E> {
     /// Completely drops the `pubkey_cache`, replacing it with a new, empty cache.
     pub fn drop_pubkey_cache(&mut self) {
         *self.pubkey_cache_mut() = PubkeyCache::default()
+    }
+
+    /// Appends newly added builders to the pubkey cache. No-op on pre-Gloas states.
+    #[instrument(skip_all, level = "debug")]
+    pub fn update_builder_pubkey_cache(&mut self) -> Result<(), BeaconStateError> {
+        let Ok(builders) = self.builders() else {
+            return Ok(());
+        };
+        let builders_len = builders.len();
+        let cache_len = self.builder_pubkey_cache()?.len();
+
+        if cache_len == builders_len {
+            return Ok(());
+        }
+
+        let mut cache = mem::take(self.builder_pubkey_cache_mut()?);
+        for (i, builder) in self.builders()?.iter().enumerate().skip(cache.len()) {
+            let idx = i as BuilderIndex;
+            if !cache.append(builder.pubkey, idx) {
+                *self.builder_pubkey_cache_mut()? = cache;
+                return Err(BeaconStateError::BuilderPubkeyCacheInconsistent);
+            }
+        }
+        *self.builder_pubkey_cache_mut()? = cache;
+
+        Ok(())
+    }
+
+    /// Resets the `builder_pubkey_cache` to an empty cache.
+    pub fn drop_builder_pubkey_cache(&mut self) {
+        if let Ok(cache) = self.builder_pubkey_cache_mut() {
+            *cache = BuilderPubkeyCache::default();
+        }
+    }
+
+    /// Looks up a builder index by pubkey. Returns `Ok(None)` on pre-Gloas states.
+    pub fn get_builder_index(
+        &mut self,
+        pubkey: &PublicKeyBytes,
+    ) -> Result<Option<BuilderIndex>, BeaconStateError> {
+        if self.builders().is_err() {
+            return Ok(None);
+        }
+        self.update_builder_pubkey_cache()?;
+        Ok(self.builder_pubkey_cache()?.get_index(pubkey))
     }
 
     pub fn has_pending_mutations(&self) -> bool {

--- a/consensus/types/src/state/builder_pubkey_cache.rs
+++ b/consensus/types/src/state/builder_pubkey_cache.rs
@@ -1,0 +1,136 @@
+use crate::BuilderIndex;
+use bls::PublicKeyBytes;
+use rpds::HashTrieMapSync as HashTrieMap;
+
+/// Bidirectional pubkey <-> index cache for the Gloas builder registry.
+#[allow(clippy::len_without_is_empty)]
+#[derive(Debug, PartialEq, Clone, Default)]
+pub struct BuilderPubkeyCache {
+    len: usize,
+    pubkey_to_index: HashTrieMap<PublicKeyBytes, BuilderIndex>,
+    index_to_pubkey: HashTrieMap<BuilderIndex, PublicKeyBytes>,
+}
+
+impl BuilderPubkeyCache {
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Append a new builder slot. Returns `false` if `index != self.len`.
+    pub fn append(&mut self, pubkey: PublicKeyBytes, index: BuilderIndex) -> bool {
+        if index as usize != self.len {
+            return false;
+        }
+        self.pubkey_to_index.insert_mut(pubkey, index);
+        self.index_to_pubkey.insert_mut(index, pubkey);
+        self.len = self
+            .len
+            .checked_add(1)
+            .expect("map length cannot exceed usize");
+        true
+    }
+
+    /// Replace the pubkey at an existing index. Returns `false` if `index >= self.len`.
+    pub fn replace(&mut self, index: BuilderIndex, new_pubkey: PublicKeyBytes) -> bool {
+        if index as usize >= self.len {
+            return false;
+        }
+        if let Some(old_pubkey) = self.index_to_pubkey.get(&index).copied() {
+            if old_pubkey == new_pubkey {
+                return true;
+            }
+            if self.pubkey_to_index.get(&old_pubkey).copied() == Some(index) {
+                self.pubkey_to_index.remove_mut(&old_pubkey);
+            }
+        }
+        self.pubkey_to_index.insert_mut(new_pubkey, index);
+        self.index_to_pubkey.insert_mut(index, new_pubkey);
+        true
+    }
+
+    /// Append (`index == self.len`) or replace (`index < self.len`). Returns `false` if
+    /// `index > self.len`.
+    pub fn set(&mut self, index: BuilderIndex, pubkey: PublicKeyBytes) -> bool {
+        match (index as usize).cmp(&self.len) {
+            std::cmp::Ordering::Equal => self.append(pubkey, index),
+            std::cmp::Ordering::Less => self.replace(index, pubkey),
+            std::cmp::Ordering::Greater => false,
+        }
+    }
+
+    pub fn get_index(&self, pubkey: &PublicKeyBytes) -> Option<BuilderIndex> {
+        self.pubkey_to_index.get(pubkey).copied()
+    }
+
+    pub fn get_pubkey(&self, index: BuilderIndex) -> Option<PublicKeyBytes> {
+        self.index_to_pubkey.get(&index).copied()
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl arbitrary::Arbitrary<'_> for BuilderPubkeyCache {
+    fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pk(byte: u8) -> PublicKeyBytes {
+        let mut bytes = [0u8; 48];
+        bytes[0] = byte;
+        PublicKeyBytes::deserialize(&bytes).unwrap()
+    }
+
+    #[test]
+    fn append_in_order() {
+        let mut cache = BuilderPubkeyCache::default();
+        assert!(cache.append(pk(1), 0));
+        assert!(cache.append(pk(2), 1));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get_index(&pk(1)), Some(0));
+        assert_eq!(cache.get_index(&pk(2)), Some(1));
+        assert_eq!(cache.get_pubkey(0), Some(pk(1)));
+        assert_eq!(cache.get_pubkey(1), Some(pk(2)));
+    }
+
+    #[test]
+    fn append_out_of_order_rejected() {
+        let mut cache = BuilderPubkeyCache::default();
+        assert!(!cache.append(pk(1), 1));
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn replace_reuses_slot() {
+        let mut cache = BuilderPubkeyCache::default();
+        cache.append(pk(1), 0);
+        cache.append(pk(2), 1);
+        assert!(cache.replace(0, pk(3)));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get_index(&pk(1)), None);
+        assert_eq!(cache.get_index(&pk(3)), Some(0));
+        assert_eq!(cache.get_pubkey(0), Some(pk(3)));
+        assert_eq!(cache.get_index(&pk(2)), Some(1));
+    }
+
+    #[test]
+    fn replace_unknown_slot_rejected() {
+        let mut cache = BuilderPubkeyCache::default();
+        cache.append(pk(1), 0);
+        assert!(!cache.replace(5, pk(2)));
+    }
+
+    #[test]
+    fn persistent_clone_is_independent() {
+        let mut cache = BuilderPubkeyCache::default();
+        cache.append(pk(1), 0);
+        let snapshot = cache.clone();
+        cache.append(pk(2), 1);
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot.get_index(&pk(2)), None);
+        assert_eq!(cache.len(), 2);
+    }
+}

--- a/consensus/types/src/state/mod.rs
+++ b/consensus/types/src/state/mod.rs
@@ -1,6 +1,7 @@
 mod activation_queue;
 mod balance;
 mod beacon_state;
+mod builder_pubkey_cache;
 #[macro_use]
 mod committee_cache;
 mod epoch_cache;
@@ -19,6 +20,7 @@ pub use beacon_state::{
     BeaconStateDeneb, BeaconStateElectra, BeaconStateError, BeaconStateFulu, BeaconStateGloas,
     BeaconStateHash, BeaconStateRef, CACHED_EPOCHS, DEFAULT_PRE_ELECTRA_WS_PERIOD, Validators,
 };
+pub use builder_pubkey_cache::BuilderPubkeyCache;
 pub use committee_cache::{
     CommitteeCache, compute_committee_index_in_epoch, compute_committee_range_in_epoch,
     get_active_validator_indices,


### PR DESCRIPTION
## Issue Addressed

Closes #8783

## Proposed Changes

This PR implements my understanding of how to fix the scenario described in #8783.
As described in the issue, this PR introduced a bidirectional cache between `builder_index` and `public_key`. It then leverage the new data structure to avoid the `O(n)` search. 

## Additional Info
- the only function Im seeing that modifies the length of the builder list is `add_builder_to_registry`. Here, a new builder is added to the list. My assumption is that the builder list 1) never shrinks 2) builders pubkeys never change. This means that the cache can only miss some entries from the builder list but will never have more entries that the builder list.

Let me know if the logic is wrong or if anything should be modified :) 