### PR TITLE
Delete bogus `InvalidBestNode` error

### DIFF
--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -1569,6 +1569,7 @@ where
         beacon_block_root: Hash256,
         mut state: Cow<BeaconState<E>>,
         state_root: Hash256,
+        payload_present_override: Option<bool>,
     ) -> Result<Attestation<E>, BeaconChainError> {
         assert_eq!(
             state.get_latest_block_root(state_root),
@@ -1603,12 +1604,17 @@ where
             *state.get_block_root(target_slot)?
         };
 
-        let payload_present = state.fork_name_unchecked().gloas_enabled()
-            && state.latest_block_header().slot != slot
-            && self
-                .chain
-                .canonical_head
-                .block_has_canonical_payload(&beacon_block_root, &self.spec)?;
+        let payload_present = match payload_present_override {
+            Some(payload_present) => payload_present,
+            None => {
+                state.fork_name_unchecked().gloas_enabled()
+                    && state.latest_block_header().slot != slot
+                    && self
+                        .chain
+                        .canonical_head
+                        .block_has_canonical_payload(&beacon_block_root, &self.spec)?
+            }
+        };
 
         Ok(Attestation::empty_for_signing(
             index,
@@ -1647,7 +1653,11 @@ where
             state_root,
             head_block_root,
             attestation_slot,
-            MakeAttestationOptions { limit: None, fork },
+            MakeAttestationOptions {
+                limit: None,
+                fork,
+                payload_present_override: None,
+            },
         )
         .0
     }
@@ -1674,7 +1684,11 @@ where
             state_root,
             head_block_root,
             attestation_slot,
-            MakeAttestationOptions { limit: None, fork },
+            MakeAttestationOptions {
+                limit: None,
+                fork,
+                payload_present_override: None,
+            },
         )
         .0
     }
@@ -1688,7 +1702,7 @@ where
         attestation_slot: Slot,
         opts: MakeAttestationOptions,
     ) -> (Vec<CommitteeSingleAttestations>, Vec<usize>) {
-        let MakeAttestationOptions { limit, fork } = opts;
+        let MakeAttestationOptions { limit, fork, .. } = opts;
         let committee_count = state.get_committee_count_at_slot(state.slot()).unwrap();
         let num_attesters = AtomicUsize::new(0);
 
@@ -1781,7 +1795,11 @@ where
         attestation_slot: Slot,
         opts: MakeAttestationOptions,
     ) -> (Vec<CommitteeAttestations<E>>, Vec<usize>) {
-        let MakeAttestationOptions { limit, fork } = opts;
+        let MakeAttestationOptions {
+            limit,
+            fork,
+            payload_present_override,
+        } = opts;
         let committee_count = state.get_committee_count_at_slot(state.slot()).unwrap();
         let num_attesters = AtomicUsize::new(0);
 
@@ -1814,6 +1832,7 @@ where
                                 head_block_root.into(),
                                 Cow::Borrowed(state),
                                 state_root,
+                                payload_present_override,
                             )
                             .unwrap();
 
@@ -2016,7 +2035,11 @@ where
             state_root,
             block_hash,
             slot,
-            MakeAttestationOptions { limit, fork },
+            MakeAttestationOptions {
+                limit,
+                fork,
+                payload_present_override: None,
+            },
         )
     }
 
