### PR TITLE
Use correct slot in custody request

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -172,7 +172,7 @@ impl<T: BeaconChainTypes> RequestState<T> for CustodyRequestState<T::EthSpec> {
         _: usize,
         cx: &mut SyncNetworkContext<T>,
     ) -> Result<LookupRequestResult, LookupRequestError> {
-        cx.custody_lookup_request(id, self.block_root, lookup_peers)
+        cx.custody_lookup_request(id, self.block_root, self.slot, lookup_peers)
             .map_err(LookupRequestError::SendFailedNetwork)
     }
 

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -239,7 +239,7 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
                     );
                 } else if cx.chain.should_fetch_custody_columns(block_epoch) {
                     self.component_requests = ComponentRequests::ActiveCustodyRequest(
-                        CustodyRequestState::new(self.block_root),
+                        CustodyRequestState::new(self.block_root, block.slot()),
                     );
                 } else {
                     self.component_requests = ComponentRequests::NotNeeded("outside da window");
@@ -397,13 +397,15 @@ impl<E: EthSpec> BlobRequestState<E> {
 pub struct CustodyRequestState<E: EthSpec> {
     #[educe(Debug(ignore))]
     pub block_root: Hash256,
+    pub slot: Slot,
     pub state: SingleLookupRequestState<DataColumnSidecarList<E>>,
 }
 
 impl<E: EthSpec> CustodyRequestState<E> {
-    pub fn new(block_root: Hash256) -> Self {
+    pub fn new(block_root: Hash256, slot: Slot) -> Self {
         Self {
             block_root,
+            slot,
             state: SingleLookupRequestState::new(),
         }
     }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -1174,34 +1174,18 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         &mut self,
         lookup_id: SingleLookupId,
         block_root: Hash256,
+        block_slot: Slot,
         lookup_peers: Arc<RwLock<HashSet<PeerId>>>,
     ) -> Result<LookupRequestResult, RpcRequestSendError> {
-        let slot = self
-            .chain
-            .canonical_head
-            .fork_choice_read_lock()
-            .get_block(&block_root)
-            .map(|block| block.slot)
-            .or_else(|| self.chain.slot().ok())
-            .ok_or_else(|| {
-                RpcRequestSendError::InternalError(format!(
-                    "Unable to determine slot for block {block_root:?}"
-                ))
-            })?;
-
         let custody_indexes_imported = self
             .chain
-            .cached_data_column_indexes(&block_root, slot)
+            .cached_data_column_indexes(&block_root, block_slot)
             .unwrap_or_default();
-
-        let current_epoch = self.chain.epoch().map_err(|e| {
-            RpcRequestSendError::InternalError(format!("Unable to read slot clock {:?}", e))
-        })?;
 
         // Include only the blob indexes not yet imported (received through gossip)
         let mut custody_indexes_to_fetch = self
             .chain
-            .sampling_columns_for_epoch(current_epoch)
+            .sampling_columns_for_epoch(block_slot.epoch(T::EthSpec::slots_per_epoch()))
             .iter()
             .copied()
             .filter(|index| !custody_indexes_imported.contains(index))


### PR DESCRIPTION
Pass the block's slot directly into `custody_lookup_request` instead of resolving it via a fork-choice lookup (which can fail or return a stale slot for a block not yet in fork choice).

This is probably some legacy code from Fulu development, and can lead to incorrect CGC computation and a broken DB. Found this while working on https://github.com/sigp/lighthouse/pull/9155 but we should fix this independently