### PR TITLE
Instrument the fork choice lock with hold-time metrics and backtraces

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -37,6 +37,9 @@ use crate::events::ServerSentEventHandler;
 use crate::execution_payload::{NotifyExecutionLayer, PreparePayloadHandle, get_execution_payload};
 use crate::fork_choice_signal::{ForkChoiceSignalRx, ForkChoiceSignalTx};
 use crate::graffiti_calculator::{GraffitiCalculator, GraffitiSettings};
+use crate::instrumented_lock::{
+    InstrumentedRwLockUpgradableReadGuard, InstrumentedRwLockWriteGuard,
+};
 use crate::light_client_finality_update_verification::{
     Error as LightClientFinalityUpdateError, VerifiedLightClientFinalityUpdate,
 };
@@ -111,7 +114,7 @@ use logging::crit;
 use operation_pool::{
     CompactAttestationRef, OperationPool, PersistedOperationPool, ReceivedPreCapella,
 };
-use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
+use parking_lot::{Mutex, RwLock};
 use proto_array::{DoNotReOrg, ProposerHeadError, ReOrgThreshold};
 use rand::RngCore;
 use safe_arith::SafeArith;
@@ -4318,7 +4321,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Take an exclusive write-lock on fork choice. It's very important to prevent deadlocks by
         // avoiding taking other locks whilst holding this lock.
-        let mut fork_choice = parking_lot::RwLockUpgradableReadGuard::upgrade(fork_choice_reader);
+        let mut fork_choice = InstrumentedRwLockUpgradableReadGuard::upgrade(fork_choice_reader);
 
         // Do not import a block that doesn't descend from the finalized root.
         let signed_block =
@@ -4550,7 +4553,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // We don't actually need this value, however it's always present when we call this function
         // and it needs to be dropped to prevent a dead-lock. Requiring it to be passed here is
         // defensive programming.