@@ -3761,6 +3784,8 @@ pub struct MakeAttestationOptions {
     pub limit: Option<usize>,
     /// Fork to use for signing attestations.
     pub fork: Fork,
+    /// Override post-Gloas regular attestation payload-present encoding.
+    pub payload_present_override: Option<bool>,
 }
 
 pub enum NumBlobs {

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -1636,6 +1636,7 @@ async fn attestation_verification_use_head_state_fork() {
                 MakeAttestationOptions {
                     fork: capella_fork,
                     limit: None,
+                    payload_present_override: None,
                 },
             )
             .0
@@ -1667,6 +1668,7 @@ async fn attestation_verification_use_head_state_fork() {
                 MakeAttestationOptions {
                     fork: bellatrix_fork,
                     limit: None,
+                    payload_present_override: None,
                 },
             )
             .0
@@ -1741,6 +1743,7 @@ async fn aggregated_attestation_verification_use_head_state_fork() {
                 MakeAttestationOptions {
                     fork: capella_fork,
                     limit: None,
+                    payload_present_override: None,
                 },
             )
             .0
@@ -1768,6 +1771,7 @@ async fn aggregated_attestation_verification_use_head_state_fork() {
                 MakeAttestationOptions {
                     fork: bellatrix_fork,
                     limit: None,
+                    payload_present_override: None,
                 },
             )
             .0

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -8,7 +8,8 @@ use beacon_chain::{
     WhenSlotSkipped,
     custody_context::NodeCustodyType,
     test_utils::{
-        AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType, test_spec,
+        AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
+        MakeAttestationOptions, test_spec,
     },
 };
 use beacon_chain::{
@@ -17,6 +18,7 @@ use beacon_chain::{
 };
 use bls::{AggregateSignature, Keypair, Signature};
 use fixed_bytes::FixedBytesExtended;
+use fork_choice::PayloadStatus;
 use logging::create_test_tracing_subscriber;
 use slasher::{Config as SlasherConfig, Slasher};
 use state_processing::{
@@ -1924,6 +1926,152 @@ async fn add_altair_block_to_base_chain() {
             })
         }
     ));
+}
+
+// This is a regression test for the bogus `InvalidBestNode` error which was reachable in Gloas
+// networks. Previously Lighthouse would return an `InvalidBestNode` error from `get_head` in
+// contradiction to the spec, which states that the justified root should be returned when no leaf
+// node is viable.
+//
+// The chain construction in this test is contrived but not impossible: the justified block's full
+// branch is what contained the evidence to justify it, but the empty branch is more weighty and
+// wins out.
+#[tokio::test]
+async fn gloas_get_head_can_return_justified_empty_payload_branch() {
+    let spec = test_spec::<E>();
+    if !spec.fork_name_at_epoch(Epoch::new(0)).gloas_enabled() {
+        return;
+    }
+
+    let harness = BeaconChainHarness::builder(MainnetEthSpec)
+        .spec(spec.clone().into())
+        .chain_config(ChainConfig {
+            archive: true,
+            ..ChainConfig::default()
+        })
+        .keypairs(KEYPAIRS[0..VALIDATOR_COUNT].to_vec())
+        .node_custody_type(NodeCustodyType::Supernode)
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build();
+
+    harness
+        .extend_slots(E::slots_per_epoch() as usize * 3)
+        .await;
+
+    let justified_checkpoint = harness.justified_checkpoint();
+    assert_ne!(justified_checkpoint.epoch, Epoch::new(0));
+    let justified_root = justified_checkpoint.root;
+    let justified_block = harness
+        .chain
+        .get_blinded_block(&justified_root)
+        .unwrap()
+        .unwrap();
+    let justified_slot = justified_block.message().slot();
+    let justified_state_root = justified_block.message().state_root();
+
+    harness.advance_slot();
+    harness
+        .extend_chain(
+            E::slots_per_epoch() as usize * 2,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::SomeValidators(vec![]),
+        )
+        .await;
+
+    let current_slot = harness.get_current_slot();
+    let current_epoch = current_slot.epoch(E::slots_per_epoch());
+    assert_eq!(
+        harness
+            .chain
+            .canonical_head
+            .cached_head()
+            .head_payload_status(),
+        PayloadStatus::Full
+    );
+
+    {
+        let fork_choice = harness.chain.canonical_head.fork_choice_read_lock();
+        assert!(fork_choice.is_payload_received(&justified_root));
+        let justified_node = fork_choice.get_block(&justified_root).unwrap();
+        let voting_source = justified_node
+            .unrealized_justified_checkpoint
+            .unwrap_or(justified_node.justified_checkpoint);
+        assert!(
+            voting_source.epoch + 2 < current_epoch,
+            "the justified node's own voting source must be stale"
+        );
+    }
+
+    let mut attestation_state = harness
+        .chain
+        .get_state(&justified_state_root, Some(justified_slot), true)
+        .unwrap()
+        .unwrap();
+    assert!(
+        attestation_state
+            .validators()
+            .iter()
+            .all(|validator| !validator.slashed),
+        "reproducer must not rely on slashed validators"
+    );
+
+    let all_validators = harness.get_all_validators();
+    let mut validators_with_empty_vote = vec![false; VALIDATOR_COUNT];
+    let attestation_start_slot = (current_epoch - 1).start_slot(E::slots_per_epoch());
+    let attestation_slot = current_slot - 1;
+    assert_eq!(
+        attestation_start_slot + E::slots_per_epoch() - 1,
+        attestation_slot
+    );
+
+    // With 32 Mainnet validators, each slot only covers that slot's committee. Use the previous
+    // epoch so every validator gets a latest vote while every attestation remains gossip-current.
+    for slot in (attestation_start_slot.as_u64()..current_slot.as_u64()).map(Slot::new) {
+        while attestation_state.slot() < slot {
+            per_slot_processing(&mut attestation_state, None, &spec).unwrap();
+        }
+        attestation_state.build_caches(&spec).unwrap();
+        let attestation_state_root = attestation_state.update_tree_hash_cache().unwrap();
+        assert_eq!(
+            attestation_state.get_latest_block_root(attestation_state_root),
+            justified_root
+        );
+
+        let fork = spec.fork_at_epoch(slot.epoch(E::slots_per_epoch()));
+        let (attestations, attesters) = harness.make_attestations_with_opts(
+            &all_validators,
+            &attestation_state,
+            attestation_state_root,
+            justified_root.into(),
+            slot,
+            MakeAttestationOptions {
+                limit: None,
+                fork,
+                payload_present_override: Some(false),
+            },
+        );
+
+        for validator_index in attesters {
+            validators_with_empty_vote[validator_index] = true;
+        }
+        harness.process_attestations(attestations, &attestation_state);
+    }
+
+    assert!(
+        validators_with_empty_vote.iter().all(|attested| *attested),
+        "all validators should have a latest regular attestation to the justified root"
+    );
+
+    let (head_root, payload_status) = harness
+        .chain
+        .canonical_head
+        .fork_choice_write_lock()
+        .get_head(current_slot, &spec)
+        .expect("fork choice should return the justified root on the empty payload branch");
+
+    assert_eq!(head_root, justified_root);
+    assert_eq!(payload_status, PayloadStatus::Empty);
 }
 
 // This is a regression test for this bug:

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -2025,8 +2025,9 @@ async fn gloas_get_head_can_return_justified_empty_payload_branch() {
         attestation_slot
     );
 
