### PR TITLE
docs: fix article usage in documentation

### DIFF
--- a/book/src/advanced_web3signer.md
+++ b/book/src/advanced_web3signer.md
@@ -5,7 +5,7 @@
 [Teku]: https://github.com/consensys/teku
 
 [Web3Signer] is a tool by Consensys which allows *remote signing*. Remote signing is when a
-Validator Client (VC) out-sources the signing of messages to a remote server (e.g., via HTTPS). This
+Validator Client (VC) out-sources the signing of messages to a remote server (e.g., vian HTTPS). This
 means that the VC does not hold the validator private keys.
 
 ## Warnings

--- a/book/src/api_bn.md
+++ b/book/src/api_bn.md
@@ -148,7 +148,7 @@ data:{"version":"capella","data":{"proposal_slot":"11047","proposer_index":"3360
 
 The HTTP server can be served over TLS by using the `--http-enable-tls`,
 `http-tls-cert` and `http-tls-key` flags.
-This allows the API to be accessed via HTTPS, encrypting traffic to
+This allows the API to be accessed vian HTTPS, encrypting traffic to
 and from the server.
 
 This is particularly useful when connecting validator clients to

--- a/book/src/api_metrics.md
+++ b/book/src/api_metrics.md
@@ -2,7 +2,7 @@
 
 Lighthouse provides an extensive suite of metrics and monitoring in the
 [Prometheus](https://prometheus.io/docs/introduction/overview/) export format
-via a HTTP server built into Lighthouse.
+via an HTTP server built into Lighthouse.
 
 These metrics are generally consumed by a Prometheus server and displayed via a
 Grafana dashboard. These components are available in a docker-compose format at

--- a/book/src/api_vc.md
+++ b/book/src/api_vc.md
@@ -13,7 +13,7 @@ signers. It also includes some Lighthouse-specific endpoints which are described
 
 ## Starting the server
 
-A Lighthouse validator client can be configured to expose a HTTP server by supplying the `--http` flag. The default listen address is `http://127.0.0.1:5062`.
+A Lighthouse validator client can be configured to expose an HTTP server by supplying the `--http` flag. The default listen address is `http://127.0.0.1:5062`.
 
 The following CLI flags control the HTTP server:
 

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -2,7 +2,7 @@
 
 ```
 The primary component which connects to the Ethereum 2.0 P2P network and
-downloads, verifies and stores blocks. Provides a HTTP API for querying the
+downloads, verifies and stores blocks. Provides an HTTP API for querying the
 beacon chain and publishing messages to the network.
 
 Usage: lighthouse beacon_node [OPTIONS] --execution-endpoint <EXECUTION-ENDPOINT>
@@ -275,7 +275,7 @@ Options:
           (e.g. beaconcha.in). This flag sets the endpoint where the beacon node
           metrics will be sent. Note: This will send information to a remote
           sever which may identify and associate your validators, IP address and
-          other personal information. Always use a HTTPS connection and never
+          other personal information. Always use an HTTPS connection and never
           provide an untrusted URL.
       --monitoring-endpoint-period <SECONDS>
           Defines how many seconds to wait between each message sent to the

--- a/book/src/help_general.md
+++ b/book/src/help_general.md
@@ -12,7 +12,7 @@ Commands:
           a, am, account]
   beacon_node
           The primary component which connects to the Ethereum 2.0 P2P network
-          and downloads, verifies and stores blocks. Provides a HTTP API for
+          and downloads, verifies and stores blocks. Provides an HTTP API for
           querying the beacon chain and publishing messages to the network.
           [aliases: b, bn, beacon]
   boot_node

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -60,7 +60,7 @@ Options:
           flag is used, it additionally requires the explicit use of the
           `--unencrypted-http-transport` flag to ensure the user is aware of the
           risks involved. For access via the Internet, users should apply
-          transport-layer security like a HTTPS reverse-proxy or SSH tunnelling.
+          transport-layer security like an HTTPS reverse-proxy or SSH tunnelling.
       --http-allow-origin <ORIGIN>
           Set the value of the Access-Control-Allow-Origin response HTTP header.
           Use * to allow any origin (not recommended in production). If no value
@@ -107,7 +107,7 @@ Options:
           (e.g. beaconcha.in). This flag sets the endpoint where the beacon node
           metrics will be sent. Note: This will send information to a remote
           sever which may identify and associate your validators, IP address and
-          other personal information. Always use a HTTPS connection and never
+          other personal information. Always use an HTTPS connection and never
           provide an untrusted URL.
       --monitoring-endpoint-period <SECONDS>
           Defines how many seconds to wait between each message sent to the


### PR DESCRIPTION
## Description
Fixed grammatical errors in documentation for improved readability.

⚠️ **Note:** Documentation-only changes. No code modified. This is a minor documentation improvement.

## Changes
- Changed `a HTTPS` → `an HTTPS` (4 occurrences)
- Changed `a HTTP` → `an HTTP` (4 occurrences)
- Improves grammar consistency across book

## Files Modified
- book/src/help_vc.md
- book/src/help_bn.md
- book/src/advanced_web3signer.md
- book/src/api_bn.md
- book/src/api_vc.md
- book/src/api_metrics.md
- book/src/help_general.md

## Impact
- Documentation clarity improvement only
- No functional changes