### PR TITLE
Improve error types for envelopes

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4101,6 +4101,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 publish_fn()?;
                 self.import_available_execution_payload_envelope(available_envelope)
                     .await
+                    .map_err(Into::into)
             }
             PayloadAvailability::MissingComponents(block_root) => Ok(
                 AvailabilityProcessingStatus::MissingComponents(slot, block_root),

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -506,6 +506,50 @@ pub struct PayloadVerificationOutcome {
     pub payload_verification_status: PayloadVerificationStatus,
 }
 
+/// The set of errors that can occur while notifying the execution layer of a new payload.
+///
+/// This is deliberately narrow: notifying the EL can only fail in these two ways. The type is
+/// shared by both the pre-Gloas block import path and the Gloas payload envelope path so that
+/// neither pipeline has to borrow the other's error enum. It converts cleanly into both
+/// [`BlockError`] and [`EnvelopeError`](crate::payload_envelope_verification::EnvelopeError) at the
+/// point where the verification handle is consumed.
+#[derive(Debug)]
+pub enum PayloadVerificationError {
+    /// The execution payload was rejected by, or could not be sent to, the execution engine.
+    ExecutionPayloadError(ExecutionPayloadError),
+    /// An internal error occurred while notifying the execution layer.
+    BeaconChainError(Box<BeaconChainError>),
+}
+
+impl From<ExecutionPayloadError> for PayloadVerificationError {
+    fn from(e: ExecutionPayloadError) -> Self {
+        PayloadVerificationError::ExecutionPayloadError(e)
+    }
+}
+
+impl From<BeaconChainError> for PayloadVerificationError {
+    fn from(e: BeaconChainError) -> Self {
+        PayloadVerificationError::BeaconChainError(Box::new(e))
+    }
+}
+
+impl From<BeaconStateError> for PayloadVerificationError {
+    fn from(e: BeaconStateError) -> Self {
+        PayloadVerificationError::BeaconChainError(Box::new(BeaconChainError::BeaconStateError(e)))
+    }
+}
+
+impl From<PayloadVerificationError> for BlockError {
+    fn from(e: PayloadVerificationError) -> Self {
+        match e {
+            PayloadVerificationError::ExecutionPayloadError(e) => {
+                BlockError::ExecutionPayloadError(e)
+            }
+            PayloadVerificationError::BeaconChainError(e) => BlockError::BeaconChainError(e),
+        }
+    }
+}
+
 /// Information about invalid blocks which might still be slashable despite being invalid.
 #[allow(clippy::enum_variant_names)]
 pub enum BlockSlashInfo<TErr> {
@@ -676,7 +720,7 @@ pub struct SignatureVerifiedBlock<T: BeaconChainTypes> {
 
 /// Used to await the result of executing payload with an EE.
 pub type PayloadVerificationHandle =
-    JoinHandle<Option<Result<PayloadVerificationOutcome, BlockError>>>;
+    JoinHandle<Option<Result<PayloadVerificationOutcome, PayloadVerificationError>>>;
 
 /// A wrapper around a `SignedBeaconBlock` that indicates that this block is fully verified and
 /// ready to import into the `BeaconChain`. The validation includes:

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -59,6 +59,7 @@ use crate::execution_payload::{
 };
 use crate::kzg_utils::blobs_to_data_column_sidecars;
 use crate::observed_block_producers::SeenBlock;
+use crate::payload_envelope_verification::EnvelopeError;
 use crate::validator_monitor::HISTORIC_EPOCHS as VALIDATOR_MONITOR_HISTORIC_EPOCHS;
 use crate::validator_pubkey_cache::ValidatorPubkeyCache;
 use crate::{
@@ -122,7 +123,9 @@ pub enum BlockError {
     ///
     /// It's unclear if this block is valid, but it cannot be processed without already knowing
     /// its parent.
-    ParentUnknown { parent_root: Hash256 },
+    ParentUnknown {
+        parent_root: Hash256,
+    },
     /// The block slot is greater than the present slot.
     ///
     /// ## Peer scoring
@@ -137,7 +140,10 @@ pub enum BlockError {
     /// ## Peer scoring
     ///
     /// The peer has incompatible state transition logic and is faulty.
-    StateRootMismatch { block: Hash256, local: Hash256 },
+    StateRootMismatch {
+        block: Hash256,
+        local: Hash256,
+    },
     /// The block was a genesis block, these blocks cannot be re-imported.
     GenesisBlock,
     /// The slot is finalized, no need to import.
@@ -156,7 +162,9 @@ pub enum BlockError {
     ///
     /// It's unclear if this block is valid, but it conflicts with finality and shouldn't be
     /// imported.
-    NotFinalizedDescendant { block_parent_root: Hash256 },
+    NotFinalizedDescendant {
+        block_parent_root: Hash256,
+    },
     /// Block is already known and valid, no need to re-import.
     ///
     /// ## Peer scoring
@@ -183,7 +191,10 @@ pub enum BlockError {
     /// ## Peer scoring
     ///
     /// The block is invalid and the peer is faulty.
-    IncorrectBlockProposer { block: u64, local_shuffling: u64 },
+    IncorrectBlockProposer {
+        block: u64,
+        local_shuffling: u64,
+    },
     /// The `block.proposal_index` is not known.
     ///
     /// ## Peer scoring
@@ -201,7 +212,10 @@ pub enum BlockError {
     /// ## Peer scoring
     ///
     /// The block is invalid and the peer is faulty.
-    BlockIsNotLaterThanParent { block_slot: Slot, parent_slot: Slot },
+    BlockIsNotLaterThanParent {
+        block_slot: Slot,
+        parent_slot: Slot,
+    },
     /// At least one block in the chain segment did not have it's parent root set to the root of
     /// the prior block.
     ///
@@ -257,7 +271,9 @@ pub enum BlockError {
     /// If it's actually our fault (e.g. our execution node database is corrupt) we have bigger
     /// problems to worry about than losing peers, and we're doing the network a favour by
     /// disconnecting.
-    ParentExecutionPayloadInvalid { parent_root: Hash256 },
+    ParentExecutionPayloadInvalid {
+        parent_root: Hash256,
+    },
     /// This is a known invalid block that was listed in Lighthouses configuration.
     /// At the moment this error is only relevant as part of the Holesky network recovery efforts.
     KnownInvalidExecutionPayload(Hash256),
@@ -288,7 +304,9 @@ pub enum BlockError {
     /// The payload envelope's block root is unknown.
     EnvelopeBlockRootUnknown(Hash256),
     /// Optimistic sync is not supported for Gloas payload envelopes.
-    OptimisticSyncNotSupported { block_root: Hash256 },
+    OptimisticSyncNotSupported {
+        block_root: Hash256,
+    },
     /// An internal error has occurred when processing the block or sidecars.
     ///
     /// ## Peer scoring
@@ -315,6 +333,7 @@ pub enum BlockError {
         bid_parent_root: Hash256,
         block_parent_root: Hash256,
     },
+    EnvelopeError(Box<EnvelopeError>),
 }
 
 /// Which specific signature(s) are invalid in a SignedBeaconBlock

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -301,8 +301,6 @@ pub enum BlockError {
     /// TODO: We may need to penalize the peer that gave us a potentially invalid rpc blob.
     /// https://github.com/sigp/lighthouse/issues/4546
     AvailabilityCheck(AvailabilityCheckError),
-    /// The payload envelope's block root is unknown.
-    EnvelopeBlockRootUnknown(Hash256),
     /// An internal error has occurred when processing the block or sidecars.
     ///
     /// ## Peer scoring

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -303,10 +303,6 @@ pub enum BlockError {
     AvailabilityCheck(AvailabilityCheckError),
     /// The payload envelope's block root is unknown.
     EnvelopeBlockRootUnknown(Hash256),
-    /// Optimistic sync is not supported for Gloas payload envelopes.
-    OptimisticSyncNotSupported {
-        block_root: Hash256,
-    },
     /// An internal error has occurred when processing the block or sidecars.
     ///
     /// ## Peer scoring

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     BeaconChain, BeaconChainError, BeaconChainTypes, BlockError, BlockProductionError,
-    ExecutionPayloadError,
+    ExecutionPayloadError, PayloadVerificationError,
 };
 use execution_layer::{
     BlockProposalContentsType, BuilderParams, NewPayloadRequest, PayloadAttributes,
@@ -104,7 +104,9 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
         })
     }
 
-    pub async fn notify_new_payload(self) -> Result<PayloadVerificationStatus, BlockError> {
+    pub async fn notify_new_payload(
+        self,
+    ) -> Result<PayloadVerificationStatus, PayloadVerificationError> {
         if let Some(precomputed_status) = self.payload_verification_status {
             Ok(precomputed_status)
         } else {
@@ -133,7 +135,7 @@ pub async fn notify_new_payload<T: BeaconChainTypes>(
     slot: Slot,
     parent_beacon_block_root: Hash256,
     new_payload_request: NewPayloadRequest<'_, T::EthSpec>,
-) -> Result<PayloadVerificationStatus, BlockError> {
+) -> Result<PayloadVerificationStatus, PayloadVerificationError> {
     let execution_layer = chain
         .execution_layer
         .as_ref()

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -86,8 +86,8 @@ pub use beacon_fork_choice_store::{
 pub use block_verification::{
     BlockError, ExecutionPayloadError, ExecutionPendingBlock, GossipVerifiedBlock,
     IntoExecutionPendingBlock, IntoGossipVerifiedBlock, InvalidSignature, ParentImportStatus,
-    PayloadVerificationOutcome, PayloadVerificationStatus, build_blob_data_column_sidecars,
-    get_block_root, signature_verify_chain_segment,
+    PayloadVerificationError, PayloadVerificationOutcome, PayloadVerificationStatus,
+    build_blob_data_column_sidecars, get_block_root, signature_verify_chain_segment,
 };
 pub use block_verification_types::AvailabilityPendingExecutedBlock;
 pub use block_verification_types::ExecutedBlock;

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -41,7 +41,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         notify_execution_layer: NotifyExecutionLayer,
         envelope_source: BlockImportSource,
         publish_fn: impl FnOnce() -> Result<(), EnvelopeError>,
-    ) -> Result<AvailabilityProcessingStatus, EnvelopeError> {
+    ) -> Result<AvailabilityProcessingStatus, BlockError> {
         let block_slot = unverified_envelope.signed_envelope.slot();
 
         // Set observed time if not already set. Usually this should be set by gossip or RPC,
@@ -85,10 +85,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .into_executed_payload_envelope(execution_pending)
                 .await
                 .map_err(|error| match error {
-                    BlockError::ExecutionPayloadError(error) => {
-                        EnvelopeError::ExecutionPayloadError(error)
-                    }
-                    error => EnvelopeError::ImportError(error),
+                    BlockError::ExecutionPayloadError(error) => BlockError::EnvelopeError(
+                        Box::new(EnvelopeError::ExecutionPayloadError(error)),
+                    ),
+                    error => error,
                 })?;
 
             // Record the time it took to wait for execution layer verification.
@@ -100,7 +100,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
             self.check_envelope_availability_and_import(executed_envelope)
                 .await
-                .map_err(EnvelopeError::ImportError)
         };
 
         // Verify and import the payload envelope.
@@ -128,28 +127,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
                 Ok(status)
             }
-            Err(EnvelopeError::BeaconChainError(e)) => {
-                if matches!(e.as_ref(), BeaconChainError::TokioJoin(_)) {
-                    debug!(error = ?e, "Envelope processing cancelled");
-                } else {
-                    warn!(error = ?e, "Execution payload envelope rejected");
-                }
-                Err(EnvelopeError::BeaconChainError(e))
-            }
-            Err(EnvelopeError::ImportError(BlockError::BeaconChainError(e))) => {
-                if matches!(e.as_ref(), BeaconChainError::TokioJoin(_)) {
-                    debug!(error = ?e, "Envelope processing cancelled");
-                } else {
-                    warn!(error = ?e, "Execution payload envelope rejected");
-                }
-                Err(EnvelopeError::ImportError(BlockError::BeaconChainError(e)))
-            }
-            Err(other) => {
+            Err(err) => {
                 warn!(
-                    reason = other.to_string(),
+                    reason = err.to_string(),
                     "Execution payload envelope rejected"
                 );
-                Err(other)
+                Err(err)
             }
         }
     }

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -183,7 +183,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub async fn import_available_execution_payload_envelope(
         self: &Arc<Self>,
         envelope: Box<AvailableExecutedEnvelope<T::EthSpec>>,
-    ) -> Result<AvailabilityProcessingStatus, BlockError> {
+    ) -> Result<AvailabilityProcessingStatus, EnvelopeError> {
         let AvailableExecutedEnvelope {
             envelope,
             block_root,
@@ -220,13 +220,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         signed_envelope: AvailableEnvelope<T::EthSpec>,
         block_root: Hash256,
         payload_verification_status: PayloadVerificationStatus,
-    ) -> Result<Hash256, BlockError> {
+    ) -> Result<Hash256, EnvelopeError> {
         // Everything in this initial section is on the hot path for processing the envelope.
         // Take an upgradable read lock on fork choice so we can check if this block has already
         // been imported. We don't want to repeat work importing a block that is already imported.
         let fork_choice_reader = self.canonical_head.fork_choice_upgradable_read_lock();
         if !fork_choice_reader.contains_block(&block_root) {
-            return Err(BlockError::EnvelopeBlockRootUnknown(block_root));
+            return Err(EnvelopeError::BlockRootNotInForkChoice(block_root));
         }
 
         // TODO(gloas) add defensive check to see if payload envelope is already in fork choice
@@ -241,7 +241,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // node which can be eligible for head.
         fork_choice
             .on_valid_payload_envelope_received(block_root)
-            .map_err(|e| BlockError::InternalError(format!("{e:?}")))?;
+            .map_err(|e| EnvelopeError::InternalError(format!("{e:?}")))?;
 
         // TODO(gloas) emit SSE event if the payload became the new head payload
 

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -83,13 +83,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             // about what the function actually does.
             let executed_envelope = chain
                 .into_executed_payload_envelope(execution_pending)
-                .await
-                .map_err(|error| match error {
-                    BlockError::ExecutionPayloadError(error) => BlockError::EnvelopeError(
-                        Box::new(EnvelopeError::ExecutionPayloadError(error)),
-                    ),
-                    error => error,
-                })?;
+                .await?;
 
             // Record the time it took to wait for execution layer verification.
             if let Some(timestamp) = slot_clock.now_duration() {
@@ -158,7 +152,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     async fn into_executed_payload_envelope(
         self: Arc<Self>,
         pending_envelope: ExecutionPendingEnvelope<T::EthSpec>,
-    ) -> Result<AvailabilityPendingExecutedEnvelope<T::EthSpec>, BlockError> {
+    ) -> Result<AvailabilityPendingExecutedEnvelope<T::EthSpec>, EnvelopeError> {
         let ExecutionPendingEnvelope {
             signed_envelope,
             block_root,
@@ -175,7 +169,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .payload_verification_status
             .is_optimistic()
         {
-            return Err(BlockError::OptimisticSyncNotSupported { block_root });
+            return Err(EnvelopeError::OptimisticSyncNotSupported { block_root });
         }
 
         Ok(AvailabilityPendingExecutedEnvelope::new(

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -33,6 +33,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// Returns an `Err` if the given payload envelope was invalid, or an error was encountered during
     /// verification.
+    ///
+    /// Note: Returns a `BlockError` even though its an envelope processing function.
+    /// The reason is that this function actually imports the envelope in `check_envelope_availability_and_import`
+    /// which is coupled tightly with the block and data column import functions.
+    /// These functions return one error type for consistency across function signatures.
+    /// In the future, we could make the import error types more generic and then
+    /// this function could return an `EnvelopeError` as well.
     #[instrument(skip_all, fields(block_root = ?block_root, envelope_source = %envelope_source))]
     pub async fn process_execution_payload_envelope(
         self: &Arc<Self>,

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
@@ -164,6 +164,14 @@ pub enum EnvelopeError {
     ExecutionPayloadError(ExecutionPayloadError),
     /// Optimistic sync is not supported for Gloas payload envelopes.
     OptimisticSyncNotSupported { block_root: Hash256 },
+    /// The envelope's beacon block was not present in fork choice at import time.
+    ///
+    /// Unlike [`EnvelopeError::BlockRootUnknown`] (raised during gossip verification, where the
+    /// block may simply not have arrived yet), this is raised during import where the block is
+    /// expected to already be present, so it indicates an internal inconsistency.
+    BlockRootNotInForkChoice(Hash256),
+    /// An internal error occurred while importing the envelope (e.g. updating fork choice).
+    InternalError(String),
 }
 
 impl std::fmt::Display for EnvelopeError {

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
@@ -155,15 +155,13 @@ pub enum EnvelopeError {
         latest_finalized_slot: Slot,
     },
     /// Some Beacon Chain Error
-    BeaconChainError(Arc<BeaconChainError>),
+    BeaconChainError(Box<BeaconChainError>),
     /// Some Beacon State error
     BeaconStateError(BeaconStateError),
     /// Some EnvelopeProcessingError
     EnvelopeProcessingError(EnvelopeProcessingError),
     /// Error verifying the execution payload
     ExecutionPayloadError(ExecutionPayloadError),
-    /// An error from importing the envelope.
-    ImportError(BlockError),
 }
 
 impl std::fmt::Display for EnvelopeError {
@@ -174,7 +172,7 @@ impl std::fmt::Display for EnvelopeError {
 
 impl From<BeaconChainError> for EnvelopeError {
     fn from(e: BeaconChainError) -> Self {
-        EnvelopeError::BeaconChainError(Arc::new(e))
+        EnvelopeError::BeaconChainError(Box::new(e))
     }
 }
 
@@ -192,7 +190,13 @@ impl From<BeaconStateError> for EnvelopeError {
 
 impl From<DBError> for EnvelopeError {
     fn from(e: DBError) -> Self {
-        EnvelopeError::BeaconChainError(Arc::new(BeaconChainError::DBError(e)))
+        EnvelopeError::BeaconChainError(Box::new(BeaconChainError::DBError(e)))
+    }
+}
+
+impl From<EnvelopeError> for BlockError {
+    fn from(e: EnvelopeError) -> Self {
+        BlockError::EnvelopeError(Box::new(e))
     }
 }
 

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
@@ -30,7 +30,7 @@ use types::{
 
 use crate::{
     BeaconChainError, BeaconChainTypes, BeaconStore, BlockError, ExecutionPayloadError,
-    PayloadVerificationOutcome,
+    PayloadVerificationError, PayloadVerificationOutcome,
 };
 
 pub mod execution_pending_envelope;
@@ -197,6 +197,17 @@ impl From<DBError> for EnvelopeError {
 impl From<EnvelopeError> for BlockError {
     fn from(e: EnvelopeError) -> Self {
         BlockError::EnvelopeError(Box::new(e))
+    }
+}
+
+impl From<PayloadVerificationError> for EnvelopeError {
+    fn from(e: PayloadVerificationError) -> Self {
+        match e {
+            PayloadVerificationError::ExecutionPayloadError(e) => {
+                EnvelopeError::ExecutionPayloadError(e)
+            }
+            PayloadVerificationError::BeaconChainError(e) => EnvelopeError::BeaconChainError(e),
+        }
     }
 }
 

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
@@ -162,6 +162,8 @@ pub enum EnvelopeError {
     EnvelopeProcessingError(EnvelopeProcessingError),
     /// Error verifying the execution payload
     ExecutionPayloadError(ExecutionPayloadError),
+    /// Optimistic sync is not supported for Gloas payload envelopes.
+    OptimisticSyncNotSupported { block_root: Hash256 },
 }
 
 impl std::fmt::Display for EnvelopeError {

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/payload_notifier.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/payload_notifier.rs
@@ -7,7 +7,7 @@ use tracing::warn;
 use types::{SignedBeaconBlock, SignedExecutionPayloadEnvelope};
 
 use crate::{
-    BeaconChain, BeaconChainTypes, BlockError, NotifyExecutionLayer,
+    BeaconChain, BeaconChainTypes, NotifyExecutionLayer, PayloadVerificationError,
     execution_payload::notify_new_payload, payload_envelope_verification::EnvelopeError,
 };
 
@@ -57,13 +57,14 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
         })
     }
 
-    pub async fn notify_new_payload(self) -> Result<PayloadVerificationStatus, BlockError> {
+    pub async fn notify_new_payload(
+        self,
+    ) -> Result<PayloadVerificationStatus, PayloadVerificationError> {
         if let Some(precomputed_status) = self.payload_verification_status {
             Ok(precomputed_status)
         } else {
             let parent_root = self.block.message().parent_root();
-            let request = Self::build_new_payload_request(&self.envelope, &self.block)
-                .map_err(|e| BlockError::EnvelopeError(Box::new(e)))?;
+            let request = Self::build_new_payload_request(&self.envelope, &self.block)?;
             notify_new_payload(&self.chain, self.envelope.slot(), parent_root, request).await
         }
     }
@@ -71,12 +72,12 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
     fn build_new_payload_request<'a>(
         envelope: &'a SignedExecutionPayloadEnvelope<T::EthSpec>,
         block: &'a SignedBeaconBlock<T::EthSpec>,
-    ) -> Result<NewPayloadRequest<'a, T::EthSpec>, EnvelopeError> {
+    ) -> Result<NewPayloadRequest<'a, T::EthSpec>, PayloadVerificationError> {
         let bid = &block
             .message()
             .body()
             .signed_execution_payload_bid()
-            .map_err(|e| EnvelopeError::BeaconChainError(Box::new(e.into())))?
+            .map_err(|e| PayloadVerificationError::BeaconChainError(Box::new(e.into())))?
             .message;
 
         let versioned_hashes = bid

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/payload_notifier.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/payload_notifier.rs
@@ -31,8 +31,7 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
 
             match notify_execution_layer {
                 NotifyExecutionLayer::No if chain.config.optimistic_finalized_sync => {
-                    let new_payload_request = Self::build_new_payload_request(&envelope, &block)
-                        .map_err(EnvelopeError::ImportError)?;
+                    let new_payload_request = Self::build_new_payload_request(&envelope, &block)?;
                     // TODO(gloas): check and test RLP block hash calculation post-Gloas
                     if let Err(e) = new_payload_request.perform_optimistic_sync_verifications() {
                         warn!(
@@ -63,7 +62,8 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
             Ok(precomputed_status)
         } else {
             let parent_root = self.block.message().parent_root();
-            let request = Self::build_new_payload_request(&self.envelope, &self.block)?;
+            let request = Self::build_new_payload_request(&self.envelope, &self.block)
+                .map_err(|e| BlockError::EnvelopeError(Box::new(e)))?;
             notify_new_payload(&self.chain, self.envelope.slot(), parent_root, request).await
         }
     }
@@ -71,12 +71,12 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
     fn build_new_payload_request<'a>(
         envelope: &'a SignedExecutionPayloadEnvelope<T::EthSpec>,
         block: &'a SignedBeaconBlock<T::EthSpec>,
-    ) -> Result<NewPayloadRequest<'a, T::EthSpec>, BlockError> {
+    ) -> Result<NewPayloadRequest<'a, T::EthSpec>, EnvelopeError> {
         let bid = &block
             .message()
             .body()
             .signed_execution_payload_bid()
-            .map_err(|e| BlockError::BeaconChainError(Box::new(e.into())))?
+            .map_err(|e| EnvelopeError::BeaconChainError(Box::new(e.into())))?
             .message;
 
         let versioned_hashes = bid

--- a/beacon_node/http_api/src/beacon/execution_payload_envelope.rs
+++ b/beacon_node/http_api/src/beacon/execution_payload_envelope.rs
@@ -144,7 +144,7 @@ pub async fn publish_execution_payload_envelope<T: BeaconChainTypes>(
             PubsubMessage::ExecutionPayload(Box::new(envelope_for_gossip)),
         )
         .map_err(|_| {
-            EnvelopeError::BeaconChainError(Arc::new(
+            EnvelopeError::BeaconChainError(Box::new(
                 beacon_chain::BeaconChainError::UnableToPublish,
             ))
         })

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1654,6 +1654,13 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 crit!(error = %e, "Internal block gossip validation error. Availability check during gossip validation");
                 return None;
             }
+            // This error variant cannot be reached from gossip processing as there is no envelope
+            // to check within a block.
+            // TODO(pawan): check this is true
+            Err(e @ BlockError::EnvelopeError(_)) => {
+                crit!(error = %e, "Internal block gossip validation error. Envelope error during gossip validation");
+                return None;
+            }
             Err(e @ BlockError::InternalError(_))
             | Err(e @ BlockError::EnvelopeBlockRootUnknown(_))
             | Err(e @ BlockError::OptimisticSyncNotSupported { .. }) => {
@@ -3747,8 +3754,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
                     EnvelopeError::PriorToFinalization { .. }
                     | EnvelopeError::BeaconChainError(_)
-                    | EnvelopeError::BeaconStateError(_)
-                    | EnvelopeError::ImportError(_) => {
+                    | EnvelopeError::BeaconStateError(_) => {
                         self.propagate_validation_result(
                             message_id,
                             peer_id,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1654,16 +1654,15 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 crit!(error = %e, "Internal block gossip validation error. Availability check during gossip validation");
                 return None;
             }
-            // This error variant cannot be reached from gossip processing as there is no envelope
-            // to check within a block.
-            // TODO(pawan): check this is true
+            // This error variant cannot be reached when doing gossip block validation: a block has
+            // no envelope to verify, and `BlockError::EnvelopeError` is only ever produced by the
+            // envelope import pipeline.
             Err(e @ BlockError::EnvelopeError(_)) => {
                 crit!(error = %e, "Internal block gossip validation error. Envelope error during gossip validation");
                 return None;
             }
             Err(e @ BlockError::InternalError(_))
-            | Err(e @ BlockError::EnvelopeBlockRootUnknown(_))
-            | Err(e @ BlockError::OptimisticSyncNotSupported { .. }) => {
+            | Err(e @ BlockError::EnvelopeBlockRootUnknown(_)) => {
                 error!(error = %e, "Internal block gossip validation error");
                 return None;
             }
@@ -3754,7 +3753,10 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
                     EnvelopeError::PriorToFinalization { .. }
                     | EnvelopeError::BeaconChainError(_)
-                    | EnvelopeError::BeaconStateError(_) => {
+                    | EnvelopeError::BeaconStateError(_)
+                    // `OptimisticSyncNotSupported` is produced during envelope import, not gossip
+                    // verification, so it cannot be reached here. Ignore it to be safe.
+                    | EnvelopeError::OptimisticSyncNotSupported { .. } => {
                         self.propagate_validation_result(
                             message_id,
                             peer_id,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1661,8 +1661,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 crit!(error = %e, "Internal block gossip validation error. Envelope error during gossip validation");
                 return None;
             }
-            Err(e @ BlockError::InternalError(_))
-            | Err(e @ BlockError::EnvelopeBlockRootUnknown(_)) => {
+            Err(e @ BlockError::InternalError(_)) => {
                 error!(error = %e, "Internal block gossip validation error");
                 return None;
             }
@@ -3754,9 +3753,11 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     EnvelopeError::PriorToFinalization { .. }
                     | EnvelopeError::BeaconChainError(_)
                     | EnvelopeError::BeaconStateError(_)
-                    // `OptimisticSyncNotSupported` is produced during envelope import, not gossip
-                    // verification, so it cannot be reached here. Ignore it to be safe.
-                    | EnvelopeError::OptimisticSyncNotSupported { .. } => {
+                    // The following variants are produced during envelope import, not gossip
+                    // verification, so they cannot be reached here. Ignore them to be safe.
+                    | EnvelopeError::OptimisticSyncNotSupported { .. }
+                    | EnvelopeError::BlockRootNotInForkChoice(_)
+                    | EnvelopeError::InternalError(_) => {
                         self.propagate_validation_result(
                             message_id,
                             peer_id,

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -1048,7 +1048,6 @@ impl From<Result<AvailabilityProcessingStatus, BlockError>> for BlockProcessingR
                     | BlockError::ParentExecutionPayloadInvalid { .. }
                     | BlockError::KnownInvalidExecutionPayload(_)
                     | BlockError::Slashable
-                    | BlockError::EnvelopeBlockRootUnknown(_)
                     | BlockError::InvalidBlobCount { .. }
                     | BlockError::BidParentRootMismatch { .. } => block_peer_penalty(&e),
                 };

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -367,7 +367,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     )
                     .await
             }
-            Err(e) => Err(e),
+            Err(e) => Err(BlockError::EnvelopeError(Box::new(e))),
         };
 
         // TODO(gloas): structured penalty classification arrives with the envelope lookup state
@@ -1024,6 +1024,10 @@ impl From<Result<AvailabilityProcessingStatus, BlockError>> for BlockProcessingR
                         } else {
                             None
                         }
+                    }
+                    BlockError::EnvelopeError(_) => {
+                        // TODO(gloas): penalize correctly in range sync PR
+                        None
                     }
                     // Remaining invalid blocks: penalize the block peer. Listed explicitly so a
                     // new `BlockError` variant forces a compile error here.

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -367,7 +367,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     )
                     .await
             }
-            Err(e) => Err(BlockError::EnvelopeError(Box::new(e))),
+            Err(e) => Err(e.into()),
         };
 
         // TODO(gloas): structured penalty classification arrives with the envelope lookup state
@@ -1049,7 +1049,6 @@ impl From<Result<AvailabilityProcessingStatus, BlockError>> for BlockProcessingR
                     | BlockError::KnownInvalidExecutionPayload(_)
                     | BlockError::Slashable
                     | BlockError::EnvelopeBlockRootUnknown(_)
-                    | BlockError::OptimisticSyncNotSupported { .. }
                     | BlockError::InvalidBlobCount { .. }
                     | BlockError::BidParentRootMismatch { .. } => block_peer_penalty(&e),
                 };


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Currently, we have `EnvelopeError` having a `ImportError` wrapping a `BlockError`. I feel this is extremely unintuitive because most of the envelope processing functions can simply return an `EnvelopeError` that makes sense in the function's context. It revealed further ugliness when implementing range sync in #9362

This PR does 2 main things: 
1. Removes `ImportError(BlockError)` variant
2. Adds `EnvelopeError(EnvelopeError)` variant to a `BlockError`. 

I feel this is more natural as there can be envelope errors when we try importing a Block but envelope errors can be contained to just envelope related errors.

The main blocker to doing this was `PayloadVerificationHandle` returning a `BlockError`. It uses a very small subset of `BlockError` which I extracted to its own error type which can be converted into both a BlockError and EnvelopeError. 

This allows us to keep most of the pure envelope processing functions to just return EnvelopeErrors while we convert it to a `BlockError` only in import paths where we need to return a consolidated `BlockError`.