### PR TITLE
Make proposer_score_boost non-optional in ChainSpec

### DIFF
--- a/beacon_node/beacon_chain/src/block_production/mod.rs
+++ b/beacon_node/beacon_chain/src/block_production/mod.rs
@@ -179,14 +179,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let re_org_max_epochs_since_finalization =
             Epoch::new(self.spec.reorg_max_epochs_since_finalization);
 
-        if self.spec.proposer_score_boost.is_none() {
-            warn!(
-                reason = "this network does not have proposer boost enabled",
-                "Ignoring proposer re-org configuration"
-            );
-            return None;
-        }
-
         let slot_delay = self
             .slot_clock
             .seconds_from_current_slot_start()

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -144,7 +144,7 @@ impl ForkChoiceTestDefinition {
     pub fn run(self) {
         let spec = self.spec.unwrap_or_else(|| {
             let mut spec = MainnetEthSpec::default_spec();
-            spec.proposer_score_boost = Some(50);
+            spec.proposer_score_boost = 50;
             // Legacy test definitions target pre-Gloas behaviour unless explicitly overridden.
             spec.gloas_fork_epoch = None;
             spec

--- a/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
@@ -2,7 +2,7 @@ use super::*;
 
 fn gloas_spec() -> ChainSpec {
     let mut spec = MainnetEthSpec::default_spec();
-    spec.proposer_score_boost = Some(50);
+    spec.proposer_score_boost = 50;
     spec.gloas_fork_epoch = Some(Epoch::new(0));
     spec
 }
@@ -977,7 +977,7 @@ mod tests {
 
     fn gloas_fork_boundary_spec() -> ChainSpec {
         let mut spec = MainnetEthSpec::default_spec();
-        spec.proposer_score_boost = Some(50);
+        spec.proposer_score_boost = 50;
         spec.gloas_fork_epoch = Some(Epoch::new(1));
         spec
     }

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -1861,10 +1861,7 @@ fn get_proposer_score<E: EthSpec>(
     justified_balances: &JustifiedBalances,
     spec: &ChainSpec,
 ) -> Result<u64, Error> {
-    let Some(proposer_score_boost) = spec.proposer_score_boost else {
-        return Ok(0);
-    };
-    calculate_committee_fraction::<E>(justified_balances, proposer_score_boost)
+    calculate_committee_fraction::<E>(justified_balances, spec.proposer_score_boost)
         .ok_or(Error::ProposerBoostOverflow(0))
 }
 

--- a/consensus/types/src/core/chain_spec.rs
+++ b/consensus/types/src/core/chain_spec.rs
@@ -151,7 +151,7 @@ pub struct ChainSpec {
     /*
      * Fork choice
      */
-    pub proposer_score_boost: Option<u64>,
+    pub proposer_score_boost: u64,
     pub reorg_head_weight_threshold: u64,
     pub reorg_parent_weight_threshold: u64,
     pub reorg_max_epochs_since_finalization: u64,
@@ -1162,7 +1162,7 @@ impl ChainSpec {
             /*
              * Fork choice
              */
-            proposer_score_boost: Some(40),
+            proposer_score_boost: 40,
             reorg_head_weight_threshold: 20,
             reorg_parent_weight_threshold: 160,
             reorg_max_epochs_since_finalization: 2,
@@ -1587,7 +1587,7 @@ impl ChainSpec {
             /*
              * Fork choice
              */
-            proposer_score_boost: Some(40),
+            proposer_score_boost: 40,
             reorg_head_weight_threshold: 20,
             reorg_parent_weight_threshold: 160,
             reorg_max_epochs_since_finalization: 2,
@@ -2640,7 +2640,9 @@ impl Config {
             min_per_epoch_churn_limit: spec.min_per_epoch_churn_limit,
             max_per_epoch_activation_churn_limit: spec.max_per_epoch_activation_churn_limit,
 
-            proposer_score_boost: spec.proposer_score_boost.map(|value| MaybeQuoted { value }),
+            proposer_score_boost: Some(MaybeQuoted {
+                value: spec.proposer_score_boost,
+            }),
             reorg_head_weight_threshold: spec.reorg_head_weight_threshold,
             reorg_parent_weight_threshold: spec.reorg_parent_weight_threshold,
             reorg_max_epochs_since_finalization: spec.reorg_max_epochs_since_finalization,
@@ -2854,7 +2856,9 @@ impl Config {
             min_per_epoch_churn_limit,
             max_per_epoch_activation_churn_limit,
             churn_limit_quotient,
-            proposer_score_boost: proposer_score_boost.map(|q| q.value),
+            proposer_score_boost: proposer_score_boost
+                .map(|q| q.value)
+                .unwrap_or(chain_spec.proposer_score_boost),
             reorg_head_weight_threshold,
             reorg_parent_weight_threshold,
             reorg_max_epochs_since_finalization,


### PR DESCRIPTION
## Description

Make `ChainSpec.proposer_score_boost` non-optional (`Option<u64>` → `u64`), per @michaelsproul's suggestion. Proposer boost is always present on real networks, so the `Option` only encoded a never-used "no boost" code path. The on-disk config YAML field stays optional and falls back to the base spec when omitted.

## Additional Info

🤖 This PR was authored by Claude Code.