-    // With 32 Mainnet validators, each slot only covers that slot's committee. Use the previous
-    // epoch so every validator gets a latest vote while every attestation remains gossip-current.
+    // Create two epochs worth of attestations with `payload_present=false`, all pointing at the
+    // justified block. This ensures it's very much the canonical head, instead of the justifying
+    // chain built off its `Full` branch.
     for slot in (attestation_start_slot.as_u64()..current_slot.as_u64()).map(Slot::new) {
         while attestation_state.slot() < slot {
             per_slot_processing(&mut attestation_state, None, &spec).unwrap();

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -2017,7 +2017,7 @@ async fn gloas_get_head_can_return_justified_empty_payload_branch() {
     );
 
     let all_validators = harness.get_all_validators();
-    let mut validators_with_empty_vote = vec![false; VALIDATOR_COUNT];
+    let mut validators_with_empty_vote = [false; VALIDATOR_COUNT];
     let attestation_start_slot = (current_epoch - 1).start_slot(E::slots_per_epoch());
     let attestation_slot = current_slot - 1;
     assert_eq!(

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -6,7 +6,7 @@ use beacon_chain::{
     BeaconChainError, BlockError, ChainConfig, ExecutionPayloadError,
     INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON, NotifyExecutionLayer, StateSkipConfig,
     WhenSlotSkipped,
-    canonical_head::{CachedHead, CanonicalHead},
+    canonical_head::CachedHead,
     test_utils::{BeaconChainHarness, EphemeralHarnessType, fork_name_from_env, test_spec},
 };
 use execution_layer::{

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -108,10 +108,6 @@ impl InvalidPayloadRig {
         self.harness.chain.canonical_head.cached_head()
     }
 
-    fn canonical_head(&self) -> &CanonicalHead<EphemeralHarnessType<E>> {
-        &self.harness.chain.canonical_head
-    }
-
     fn previous_forkchoice_update_params(&self) -> (ForkchoiceState, PayloadAttributes) {
         let mock_execution_layer = self.harness.mock_execution_layer.as_ref().unwrap();
         let json = mock_execution_layer
@@ -352,19 +348,6 @@ impl InvalidPayloadRig {
             .process_invalid_execution_payload(&InvalidationOperation::InvalidateOne { block_root })
             .await
             .unwrap();
-    }
-
-    fn assert_get_head_error_contains(&self, s: &str) {
-        match self
-            .harness
-            .chain
-            .canonical_head
-            .fork_choice_write_lock()
-            .get_head(self.harness.chain.slot().unwrap(), &self.harness.chain.spec)
-        {
-            Err(ForkChoiceError::ProtoArrayStringError(e)) if e.contains(s) => (),
-            other => panic!("expected {} error, got {:?}", s, other),
-        };
     }
 }
 
@@ -1297,21 +1280,14 @@ impl InvalidHeadSetup {
         rig.invalidate_manually(invalid_head.head_block_root())
             .await;
 
-        // Since our setup ensures that there is only a single, invalid block
-        // that's viable for head (according to FFG filtering), setting the
-        // head block as invalid should not result in another head being chosen.
-        // Rather, it should fail to run fork choice and leave the invalid block as
-        // the head.
-        assert!(
-            rig.canonical_head()
-                .head_execution_status()
-                .unwrap()
-                .is_invalid()
-        );
-
-        // Ensure that we're getting the correct error when trying to find a new
-        // head.
-        rig.assert_get_head_error_contains("InvalidBestNode");
+        // Ensure the justified root is the head. This is the spec-correct choice of head when
+        // all leaves are ineligible.
+        let mut fork_choice = rig.harness.chain.canonical_head.fork_choice_write_lock();
+        let head = fork_choice
+            .get_head(rig.harness.chain.slot().unwrap(), &rig.harness.chain.spec)
+            .unwrap();
+        assert_eq!(head.0, fork_choice.justified_checkpoint().root);
+        drop(fork_choice);
 
         Self {
             rig,

--- a/consensus/proto_array/src/error.rs
+++ b/consensus/proto_array/src/error.rs
@@ -1,6 +1,6 @@
 use crate::PayloadStatus;
 use safe_arith::ArithError;
-use types::{Checkpoint, Epoch, ExecutionBlockHash, Hash256, Slot};
+use types::{Epoch, ExecutionBlockHash, Hash256};
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum Error {
@@ -9,8 +9,6 @@ pub enum Error {
     NodeUnknown(Hash256),
     InvalidFinalizedRootChange,
     InvalidNodeIndex(usize),
-    InvalidParentIndex(usize),
-    InvalidBestChildIndex(usize),
     InvalidJustifiedIndex(usize),
     InvalidBestDescendant(usize),
     InvalidParentDelta(usize),
@@ -30,7 +28,6 @@ pub enum Error {
         current_finalized_epoch: Epoch,
         new_finalized_epoch: Epoch,
     },
-    InvalidBestNode(Box<InvalidBestNodeInfo>),
     InvalidAncestorOfValidPayload {
         ancestor_block_root: Hash256,
         ancestor_payload_block_hash: ExecutionBlockHash,
@@ -73,15 +70,4 @@ impl From<ArithError> for Error {
     fn from(e: ArithError) -> Self {
         Error::Arith(e)
     }
-}
-
-#[derive(Clone, PartialEq, Debug)]
-pub struct InvalidBestNodeInfo {
-    pub current_slot: Slot,
-    pub start_root: Hash256,
-    pub justified_checkpoint: Checkpoint,
-    pub finalized_checkpoint: Checkpoint,
-    pub head_root: Hash256,
-    pub head_justified_checkpoint: Checkpoint,
-    pub head_finalized_checkpoint: Checkpoint,
 }

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -1,4 +1,3 @@
-use crate::error::InvalidBestNodeInfo;
 use crate::proto_array_fork_choice::IndexedForkChoiceNode;
 use crate::{
     Block, ExecutionStatus, JustifiedBalances, LatestMessage, PayloadStatus, error::Error,
@@ -1092,28 +1091,6 @@ impl ProtoArray {
             justified_balances,
             spec,
         )?;
-
-        // Perform a sanity check that the node is indeed valid to be the head.
-        let best_node = self
-            .nodes
-            .get(best_fc_node.proto_node_index)
-            .ok_or(Error::InvalidNodeIndex(best_fc_node.proto_node_index))?;
-        if !self.node_is_viable_for_head::<E>(
-            best_node,
-            current_slot,
-            best_justified_checkpoint,
-            best_finalized_checkpoint,
-        ) {
-            return Err(Error::InvalidBestNode(Box::new(InvalidBestNodeInfo {
-                current_slot,
-                start_root: *justified_root,
-                justified_checkpoint: best_justified_checkpoint,
-                finalized_checkpoint: best_finalized_checkpoint,
-                head_root: best_node.root(),
-                head_justified_checkpoint: *best_node.justified_checkpoint(),
-                head_finalized_checkpoint: *best_node.finalized_checkpoint(),
-            })));
-        }
 
         Ok((best_fc_node.root, best_fc_node.payload_status))
     }


### PR DESCRIPTION
## Issue Addressed

On Glamsterdam devnets we started seeing Lighthouse nodes unable to start with errors like:

> May 26 04:34:01.582 CRIT  Failed to start beacon node                   reason: "Unable to load fork choice from disk: ForkChoiceError(ProtoArrayStringError(\"find_head failed: InvalidBestNode(InvalidBestNodeInfo { current_slot: Slot(23550), start_root: 0x2c70b1641c29ec46360c99f9a8512f077862cbbc603e16f4a423007d210b0c5f, justified_checkpoint: Checkpoint { epoch: Epoch(712), root: 0x2c70b1641c29ec46360c99f9a8512f077862cbbc603e16f4a423007d210b0c5f }, finalized_checkpoint: Checkpoint { epoch: Epoch(710), root: 0xede5e0b09b51bdb5445ade3398e685bd193b845e0b0ffb827f0c3fec8277ea51 }, head_root: 0x2c70b1641c29ec46360c99f9a8512f077862cbbc603e16f4a423007d210b0c5f, head_justified_checkpoint: Checkpoint { epoch: Epoch(710), root: 0xede5e0b09b51bdb5445ade3398e685bd193b845e0b0ffb827f0c3fec8277ea51 }, head_finalized_checkpoint: Checkpoint { epoch: Epoch(709), root: 0xbb243eff616ff362c52b83113e7c536d0a68cb9ca3d6a1cb1055e732219d9736 } })\"))"

This error was the result of an overly-strict sanity check, based on assumptions that are not true under extreme network conditions.

## Proposed Changes

Completely remove the `InvalidBestNode` failure path: it is not compliant with the spec, and is actively harmful when triggered (it prevents Lighthouse from starting at all). The error was reachable in any situation where all leaf nodes of fork choice were ineligible to be the head. The payload invalidation tests show some examples of cases where this would happen, and the [newly-added regression test](9a5df1d982b145992c0bafce634cd9a7e5907098) shows a contrived case where it can happen on a Gloas network without _any_ slashings or invalid blocks. There are probably many more cases where it can happen.

We do not lose anything by removing it. The spec's implementation of `get_head` _always_ returns something (unless it crashes), and in these cases it is correct to return the starting node of the traversal: the justified checkpoint block. This is what we now do, and what the new test verifies.

I've also added some facilities to the harness for injecting attestations with fixed `payload_present` fields. @hopinheimer found himself needing something similar when messing with reorg tests, so I think these are probably useful. It might be possible to do without them by juggling the payload reveal timing in just the right way, but I think this approach is just way simpler.
