### PR TITLE
Expose process_cpu_seconds_total as a counter

### DIFF
--- a/common/health_metrics/src/metrics.rs
+++ b/common/health_metrics/src/metrics.rs
@@ -27,8 +27,8 @@ pub static PROCESS_SHR_MEM: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
         "Shared memory used by the current process",
     )
 });
-pub static PROCESS_SECONDS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
-    try_create_int_gauge(
+pub static PROCESS_SECONDS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
         "process_cpu_seconds_total",
         "Total cpu time taken by the current process",
     )
@@ -135,7 +135,7 @@ pub fn scrape_process_health_metrics() {
         set_gauge(&PROCESS_RES_MEM, health.pid_mem_resident_set_size as i64);
         set_gauge(&PROCESS_VIRT_MEM, health.pid_mem_virtual_memory_size as i64);
         set_gauge(&PROCESS_SHR_MEM, health.pid_mem_shared_memory_size as i64);
-        set_gauge(&PROCESS_SECONDS, health.pid_process_seconds_total as i64);
+        set_counter_from_absolute(&PROCESS_SECONDS, health.pid_process_seconds_total);
     }
 }
 
@@ -186,5 +186,24 @@ pub fn scrape_system_health_metrics() {
             &NETWORK_BYTES_SENT,
             health.network_node_bytes_total_transmit as i64,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_cpu_seconds_total_is_a_counter() {
+        PROCESS_SECONDS
+            .as_ref()
+            .expect("process CPU seconds metric should initialize");
+
+        let metric = gather()
+            .into_iter()
+            .find(|metric| metric.get_name() == "process_cpu_seconds_total")
+            .expect("process CPU seconds metric should be registered");
+
+        assert_eq!(metric.get_field_type(), MetricType::COUNTER);
     }
 }

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -308,6 +308,15 @@ pub fn inc_counter_by(counter: &Result<IntCounter>, value: u64) {
     }
 }
 
+pub fn set_counter_from_absolute(counter: &Result<IntCounter>, value: u64) {
+    if let Ok(counter) = counter {
+        let current = counter.get();
+        if value > current {
+            counter.inc_by(value - current);
+        }
+    }
+}
+
 pub fn set_gauge_vec(int_gauge_vec: &Result<IntGaugeVec>, name: &[&str], value: i64) {
     if let Some(gauge) = get_int_gauge(int_gauge_vec, name) {
         gauge.set(value);
@@ -439,5 +448,28 @@ impl<T> TryExt for Option<T> {
             timer.stop_and_discard();
         }
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_counter_from_absolute_only_increments_positive_delta() {
+        let counter = Ok(IntCounter::new(
+            "set_counter_from_absolute_test_total",
+            "counter helper test",
+        )
+        .expect("should create counter"));
+
+        set_counter_from_absolute(&counter, 10);
+        assert_eq!(counter.as_ref().expect("counter should exist").get(), 10);
+
+        set_counter_from_absolute(&counter, 15);
+        assert_eq!(counter.as_ref().expect("counter should exist").get(), 15);
+
+        set_counter_from_absolute(&counter, 12);
+        assert_eq!(counter.as_ref().expect("counter should exist").get(), 15);
     }
 }


### PR DESCRIPTION
## Issue Addressed

Closes #3108

## Proposed Changes

- Register `process_cpu_seconds_total` as an `IntCounter` instead of an `IntGauge`.
- Add a small helper for updating a counter from an observed absolute value by incrementing only the positive delta.
- Add regression coverage for the helper behavior and the registered Prometheus metric type.

## Additional Info

The scrape path still consumes the absolute process CPU seconds value from the OS. The counter update avoids resetting or moving the Prometheus counter backwards if the observed value is lower than the current metric value.

## Test plan

- `cargo fmt --all --check`
- `cargo test -p metrics --lib`
- `cargo test -p health_metrics --features eth2/events process_cpu_seconds_total_is_a_counter`
- `cargo check -p health_metrics --features eth2/events`
- `git diff --check`