-        fork_choice_write_lock: RwLockWriteGuard<BeaconForkChoice<T>>,
+        fork_choice_write_lock: InstrumentedRwLockWriteGuard<BeaconForkChoice<T>>,
     ) -> Result<(), BlockError> {
         // Clear the early attester cache to prevent attestations which we would later be unable
         // to verify due to the failure.

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -58,6 +58,7 @@ use crate::data_column_verification::GossipDataColumnError;
 use crate::execution_payload::{
     NotifyExecutionLayer, PayloadNotifier, validate_execution_payload_for_gossip,
 };
+use crate::instrumented_lock::InstrumentedRwLockReadGuard;
 use crate::kzg_utils::blobs_to_data_column_sidecars;
 use crate::observed_block_producers::SeenBlock;
 use crate::payload_envelope_verification::EnvelopeError;
@@ -1911,7 +1912,7 @@ pub fn get_block_header_root(block_header: &SignedBeaconBlockHeader) -> Hash256 
 /// fork choice; both missing cases return `ParentUnknown`.
 #[allow(clippy::type_complexity)]
 fn verify_parent_block_and_envelope_are_known<T: BeaconChainTypes>(
-    fork_choice_read_lock: &RwLockReadGuard<BeaconForkChoice<T>>,
+    fork_choice_read_lock: &InstrumentedRwLockReadGuard<BeaconForkChoice<T>>,
     block: Arc<SignedBeaconBlock<T::EthSpec>>,
 ) -> Result<(ProtoBlock, Arc<SignedBeaconBlock<T::EthSpec>>), BlockError> {
     match fork_choice_read_lock.get_parent_import_status(&block) {

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -58,8 +58,12 @@ use fork_choice::{
 };
 use itertools::process_results;
 
+use crate::instrumented_lock::{
+    InstrumentedRwLock, InstrumentedRwLockReadGuard, InstrumentedRwLockUpgradableReadGuard,
+    InstrumentedRwLockWriteGuard,
+};
 use logging::crit;
-use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
+use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use slot_clock::SlotClock;
 use state_processing::AllCaches;
 use state_processing::state_advance::complete_state_advance;
@@ -89,10 +93,6 @@ impl<T> CanonicalHeadRwLock<T> {
 
     fn read(&self) -> RwLockReadGuard<'_, T> {
         self.0.read()
-    }
-
-    fn upgradable_read(&self) -> RwLockUpgradableReadGuard<'_, T> {
-        self.0.upgradable_read()
     }
 
     fn write(&self) -> RwLockWriteGuard<'_, T> {
@@ -265,6 +265,11 @@ impl<E: EthSpec> CachedHead<E> {
     }
 }
 
+/// Emit a backtrace (and record the hold-time metric) when the fork-choice lock is held for
+/// longer than this. Tuned to catch the multi-hundred-millisecond stalls described in issue
+/// #8147 without being noisy during normal operation.
+const FORK_CHOICE_LOCK_HOLD_WARN_THRESHOLD: Duration = Duration::from_millis(100);
+
 /// Represents the "canonical head" of the beacon chain.
 ///
 /// The `cached_head` is elected by the `fork_choice` algorithm contained in this struct.
@@ -276,7 +281,7 @@ impl<E: EthSpec> CachedHead<E> {
 pub struct CanonicalHead<T: BeaconChainTypes> {
     /// Provides an in-memory representation of the non-finalized block tree and is used to run the
     /// fork choice algorithm and determine the canonical head.
-    fork_choice: CanonicalHeadRwLock<BeaconForkChoice<T>>,
+    fork_choice: InstrumentedRwLock<BeaconForkChoice<T>>,
     /// Provides values cached from a previous execution of `self.fork_choice.get_head`.
     ///
     /// Although `self.fork_choice` might be slightly more advanced that this value, it is safe to
@@ -332,7 +337,12 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         };
 
         Ok(Self {
-            fork_choice: CanonicalHeadRwLock::new(fork_choice),
+            fork_choice: InstrumentedRwLock::new(
+                fork_choice,
+                &metrics::FORK_CHOICE_LOCK_METRICS,
+                "fork_choice",
+                FORK_CHOICE_LOCK_HOLD_WARN_THRESHOLD,
+            ),
             cached_head: CanonicalHeadRwLock::new(cached_head),
             recompute_head_lock: Mutex::new(()),
             fast_confirmation: fcr,
@@ -349,7 +359,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         // We don't actually need this value, however it's always present when we call this function
         // and it needs to be dropped to prevent a dead-lock. Requiring it to be passed here is
         // defensive programming.
-        mut fork_choice_write_lock: RwLockWriteGuard<BeaconForkChoice<T>>,
+        mut fork_choice_write_lock: InstrumentedRwLockWriteGuard<BeaconForkChoice<T>>,
         reset_payload_statuses: ResetPayloadStatuses,
         store: &BeaconStore<T>,
         spec: &ChainSpec,
@@ -494,23 +504,20 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
     }
 
     /// Access a read-lock for fork choice.
-    pub fn fork_choice_read_lock(&self) -> RwLockReadGuard<'_, BeaconForkChoice<T>> {
-        let _timer = metrics::start_timer(&metrics::FORK_CHOICE_READ_LOCK_AQUIRE_TIMES);
+    pub fn fork_choice_read_lock(&self) -> InstrumentedRwLockReadGuard<'_, BeaconForkChoice<T>> {
         self.fork_choice.read()
     }
 
     /// Access an upgradable read-lock for fork choice.
     pub fn fork_choice_upgradable_read_lock(
         &self,
-    ) -> RwLockUpgradableReadGuard<'_, BeaconForkChoice<T>> {
-        let _timer = metrics::start_timer(&metrics::FORK_CHOICE_UPGRADABLE_READ_LOCK_AQUIRE_TIMES);
+    ) -> InstrumentedRwLockUpgradableReadGuard<'_, BeaconForkChoice<T>> {
         self.fork_choice.upgradable_read()
     }
 
     /// Access a write-lock for fork choice.
     #[instrument(skip_all)]
-    pub fn fork_choice_write_lock(&self) -> RwLockWriteGuard<'_, BeaconForkChoice<T>> {
-        let _timer = metrics::start_timer(&metrics::FORK_CHOICE_WRITE_LOCK_AQUIRE_TIMES);
+    pub fn fork_choice_write_lock(&self) -> InstrumentedRwLockWriteGuard<'_, BeaconForkChoice<T>> {
         self.fork_choice.write()
     }
 }
@@ -699,7 +706,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Downgrade the fork choice write-lock to a read lock, without allowing access to any
         // other writers.
-        let fork_choice_read_lock = RwLockWriteGuard::downgrade(fork_choice_write_lock);
+        let fork_choice_read_lock = InstrumentedRwLockWriteGuard::downgrade(fork_choice_write_lock);
 
         // Read the current head value from the fork choice algorithm.
         let new_view = fork_choice_read_lock.cached_fork_choice_view();

