### PR TITLE
Reject importing Gloas block until parent's payload is imported

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -70,7 +70,7 @@ use bls::{PublicKey, PublicKeyBytes};
 use educe::Educe;
 use eth2::types::{BlockGossip, EventKind};
 use execution_layer::PayloadStatus;
-pub use fork_choice::{AttestationFromBlock, ParentImportedStatus, PayloadVerificationStatus};
+pub use fork_choice::{AttestationFromBlock, ParentImportStatus, PayloadVerificationStatus};
 use metrics::TryExt;
 use parking_lot::RwLockReadGuard;
 use proto_array::Block as ProtoBlock;
@@ -870,7 +870,7 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
 
         let block_epoch = block.slot().epoch(T::EthSpec::slots_per_epoch());
         let (parent_block, block) =
-            verify_parent_block_is_known::<T>(&fork_choice_read_lock, block)?;
+            verify_parent_block_and_envelope_are_known::<T>(&fork_choice_read_lock, block)?;
 
         // [New in Gloas]: Verify bid.parent_block_root matches block.parent_root.
         if let Ok(bid) = block.message().body().signed_execution_payload_bid()
@@ -1377,9 +1377,9 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
         match chain
             .canonical_head
             .fork_choice_read_lock()
-            .is_parent_imported_status(block.as_block())
+            .get_parent_import_status(block.as_block())
         {
-            ParentImportedStatus::Imported(parent) => {
+            ParentImportStatus::Imported(parent) => {
                 // Reject any block where the parent has an invalid payload. It's impossible for a valid
                 // block to descend from an invalid parent.
                 if parent.execution_status.is_invalid() {
@@ -1388,7 +1388,7 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
                     });
                 }
             }
