### PR TITLE
DuplicateCache: await in-progress block import instead of the reprocess queue

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -68,9 +68,8 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tracing::{debug, error, trace, warn};
 use types::{EthSpec, Hash256, SignedAggregateAndProof, SingleAttestation, Slot, SubnetId};
-use work_reprocessing_queue::IgnoredRpcBlock;
 use work_reprocessing_queue::{
-    QueuedAggregate, QueuedLightClientUpdate, QueuedRpcBlock, QueuedUnaggregate, ReadyWork,
+    QueuedAggregate, QueuedLightClientUpdate, QueuedUnaggregate, ReadyWork,
     spawn_reprocess_scheduler,
 };
 
@@ -300,21 +299,6 @@ impl<E: EthSpec> From<ReadyWork> for WorkEvent<E> {
                     process_fn,
                 },
             },
-            ReadyWork::RpcBlock(QueuedRpcBlock {
-                beacon_block_root,
-                process_fn,
-                ignore_fn: _,
-            }) => Self {
-                drop_during_sync: false,
-                work: Work::RpcBlock {
-                    process_fn,
-                    beacon_block_root,
-                },
-            },
-            ReadyWork::IgnoredRpcBlock(IgnoredRpcBlock { process_fn }) => Self {
-                drop_during_sync: false,
-                work: Work::IgnoredRpcBlock { process_fn },
-            },
             ReadyWork::Unaggregate(QueuedUnaggregate {
                 beacon_block_root: _,
                 process_fn,
@@ -471,9 +455,6 @@ pub enum Work<E: EthSpec> {
     RpcCustodyColumn(AsyncFn),
     RpcEnvelope(AsyncFn),
     ColumnReconstruction(AsyncFn),
-    IgnoredRpcBlock {
-        process_fn: BlockingFn,
-    },
     ChainSegment {
         process_fn: AsyncFn,
         /// (chain_id, batch_epoch) for test observability
@@ -539,7 +520,6 @@ pub enum WorkType {
     RpcCustodyColumn,
     RpcEnvelope,
     ColumnReconstruction,
-    IgnoredRpcBlock,
     ChainSegment,
     ChainSegmentBackfill,
     Status,
@@ -602,7 +582,6 @@ impl<E: EthSpec> Work<E> {
             Work::RpcCustodyColumn { .. } => WorkType::RpcCustodyColumn,
             Work::RpcEnvelope(_) => WorkType::RpcEnvelope,
             Work::ColumnReconstruction(_) => WorkType::ColumnReconstruction,
-            Work::IgnoredRpcBlock { .. } => WorkType::IgnoredRpcBlock,
             Work::ChainSegment { .. } => WorkType::ChainSegment,
             Work::ChainSegmentBackfill(_) => WorkType::ChainSegmentBackfill,
             Work::Status(_) => WorkType::Status,
@@ -1242,7 +1221,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             Work::GossipLightClientOptimisticUpdate { .. } => work_queues
                                 .lc_gossip_optimistic_update_queue
                                 .push(work, work_id),
-                            Work::RpcBlock { .. } | Work::IgnoredRpcBlock { .. } => {
+                            Work::RpcBlock { .. } => {
                                 work_queues.rpc_block_queue.push(work, work_id)
                             }
                             Work::RpcBlobs { .. } => work_queues.rpc_blob_queue.push(work, work_id),
@@ -1389,9 +1368,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             work_queues.lc_gossip_optimistic_update_queue.len()
                         }
                         WorkType::RpcBlock => work_queues.rpc_block_queue.len(),
-                        WorkType::RpcBlobs | WorkType::IgnoredRpcBlock => {
-                            work_queues.rpc_blob_queue.len()
-                        }
+                        WorkType::RpcBlobs => work_queues.rpc_blob_queue.len(),
                         WorkType::RpcEnvelope => work_queues.rpc_envelope_queue.len(),
                         WorkType::RpcCustodyColumn => work_queues.rpc_custody_column_queue.len(),
                         WorkType::ColumnReconstruction => {
@@ -1589,7 +1566,6 @@ impl<E: EthSpec> BeaconProcessor<E> {
             | Work::RpcCustodyColumn(process_fn)
             | Work::RpcEnvelope(process_fn)
             | Work::ColumnReconstruction(process_fn) => task_spawner.spawn_async(process_fn),
-            Work::IgnoredRpcBlock { process_fn } => task_spawner.spawn_blocking(process_fn),
             Work::GossipBlock(work)
             | Work::GossipDataColumnSidecar(work)
             | Work::GossipPartialDataColumnSidecar(work)

--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -232,6 +232,21 @@ impl DuplicateCache {
         }
     }
 
+    /// Insert `block_root`, awaiting and retrying while another task is already processing it, and
+    /// return a handle once this task becomes the one responsible for it. The handle must be held
+    /// for the duration of processing; dropping it removes the entry and wakes any waiters.
+    pub async fn insert_or_wait(&self, block_root: Hash256) -> DuplicateCacheHandle {
+        loop {
+            match self.check_and_insert(block_root) {
+                DuplicateCacheResult::New(handle) => return handle,
+                DuplicateCacheResult::Duplicate(waiter) => {
+                    debug!(%block_root, "Block root is being processed by another source, awaiting");
+                    waiter.wait().await;
+                }
+            }
+        }
+    }
+
     /// Remove the given block_root from the cache, waking any waiters (the sender is dropped).
     pub fn remove(&self, block_root: &Hash256) {
         let mut inner = self.inner.lock();

--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -176,77 +176,39 @@ impl Drop for DuplicateCacheHandle {
     }
 }
 
-/// The outcome of [`DuplicateCache::check_and_insert`].
-pub enum DuplicateCacheResult {
-    /// The block root was not present: the caller is the first to process it and holds the returned
-    /// handle for the duration of processing.
-    New(DuplicateCacheHandle),
-    /// The block root is already being processed by another task. Await the returned waiter to be
-    /// notified once that processing completes, then retry.
-    Duplicate(DuplicateCacheWaiter),
-}
-
-/// Awaits completion of an in-progress processing of the same block root.
-pub struct DuplicateCacheWaiter {
-    receiver: broadcast::Receiver<()>,
-}
-
-impl DuplicateCacheWaiter {
-    /// Resolves when the in-progress processing of the block root completes, i.e. its
-    /// [`DuplicateCacheHandle`] is dropped (which closes the channel).
-    pub async fn wait(mut self) {
-        // A `Closed` (or any) result signals the in-progress processing has finished.
-        let _ = self.receiver.recv().await;
-    }
-}
-
-/// A simple cache for detecting duplicate block roots across multiple threads. Tasks processing a
-/// block root that is already in flight can await its completion via [`DuplicateCacheResult`].
+/// A simple cache for detecting duplicate block roots across multiple threads.
 #[derive(Clone, Default)]
 pub struct DuplicateCache {
     inner: Arc<Mutex<HashMap<Hash256, broadcast::Sender<()>>>>,
 }
 
 impl DuplicateCache {
-    /// Inserts `block_root` if absent and returns [`DuplicateCacheResult::New`] with a handle;
-    /// otherwise returns [`DuplicateCacheResult::Duplicate`] with a waiter for the in-progress task.
-    ///
-    /// The handle removes the entry from the cache when it is dropped. This ensures that any unclean
-    /// shutdowns in the worker tasks does not leave inconsistent state in the cache, and notifies
-    /// any waiters that processing has completed.
-    pub fn check_and_insert(&self, block_root: Hash256) -> DuplicateCacheResult {
-        let mut inner = self.inner.lock();
-        match inner.entry(block_root) {
-            Entry::Vacant(entry) => {
-                let (sender, _) = broadcast::channel(1);
-                entry.insert(sender);
-                DuplicateCacheResult::New(DuplicateCacheHandle {
-                    entry: block_root,
-                    cache: self.clone(),
-                })
-            }
-            Entry::Occupied(entry) => DuplicateCacheResult::Duplicate(DuplicateCacheWaiter {
-                receiver: entry.get().subscribe(),
-            }),
-        }
-    }
-
-    /// Insert `block_root`, awaiting and retrying while another task is already processing it, and
-    /// return a handle once this task becomes the one responsible for it. The handle must be held
-    /// for the duration of processing; dropping it removes the entry and wakes any waiters.
+    /// Returns a handle for processing `block_root`, awaiting and retrying while another task is
+    /// already processing it. The handle must be held for the duration of processing; dropping it
+    /// removes the entry from the cache and wakes any waiters.
     pub async fn insert_or_wait(&self, block_root: Hash256) -> DuplicateCacheHandle {
         loop {
-            match self.check_and_insert(block_root) {
-                DuplicateCacheResult::New(handle) => return handle,
-                DuplicateCacheResult::Duplicate(waiter) => {
-                    debug!(%block_root, "Block root is being processed by another source, awaiting");
-                    waiter.wait().await;
+            let mut receiver = {
+                let mut inner = self.inner.lock();
+                match inner.entry(block_root) {
+                    Entry::Vacant(entry) => {
+                        let (sender, _) = broadcast::channel(1);
+                        entry.insert(sender);
+                        return DuplicateCacheHandle {
+                            entry: block_root,
+                            cache: self.clone(),
+                        };
+                    }
+                    Entry::Occupied(entry) => entry.get().subscribe(),
                 }
-            }
+            };
+            debug!(%block_root, "Block root is being processed by another source, awaiting");
+            // A `Closed` result (the handle was dropped) signals processing has finished.
+            let _ = receiver.recv().await;
         }
     }
 
-    /// Remove the given block_root from the cache, waking any waiters (the sender is dropped).
+    /// Remove the given block_root from the cache.
     pub fn remove(&self, block_root: &Hash256) {
         let mut inner = self.inner.lock();
         inner.remove(block_root);

--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -53,7 +53,8 @@ pub use scheduler::work_reprocessing_queue;
 use serde::{Deserialize, Serialize};
 use slot_clock::SlotClock;
 use std::cmp;
-use std::collections::HashSet;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -62,6 +63,7 @@ use std::task::Context;
 use std::time::{Duration, Instant};
 use strum::IntoStaticStr;
 use task_executor::{RayonPoolType, TaskExecutor};
+use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tracing::{debug, error, trace, warn};
@@ -175,34 +177,62 @@ impl Drop for DuplicateCacheHandle {
     }
 }
 
-/// A simple  cache for detecting duplicate block roots across multiple threads.
+/// The outcome of [`DuplicateCache::check_and_insert`].
+pub enum DuplicateCacheResult {
+    /// The block root was not present: the caller is the first to process it and holds the returned
+    /// handle for the duration of processing.
+    New(DuplicateCacheHandle),
+    /// The block root is already being processed by another task. Await the returned waiter to be
+    /// notified once that processing completes, then retry.
+    Duplicate(DuplicateCacheWaiter),
+}
+
+/// Awaits completion of an in-progress processing of the same block root.
+pub struct DuplicateCacheWaiter {
+    receiver: broadcast::Receiver<()>,
+}
+
+impl DuplicateCacheWaiter {
+    /// Resolves when the in-progress processing of the block root completes, i.e. its
+    /// [`DuplicateCacheHandle`] is dropped (which closes the channel).
+    pub async fn wait(mut self) {
+        // A `Closed` (or any) result signals the in-progress processing has finished.
+        let _ = self.receiver.recv().await;
+    }
+}
+
+/// A simple cache for detecting duplicate block roots across multiple threads. Tasks processing a
+/// block root that is already in flight can await its completion via [`DuplicateCacheResult`].
 #[derive(Clone, Default)]
 pub struct DuplicateCache {
-    inner: Arc<Mutex<HashSet<Hash256>>>,
+    inner: Arc<Mutex<HashMap<Hash256, broadcast::Sender<()>>>>,
 }
 
 impl DuplicateCache {
-    /// Checks if the given block_root exists and inserts it into the cache if
-    /// it doesn't exist.
-    ///
-    /// Returns a `Some(DuplicateCacheHandle)` if the block_root was successfully
-    /// inserted and `None` if the block root already existed in the cache.
+    /// Inserts `block_root` if absent and returns [`DuplicateCacheResult::New`] with a handle;
+    /// otherwise returns [`DuplicateCacheResult::Duplicate`] with a waiter for the in-progress task.
     ///
     /// The handle removes the entry from the cache when it is dropped. This ensures that any unclean
-    /// shutdowns in the worker tasks does not leave inconsistent state in the cache.
-    pub fn check_and_insert(&self, block_root: Hash256) -> Option<DuplicateCacheHandle> {
+    /// shutdowns in the worker tasks does not leave inconsistent state in the cache, and notifies
+    /// any waiters that processing has completed.
+    pub fn check_and_insert(&self, block_root: Hash256) -> DuplicateCacheResult {
         let mut inner = self.inner.lock();
-        if inner.insert(block_root) {
-            Some(DuplicateCacheHandle {
-                entry: block_root,
-                cache: self.clone(),
-            })
-        } else {
-            None
+        match inner.entry(block_root) {
+            Entry::Vacant(entry) => {
+                let (sender, _) = broadcast::channel(1);
+                entry.insert(sender);
+                DuplicateCacheResult::New(DuplicateCacheHandle {
+                    entry: block_root,
+                    cache: self.clone(),
+                })
+            }
+            Entry::Occupied(entry) => DuplicateCacheResult::Duplicate(DuplicateCacheWaiter {
+                receiver: entry.get().subscribe(),
+            }),
         }
     }
 
-    /// Remove the given block_root from the cache.
+    /// Remove the given block_root from the cache, waking any waiters (the sender is dropped).
     pub fn remove(&self, block_root: &Hash256) {
         let mut inner = self.inner.lock();
         inner.remove(block_root);

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -36,7 +36,6 @@ use types::{EthSpec, Hash256, Slot};
 const TASK_NAME: &str = "beacon_processor_reprocess_queue";
 const GOSSIP_BLOCKS: &str = "gossip_blocks";
 const GOSSIP_ENVELOPES: &str = "gossip_envelopes";
-const RPC_BLOCKS: &str = "rpc_blocks";
 const ATTESTATIONS: &str = "attestations";
 const ATTESTATIONS_PER_ROOT: &str = "attestations_per_root";
 const LIGHT_CLIENT_UPDATES: &str = "lc_updates";
@@ -59,9 +58,6 @@ const QUEUED_DATA_COLUMN_DELAY_SLOTS: u32 = 1;
 /// Envelope timeout as a multiplier of slot duration. Envelopes waiting for their block will be
 /// sent for processing after this many slots worth of time, even if the block hasn't arrived.
 const QUEUED_ENVELOPE_DELAY_SLOTS: u32 = 1;
-
-/// For how long to queue rpc blocks before sending them back for reprocessing.
-pub const QUEUED_RPC_BLOCK_DELAY: Duration = Duration::from_secs(4);
 
 /// For how long to queue sampling requests for reprocessing.
 pub const QUEUED_SAMPLING_REQUESTS_DELAY: Duration = Duration::from_secs(12);
@@ -110,9 +106,6 @@ pub enum ReprocessQueueMessage {
     EarlyBlock(QueuedGossipBlock),
     /// An execution payload envelope that references a block not yet in fork choice.
     UnknownBlockForEnvelope(QueuedGossipEnvelope),
-    /// A gossip block for hash `X` is being imported, we should queue the rpc block for the same
-    /// hash until the gossip block is imported.
-    RpcBlock(QueuedRpcBlock),
     /// A block that was successfully processed. We use this to handle attestations updates
     /// for unknown blocks.
     BlockImported {
@@ -140,8 +133,6 @@ pub enum ReprocessQueueMessage {
 pub enum ReadyWork {
     Block(QueuedGossipBlock),
     Envelope(QueuedGossipEnvelope),
-    RpcBlock(QueuedRpcBlock),
-    IgnoredRpcBlock(IgnoredRpcBlock),
     Unaggregate(QueuedUnaggregate),
     Aggregate(QueuedAggregate),
     LightClientUpdate(QueuedLightClientUpdate),
@@ -183,22 +174,6 @@ pub struct QueuedGossipEnvelope {
     pub beacon_block_slot: Slot,
     pub beacon_block_root: Hash256,
     pub process_fn: AsyncFn,
-}
-
-/// A block that arrived for processing when the same block was being imported over gossip.
-/// It is queued for later import.
-pub struct QueuedRpcBlock {
-    pub beacon_block_root: Hash256,
-    /// Processes/imports the block.
-    pub process_fn: AsyncFn,
-    /// Ignores the block.
-    pub ignore_fn: BlockingFn,
-}
-
-/// A block that arrived for processing when the same block was being imported over gossip.
-/// It is queued for later import.
-pub struct IgnoredRpcBlock {
-    pub process_fn: BlockingFn,
 }
 
 /// A backfill batch work that has been queued for processing later.
@@ -245,9 +220,6 @@ enum InboundEvent {
     ReadyGossipBlock(QueuedGossipBlock),
     /// An envelope whose block has been imported and is now ready for processing.
     ReadyEnvelope(Hash256),
-    /// A rpc block that was queued because the same gossip block was being imported
-    /// will now be retried for import.
-    ReadyRpcBlock(QueuedRpcBlock),
     /// An aggregated or unaggregated attestation is ready for re-processing.
     ReadyAttestation(QueuedAttestationId),
     /// A light client update that is ready for re-processing.
@@ -274,8 +246,6 @@ struct ReprocessQueue<S> {
     gossip_block_delay_queue: DelayQueue<QueuedGossipBlock>,
     /// Queue to manage envelope timeouts (keyed by block root).
     envelope_delay_queue: DelayQueue<Hash256>,
-    /// Queue to manage scheduled early blocks.
-    rpc_block_delay_queue: DelayQueue<QueuedRpcBlock>,
     /// Queue to manage scheduled attestations.
     attestations_delay_queue: DelayQueue<QueuedAttestationId>,
     /// Queue to manage scheduled light client updates.
@@ -315,7 +285,6 @@ struct ReprocessQueue<S> {
     next_lc_update: usize,
     early_block_debounce: TimeLatch,
     envelope_delay_debounce: TimeLatch,
-    rpc_block_debounce: TimeLatch,
     attestation_delay_debounce: TimeLatch,
     lc_update_delay_debounce: TimeLatch,
     data_column_delay_debounce: TimeLatch,
@@ -369,15 +338,6 @@ impl<S: SlotClock> Stream for ReprocessQueue<S> {
             Poll::Ready(Some(block_root)) => {
                 return Poll::Ready(Some(InboundEvent::ReadyEnvelope(block_root.into_inner())));
             }
-            Poll::Ready(None) | Poll::Pending => (),
-        }
-
-        match self.rpc_block_delay_queue.poll_expired(cx) {
-            Poll::Ready(Some(queued_block)) => {
-                return Poll::Ready(Some(InboundEvent::ReadyRpcBlock(queued_block.into_inner())));
-            }
-            // `Poll::Ready(None)` means that there are no more entries in the delay queue and we
-            // will continue to get this result until something else is added into the queue.
             Poll::Ready(None) | Poll::Pending => (),
         }
 
@@ -483,7 +443,6 @@ impl<S: SlotClock> ReprocessQueue<S> {
             ready_work_tx,
             gossip_block_delay_queue: DelayQueue::new(),
             envelope_delay_queue: DelayQueue::new(),
-            rpc_block_delay_queue: DelayQueue::new(),
             attestations_delay_queue: DelayQueue::new(),
             lc_updates_delay_queue: DelayQueue::new(),
             column_reconstructions_delay_queue: DelayQueue::new(),
@@ -503,7 +462,6 @@ impl<S: SlotClock> ReprocessQueue<S> {
             next_lc_update: 0,
             early_block_debounce: TimeLatch::default(),
             envelope_delay_debounce: TimeLatch::default(),
-            rpc_block_debounce: TimeLatch::default(),
             attestation_delay_debounce: TimeLatch::default(),
             lc_update_delay_debounce: TimeLatch::default(),
             data_column_delay_debounce: TimeLatch::default(),
@@ -608,51 +566,6 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 // Store the envelope keyed by block root.
                 self.awaiting_envelopes_per_root
                     .insert(block_root, (queued_envelope, delay_key));
-            }
-            // A rpc block arrived for processing at the same time when a gossip block
-            // for the same block hash is being imported. We wait for `QUEUED_RPC_BLOCK_DELAY`
-            // and then send the rpc block back for processing assuming the gossip import
-            // has completed by then.
-            InboundEvent::Msg(RpcBlock(rpc_block)) => {
-                // Check to ensure this won't over-fill the queue.
-                if self.rpc_block_delay_queue.len() >= MAXIMUM_QUEUED_BLOCKS {
-                    if self.rpc_block_debounce.elapsed() {
-                        warn!(
-                            queue_size = MAXIMUM_QUEUED_BLOCKS,
-                            msg = "system resources may be saturated",
-                            "RPC blocks queue is full"
-                        );
-                    }
-                    // Return the block to the beacon processor signalling to
-                    // ignore processing for this block
-                    if self
-                        .ready_work_tx
-                        .try_send(ReadyWork::IgnoredRpcBlock(IgnoredRpcBlock {
-                            process_fn: rpc_block.ignore_fn,
-                        }))
-                        .is_err()
-                    {
-                        error!("Failed to send rpc block to beacon processor");
-                    }
-                    return;
-                }
-
-                // Queue the block for 1/3rd of a slot
-                self.rpc_block_delay_queue
-                    .insert(rpc_block, QUEUED_RPC_BLOCK_DELAY);
-            }
-            InboundEvent::ReadyRpcBlock(queued_rpc_block) => {
-                debug!(
-                    %queued_rpc_block.beacon_block_root,
-                    "Sending rpc block for reprocessing"
-                );
-                if self
-                    .ready_work_tx
-                    .try_send(ReadyWork::RpcBlock(queued_rpc_block))
-                    .is_err()
-                {
-                    error!("Failed to send rpc block to beacon processor");
-                }
             }
             InboundEvent::Msg(UnknownBlockAggregate(queued_aggregate)) => {
                 if self.attestations_delay_queue.len() >= MAXIMUM_QUEUED_ATTESTATIONS {
@@ -1168,11 +1081,6 @@ impl<S: SlotClock> ReprocessQueue<S> {
         );
         metrics::set_gauge_vec(
             &metrics::BEACON_PROCESSOR_REPROCESSING_QUEUE_TOTAL,
-            &[RPC_BLOCKS],
-            self.rpc_block_delay_queue.len() as i64,
-        );
-        metrics::set_gauge_vec(
-            &metrics::BEACON_PROCESSOR_REPROCESSING_QUEUE_TOTAL,
             &[ATTESTATIONS],
             self.attestations_delay_queue.len() as i64,
         );
@@ -1306,9 +1214,9 @@ mod tests {
 
         // Send some random work to `ready_work_tx` to fill up the capacity first.
         ready_work_tx
-            .try_send(ReadyWork::IgnoredRpcBlock(IgnoredRpcBlock {
-                process_fn: Box::new(|| {}),
-            }))
+            .try_send(ReadyWork::BackfillSync(QueuedBackfillBatch(Box::new(
+                || {},
+            ))))
             .unwrap();
 
         // Now queue a backfill sync batch.
@@ -1329,7 +1237,7 @@ mod tests {
         // Now drain the `ready_work` channel.
         assert!(matches!(
             ready_work_rx.try_recv(),
-            Ok(ReadyWork::IgnoredRpcBlock { .. })
+            Ok(ReadyWork::BackfillSync { .. })
         ));
         assert!(ready_work_rx.try_recv().is_err());
 

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -59,7 +59,7 @@ use types::{
 
 use beacon_processor::work_reprocessing_queue::QueuedColumnReconstruction;
 use beacon_processor::{
-    DuplicateCache, DuplicateCacheResult, GossipAggregatePackage, GossipAttestationBatch,
+    DuplicateCache, GossipAggregatePackage, GossipAttestationBatch,
     work_reprocessing_queue::{
         QueuedAggregate, QueuedGossipBlock, QueuedGossipDataColumn, QueuedGossipEnvelope,
         QueuedLightClientUpdate, QueuedUnaggregate, ReprocessQueueMessage,
@@ -1445,18 +1445,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
             // If the block is already being imported by another source, await that import and
             // retry, so we observe a result (a `DuplicateFullyImported`) rather than dropping it.
-            let handle = loop {
-                match duplicate_cache.check_and_insert(block_root) {
-                    DuplicateCacheResult::New(handle) => break handle,
-                    DuplicateCacheResult::Duplicate(waiter) => {
-                        debug!(
-                            %block_root,
-                            "Gossip block is being processed by another source, awaiting result"
-                        );
-                        waiter.wait().await;
-                    }
-                }
-            };
+            let handle = duplicate_cache.insert_or_wait(block_root).await;
             self.process_gossip_verified_block(
                 peer_id,
                 gossip_verified_block,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1443,18 +1443,18 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             let block_root = gossip_verified_block.block_root;
             Span::current().record("block_root", block_root.to_string());
 
-            // If the block is already being imported by another source, await that import and
-            // retry, so we observe a result (a `DuplicateFullyImported`) rather than dropping it.
-            let handle = duplicate_cache.insert_or_wait(block_root).await;
-            self.process_gossip_verified_block(
-                peer_id,
-                gossip_verified_block,
-                invalid_block_storage,
-                seen_duration,
-            )
-            .await;
-            // Drop the handle to remove the entry from the cache
-            drop(handle);
+            // Hold the duplicate-cache handle (awaiting any in-progress import) for the duration of
+            // processing; it is removed from the cache when dropped at the end of this block.
+            {
+                let _handle = duplicate_cache.insert_or_wait(block_root).await;
+                self.process_gossip_verified_block(
+                    peer_id,
+                    gossip_verified_block,
+                    invalid_block_storage,
+                    seen_duration,
+                )
+                .await;
+            }
         }
     }
 

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -59,7 +59,7 @@ use types::{
 
 use beacon_processor::work_reprocessing_queue::QueuedColumnReconstruction;
 use beacon_processor::{
-    DuplicateCache, GossipAggregatePackage, GossipAttestationBatch,
+    DuplicateCache, DuplicateCacheResult, GossipAggregatePackage, GossipAttestationBatch,
     work_reprocessing_queue::{
         QueuedAggregate, QueuedGossipBlock, QueuedGossipDataColumn, QueuedGossipEnvelope,
         QueuedLightClientUpdate, QueuedUnaggregate, ReprocessQueueMessage,
@@ -1443,21 +1443,25 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             let block_root = gossip_verified_block.block_root;
             Span::current().record("block_root", block_root.to_string());
 
-            if let Some(handle) = duplicate_cache.check_and_insert(block_root) {
-                self.process_gossip_verified_block(
-                    peer_id,
-                    gossip_verified_block,
-                    invalid_block_storage,
-                    seen_duration,
-                )
-                .await;
-                // Drop the handle to remove the entry from the cache
-                drop(handle);
-            } else {
-                debug!(
-                    %block_root,
-                    "RPC block is being imported"
-                );
+            match duplicate_cache.check_and_insert(block_root) {
+                DuplicateCacheResult::New(handle) => {
+                    self.process_gossip_verified_block(
+                        peer_id,
+                        gossip_verified_block,
+                        invalid_block_storage,
+                        seen_duration,
+                    )
+                    .await;
+                    // Drop the handle to remove the entry from the cache
+                    drop(handle);
+                }
+                // Another source is already importing this block; nothing to do for gossip.
+                DuplicateCacheResult::Duplicate(_) => {
+                    debug!(
+                        %block_root,
+                        "RPC block is being imported"
+                    );
+                }
             }
         }
     }

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1443,26 +1443,29 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             let block_root = gossip_verified_block.block_root;
             Span::current().record("block_root", block_root.to_string());
 
-            match duplicate_cache.check_and_insert(block_root) {
-                DuplicateCacheResult::New(handle) => {
-                    self.process_gossip_verified_block(
-                        peer_id,
-                        gossip_verified_block,
-                        invalid_block_storage,
-                        seen_duration,
-                    )
-                    .await;
-                    // Drop the handle to remove the entry from the cache
-                    drop(handle);
+            // If the block is already being imported by another source, await that import and
+            // retry, so we observe a result (a `DuplicateFullyImported`) rather than dropping it.
+            let handle = loop {
+                match duplicate_cache.check_and_insert(block_root) {
+                    DuplicateCacheResult::New(handle) => break handle,
+                    DuplicateCacheResult::Duplicate(waiter) => {
+                        debug!(
+                            %block_root,
+                            "Gossip block is being processed by another source, awaiting result"
+                        );
+                        waiter.wait().await;
+                    }
                 }
-                // Another source is already importing this block; nothing to do for gossip.
-                DuplicateCacheResult::Duplicate(_) => {
-                    debug!(
-                        %block_root,
-                        "RPC block is being imported"
-                    );
-                }
-            }
+            };
+            self.process_gossip_verified_block(
+                peer_id,
+                gossip_verified_block,
+                invalid_block_storage,
+                seen_duration,
+            )
+            .await;
+            // Drop the handle to remove the entry from the cache
+            drop(handle);
         }
     }
 

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -17,8 +17,7 @@ use beacon_chain::{
     HistoricalBlockError, NotifyExecutionLayer, validator_monitor::get_slot_delay_ms,
 };
 use beacon_processor::{
-    AsyncFn, BlockingFn, DuplicateCache,
-    work_reprocessing_queue::{QueuedRpcBlock, ReprocessQueueMessage},
+    AsyncFn, DuplicateCache, DuplicateCacheResult, work_reprocessing_queue::ReprocessQueueMessage,
 };
 use beacon_processor::{Work, WorkEvent};
 use lighthouse_network::PeerAction;
@@ -73,39 +72,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         Box::pin(process_fn)
     }
 
-    /// Returns the `process_fn` and `ignore_fn` required when requeuing an RPC block.
-    pub fn generate_lookup_beacon_block_fns(
-        self: Arc<Self>,
-        block_root: Hash256,
-        block: LookupBlock<T::EthSpec>,
-        seen_timestamp: Duration,
-        process_type: BlockProcessType,
-    ) -> (AsyncFn, BlockingFn) {
-        // An async closure which will import the block.
-        let process_fn = self.clone().generate_lookup_beacon_block_process_fn(
-            block_root,
-            block,
-            seen_timestamp,
-            process_type.clone(),
-        );
-        // A closure which will ignore the block.
-        let ignore_fn = move || {
-            warn!(
-                ?process_type,
-                "Block processing task dropped, cpu might be overloaded"
-            );
-            // Sync handles these results
-            self.send_sync_message(SyncMessage::BlockComponentProcessed {
-                process_type,
-                result: BlockProcessingResult::Error {
-                    penalty: None,
-                    reason: "ignored_processor_overloaded".to_string(),
-                },
-            });
-        };
-        (process_fn, Box::new(ignore_fn))
-    }
-
     /// Attempt to process a block received from a direct RPC request.
     #[allow(clippy::too_many_arguments)]
     #[instrument(
@@ -123,39 +89,21 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         process_type: BlockProcessType,
         duplicate_cache: DuplicateCache,
     ) {
-        // Check if the block is already being imported through another source
-        let Some(handle) = duplicate_cache.check_and_insert(block_root) else {
-            debug!(
-                action = "sending lookup block to reprocessing queue",
-                %block_root,
-                ?process_type,
-                "Gossip block is being processed"
-            );
-
-            // Send message to work reprocess queue to retry the block
-            let (process_fn, ignore_fn) = self.clone().generate_lookup_beacon_block_fns(
-                block_root,
-                block,
-                seen_timestamp,
-                process_type,
-            );
-            let reprocess_msg = ReprocessQueueMessage::RpcBlock(QueuedRpcBlock {
-                beacon_block_root: block_root,
-                process_fn,
-                ignore_fn,
-            });
-
-            if self
-                .beacon_processor_send
-                .try_send(WorkEvent {
-                    drop_during_sync: false,
-                    work: Work::Reprocess(reprocess_msg),
-                })
-                .is_err()
-            {
-                error!(source = "rpc", %block_root,"Failed to inform block import")
-            };
-            return;
+        // If the block is already being imported by another source, await that import and retry, so
+        // that this `process_type` always observes a processing result (e.g. a
+        // `DuplicateFullyImported` once the in-progress import completes).
+        let handle = loop {
+            match duplicate_cache.check_and_insert(block_root) {
+                DuplicateCacheResult::New(handle) => break handle,
+                DuplicateCacheResult::Duplicate(waiter) => {
+                    debug!(
+                        %block_root,
+                        ?process_type,
+                        "Lookup block is being processed by another source, awaiting result"
+                    );
+                    waiter.wait().await;
+                }
+            }
         };
 
         let slot = block.slot();

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -16,9 +16,7 @@ use beacon_chain::{
     AvailabilityProcessingStatus, BeaconChainTypes, BlockError, ChainSegmentResult,
     HistoricalBlockError, NotifyExecutionLayer, validator_monitor::get_slot_delay_ms,
 };
-use beacon_processor::{
-    AsyncFn, DuplicateCache, DuplicateCacheResult, work_reprocessing_queue::ReprocessQueueMessage,
-};
+use beacon_processor::{AsyncFn, DuplicateCache, work_reprocessing_queue::ReprocessQueueMessage};
 use beacon_processor::{Work, WorkEvent};
 use lighthouse_network::PeerAction;
 use lighthouse_network::PeerId;
@@ -92,19 +90,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         // If the block is already being imported by another source, await that import and retry, so
         // that this `process_type` always observes a processing result (e.g. a
         // `DuplicateFullyImported` once the in-progress import completes).
-        let handle = loop {
-            match duplicate_cache.check_and_insert(block_root) {
-                DuplicateCacheResult::New(handle) => break handle,
-                DuplicateCacheResult::Duplicate(waiter) => {
-                    debug!(
-                        %block_root,
-                        ?process_type,
-                        "Lookup block is being processed by another source, awaiting result"
-                    );
-                    waiter.wait().await;
-                }
-            }
-        };
+        let handle = duplicate_cache.insert_or_wait(block_root).await;
 
         let slot = block.slot();
         let parent_root = block.message().parent_root();

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -87,9 +87,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         process_type: BlockProcessType,
         duplicate_cache: DuplicateCache,
     ) {
-        // If the block is already being imported by another source, await that import and retry, so
-        // that this `process_type` always observes a processing result (e.g. a
-        // `DuplicateFullyImported` once the in-progress import completes).
+        // Check if the block is already being imported through another source
         let handle = duplicate_cache.insert_or_wait(block_root).await;
 
         let slot = block.slot();

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -1533,41 +1533,33 @@ async fn import_misc_gossip_ops() {
 /// works when the duplicate cache handle is held by another task.
 #[tokio::test]
 async fn test_rpc_block_reprocessing() {
-    let mut rig = TestRig::new(SMALL_CHAIN).await;
+    let rig = TestRig::new(SMALL_CHAIN).await;
     let next_block_root = rig.next_block.canonical_root();
 
-    // Insert the next block into the duplicate cache manually
-    let handle = rig.duplicate_cache.check_and_insert(next_block_root);
-    rig.enqueue_single_lookup_block();
-    rig.assert_event_journal_completes(&[WorkType::RpcBlock])
-        .await;
+    // Hold the duplicate-cache handle so the lookup observes an in-progress import of this block.
+    let DuplicateCacheResult::New(handle) = rig.duplicate_cache.check_and_insert(next_block_root)
+    else {
+        panic!("expected a new duplicate cache entry");
+    };
 
+    rig.enqueue_single_lookup_block();
     let num_data_columns = rig.next_data_columns.as_ref().map(|c| c.len()).unwrap_or(0);
     if num_data_columns > 0 {
         rig.enqueue_single_lookup_rpc_data_columns();
-        rig.assert_event_journal_completes(&[WorkType::RpcCustodyColumn])
-            .await;
     }
 
-    // next_block shouldn't be processed since it couldn't get the
-    // duplicate cache handle
+    // While the handle is held, the lookup block awaits the in-progress import, so it is not yet
+    // imported.
+    tokio::time::sleep(Duration::from_millis(50)).await;
     assert_ne!(next_block_root, rig.head_root());
 
+    // Dropping the handle wakes the awaiting lookup, which retries and imports the block.
     drop(handle);
 
-    // The block should arrive at the beacon processor again after
-    // the specified delay.
-    tokio::time::sleep(QUEUED_RPC_BLOCK_DELAY).await;
-
-    rig.assert_event_journal(&[WorkType::RpcBlock.into()]).await;
-
-    let max_retries = 3;
+    let max_retries = 10;
     let mut success = false;
     for _ in 0..max_retries {
-        // Add an extra delay for block processing
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        // head should update to the next block now since the duplicate
-        // cache handle was dropped.
+        tokio::time::sleep(Duration::from_millis(20)).await;
         if next_block_root == rig.head_root() {
             success = true;
             break;

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -1537,10 +1537,7 @@ async fn test_rpc_block_reprocessing() {
     let next_block_root = rig.next_block.canonical_root();
 
     // Hold the duplicate-cache handle so the lookup observes an in-progress import of this block.
-    let DuplicateCacheResult::New(handle) = rig.duplicate_cache.check_and_insert(next_block_root)
-    else {
-        panic!("expected a new duplicate cache entry");
-    };
+    let handle = rig.duplicate_cache.insert_or_wait(next_block_root).await;
 
     rig.enqueue_single_lookup_block();
     let num_data_columns = rig.next_data_columns.as_ref().map(|c| c.len()).unwrap_or(0);


### PR DESCRIPTION
Makes the duplicate cache awaitable: `check_and_insert` now returns `New(handle)` / `Duplicate(waiter)`. When a block root is already being processed, the second caller awaits the in-flight import and retries, so it always observes a processing result (e.g. `DuplicateFullyImported`) instead of bouncing through the RPC block reprocess queue. Both the lookup (`process_lookup_block`) and gossip (`process_gossip_block`) paths use the same loop.

- EDIT: this is not necessary for #9155, it's just a simplification at the cost of slightly higher occupancy of the beacon processor workers

## AI disclosure

Implemented with AI assistance (Claude Code).