--- a/beacon_node/beacon_chain/src/instrumented_lock.rs
+++ b/beacon_node/beacon_chain/src/instrumented_lock.rs
@@ -1,0 +1,359 @@
+//! An instrumented `parking_lot::RwLock` wrapper.
+//!
+//! This is the reusable building block requested in issue #8147: instead of
+//! manually instrumenting every call site that acquires a contended lock, the
+//! lock itself measures contention. An [`InstrumentedRwLock`]:
+//!
+//! 1. records the time spent **acquiring** the lock (wait time),
+//! 2. records the time the guard was **held** (hold time), and
+//! 3. logs a backtrace whenever a guard is held for longer than a configured
+//!    threshold, pointing directly at the release site.
+//!
+//! All instrumentation is transparent to callers: the returned guards
+//! `Deref`/`DerefMut` to the protected value and the measurements happen in
+//! their `Drop` implementations. The guards intentionally contain only
+//! `Send + Sync` metadata, so they keep the same `Send`/`Sync` properties as
+//! the underlying `parking_lot` guards.
+
+use parking_lot::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
+use std::backtrace::Backtrace;
+use std::ops::{Deref, DerefMut};
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
+use ::metrics::{Histogram, Result as MetricsResult};
+
+/// A lazily-initialised Prometheus histogram, matching the pattern used in
+/// `beacon_chain::metrics`.
+type LockMetric = LazyLock<MetricsResult<Histogram>>;
+
+/// The histograms a single [`InstrumentedRwLock`] reports to.
+///
+/// `*_acquire` histograms measure the time spent waiting to obtain the lock;
+/// `*_hold` histograms measure how long the guard stayed alive once acquired.
+pub struct LockMetrics {
+    pub read_acquire: &'static LockMetric,
+    pub write_acquire: &'static LockMetric,
+    pub upgradable_acquire: &'static LockMetric,
+    pub read_hold: &'static LockMetric,
+    pub write_hold: &'static LockMetric,
+    pub upgradable_hold: &'static LockMetric,
+}
+
+fn observe(metric: &'static LockMetric, duration: Duration) {
+    if let Ok(histogram) = &**metric {
+        histogram.observe(duration.as_secs_f64());
+    }
+}
+
+/// Record the hold time of a guard and, if it exceeds `threshold`, emit a
+/// warning containing a backtrace of the release site.
+fn record_hold(
+    name: &'static str,
+    mode: &'static str,
+    acquired: Instant,
+    threshold: Duration,
+    hold_metric: &'static LockMetric,
+) {
+    let held = acquired.elapsed();
+    observe(hold_metric, held);
+
+    if held > threshold {
+        tracing::warn!(
+            lock = name,
+            mode,
+            held_ms = held.as_millis() as u64,
+            threshold_ms = threshold.as_millis() as u64,
+            backtrace = %Backtrace::force_capture(),
+            "Lock held longer than threshold",
+        );
+    }
+}
+
+/// A `parking_lot::RwLock` that automatically instruments acquisition and hold
+/// times. See the module-level documentation for details.
+pub struct InstrumentedRwLock<T> {
+    inner: RwLock<T>,
+    metrics: &'static LockMetrics,
+    name: &'static str,
+    hold_threshold: Duration,
+}
+
+impl<T> InstrumentedRwLock<T> {
+    pub fn new(
+        value: T,
+        metrics: &'static LockMetrics,
+        name: &'static str,
+        hold_threshold: Duration,
+    ) -> Self {
+        Self {
+            inner: RwLock::new(value),
+            metrics,
+            name,
+            hold_threshold,
+        }
+    }
+
+    pub fn read(&self) -> InstrumentedRwLockReadGuard<'_, T> {
+        let timer = ::metrics::start_timer(self.metrics.read_acquire);
+        let guard = self.inner.read();
+        ::metrics::stop_timer(timer);
+        InstrumentedRwLockReadGuard {
+            guard: Some(guard),
+            metrics: self.metrics,
+            name: self.name,
+            hold_threshold: self.hold_threshold,
+            acquired: Instant::now(),
+        }
+    }
+
+    pub fn write(&self) -> InstrumentedRwLockWriteGuard<'_, T> {
+        let timer = ::metrics::start_timer(self.metrics.write_acquire);
+        let guard = self.inner.write();
+        ::metrics::stop_timer(timer);
+        InstrumentedRwLockWriteGuard {
+            guard: Some(guard),
+            metrics: self.metrics,
+            name: self.name,
+            hold_threshold: self.hold_threshold,
+            acquired: Instant::now(),
+        }
+    }
+
+    pub fn upgradable_read(&self) -> InstrumentedRwLockUpgradableReadGuard<'_, T> {
+        let timer = ::metrics::start_timer(self.metrics.upgradable_acquire);
+        let guard = self.inner.upgradable_read();
+        ::metrics::stop_timer(timer);
+        InstrumentedRwLockUpgradableReadGuard {
+            guard: Some(guard),
+            metrics: self.metrics,
+            name: self.name,
+            hold_threshold: self.hold_threshold,
+            acquired: Instant::now(),
+        }
+    }
+}
+
+// ---- Read guard ----
+
+pub struct InstrumentedRwLockReadGuard<'a, T> {
+    guard: Option<RwLockReadGuard<'a, T>>,
+    metrics: &'static LockMetrics,
+    name: &'static str,
+    hold_threshold: Duration,
+    acquired: Instant,
+}
+
+impl<T> Deref for InstrumentedRwLockReadGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.guard.as_ref().expect("guard is present until drop")
+    }
+}
+
+impl<T> Drop for InstrumentedRwLockReadGuard<'_, T> {
+    fn drop(&mut self) {
+        if let Some(guard) = self.guard.take() {
+            drop(guard);
+            record_hold(
+                self.name,
+                "read",
+                self.acquired,
+                self.hold_threshold,
+                self.metrics.read_hold,
+            );
+        }
+    }
+}
+
+// ---- Write guard ----
+
+pub struct InstrumentedRwLockWriteGuard<'a, T> {
+    guard: Option<RwLockWriteGuard<'a, T>>,
+    metrics: &'static LockMetrics,
+    name: &'static str,
+    hold_threshold: Duration,
+    acquired: Instant,
+}
+
+impl<'a, T> InstrumentedRwLockWriteGuard<'a, T> {
+    /// Atomically downgrade a write guard into a read guard, preserving
+    /// instrumentation. The write-hold time is recorded at the point of
+    /// downgrade and a fresh read-hold measurement begins.
+    pub fn downgrade(mut s: Self) -> InstrumentedRwLockReadGuard<'a, T> {
+        let guard = s.guard.take().expect("guard is present until drop");
+        record_hold(
+            s.name,
+            "write",
+            s.acquired,
+            s.hold_threshold,
+            s.metrics.write_hold,
+        );
+        let read_guard = RwLockWriteGuard::downgrade(guard);
+        InstrumentedRwLockReadGuard {
+            guard: Some(read_guard),
+            metrics: s.metrics,
+            name: s.name,
+            hold_threshold: s.hold_threshold,
+            acquired: Instant::now(),
+        }
+    }
+}
+
+impl<T> Deref for InstrumentedRwLockWriteGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.guard.as_ref().expect("guard is present until drop")
+    }
+}
+
+impl<T> DerefMut for InstrumentedRwLockWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.guard.as_mut().expect("guard is present until drop")
+    }
+}
+
+impl<T> Drop for InstrumentedRwLockWriteGuard<'_, T> {
+    fn drop(&mut self) {
+        if let Some(guard) = self.guard.take() {
+            drop(guard);
+            record_hold(
+                self.name,
+                "write",
+                self.acquired,
+                self.hold_threshold,
+                self.metrics.write_hold,
+            );
+        }
+    }
+}
+
+// ---- Upgradable read guard ----
+
+pub struct InstrumentedRwLockUpgradableReadGuard<'a, T> {
+    guard: Option<RwLockUpgradableReadGuard<'a, T>>,
+    metrics: &'static LockMetrics,
+    name: &'static str,
+    hold_threshold: Duration,
+    acquired: Instant,
+}
+
+impl<'a, T> InstrumentedRwLockUpgradableReadGuard<'a, T> {
+    /// Atomically upgrade to a write guard, preserving instrumentation. The
+    /// upgradable-read hold time is recorded at the point of upgrade and a
+    /// fresh write-hold measurement begins.
+    pub fn upgrade(mut s: Self) -> InstrumentedRwLockWriteGuard<'a, T> {
+        let guard = s.guard.take().expect("guard is present until drop");
+        record_hold(
+            s.name,
+            "upgradable",
+            s.acquired,
+            s.hold_threshold,
+            s.metrics.upgradable_hold,
+        );
+        let write_guard = RwLockUpgradableReadGuard::upgrade(guard);
+        InstrumentedRwLockWriteGuard {
+            guard: Some(write_guard),
+            metrics: s.metrics,
+            name: s.name,
+            hold_threshold: s.hold_threshold,
+            acquired: Instant::now(),
+        }
+    }
+}
+
+impl<T> Deref for InstrumentedRwLockUpgradableReadGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.guard.as_ref().expect("guard is present until drop")
+    }
+}
+
+impl<T> Drop for InstrumentedRwLockUpgradableReadGuard<'_, T> {
+    fn drop(&mut self) {
+        if let Some(guard) = self.guard.take() {
+            drop(guard);
+            record_hold(
+                self.name,
+                "upgradable",
+                self.acquired,
+                self.hold_threshold,
+                self.metrics.upgradable_hold,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::metrics::{exponential_buckets, try_create_histogram_with_buckets};
+
+    static TEST_ACQUIRE: LockMetric = LazyLock::new(|| {
+        try_create_histogram_with_buckets(
+            "test_instrumented_lock_acquire_seconds",
+            "Test acquire histogram",
+            exponential_buckets(1e-6, 4.0, 7),
+        )
+    });
+    static TEST_HOLD: LockMetric = LazyLock::new(|| {
+        try_create_histogram_with_buckets(
+            "test_instrumented_lock_hold_seconds",
+            "Test hold histogram",
+            exponential_buckets(1e-6, 4.0, 7),
+        )
+    });
+    static TEST_METRICS: LockMetrics = LockMetrics {
+        read_acquire: &TEST_ACQUIRE,
+        write_acquire: &TEST_ACQUIRE,
+        upgradable_acquire: &TEST_ACQUIRE,
+        read_hold: &TEST_HOLD,
+        write_hold: &TEST_HOLD,
+        upgradable_hold: &TEST_HOLD,
+    };
+
+    fn lock(value: i32) -> InstrumentedRwLock<i32> {
+        InstrumentedRwLock::new(value, &TEST_METRICS, "test", Duration::from_millis(50))
+    }
+
+    #[test]
+    fn read_then_write_are_transparent() {
+        let l = lock(1);
+        assert_eq!(*l.read(), 1);
+        {
+            let mut w = l.write();
+            *w = 42;
+        }
+        assert_eq!(*l.read(), 42);
+    }
+
+    #[test]
+    fn downgrade_preserves_mutation() {
+        let l = lock(0);
+        let mut w = l.write();
+        *w = 7;
+        let r = InstrumentedRwLockWriteGuard::downgrade(w);
+        assert_eq!(*r, 7);
+    }
+
+    #[test]
+    fn upgrade_then_mutate_is_visible() {
+        let l = lock(0);
+        let u = l.upgradable_read();
+        assert_eq!(*u, 0);
+        let mut w = InstrumentedRwLockUpgradableReadGuard::upgrade(u);
+        *w = 9;
+        drop(w);
+        assert_eq!(*l.read(), 9);
+    }
+
+    #[test]
+    fn holding_past_threshold_does_not_panic() {
+        // Exceeds the 50ms threshold so the backtrace/warn path in `record_hold`
+        // is exercised on drop.
+        let l = lock(0);
+        let r = l.read();
+        std::thread::sleep(Duration::from_millis(60));
+        drop(r);
+    }
+}

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -29,6 +29,7 @@ pub mod fork_choice_signal;
 pub mod graffiti_calculator;
 pub mod historical_blocks;
 pub mod historical_data_columns;
+pub mod instrumented_lock;
 pub mod invariants;
 pub mod kzg_utils;
 pub mod light_client_finality_update_verification;
@@ -97,6 +98,10 @@ pub use events::ServerSentEventHandler;
 pub use execution_layer::EngineState;
 pub use execution_payload::NotifyExecutionLayer;
 pub use fork_choice::{ExecutionStatus, ForkchoiceUpdateParameters};
+pub use instrumented_lock::{
+    InstrumentedRwLock, InstrumentedRwLockReadGuard, InstrumentedRwLockUpgradableReadGuard,
+    InstrumentedRwLockWriteGuard,
+};
 pub use kzg::{Kzg, TrustedSetup};
 pub use metrics::scrape_for_metrics;
 pub use migrate::MigratorConfig;

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -612,6 +612,39 @@ pub static FORK_CHOICE_WRITE_LOCK_AQUIRE_TIMES: LazyLock<Result<Histogram>> = La
         exponential_buckets(1e-3, 4.0, 7),
     )
 });