-            ParentImportedStatus::UnknownBlock | ParentImportedStatus::UnimportedPayload => {
+            ParentImportStatus::UnknownBlock | ParentImportStatus::UnimportedPayload => {
                 // Reject any block if its parent is not known to fork choice.
                 //
                 // A block that is not in fork choice is either:
@@ -1861,7 +1861,7 @@ pub fn get_block_header_root(block_header: &SignedBeaconBlockHeader) -> Hash256 
 /// Verify the parent of `block` is known, returning some information about the parent block from
 /// fork choice.
 #[allow(clippy::type_complexity)]
-fn verify_parent_block_is_known<T: BeaconChainTypes>(
+fn verify_parent_block_and_envelope_are_known<T: BeaconChainTypes>(
     fork_choice_read_lock: &RwLockReadGuard<BeaconForkChoice<T>>,
     block: Arc<SignedBeaconBlock<T::EthSpec>>,
 ) -> Result<(ProtoBlock, Arc<SignedBeaconBlock<T::EthSpec>>), BlockError> {
@@ -1870,9 +1870,9 @@ fn verify_parent_block_is_known<T: BeaconChainTypes>(
     // once the parent payload is retrieved). If execution_payload verification of block's execution
     // payload parent by an execution node is complete, verify the block's execution payload
     // parent (defined by bid.parent_block_hash) passes all validation.
-    match fork_choice_read_lock.is_parent_imported_status(&block) {
-        ParentImportedStatus::Imported(parent) => Ok((parent, block)),
-        ParentImportedStatus::UnknownBlock | ParentImportedStatus::UnimportedPayload => {
+    match fork_choice_read_lock.get_parent_import_status(&block) {
+        ParentImportStatus::Imported(parent) => Ok((parent, block)),
+        ParentImportStatus::UnknownBlock | ParentImportStatus::UnimportedPayload => {
             Err(BlockError::ParentUnknown {
                 parent_root: block.parent_root(),
             })

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1380,8 +1380,6 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
             .get_parent_import_status(block.as_block())
         {
             ParentImportStatus::Imported(parent) => {
-                // Reject any block where the parent has an invalid payload. It's impossible for a valid
-                // block to descend from an invalid parent.
                 if parent.execution_status.is_invalid() {
                     return Err(BlockError::ParentExecutionPayloadInvalid {
                         parent_root: block.parent_root(),
@@ -1389,16 +1387,6 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
                 }
             }
             ParentImportStatus::UnknownBlock | ParentImportStatus::UnknownPayload => {
-                // Reject any block if its parent is not known to fork choice.
-                //
-                // A block that is not in fork choice is either:
-                //
-                //  - Not yet imported: we should reject this block because we should only import a child
-                //  after its parent has been fully imported.
-                //  - Pre-finalized: if the parent block is _prior_ to finalization, we should ignore it
-                //  because it will revert finalization. Note that the finalized block is stored in fork
-                //  choice, so we will not reject any child of the finalized block (this is relevant during
-                //  genesis).
                 return Err(BlockError::ParentUnknown {
                     parent_root: block.parent_root(),
                 });
@@ -1858,18 +1846,13 @@ pub fn get_block_header_root(block_header: &SignedBeaconBlockHeader) -> Hash256 
     block_root
 }
 
-/// Verify the parent of `block` is known, returning some information about the parent block from
-/// fork choice.
+/// Verify the parent block — and, for a post-Gloas FULL child, the parent payload — are known to
+/// fork choice; both missing cases return `ParentUnknown`.
 #[allow(clippy::type_complexity)]
 fn verify_parent_block_and_envelope_are_known<T: BeaconChainTypes>(
     fork_choice_read_lock: &RwLockReadGuard<BeaconForkChoice<T>>,
     block: Arc<SignedBeaconBlock<T::EthSpec>>,
 ) -> Result<(ProtoBlock, Arc<SignedBeaconBlock<T::EthSpec>>), BlockError> {
-    // The block's parent execution payload (defined by bid.parent_block_hash) has been seen
-    // (via gossip or non-gossip sources) (a client MAY queue blocks for processing
-    // once the parent payload is retrieved). If execution_payload verification of block's execution
-    // payload parent by an execution node is complete, verify the block's execution payload
-    // parent (defined by bid.parent_block_hash) passes all validation.
     match fork_choice_read_lock.get_parent_import_status(&block) {
         ParentImportStatus::Imported(parent) => Ok((parent, block)),
         ParentImportStatus::UnknownBlock | ParentImportStatus::UnknownPayload => {

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -70,7 +70,7 @@ use bls::{PublicKey, PublicKeyBytes};
 use educe::Educe;
 use eth2::types::{BlockGossip, EventKind};
 use execution_layer::PayloadStatus;
-pub use fork_choice::{AttestationFromBlock, PayloadVerificationStatus};
+pub use fork_choice::{AttestationFromBlock, ParentImportedStatus, PayloadVerificationStatus};
 use metrics::TryExt;
 use parking_lot::RwLockReadGuard;
 use proto_array::Block as ProtoBlock;
@@ -882,13 +882,6 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
             });
         }
 
-        // TODO(gloas) The following validation can only be completed once fork choice has been implemented:
-        // The block's parent execution payload (defined by bid.parent_block_hash) has been seen
-        // (via gossip or non-gossip sources) (a client MAY queue blocks for processing
-        // once the parent payload is retrieved). If execution_payload verification of block's execution
-        // payload parent by an execution node is complete, verify the block's execution payload
-        // parent (defined by bid.parent_block_hash) passes all validation.
-
         drop(fork_choice_read_lock);
 
         // Track the number of skip slots between the block and its parent.
@@ -1381,32 +1374,35 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
             .observe_proposal(block_root, block.message())
             .map_err(|e| BlockError::BeaconChainError(Box::new(e.into())))?;
 
-        if let Some(parent) = chain
+        match chain
             .canonical_head
             .fork_choice_read_lock()
-            .get_block(&block.parent_root())
+            .is_parent_imported_status(block.as_block())
         {
-            // Reject any block where the parent has an invalid payload. It's impossible for a valid
-            // block to descend from an invalid parent.
-            if parent.execution_status.is_invalid() {
-                return Err(BlockError::ParentExecutionPayloadInvalid {
+            ParentImportedStatus::Imported(parent) => {
+                // Reject any block where the parent has an invalid payload. It's impossible for a valid
+                // block to descend from an invalid parent.
+                if parent.execution_status.is_invalid() {
+                    return Err(BlockError::ParentExecutionPayloadInvalid {
+                        parent_root: block.parent_root(),
+                    });
+                }
+            }
+            ParentImportedStatus::UnknownBlock | ParentImportedStatus::UnimportedPayload => {
+                // Reject any block if its parent is not known to fork choice.
+                //
+                // A block that is not in fork choice is either:
+                //
+                //  - Not yet imported: we should reject this block because we should only import a child
+                //  after its parent has been fully imported.
+                //  - Pre-finalized: if the parent block is _prior_ to finalization, we should ignore it
+                //  because it will revert finalization. Note that the finalized block is stored in fork
+                //  choice, so we will not reject any child of the finalized block (this is relevant during
+                //  genesis).
+                return Err(BlockError::ParentUnknown {
                     parent_root: block.parent_root(),
                 });
             }
-        } else {
-            // Reject any block if its parent is not known to fork choice.
-            //
-            // A block that is not in fork choice is either:
-            //
-            //  - Not yet imported: we should reject this block because we should only import a child
-            //  after its parent has been fully imported.
-            //  - Pre-finalized: if the parent block is _prior_ to finalization, we should ignore it
-            //  because it will revert finalization. Note that the finalized block is stored in fork
-            //  choice, so we will not reject any child of the finalized block (this is relevant during
-            //  genesis).
-            return Err(BlockError::ParentUnknown {
-                parent_root: block.parent_root(),
-            });
         }
 
         /*
@@ -1869,12 +1865,18 @@ fn verify_parent_block_is_known<T: BeaconChainTypes>(
     fork_choice_read_lock: &RwLockReadGuard<BeaconForkChoice<T>>,
     block: Arc<SignedBeaconBlock<T::EthSpec>>,
 ) -> Result<(ProtoBlock, Arc<SignedBeaconBlock<T::EthSpec>>), BlockError> {
-    if let Some(proto_block) = fork_choice_read_lock.get_block(&block.parent_root()) {
-        Ok((proto_block, block))
-    } else {
-        Err(BlockError::ParentUnknown {
-            parent_root: block.parent_root(),
-        })
+    // The block's parent execution payload (defined by bid.parent_block_hash) has been seen
+    // (via gossip or non-gossip sources) (a client MAY queue blocks for processing
+    // once the parent payload is retrieved). If execution_payload verification of block's execution
+    // payload parent by an execution node is complete, verify the block's execution payload
+    // parent (defined by bid.parent_block_hash) passes all validation.
+    match fork_choice_read_lock.is_parent_imported_status(&block) {
+        ParentImportedStatus::Imported(parent) => Ok((parent, block)),
+        ParentImportedStatus::UnknownBlock | ParentImportedStatus::UnimportedPayload => {
+            Err(BlockError::ParentUnknown {
+                parent_root: block.parent_root(),
+            })
+        }
     }
 }
 
@@ -1901,7 +1903,7 @@ fn load_parent<T: BeaconChainTypes, B: AsBlock<T::EthSpec>>(
     if !chain
         .canonical_head
         .fork_choice_read_lock()
-        .contains_block(&block.parent_root())
+        .is_parent_imported(block.as_block())
     {
         return Err(BlockError::ParentUnknown {
             parent_root: block.parent_root(),

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1388,7 +1388,7 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
                     });
                 }
             }
-            ParentImportStatus::UnknownBlock | ParentImportStatus::UnimportedPayload => {
+            ParentImportStatus::UnknownBlock | ParentImportStatus::UnknownPayload => {
                 // Reject any block if its parent is not known to fork choice.
                 //
                 // A block that is not in fork choice is either:
@@ -1872,7 +1872,7 @@ fn verify_parent_block_and_envelope_are_known<T: BeaconChainTypes>(
     // parent (defined by bid.parent_block_hash) passes all validation.
     match fork_choice_read_lock.get_parent_import_status(&block) {
         ParentImportStatus::Imported(parent) => Ok((parent, block)),
-        ParentImportStatus::UnknownBlock | ParentImportStatus::UnimportedPayload => {
+        ParentImportStatus::UnknownBlock | ParentImportStatus::UnknownPayload => {
             Err(BlockError::ParentUnknown {
                 parent_root: block.parent_root(),
             })

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -85,7 +85,7 @@ pub use beacon_fork_choice_store::{
 };
 pub use block_verification::{
     BlockError, ExecutionPayloadError, ExecutionPendingBlock, GossipVerifiedBlock,
-    IntoExecutionPendingBlock, IntoGossipVerifiedBlock, InvalidSignature,
+    IntoExecutionPendingBlock, IntoGossipVerifiedBlock, InvalidSignature, ParentImportedStatus,
     PayloadVerificationOutcome, PayloadVerificationStatus, build_blob_data_column_sidecars,
     get_block_root, signature_verify_chain_segment,
 };

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -85,7 +85,7 @@ pub use beacon_fork_choice_store::{
 };
 pub use block_verification::{
     BlockError, ExecutionPayloadError, ExecutionPendingBlock, GossipVerifiedBlock,
-    IntoExecutionPendingBlock, IntoGossipVerifiedBlock, InvalidSignature, ParentImportedStatus,
+    IntoExecutionPendingBlock, IntoGossipVerifiedBlock, InvalidSignature, ParentImportStatus,
     PayloadVerificationOutcome, PayloadVerificationStatus, build_blob_data_column_sidecars,
     get_block_root, signature_verify_chain_segment,
 };

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -359,7 +359,7 @@ fn update_data_column_signed_header<E: EthSpec>(
 
 #[tokio::test]
 async fn chain_segment_full_segment() {
-    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes. A multi-block
+    // TODO(gloas): re-enable for Gloas once range sync imports payload envelopes. A multi-block
     // segment of consecutive FULL Gloas blocks can't be imported by `process_chain_segment` until
     // it imports payload envelopes alongside blocks.
     if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
@@ -405,7 +405,7 @@ async fn chain_segment_full_segment() {
 
 #[tokio::test]
 async fn chain_segment_varying_chunk_size() {
-    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    // TODO(gloas): re-enable for Gloas once range sync imports payload envelopes.
     if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
         return;
     }
@@ -689,7 +689,7 @@ async fn get_invalid_sigs_harness(
 }
 #[tokio::test]
 async fn invalid_signature_gossip_block() {
-    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    // TODO(gloas): re-enable for Gloas once range sync imports payload envelopes.
     if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
         return;
     }
@@ -749,7 +749,7 @@ async fn invalid_signature_gossip_block() {
 
 #[tokio::test]
 async fn invalid_signature_block_proposal() {
-    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    // TODO(gloas): re-enable for Gloas once range sync imports payload envelopes.
     if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
         return;
     }
@@ -792,7 +792,7 @@ async fn invalid_signature_block_proposal() {
 
 #[tokio::test]
 async fn invalid_signature_randao_reveal() {
-    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    // TODO(gloas): re-enable for Gloas once range sync imports payload envelopes.
     if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
         return;
     }
@@ -824,7 +824,7 @@ async fn invalid_signature_randao_reveal() {
 
 #[tokio::test]
 async fn invalid_signature_proposer_slashing() {
-    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    // TODO(gloas): re-enable for Gloas once range sync imports payload envelopes.
     if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
         return;
     }
@@ -870,7 +870,7 @@ async fn invalid_signature_proposer_slashing() {
 
 #[tokio::test]
 async fn invalid_signature_attester_slashing() {
-    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    // TODO(gloas): re-enable for Gloas once range sync imports payload envelopes.
     if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
         return;
     }
@@ -995,7 +995,7 @@ async fn invalid_signature_attester_slashing() {
 
 #[tokio::test]
 async fn invalid_signature_attestation() {
-    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    // TODO(gloas): re-enable for Gloas once range sync imports payload envelopes.
     if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
         return;
     }
@@ -1124,7 +1124,7 @@ async fn invalid_signature_deposit() {
 
 #[tokio::test]
 async fn invalid_signature_exit() {
-    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    // TODO(gloas): re-enable for Gloas once range sync imports payload envelopes.
     if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
         return;
     }

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -359,9 +359,7 @@ fn update_data_column_signed_header<E: EthSpec>(
 
 #[tokio::test]
 async fn chain_segment_full_segment() {
-    // TODO(gloas): re-enable for Gloas once range sync imports payload envelopes. A multi-block
-    // segment of consecutive FULL Gloas blocks can't be imported by `process_chain_segment` until
-    // it imports payload envelopes alongside blocks.
+    // TODO(gloas): re-enable for Gloas once range sync imports payload envelopes.
     if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
         return;
     }

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -9,7 +9,7 @@ use beacon_chain::{
     custody_context::NodeCustodyType,
     test_utils::{
         AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
-        MakeAttestationOptions, test_spec,
+        MakeAttestationOptions, fork_name_from_env, test_spec,
     },
 };
 use beacon_chain::{
@@ -238,55 +238,6 @@ fn update_fork_choice_with_envelopes(
     }
 }
 
-/// Import a chain segment, registering each block's payload envelope with fork choice immediately
-/// after the block is imported.
-///
-/// Post-Gloas, a FULL child block can only be imported once its parent's payload envelope has been
-/// imported into fork choice. `process_chain_segment` currently imports blocks only, so a
-/// multi-block segment of consecutive FULL Gloas blocks cannot be imported in a single batch. This
-/// helper imports each block and then registers its payload envelope before importing the next.
-///
-/// Pre-Gloas, where blocks carry no payload envelope, the whole segment is imported in a single
-/// batch so the batch import path is still exercised.
-///
-/// `chain_segment` and `blocks` must be aligned by index.
-async fn import_chain_segment_with_envelopes(
-    chain_segment: &[BeaconSnapshot<E>],
-    blocks: &[RangeSyncBlock<E>],
-    harness: &BeaconChainHarness<EphemeralHarnessType<E>>,
-) -> Result<(), BlockError> {
-    let has_envelopes = chain_segment
-        .iter()
-        .any(|snapshot| snapshot.execution_envelope.is_some());
-
-    if !has_envelopes {
-        return harness
-            .chain
-            .process_chain_segment(blocks.to_vec(), NotifyExecutionLayer::Yes)
-            .await
-            .into_block_error();
-    }
-
-    for (snapshot, block) in chain_segment.iter().zip(blocks.iter()) {
-        harness
-            .chain
-            .process_chain_segment(vec![block.clone()], NotifyExecutionLayer::Yes)
-            .await
-            .into_block_error()?;
-
-        if snapshot.execution_envelope.is_some() {
-            harness
-                .chain
-                .canonical_head
-                .fork_choice_write_lock()
-                .on_valid_payload_envelope_received(snapshot.beacon_block_root)
-                .map_err(|e| BlockError::InternalError(format!("{e:?}")))?;
-        }
-    }
-
-    Ok(())
-}
-
 fn junk_signature() -> Signature {
     let kp = generate_deterministic_keypair(VALIDATOR_COUNT);
     let message = Hash256::from_slice(&[42; 32]);
@@ -408,6 +359,12 @@ fn update_data_column_signed_header<E: EthSpec>(
 
 #[tokio::test]
 async fn chain_segment_full_segment() {
+    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes. A multi-block
+    // segment of consecutive FULL Gloas blocks can't be imported by `process_chain_segment` until
+    // it imports payload envelopes alongside blocks.
+    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
     let harness = get_harness(VALIDATOR_COUNT, NodeCustodyType::Fullnode);
     let (chain_segment, chain_segment_blobs) = get_chain_segment().await;
     store_envelopes_for_chain_segment(&chain_segment, &harness);
@@ -429,10 +386,14 @@ async fn chain_segment_full_segment() {
         .into_block_error()
         .expect("should import empty chain segment");
 
-    import_chain_segment_with_envelopes(&chain_segment, &blocks, &harness)
+    harness
+        .chain
+        .process_chain_segment(blocks.clone(), NotifyExecutionLayer::Yes)
         .await
+        .into_block_error()
         .expect("should import chain segment");
 
+    update_fork_choice_with_envelopes(&chain_segment, &harness);
     harness.chain.recompute_head_at_current_slot().await;
 
     assert_eq!(
@@ -444,6 +405,10 @@ async fn chain_segment_full_segment() {
 
 #[tokio::test]
 async fn chain_segment_varying_chunk_size() {
+    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
     let (chain_segment, chain_segment_blobs) = get_chain_segment().await;
     let harness = get_harness(VALIDATOR_COUNT, NodeCustodyType::Fullnode);
     let blocks: Vec<RangeSyncBlock<E>> =
@@ -460,15 +425,16 @@ async fn chain_segment_varying_chunk_size() {
             .slot_clock
             .set_slot(blocks.last().unwrap().slot().as_u64());
 
-        for (segment_chunk, block_chunk) in chain_segment
-            .chunks(*chunk_size)
-            .zip(blocks.chunks(*chunk_size))
-        {
-            import_chain_segment_with_envelopes(segment_chunk, block_chunk, &harness)
+        for chunk in blocks.clone().chunks(*chunk_size) {
+            harness
+                .chain
+                .process_chain_segment(chunk.to_vec(), NotifyExecutionLayer::Yes)
                 .await
+                .into_block_error()
                 .unwrap_or_else(|_| panic!("should import chain segment of len {}", chunk_size));
         }
 
+        update_fork_choice_with_envelopes(&chain_segment, &harness);
         harness.chain.recompute_head_at_current_slot().await;
 
         assert_eq!(
@@ -629,45 +595,18 @@ async fn assert_invalid_signature(
         })
         .collect();
 
-    // Import the valid ancestor blocks first, registering each block's payload envelope, so the
-    // invalid block's parent payload is available in fork choice. Post-Gloas this is required for
-    // the segment import below to reach the invalid signature instead of failing earlier with
-    // `ParentUnknown`. These already-imported ancestors are filtered out of the segment below.
-    let valid_ancestor_blocks: Vec<RangeSyncBlock<E>> = chain_segment
-        .iter()
-        .take(block_index)
-        .zip(chain_segment_blobs.iter())
-        .map(|(snapshot, blobs)| {
-            build_range_sync_block(snapshot.beacon_block.clone(), blobs, harness.chain.clone())
-        })
-        .collect();
-    // `Box::pin` to keep this future off the stack: `assert_invalid_signature` otherwise exceeds
-    // Clippy's `large_stack_frames` threshold.
-    Box::pin(import_chain_segment_with_envelopes(
-        &chain_segment[..block_index],
-        &valid_ancestor_blocks,
-        harness,
-    ))
-    .await
-    .expect("should import valid ancestor blocks");
-
-    // Ensure the block will be rejected if imported in a chain segment. The already-imported
-    // ancestors are dropped from the segment: re-submitting them would re-process blocks that
-    // finalization may have pruned from fork choice, yielding a spurious `ParentUnknown`. The
-    // suffix begins at the invalid block, whose parent (the last ancestor) is imported above.
-    let segment_res = harness
-        .chain
-        .process_chain_segment(blocks[block_index..].to_vec(), NotifyExecutionLayer::Yes)
-        .await
-        .into_block_error();
+    // Ensure the block will be rejected if imported in a chain segment.
     assert!(
         matches!(
-            segment_res,
+            harness
+                .chain
+                .process_chain_segment(blocks, NotifyExecutionLayer::Yes)
+                .await
+                .into_block_error(),
             Err(BlockError::InvalidSignature(InvalidSignature::Unknown))
         ),
-        "should not import chain segment with an invalid {} signature, got: {:?}",
-        item,
-        segment_res
+        "should not import chain segment with an invalid {} signature",
+        item
     );
 
     // Call fork choice to update cached head (including finalization).
@@ -750,6 +689,10 @@ async fn get_invalid_sigs_harness(
 }
 #[tokio::test]
 async fn invalid_signature_gossip_block() {
+    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
     let (chain_segment, chain_segment_blobs) = get_chain_segment().await;
     for &block_index in BLOCK_INDICES {
         // Ensure the block will be rejected if imported on its own (without gossip checking).
@@ -764,9 +707,8 @@ async fn invalid_signature_gossip_block() {
             block.clone(),
             junk_signature(),
         ));
-        // Import all the ancestors before the `block_index` block, registering each block's
-        // payload envelope so post-Gloas FULL children can be imported.
-        let ancestor_blocks: Vec<RangeSyncBlock<E>> = chain_segment
+        // Import all the ancestors before the `block_index` block.
+        let ancestor_blocks = chain_segment
             .iter()
             .take(block_index)
             .zip(chain_segment_blobs.iter())
@@ -774,13 +716,12 @@ async fn invalid_signature_gossip_block() {
                 build_range_sync_block(snapshot.beacon_block.clone(), blobs, harness.chain.clone())
             })
             .collect();
-        import_chain_segment_with_envelopes(
-            &chain_segment[..block_index],
-            &ancestor_blocks,
-            &harness,
-        )
-        .await
-        .expect("should import all blocks prior to the one being tested");
+        harness
+            .chain
+            .process_chain_segment(ancestor_blocks, NotifyExecutionLayer::Yes)
+            .await
+            .into_block_error()
+            .expect("should import all blocks prior to the one being tested");
         let signed_block = SignedBeaconBlock::from_block(block, junk_signature());
         let lookup_block = LookupBlock::new(Arc::new(signed_block));
         let process_res = harness
@@ -808,6 +749,10 @@ async fn invalid_signature_gossip_block() {
 
 #[tokio::test]
 async fn invalid_signature_block_proposal() {
+    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
     let (chain_segment, chain_segment_blobs) = get_chain_segment().await;
     for &block_index in BLOCK_INDICES {
         let harness = get_invalid_sigs_harness(&chain_segment).await;
@@ -828,30 +773,10 @@ async fn invalid_signature_block_proposal() {
                 build_range_sync_block(snapshot.beacon_block.clone(), blobs, harness.chain.clone())
             })
             .collect::<Vec<_>>();
-        // Import the valid ancestor blocks first (registering payload envelopes) so the segment
-        // import below reaches the invalid signature instead of failing earlier with
-        // `ParentUnknown`. The already-imported ancestors are filtered out of the segment.
-        let valid_ancestor_blocks: Vec<RangeSyncBlock<E>> = chain_segment
-            .iter()
-            .take(block_index)
-            .zip(chain_segment_blobs.iter())
-            .map(|(snapshot, blobs)| {
-                build_range_sync_block(snapshot.beacon_block.clone(), blobs, harness.chain.clone())
-            })
-            .collect();
-        import_chain_segment_with_envelopes(
-            &chain_segment[..block_index],
-            &valid_ancestor_blocks,
-            &harness,
-        )
-        .await
-        .expect("should import valid ancestor blocks");
-        // Ensure the block will be rejected if imported in a chain segment. The already-imported
-        // ancestors are dropped from the segment (see `assert_invalid_signature`); the suffix
-        // begins at the invalid block, whose parent is imported above.
+        // Ensure the block will be rejected if imported in a chain segment.
         let process_res = harness
             .chain
-            .process_chain_segment(blocks[block_index..].to_vec(), NotifyExecutionLayer::Yes)
+            .process_chain_segment(blocks, NotifyExecutionLayer::Yes)
             .await
             .into_block_error();
         assert!(
@@ -867,6 +792,10 @@ async fn invalid_signature_block_proposal() {
 
 #[tokio::test]
 async fn invalid_signature_randao_reveal() {
+    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
     let (chain_segment, mut chain_segment_blobs) = get_chain_segment().await;
     for &block_index in BLOCK_INDICES {
         let harness = get_invalid_sigs_harness(&chain_segment).await;
@@ -895,6 +824,10 @@ async fn invalid_signature_randao_reveal() {
 
 #[tokio::test]
 async fn invalid_signature_proposer_slashing() {
+    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
     let (chain_segment, mut chain_segment_blobs) = get_chain_segment().await;
     for &block_index in BLOCK_INDICES {
         let harness = get_invalid_sigs_harness(&chain_segment).await;
@@ -937,6 +870,10 @@ async fn invalid_signature_proposer_slashing() {
 
 #[tokio::test]
 async fn invalid_signature_attester_slashing() {
+    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
     let (chain_segment, mut chain_segment_blobs) = get_chain_segment().await;
     for &block_index in BLOCK_INDICES {
         let harness = get_invalid_sigs_harness(&chain_segment).await;
@@ -1058,6 +995,10 @@ async fn invalid_signature_attester_slashing() {
 
 #[tokio::test]
 async fn invalid_signature_attestation() {
+    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
     let (chain_segment, mut chain_segment_blobs) = get_chain_segment().await;
     let mut checked_attestation = false;
 
@@ -1183,6 +1124,10 @@ async fn invalid_signature_deposit() {
 
 #[tokio::test]
 async fn invalid_signature_exit() {
+    // TODO(#9362): re-enable for Gloas once range sync imports payload envelopes.
+    if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
     let (chain_segment, mut chain_segment_blobs) = get_chain_segment().await;
     for &block_index in BLOCK_INDICES {
         let harness = get_invalid_sigs_harness(&chain_segment).await;

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -242,10 +242,9 @@ fn update_fork_choice_with_envelopes(
 /// after the block is imported.
 ///
 /// Post-Gloas, a FULL child block can only be imported once its parent's payload envelope has been
-/// imported into fork choice. `process_chain_segment` imports blocks only (in production, payload
-/// envelopes are fetched and imported separately), so a multi-block segment of consecutive FULL
-/// Gloas blocks cannot be imported in a single batch. This helper mirrors production sync ordering:
-/// it imports each block and then registers its payload envelope before importing the next block.
+/// imported into fork choice. `process_chain_segment` currently imports blocks only, so a
+/// multi-block segment of consecutive FULL Gloas blocks cannot be imported in a single batch. This
+/// helper imports each block and then registers its payload envelope before importing the next.
 ///
 /// Pre-Gloas, where blocks carry no payload envelope, the whole segment is imported in a single
 /// batch so the batch import path is still exercised.

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -238,6 +238,56 @@ fn update_fork_choice_with_envelopes(
     }
 }
 
+/// Import a chain segment, registering each block's payload envelope with fork choice immediately
+/// after the block is imported.
+///
+/// Post-Gloas, a FULL child block can only be imported once its parent's payload envelope has been
+/// imported into fork choice. `process_chain_segment` imports blocks only (in production, payload
+/// envelopes are fetched and imported separately), so a multi-block segment of consecutive FULL
+/// Gloas blocks cannot be imported in a single batch. This helper mirrors production sync ordering:
+/// it imports each block and then registers its payload envelope before importing the next block.
+///
+/// Pre-Gloas, where blocks carry no payload envelope, the whole segment is imported in a single
+/// batch so the batch import path is still exercised.
+///
+/// `chain_segment` and `blocks` must be aligned by index.
+async fn import_chain_segment_with_envelopes(
+    chain_segment: &[BeaconSnapshot<E>],
+    blocks: &[RangeSyncBlock<E>],
+    harness: &BeaconChainHarness<EphemeralHarnessType<E>>,
+) -> Result<(), BlockError> {
+    let has_envelopes = chain_segment
+        .iter()
+        .any(|snapshot| snapshot.execution_envelope.is_some());
+
+    if !has_envelopes {
+        return harness
+            .chain
+            .process_chain_segment(blocks.to_vec(), NotifyExecutionLayer::Yes)
+            .await
+            .into_block_error();
+    }
+
+    for (snapshot, block) in chain_segment.iter().zip(blocks.iter()) {
+        harness
+            .chain
+            .process_chain_segment(vec![block.clone()], NotifyExecutionLayer::Yes)
+            .await
+            .into_block_error()?;
+
+        if snapshot.execution_envelope.is_some() {
+            harness
+                .chain
+                .canonical_head
+                .fork_choice_write_lock()
+                .on_valid_payload_envelope_received(snapshot.beacon_block_root)
+                .map_err(|e| BlockError::InternalError(format!("{e:?}")))?;
+        }
+    }
+
+    Ok(())
+}
+
 fn junk_signature() -> Signature {
     let kp = generate_deterministic_keypair(VALIDATOR_COUNT);
     let message = Hash256::from_slice(&[42; 32]);
@@ -380,14 +430,10 @@ async fn chain_segment_full_segment() {
         .into_block_error()
         .expect("should import empty chain segment");
 
-    harness
-        .chain
-        .process_chain_segment(blocks.clone(), NotifyExecutionLayer::Yes)
+    import_chain_segment_with_envelopes(&chain_segment, &blocks, &harness)
         .await
-        .into_block_error()
         .expect("should import chain segment");
 
-    update_fork_choice_with_envelopes(&chain_segment, &harness);
     harness.chain.recompute_head_at_current_slot().await;
 
     assert_eq!(
@@ -415,16 +461,15 @@ async fn chain_segment_varying_chunk_size() {
             .slot_clock
             .set_slot(blocks.last().unwrap().slot().as_u64());
 
-        for chunk in blocks.clone().chunks(*chunk_size) {
-            harness
-                .chain
-                .process_chain_segment(chunk.to_vec(), NotifyExecutionLayer::Yes)
+        for (segment_chunk, block_chunk) in chain_segment
+            .chunks(*chunk_size)
+            .zip(blocks.chunks(*chunk_size))
+        {
+            import_chain_segment_with_envelopes(segment_chunk, block_chunk, &harness)
                 .await
-                .into_block_error()
                 .unwrap_or_else(|_| panic!("should import chain segment of len {}", chunk_size));
         }
 
-        update_fork_choice_with_envelopes(&chain_segment, &harness);
         harness.chain.recompute_head_at_current_slot().await;
 
         assert_eq!(
@@ -585,18 +630,45 @@ async fn assert_invalid_signature(
         })
         .collect();
 
-    // Ensure the block will be rejected if imported in a chain segment.
+    // Import the valid ancestor blocks first, registering each block's payload envelope, so the
+    // invalid block's parent payload is available in fork choice. Post-Gloas this is required for
+    // the segment import below to reach the invalid signature instead of failing earlier with
+    // `ParentUnknown`. These already-imported ancestors are filtered out of the segment below.
+    let valid_ancestor_blocks: Vec<RangeSyncBlock<E>> = chain_segment
+        .iter()
+        .take(block_index)
+        .zip(chain_segment_blobs.iter())
+        .map(|(snapshot, blobs)| {
+            build_range_sync_block(snapshot.beacon_block.clone(), blobs, harness.chain.clone())
+        })
+        .collect();
+    // `Box::pin` to keep this future off the stack: `assert_invalid_signature` otherwise exceeds
+    // Clippy's `large_stack_frames` threshold.
+    Box::pin(import_chain_segment_with_envelopes(
+        &chain_segment[..block_index],
+        &valid_ancestor_blocks,
+        harness,
+    ))
+    .await
+    .expect("should import valid ancestor blocks");
+
+    // Ensure the block will be rejected if imported in a chain segment. The already-imported
+    // ancestors are dropped from the segment: re-submitting them would re-process blocks that
+    // finalization may have pruned from fork choice, yielding a spurious `ParentUnknown`. The
+    // suffix begins at the invalid block, whose parent (the last ancestor) is imported above.
+    let segment_res = harness
+        .chain
+        .process_chain_segment(blocks[block_index..].to_vec(), NotifyExecutionLayer::Yes)
+        .await
+        .into_block_error();
     assert!(
         matches!(
-            harness
-                .chain
-                .process_chain_segment(blocks, NotifyExecutionLayer::Yes)
-                .await
-                .into_block_error(),
+            segment_res,
             Err(BlockError::InvalidSignature(InvalidSignature::Unknown))
         ),
-        "should not import chain segment with an invalid {} signature",
-        item
+        "should not import chain segment with an invalid {} signature, got: {:?}",
+        item,
+        segment_res
     );
 
     // Call fork choice to update cached head (including finalization).
@@ -693,8 +765,9 @@ async fn invalid_signature_gossip_block() {
             block.clone(),
             junk_signature(),
         ));
-        // Import all the ancestors before the `block_index` block.
-        let ancestor_blocks = chain_segment
+        // Import all the ancestors before the `block_index` block, registering each block's
+        // payload envelope so post-Gloas FULL children can be imported.
+        let ancestor_blocks: Vec<RangeSyncBlock<E>> = chain_segment
             .iter()
             .take(block_index)
             .zip(chain_segment_blobs.iter())
@@ -702,12 +775,13 @@ async fn invalid_signature_gossip_block() {
                 build_range_sync_block(snapshot.beacon_block.clone(), blobs, harness.chain.clone())
             })
             .collect();
-        harness
-            .chain
-            .process_chain_segment(ancestor_blocks, NotifyExecutionLayer::Yes)
-            .await
-            .into_block_error()
-            .expect("should import all blocks prior to the one being tested");
+        import_chain_segment_with_envelopes(
+            &chain_segment[..block_index],
+            &ancestor_blocks,
+            &harness,
+        )
+        .await
+        .expect("should import all blocks prior to the one being tested");
         let signed_block = SignedBeaconBlock::from_block(block, junk_signature());
         let lookup_block = LookupBlock::new(Arc::new(signed_block));
         let process_res = harness
@@ -755,10 +829,30 @@ async fn invalid_signature_block_proposal() {
                 build_range_sync_block(snapshot.beacon_block.clone(), blobs, harness.chain.clone())
             })
             .collect::<Vec<_>>();
-        // Ensure the block will be rejected if imported in a chain segment.
+        // Import the valid ancestor blocks first (registering payload envelopes) so the segment
+        // import below reaches the invalid signature instead of failing earlier with
+        // `ParentUnknown`. The already-imported ancestors are filtered out of the segment.
+        let valid_ancestor_blocks: Vec<RangeSyncBlock<E>> = chain_segment
+            .iter()
+            .take(block_index)
+            .zip(chain_segment_blobs.iter())
+            .map(|(snapshot, blobs)| {
+                build_range_sync_block(snapshot.beacon_block.clone(), blobs, harness.chain.clone())
+            })
+            .collect();
+        import_chain_segment_with_envelopes(
+            &chain_segment[..block_index],
+            &valid_ancestor_blocks,
+            &harness,
+        )
+        .await
+        .expect("should import valid ancestor blocks");
+        // Ensure the block will be rejected if imported in a chain segment. The already-imported
+        // ancestors are dropped from the segment (see `assert_invalid_signature`); the suffix
+        // begins at the invalid block, whose parent is imported above.
         let process_res = harness
             .chain
-            .process_chain_segment(blocks, NotifyExecutionLayer::Yes)
+            .process_chain_segment(blocks[block_index..].to_vec(), NotifyExecutionLayer::Yes)
             .await
             .into_block_error();
         assert!(

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -3195,44 +3195,14 @@ async fn weak_subjectivity_sync_test(
             .await
             .unwrap();
 
-        // Store the envelope, its columns, and apply to fork choice.
+        // Placeholder until range sync imports payload envelopes (#9362): persist the envelope so
+        // the block can be reconstructed for cold-storage migration, and mark the payload received
+        // in fork choice so the next (FULL) block can be imported.
         if let Some(envelope) = &snapshot.execution_envelope {
-            // Persist data columns for Gloas blocks. This mirrors what production does in
-            // `import_available_execution_payload_envelope` and what the harness now does in
-            // `process_envelope` — the WSS forward-sync loop bypasses both, so do it directly.
-            let mut ops = vec![];
-            let columns_block = beacon_chain
-                .store
-                .get_blinded_block(&block_root)
-                .unwrap()
-                .and_then(|b| beacon_chain.store.make_full_block(&block_root, b).ok());
-            if let Some(full_block) = columns_block {
-                let columns = beacon_chain::test_utils::generate_data_column_sidecars_from_block(
-                    &full_block,
-                    &beacon_chain.spec,
-                );
-                if !columns.is_empty()
-                    && let Some(store_op) = beacon_chain.get_blobs_or_columns_store_op(
-                        block_root,
-                        full_block.slot(),
-                        beacon_chain::block_verification_types::AvailableBlockData::DataColumns(
-                            columns,
-                        ),
-                    )
-                {
-                    ops.push(store_op);
-                }
-            }
-            ops.push(store::StoreOp::PutPayloadEnvelope(
-                block_root,
-                std::sync::Arc::new(envelope.as_ref().clone()),
-            ));
             beacon_chain
                 .store
-                .do_atomically_with_block_and_blobs_cache(ops)
+                .put_payload_envelope(&block_root, envelope)
                 .unwrap();
-
-            // Update fork choice so head selection accounts for Full payload status.
             beacon_chain
                 .canonical_head
                 .fork_choice_write_lock()

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -3195,7 +3195,7 @@ async fn weak_subjectivity_sync_test(
             .await
             .unwrap();
 
-        // Placeholder until range sync imports payload envelopes (#9362): persist the envelope so
+        // TODO(gloas): persist the envelope so
         // the block can be reconstructed for cold-storage migration, and mark the payload received
         // in fork choice so the next (FULL) block can be imported.
         if let Some(envelope) = &snapshot.execution_envelope {

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -3195,7 +3195,9 @@ async fn weak_subjectivity_sync_test(
 
         // Store the envelope, its columns, and apply to fork choice.
         if let Some(envelope) = &snapshot.execution_envelope {
-            // Persist data columns, mirroring `import_available_execution_payload_envelope`.
+            // Persist data columns for Gloas blocks. This mirrors what production does in
+            // `import_available_execution_payload_envelope` and what the harness now does in
+            // `process_envelope` — the WSS forward-sync loop bypasses both, so do it directly.
             let mut ops = vec![];
             let columns_block = beacon_chain
                 .store

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -3149,10 +3149,8 @@ async fn weak_subjectivity_sync_test(
             .put_payload_envelope(&wss_block_root, &envelope)
             .unwrap();
 
-        // Mark the checkpoint block's payload as received in fork choice. The anchor block is a
-        // trusted, finalized block whose payload we already have, but it is loaded via
-        // `from_anchor` and so is never marked payload-received. Without this, the first forward
-        // block (a FULL child of the anchor) would be rejected with `ParentUnknown`.
+        // `from_anchor` doesn't mark the anchor's payload received, so do it here; otherwise the
+        // first forward block (a FULL child of the anchor) would be rejected with `ParentUnknown`.
         beacon_chain
             .canonical_head
             .fork_choice_write_lock()

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -3195,9 +3195,37 @@ async fn weak_subjectivity_sync_test(
 
         // Store the envelope, its columns, and apply to fork choice.
         if let Some(envelope) = &snapshot.execution_envelope {
+            // Persist data columns, mirroring `import_available_execution_payload_envelope`.
+            let mut ops = vec![];
+            let columns_block = beacon_chain
+                .store
+                .get_blinded_block(&block_root)
+                .unwrap()
+                .and_then(|b| beacon_chain.store.make_full_block(&block_root, b).ok());
+            if let Some(full_block) = columns_block {
+                let columns = beacon_chain::test_utils::generate_data_column_sidecars_from_block(
+                    &full_block,
+                    &beacon_chain.spec,
+                );
+                if !columns.is_empty()
+                    && let Some(store_op) = beacon_chain.get_blobs_or_columns_store_op(
+                        block_root,
+                        full_block.slot(),
+                        beacon_chain::block_verification_types::AvailableBlockData::DataColumns(
+                            columns,
+                        ),
+                    )
+                {
+                    ops.push(store_op);
+                }
+            }
+            ops.push(store::StoreOp::PutPayloadEnvelope(
+                block_root,
+                std::sync::Arc::new(envelope.as_ref().clone()),
+            ));
             beacon_chain
                 .store
-                .put_payload_envelope(&block_root, envelope)
+                .do_atomically_with_block_and_blobs_cache(ops)
                 .unwrap();
 
             // Update fork choice so head selection accounts for Full payload status.

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -3195,14 +3195,14 @@ async fn weak_subjectivity_sync_test(
             .await
             .unwrap();
 
-        // TODO(gloas): persist the envelope so
-        // the block can be reconstructed for cold-storage migration, and mark the payload received
-        // in fork choice so the next (FULL) block can be imported.
+        // Store the envelope, its columns, and apply to fork choice.
         if let Some(envelope) = &snapshot.execution_envelope {
             beacon_chain
                 .store
                 .put_payload_envelope(&block_root, envelope)
                 .unwrap();
+
+            // Update fork choice so head selection accounts for Full payload status.
             beacon_chain
                 .canonical_head
                 .fork_choice_write_lock()

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -3148,6 +3148,16 @@ async fn weak_subjectivity_sync_test(
             .store
             .put_payload_envelope(&wss_block_root, &envelope)
             .unwrap();
+
+        // Mark the checkpoint block's payload as received in fork choice. The anchor block is a
+        // trusted, finalized block whose payload we already have, but it is loaded via
+        // `from_anchor` and so is never marked payload-received. Without this, the first forward
+        // block (a FULL child of the anchor) would be rejected with `ParentUnknown`.
+        beacon_chain
+            .canonical_head
+            .fork_choice_write_lock()
+            .on_valid_payload_envelope_received(wss_block_root)
+            .unwrap();
     }
 
     // Apply blocks forward to reach head.

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1560,19 +1560,12 @@ where
 
     /// Returns the import status of the parent of `block`.
     ///
-    /// A child block can only be imported after its parent has been fully imported. Post-Gloas
-    /// additionally requires that the parent payload committed to by the child's bid has been
-    /// received by fork choice.
-    ///
-    /// This requirement only applies when the parent is itself a post-Gloas block, whose payload is
-    /// imported separately from the block. A pre-Gloas parent's execution payload is embedded in the
-    /// block and is therefore always present, so a Gloas child at the fork-transition boundary must
-    /// not be gated on it.
+    /// A post-Gloas FULL child also requires the parent's payload (committed to by the child's bid)
+    /// to have been received by fork choice.
     pub fn get_parent_import_status(&self, block: &SignedBeaconBlock<E>) -> ParentImportStatus {
         if let Some(parent_block) = self.get_block(&block.parent_root()) {
             let Some(parent_block_hash) = parent_block.execution_payload_block_hash else {
-                // `execution_payload_block_hash` is only set for post-Gloas proto nodes; a
-                // pre-Gloas parent (`None`) has no separately-imported payload to wait for.
+                // Pre-Gloas parent: payload is embedded in the block, so treat as imported.
                 return ParentImportStatus::Imported(parent_block);
             };
             if block.is_parent_block_full(parent_block_hash)

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -207,6 +207,18 @@ pub enum InvalidPayloadAttestation {
     },
 }
 
+/// The import status of a block's parent, as seen by fork choice.
+#[allow(clippy::large_enum_variant)]
+pub enum ParentImportedStatus {
+    /// The parent block is imported. For a post-Gloas FULL child, its parent's payload has been
+    /// imported too.
+    Imported(ProtoBlock),
+    /// The parent block is not known to fork choice.
+    UnknownBlock,
+    /// The parent block is known, but this (FULL) child's parent payload has not been imported yet.
+    UnimportedPayload,
+}
+
 impl<T> From<String> for Error<T> {
     fn from(e: String) -> Self {
         Error::ProtoArrayStringError(e)
@@ -1535,6 +1547,34 @@ where
     pub fn is_payload_received(&self, block_root: &Hash256) -> bool {
         self.proto_array.is_payload_received(block_root)
             && self.is_finalized_checkpoint_or_descendant(*block_root)
+    }
+
+    /// Returns `true` if the block's parent is imported (and, for a post-Gloas FULL child, its
+    /// parent's payload is imported too). See [`Self::is_parent_imported_status`].
+    pub fn is_parent_imported(&self, block: &SignedBeaconBlock<E>) -> bool {
+        matches!(
+            self.is_parent_imported_status(block),
+            ParentImportedStatus::Imported(_)
+        )
+    }
+
+    /// Returns the import status of the parent of `block`.
+    ///
+    /// A child block can only be imported after its parent has been fully imported. For a post-Gloas
+    /// FULL child (one whose bid commits to the parent's execution payload), "fully imported" also
+    /// requires the parent's payload to have been received by fork choice.
+    pub fn is_parent_imported_status(&self, block: &SignedBeaconBlock<E>) -> ParentImportedStatus {
+        if let Some(proto_block) = self.get_block(&block.parent_root()) {
+            if let Ok(bid) = block.message().body().signed_execution_payload_bid()
+                && proto_block.is_child_full(bid)
+                && !self.is_payload_received(&block.parent_root())
+            {
+                return ParentImportedStatus::UnimportedPayload;
+            }
+            ParentImportedStatus::Imported(proto_block)
+        } else {
+            ParentImportedStatus::UnknownBlock
+        }
     }
 
     /// Called by the proposer to decide whether to build on the full or empty parent.

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -210,12 +210,12 @@ pub enum InvalidPayloadAttestation {
 /// The import status of a block's parent, as seen by fork choice.
 #[allow(clippy::large_enum_variant)]
 pub enum ParentImportedStatus {
-    /// The parent block is imported. For a post-Gloas FULL child, its parent's payload has been
-    /// imported too.
+    /// The parent block is imported and the child's bid commits to a parent payload known to fork
+    /// choice.
     Imported(ProtoBlock),
     /// The parent block is not known to fork choice.
     UnknownBlock,
-    /// The parent block is known, but this (FULL) child's parent payload has not been imported yet.
+    /// The parent block is known, but the child's bid commits to a payload not known to fork choice.
     UnimportedPayload,
 }
 
@@ -1560,9 +1560,9 @@ where
 
     /// Returns the import status of the parent of `block`.
     ///
-    /// A child block can only be imported after its parent has been fully imported. For a post-Gloas
-    /// FULL child (one whose bid commits to the parent's execution payload), "fully imported" also
-    /// requires the parent's payload to have been received by fork choice.
+    /// A child block can only be imported after its parent has been fully imported. Post-Gloas
+    /// additionally requires that the parent payload committed to by the child's bid has been
+    /// received by fork choice.
     ///
     /// This requirement only applies when the parent is itself a post-Gloas block, whose payload is
     /// imported separately from the block. A pre-Gloas parent's execution payload is embedded in the
@@ -1575,7 +1575,7 @@ where
             let parent_is_post_gloas = proto_block.execution_payload_block_hash.is_some();
             if parent_is_post_gloas
                 && let Ok(bid) = block.message().body().signed_execution_payload_bid()
-                && proto_block.is_child_full(bid)
+                && proto_block.is_parent_full(bid)
                 && !self.is_payload_received(&block.parent_root())
             {
                 return ParentImportedStatus::UnimportedPayload;

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -209,7 +209,7 @@ pub enum InvalidPayloadAttestation {
 
 /// The import status of a block's parent, as seen by fork choice.
 #[allow(clippy::large_enum_variant)]
-pub enum ParentImportedStatus {
+pub enum ParentImportStatus {
     /// The parent block is imported and the child's bid commits to a parent payload known to fork
     /// choice.
     Imported(ProtoBlock),
@@ -1550,11 +1550,11 @@ where
     }
 
     /// Returns `true` if the block's parent is imported (and, for a post-Gloas FULL child, its
-    /// parent's payload is imported too). See [`Self::is_parent_imported_status`].
+    /// parent's payload is imported too). See [`Self::get_parent_import_status`].
     pub fn is_parent_imported(&self, block: &SignedBeaconBlock<E>) -> bool {
         matches!(
-            self.is_parent_imported_status(block),
-            ParentImportedStatus::Imported(_)
+            self.get_parent_import_status(block),
+            ParentImportStatus::Imported(_)
         )
     }
 
@@ -1568,22 +1568,22 @@ where
     /// imported separately from the block. A pre-Gloas parent's execution payload is embedded in the
     /// block and is therefore always present, so a Gloas child at the fork-transition boundary must
     /// not be gated on it.
-    pub fn is_parent_imported_status(&self, block: &SignedBeaconBlock<E>) -> ParentImportedStatus {
+    pub fn get_parent_import_status(&self, block: &SignedBeaconBlock<E>) -> ParentImportStatus {
         if let Some(parent_block) = self.get_block(&block.parent_root()) {
             let Some(parent_block_hash) = parent_block.execution_payload_block_hash else {
                 // `execution_payload_block_hash` is only set for post-Gloas proto nodes; a
                 // pre-Gloas parent (`None`) has no separately-imported payload to wait for.
-                return ParentImportedStatus::Imported(parent_block);
+                return ParentImportStatus::Imported(parent_block);
             };
             if block.is_parent_block_full(parent_block_hash)
                 && !self.is_payload_received(&block.parent_root())
             {
-                ParentImportedStatus::UnimportedPayload
+                ParentImportStatus::UnimportedPayload
             } else {
-                ParentImportedStatus::Imported(parent_block)
+                ParentImportStatus::Imported(parent_block)
             }
         } else {
-            ParentImportedStatus::UnknownBlock
+            ParentImportStatus::UnknownBlock
         }
     }
 

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1563,9 +1563,18 @@ where
     /// A child block can only be imported after its parent has been fully imported. For a post-Gloas
     /// FULL child (one whose bid commits to the parent's execution payload), "fully imported" also
     /// requires the parent's payload to have been received by fork choice.
+    ///
+    /// This requirement only applies when the parent is itself a post-Gloas block, whose payload is
+    /// imported separately from the block. A pre-Gloas parent's execution payload is embedded in the
+    /// block and is therefore always present, so a Gloas child at the fork-transition boundary must
+    /// not be gated on it.
     pub fn is_parent_imported_status(&self, block: &SignedBeaconBlock<E>) -> ParentImportedStatus {
         if let Some(proto_block) = self.get_block(&block.parent_root()) {
-            if let Ok(bid) = block.message().body().signed_execution_payload_bid()
+            // `execution_payload_block_hash` is only set for post-Gloas proto nodes; a pre-Gloas
+            // parent (`None`) has no separately-imported payload to wait for.
+            let parent_is_post_gloas = proto_block.execution_payload_block_hash.is_some();
+            if parent_is_post_gloas
+                && let Ok(bid) = block.message().body().signed_execution_payload_bid()
                 && proto_block.is_child_full(bid)
                 && !self.is_payload_received(&block.parent_root())
             {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1569,18 +1569,19 @@ where
     /// block and is therefore always present, so a Gloas child at the fork-transition boundary must
     /// not be gated on it.
     pub fn is_parent_imported_status(&self, block: &SignedBeaconBlock<E>) -> ParentImportedStatus {
-        if let Some(proto_block) = self.get_block(&block.parent_root()) {
-            // `execution_payload_block_hash` is only set for post-Gloas proto nodes; a pre-Gloas
-            // parent (`None`) has no separately-imported payload to wait for.
-            let parent_is_post_gloas = proto_block.execution_payload_block_hash.is_some();
-            if parent_is_post_gloas
-                && let Ok(bid) = block.message().body().signed_execution_payload_bid()
-                && proto_block.is_parent_full(bid)
+        if let Some(parent_block) = self.get_block(&block.parent_root()) {
+            let Some(parent_block_hash) = parent_block.execution_payload_block_hash else {
+                // `execution_payload_block_hash` is only set for post-Gloas proto nodes; a
+                // pre-Gloas parent (`None`) has no separately-imported payload to wait for.
+                return ParentImportedStatus::Imported(parent_block);
+            };
+            if block.is_parent_block_full(parent_block_hash)
                 && !self.is_payload_received(&block.parent_root())
             {
-                return ParentImportedStatus::UnimportedPayload;
+                ParentImportedStatus::UnimportedPayload
+            } else {
+                ParentImportedStatus::Imported(parent_block)
             }
-            ParentImportedStatus::Imported(proto_block)
         } else {
             ParentImportedStatus::UnknownBlock
         }

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -216,7 +216,7 @@ pub enum ParentImportStatus {
     /// The parent block is not known to fork choice.
     UnknownBlock,
     /// The parent block is known, but the child's bid commits to a payload not known to fork choice.
-    UnimportedPayload,
+    UnknownPayload,
 }
 
 impl<T> From<String> for Error<T> {
@@ -1578,7 +1578,7 @@ where
             if block.is_parent_block_full(parent_block_hash)
                 && !self.is_payload_received(&block.parent_root())
             {
-                ParentImportStatus::UnimportedPayload
+                ParentImportStatus::UnknownPayload
             } else {
                 ParentImportStatus::Imported(parent_block)
             }

--- a/consensus/fork_choice/src/lib.rs
+++ b/consensus/fork_choice/src/lib.rs
@@ -4,9 +4,9 @@ mod metrics;
 
 pub use crate::fork_choice::{
     AttestationFromBlock, Error, ForkChoice, ForkChoiceView, ForkchoiceUpdateParameters,
-    InvalidAttestation, InvalidBlock, InvalidPayloadAttestation, PayloadVerificationStatus,
-    PersistedForkChoice, PersistedForkChoiceV28, PersistedForkChoiceV29, QueuedAttestation,
-    ResetPayloadStatuses,
+    InvalidAttestation, InvalidBlock, InvalidPayloadAttestation, ParentImportedStatus,
+    PayloadVerificationStatus, PersistedForkChoice, PersistedForkChoiceV28, PersistedForkChoiceV29,
+    QueuedAttestation, ResetPayloadStatuses,
 };
 pub use fork_choice_store::ForkChoiceStore;
 pub use proto_array::{

--- a/consensus/fork_choice/src/lib.rs
+++ b/consensus/fork_choice/src/lib.rs
@@ -4,7 +4,7 @@ mod metrics;
 
 pub use crate::fork_choice::{
     AttestationFromBlock, Error, ForkChoice, ForkChoiceView, ForkchoiceUpdateParameters,
-    InvalidAttestation, InvalidBlock, InvalidPayloadAttestation, ParentImportedStatus,
+    InvalidAttestation, InvalidBlock, InvalidPayloadAttestation, ParentImportStatus,
     PayloadVerificationStatus, PersistedForkChoice, PersistedForkChoiceV28, PersistedForkChoiceV29,
     QueuedAttestation, ResetPayloadStatuses,
 };

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -293,9 +293,9 @@ impl Block {
         }
     }
 
-    /// Returns `true` if the given (post-Gloas) `child_bid` commits to *this* block's execution
-    /// payload, i.e. the child is "FULL" relative to this parent.
-    pub fn is_child_full<E: EthSpec>(&self, child_bid: &SignedExecutionPayloadBid<E>) -> bool {
+    /// Returns `true` if *this* (parent) block's execution payload is the one committed to by the
+    /// given (post-Gloas) `child_bid`, i.e. the parent is "FULL" from the child's perspective.
+    pub fn is_parent_full<E: EthSpec>(&self, child_bid: &SignedExecutionPayloadBid<E>) -> bool {
         if let Some(execution_payload_block_hash) = self.execution_payload_block_hash {
             execution_payload_block_hash == child_bid.message.parent_block_hash
         } else if let Some(execution_block_hash) = self.execution_status.block_hash() {

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -17,7 +17,7 @@ use std::{
 };
 use types::{
     AttestationShufflingId, ChainSpec, Checkpoint, Epoch, EthSpec, ExecutionBlockHash, Hash256,
-    Slot,
+    SignedExecutionPayloadBid, Slot,
 };
 
 pub const DEFAULT_PRUNE_THRESHOLD: usize = 256;
@@ -290,6 +290,22 @@ impl Block {
                 // block (its parent) will be the decision block.
                 self.root
             }
+        }
+    }
+
+    /// Returns `true` if the given (post-Gloas) `child_bid` commits to *this* block's execution
+    /// payload, i.e. the child is "FULL" relative to this parent. A FULL child requires this
+    /// parent's payload to have been imported before the child can be imported.
+    pub fn is_child_full<E: EthSpec>(&self, child_bid: &SignedExecutionPayloadBid<E>) -> bool {
+        if let Some(execution_payload_block_hash) = self.execution_payload_block_hash {
+            execution_payload_block_hash == child_bid.message.parent_block_hash
+        } else if let Some(execution_block_hash) = self.execution_status.block_hash() {
+            // Parent is before Gloas, and child is gloas
+            execution_block_hash == child_bid.message.parent_block_hash
+        } else {
+            // TODO(gloas): What to return here? The child is Gloas but parent doesn't have an
+            // execution hash
+            false
         }
     }
 }

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -17,7 +17,7 @@ use std::{
 };
 use types::{
     AttestationShufflingId, ChainSpec, Checkpoint, Epoch, EthSpec, ExecutionBlockHash, Hash256,
-    SignedExecutionPayloadBid, Slot,
+    Slot,
 };
 
 pub const DEFAULT_PRUNE_THRESHOLD: usize = 256;
@@ -290,21 +290,6 @@ impl Block {
                 // block (its parent) will be the decision block.
                 self.root
             }
-        }
-    }
-
-    /// Returns `true` if *this* (parent) block's execution payload is the one committed to by the
-    /// given (post-Gloas) `child_bid`, i.e. the parent is "FULL" from the child's perspective.
-    pub fn is_parent_full<E: EthSpec>(&self, child_bid: &SignedExecutionPayloadBid<E>) -> bool {
-        if let Some(execution_payload_block_hash) = self.execution_payload_block_hash {
-            execution_payload_block_hash == child_bid.message.parent_block_hash
-        } else if let Some(execution_block_hash) = self.execution_status.block_hash() {
-            // Parent is before Gloas, and child is gloas
-            execution_block_hash == child_bid.message.parent_block_hash
-        } else {
-            // TODO(gloas): What to return here? The child is Gloas but parent doesn't have an
-            // execution hash
-            false
         }
     }
 }

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -294,8 +294,7 @@ impl Block {
     }
 
     /// Returns `true` if the given (post-Gloas) `child_bid` commits to *this* block's execution
-    /// payload, i.e. the child is "FULL" relative to this parent. A FULL child requires this
-    /// parent's payload to have been imported before the child can be imported.
+    /// payload, i.e. the child is "FULL" relative to this parent.
     pub fn is_child_full<E: EthSpec>(&self, child_bid: &SignedExecutionPayloadBid<E>) -> bool {
         if let Some(execution_payload_block_hash) = self.execution_payload_block_hash {
             execution_payload_block_hash == child_bid.message.parent_block_hash


### PR DESCRIPTION
Gloas spec states:

```py
def on_block(...):
    if is_parent_node_full(store, block):
        assert is_payload_verified(store, block.parent_root)
```

In other words: if the block is FULL child, the payload+data must have been imported before hand. We need to gate Gossip / REST API and sync import flows on that condition. To de-duplicate logic I added `is_parent_imported_status` in fork-choice.

- So if the payload is missing, lookup sync will get a `ParentUnknown`, handle it and fetch the payload. This part is implemented in https://github.com/sigp/lighthouse/pull/9155