+pub static FORK_CHOICE_READ_LOCK_HOLD_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram_with_buckets(
+        "beacon_fork_choice_read_lock_hold_seconds",
+        "Time the fork-choice read lock was held",
+        exponential_buckets(1e-3, 4.0, 7),
+    )
+});
+pub static FORK_CHOICE_WRITE_LOCK_HOLD_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram_with_buckets(
+        "beacon_fork_choice_write_lock_hold_seconds",
+        "Time the fork-choice write lock was held",
+        exponential_buckets(1e-3, 4.0, 7),
+    )
+});
+pub static FORK_CHOICE_UPGRADABLE_READ_LOCK_HOLD_TIMES: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram_with_buckets(
+            "beacon_fork_choice_upgradable_read_lock_hold_seconds",
+            "Time the fork-choice upgradable read lock was held",
+            exponential_buckets(1e-3, 4.0, 7),
+        )
+    });
+/// Instrumentation bundle wiring the fork-choice `InstrumentedRwLock` to the
+/// acquire/hold histograms defined above.
+pub static FORK_CHOICE_LOCK_METRICS: crate::instrumented_lock::LockMetrics =
+    crate::instrumented_lock::LockMetrics {
+        read_acquire: &FORK_CHOICE_READ_LOCK_AQUIRE_TIMES,
+        write_acquire: &FORK_CHOICE_WRITE_LOCK_AQUIRE_TIMES,
+        upgradable_acquire: &FORK_CHOICE_UPGRADABLE_READ_LOCK_AQUIRE_TIMES,
+        read_hold: &FORK_CHOICE_READ_LOCK_HOLD_TIMES,
+        write_hold: &FORK_CHOICE_WRITE_LOCK_HOLD_TIMES,
+        upgradable_hold: &FORK_CHOICE_UPGRADABLE_READ_LOCK_HOLD_TIMES,
+    };
 pub static FORK_CHOICE_ENCODE_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
     try_create_histogram(
         "beacon_fork_choice_encode_seconds",

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -242,7 +242,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Take an exclusive write-lock on fork choice. It's very important to prevent deadlocks by
         // avoiding taking other locks whilst holding this lock.
-        let mut fork_choice = parking_lot::RwLockUpgradableReadGuard::upgrade(fork_choice_reader);
+        let mut fork_choice =
+            crate::instrumented_lock::InstrumentedRwLockUpgradableReadGuard::upgrade(
+                fork_choice_reader,
+            );
 
         // Update the block's payload to received in fork choice, which creates the `Full` virtual
         // node which can be eligible for head.


### PR DESCRIPTION
## Issue Addressed

Part of #8147.

In that issue @michaelsproul described wanting a custom `RwLock` that can:

> - Auto instrument itself
> - Log backtraces when it is held for a long time
> - Output metrics for its wait time, hold time, etc

This implements that wrapper and uses it for the fork choice lock. It's
complementary to #9306, which adds tracing context to the individual
`fork_choice_write_lock` call sites (the separate instrumentation step @dapplion
suggested). That work annotates the callers; this makes the lock itself report
contention and point at whoever is holding it for too long.

## Proposed Changes

`InstrumentedRwLock<T>` is a thin wrapper around `parking_lot::RwLock`, used for
the fork choice lock in `CanonicalHead`. For read, write and upgradable-read
guards it records how long the guard waited to acquire the lock and how long it
was then held, both as Prometheus histograms. If a guard is held past a
configurable threshold (100ms for fork choice) it logs a `WARN` with a captured
backtrace, so a long hold points straight at the release site without having to
pre-instrument every caller.

The guards `Deref`/`DerefMut` to the underlying `parking_lot` guard types, so
call sites only change in the guard type they name. `downgrade` (write to read)
and `upgrade` (upgradable-read to write) keep the same semantics, with the hold
time attributed correctly across the transition. The backtrace and the hold
metric are recorded after the guard is released, so the instrumentation never
extends the time the lock is actually held.

It's observability only. Locking behaviour and the atomicity of the
fork-choice/DB write are unchanged, matching the conclusion earlier in the thread
that the atomic write is worth keeping.

New metrics:

- `beacon_fork_choice_{read,write,upgradable_read}_lock_hold_seconds`

The existing `beacon_fork_choice_*_lock_aquire_seconds` timers keep their names
and are now emitted by the wrapper instead of ad-hoc timers in the accessors, so
existing dashboards keep working.

## Additional Info

The threshold and metric label are constructor arguments, so the same wrapper can
be reused for other hot locks (for example the `state_cache` spots mentioned in
the issue) if that turns out to be worthwhile.
