### PR TITLE
Add Unix domain socket support for the beacon HTTP API

### DIFF
--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -661,7 +661,8 @@ where
                 .executor
                 .spawn_without_exit(http_api_task, "http-api");
 
-            Some(listen_addr)
+            // `listen_addr` is `None` when the API is served over a Unix domain socket.
+            listen_addr
         } else {
             info!("HTTP server is disabled");
             None

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -44,7 +44,7 @@ store = { workspace = true }
 sysinfo = { workspace = true }
 system_health = { path = "../../common/system_health" }
 task_executor = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["net", "time"] }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
 tree_hash = { workspace = true }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -91,6 +91,7 @@ use std::sync::Arc;
 use sysinfo::{System, SystemExt};
 use system_health::{observe_nat, observe_system_health_bn};
 use task_spawner::{Priority, TaskSpawner};
+use tokio::net::UnixListener;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio_stream::{
     StreamExt,
@@ -116,7 +117,10 @@ use warp_utils::{query::multi_key_query, uor::UnifyingOrFilter};
 const API_PREFIX: &str = "eth";
 
 /// A custom type which allows for both unsecured and TLS-enabled HTTP servers.
-type HttpServer = (SocketAddr, Pin<Box<dyn Future<Output = ()> + Send>>);
+///
+/// The `SocketAddr` is `None` when the API is served over a Unix domain socket, which has no
+/// associated `SocketAddr`.
+type HttpServer = (Option<SocketAddr>, Pin<Box<dyn Future<Output = ()> + Send>>);
 
 /// Alias for readability.
 pub type ExecutionOptimistic = bool;
@@ -149,6 +153,9 @@ pub struct Config {
     pub listen_port: u16,
     pub allow_origin: Option<String>,
     pub tls_config: Option<TlsConfig>,
+    /// When set, the API is served over this Unix domain socket instead of binding a TCP
+    /// listener. Mutually exclusive with TLS.
+    pub unix_socket: Option<PathBuf>,
     pub data_dir: PathBuf,
     pub sse_capacity_multiplier: usize,
     pub enable_beacon_processor: bool,
@@ -166,6 +173,7 @@ impl Default for Config {
             listen_port: 5052,
             allow_origin: None,
             tls_config: None,
+            unix_socket: None,
             data_dir: PathBuf::from(DEFAULT_ROOT_DIR),
             sse_capacity_multiplier: 1,
             enable_beacon_processor: true,
@@ -3517,34 +3525,107 @@ pub fn serve<T: BeaconChainTypes>(
         .with(cors_builder.build())
         .boxed();
 
-    let http_socket: SocketAddr = SocketAddr::new(config.listen_addr, config.listen_port);
-    let http_server: HttpServer = match config.tls_config {
-        Some(tls_config) => {
-            let (socket, server) = warp::serve(routes)
-                .tls()
-                .cert_path(tls_config.cert)
-                .key_path(tls_config.key)
-                .try_bind_with_graceful_shutdown(http_socket, async {
-                    shutdown.await;
-                })?;
-
-            info!("HTTP API is being served over TLS");
-
-            (socket, Box::pin(server))
+    let http_server: HttpServer = if let Some(socket_path) = config.unix_socket.clone() {
+        // TLS over a local Unix domain socket doesn't make sense, so reject the combination
+        // rather than silently ignoring the certificate.
+        if config.tls_config.is_some() {
+            return Err(Error::Other(
+                "TLS cannot be used together with a Unix domain socket".to_string(),
+            ));
         }
-        None => {
-            let (socket, server) =
-                warp::serve(routes).try_bind_with_graceful_shutdown(http_socket, async {
-                    shutdown.await;
-                })?;
-            (socket, Box::pin(server))
+
+        // Remove any socket file left behind by a previous run so the bind doesn't fail with
+        // `AddrInUse`.
+        if socket_path.exists() {
+            std::fs::remove_file(&socket_path).map_err(|e| {
+                Error::Other(format!(
+                    "Unable to remove existing socket file {}: {e}",
+                    socket_path.display()
+                ))
+            })?;
+        }
+
+        let listener = UnixListener::bind(&socket_path).map_err(|e| {
+            Error::Other(format!(
+                "Unable to bind Unix domain socket {}: {e}",
+                socket_path.display()
+            ))
+        })?;
+
+        // Resilient acceptor: log transient `accept` errors and keep serving instead of letting a
+        // single error tear down the whole HTTP server. This mirrors the behaviour hyper applies
+        // to TCP listeners via `AddrIncoming::set_sleep_on_errors`, which the `serve_incoming`
+        // path does not provide.
+        let incoming = futures::stream::unfold(listener, |listener| async {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _addr)) => {
+                        return Some((Ok::<_, std::io::Error>(stream), listener));
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "Error accepting Unix domain socket connection");
+                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    }
+                }
+            }
+        });
+
+        let server = warp::serve(routes).serve_incoming_with_graceful_shutdown(incoming, async {
+            shutdown.await;
+        });
+
+        info!(
+            socket = %socket_path.display(),
+            "HTTP API is being served over a Unix domain socket"
+        );
+
+        // Best-effort removal of the socket file once the server has stopped, so a subsequent
+        // run starts from a clean slate.
+        let server = async move {
+            server.await;
+            let _ = std::fs::remove_file(&socket_path);
+        };
+
+        (
+            None,
+            Box::pin(server) as Pin<Box<dyn Future<Output = ()> + Send>>,
+        )
+    } else {
+        let http_socket: SocketAddr = SocketAddr::new(config.listen_addr, config.listen_port);
+        match config.tls_config {
+            Some(tls_config) => {
+                let (socket, server) = warp::serve(routes)
+                    .tls()
+                    .cert_path(tls_config.cert)
+                    .key_path(tls_config.key)
+                    .try_bind_with_graceful_shutdown(http_socket, async {
+                        shutdown.await;
+                    })?;
+
+                info!("HTTP API is being served over TLS");
+
+                (
+                    Some(socket),
+                    Box::pin(server) as Pin<Box<dyn Future<Output = ()> + Send>>,
+                )
+            }
+            None => {
+                let (socket, server) =
+                    warp::serve(routes).try_bind_with_graceful_shutdown(http_socket, async {
+                        shutdown.await;
+                    })?;
+                (
+                    Some(socket),
+                    Box::pin(server) as Pin<Box<dyn Future<Output = ()> + Send>>,
+                )
+            }
         }
     };
 
-    info!(
-        listen_address = %http_server.0,
-        "HTTP API started"
-    );
+    match http_server.0 {
+        Some(addr) => info!(listen_address = %addr, "HTTP API started"),
+        None => info!("HTTP API started"),
+    }
 
     Ok(http_server)
 }

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -49,7 +49,8 @@ pub struct InteractiveTester<E: EthSpec> {
 pub struct ApiServer<T: BeaconChainTypes, SFut: Future<Output = ()>> {
     pub ctx: Arc<Context<T>>,
     pub server: SFut,
-    pub listening_socket: SocketAddr,
+    /// `None` when the server is bound to a Unix domain socket rather than a TCP port.
+    pub listening_socket: Option<SocketAddr>,
     pub network_rx: NetworkReceivers<T::EthSpec>,
     pub local_enr: Enr,
     pub external_peer_id: PeerId,
@@ -131,6 +132,8 @@ impl<E: EthSpec> InteractiveTester<E> {
 
         // Late-initalize the mock builder now that the mock execution node and beacon API ports
         // have been allocated.
+        let listening_socket =
+            listening_socket.expect("the interactive tester serves the API over TCP");
         let beacon_api_ip = listening_socket.ip();
         let beacon_api_port = listening_socket.port();
         let beacon_url =

--- a/beacon_node/http_api/tests/main.rs
+++ b/beacon_node/http_api/tests/main.rs
@@ -5,3 +5,4 @@ pub mod fork_tests;
 pub mod interactive_tests;
 pub mod status_tests;
 pub mod tests;
+pub mod unix_socket_tests;

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -291,7 +291,9 @@ impl ApiTester {
 
         // Late-initalize the mock builder now that the mock execution node and beacon API ports
         // have been allocated.
-        let beacon_api_port = listening_socket.port();
+        let beacon_api_port = listening_socket
+            .expect("the API tester serves the API over TCP")
+            .port();
         let beacon_url =
             SensitiveUrl::parse(format!("http://127.0.0.1:{beacon_api_port}").as_str()).unwrap();
 
@@ -399,6 +401,7 @@ impl ApiTester {
 
         harness.runtime.task_executor.spawn(server, "api_server");
 
+        let listening_socket = listening_socket.expect("the API tester serves the API over TCP");
         let client = BeaconNodeHttpClient::new(
             SensitiveUrl::parse(&format!(
                 "http://{}:{}",

--- a/beacon_node/http_api/tests/unix_socket_tests.rs
+++ b/beacon_node/http_api/tests/unix_socket_tests.rs
@@ -1,0 +1,98 @@
+//! Tests for serving the beacon HTTP API over a Unix domain socket (`--http-unix-socket`).
+
+use beacon_chain::test_utils::BeaconChainHarness;
+use http_api::{
+    Config,
+    test_utils::{ApiServer, create_api_server_with_config},
+};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+use types::MainnetEthSpec;
+
+type E = MainnetEthSpec;
+
+const VALIDATOR_COUNT: usize = 8;
+
+/// A unique socket path under the temp dir, so parallel test binaries don't collide and we stay
+/// well under the platform's socket path length limit.
+fn unique_socket_path() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("lh-http-api-{}-{nanos}.sock", std::process::id()))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn serves_the_api_over_a_unix_socket() {
+    let harness = BeaconChainHarness::builder(E::default())
+        .spec_or_default(None)
+        .mock_execution_layer()
+        .deterministic_keypairs(VALIDATOR_COUNT)
+        .fresh_ephemeral_store()
+        .build();
+
+    let socket_path = unique_socket_path();
+    let config = Config {
+        unix_socket: Some(socket_path.clone()),
+        ..Config::default()
+    };
+
+    let ApiServer {
+        server,
+        listening_socket,
+        ..
+    } = create_api_server_with_config(harness.chain.clone(), config, &harness.runtime).await;
+
+    // No TCP socket is allocated when serving over a Unix domain socket.
+    assert!(
+        listening_socket.is_none(),
+        "a Unix-socket server must not report a TCP `SocketAddr`"
+    );
+
+    harness
+        .runtime
+        .task_executor
+        .spawn(server, "api_server_unix_socket");
+
+    // The socket file should exist once the listener is bound.
+    assert!(
+        socket_path.exists(),
+        "socket file should be created at {}",
+        socket_path.display()
+    );
+
+    // Send a minimal HTTP/1.1 request over the socket and assert a successful response from a
+    // real route.
+    let mut stream = UnixStream::connect(&socket_path)
+        .await
+        .expect("should connect to the API unix socket");
+    stream
+        .write_all(
+            b"GET /eth/v1/node/version HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        )
+        .await
+        .expect("should write request to the socket");
+
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .await
+        .expect("should read response from the socket");
+    let response = String::from_utf8_lossy(&response);
+
+    assert!(
+        response.starts_with("HTTP/1.1 200 "),
+        "expected a 200 response, got: {response}"
+    );
+    // The `Server` header and the `/version` body both carry the Lighthouse identifier.
+    assert!(
+        response.contains("Lighthouse"),
+        "response should identify Lighthouse: {response}"
+    );
+
+    // Clean up the socket file (the server also removes it on graceful shutdown).
+    let _ = std::fs::remove_file(&socket_path);
+}

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -544,6 +544,18 @@ pub fn cli_app() -> Command {
                 .display_order(0)
         )
         .arg(
+            Arg::new("http-unix-socket")
+                .long("http-unix-socket")
+                .requires("enable_http")
+                .conflicts_with_all(["http-tls-cert", "http-tls-key"])
+                .value_name("PATH")
+                .help("Serve the RESTful HTTP API over the specified Unix domain socket instead \
+                    of a TCP listener. Useful when the consensus and execution clients run on \
+                    the same machine. Mutually exclusive with the HTTP TLS options.")
+                .action(ArgAction::Set)
+                .display_order(0)
+        )
+        .arg(
             Arg::new("http-allow-origin")
                 .long("http-allow-origin")
                 .requires("enable_http")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -172,6 +172,10 @@ pub fn get_config<E: EthSpec>(
                 .map_err(|_| "http-port is not a valid u16.")?;
         }
 
+        if let Some(socket_path) = cli_args.get_one::<String>("http-unix-socket") {
+            client_config.http_api.unix_socket = Some(PathBuf::from(socket_path));
+        }
+
         if let Some(allow_origin) = cli_args.get_one::<String>("http-allow-origin") {
             // Pre-validate the config value to give feedback to the user on node startup, instead of
             // as late as when the first API response is produced.

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -211,6 +211,11 @@ Options:
       --http-tls-key <http-tls-key>
           The path of the private key to be used when serving the HTTP API
           server over TLS. Must not be password-protected.
+      --http-unix-socket <PATH>
+          Serve the RESTful HTTP API over the specified Unix domain socket
+          instead of a TCP listener. Useful when the consensus and execution
+          clients run on the same machine. Mutually exclusive with the HTTP TLS
+          options.
       --inbound-rate-limiter-protocols <inbound-rate-limiter-protocols>
           Configures the inbound rate limiter (requests received by this
           node).Rate limit quotas per protocol can be set in the form of

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1628,6 +1628,27 @@ fn http_port_flag() {
         .run()
         .with_config(|config| assert_eq!(config.http_api.listen_port, port1));
 }
+#[test]
+fn http_unix_socket_flag() {
+    let socket_path = "/tmp/lighthouse-test-http.sock";
+    CommandLineTest::new()
+        .flag("http", None)
+        .flag("http-unix-socket", Some(socket_path))
+        .run()
+        .with_config(|config| {
+            assert_eq!(
+                config.http_api.unix_socket,
+                Some(std::path::PathBuf::from(socket_path))
+            )
+        });
+}
+#[test]
+fn http_no_unix_socket_by_default() {
+    CommandLineTest::new()
+        .flag("http", None)
+        .run()
+        .with_config(|config| assert_eq!(config.http_api.unix_socket, None));
+}
 
 #[test]
 fn empty_inbound_rate_limiter_flag() {


### PR DESCRIPTION
## Issue Addressed

Closes #8100

## Proposed Changes

Adds `--http-unix-socket <PATH>` to serve the beacon HTTP API over a Unix domain socket instead of a TCP listener, for the common case where the consensus and execution clients share a host. As suggested by @michaelsproul in the issue, this serves the *existing* HTTP API over the socket via warp's `serve_incoming_with_graceful_shutdown` — no new "beacon IPC" protocol is introduced.

- When `--http-unix-socket` is set, the API is served over that socket instead of binding a TCP port.
- A Unix domain socket is local, so this path is plaintext; it is rejected in combination with the HTTP TLS options, both at the CLI (`conflicts_with`) and in `serve`.
- The acceptor logs and continues on transient `accept` errors so a single error does not tear down the whole server, mirroring the behaviour hyper applies to TCP listeners via `AddrIncoming`'s sleep-on-errors. (`serve_incoming` does not provide this itself.)
- The socket file is removed before bind (clearing a stale file) and again on graceful shutdown.

## Additional Info

- `http_api::serve` now returns `Option<SocketAddr>` — `None` for the UDS case, since a Unix domain socket has no `SocketAddr`.
- **Open question for maintainers:** when `--http-unix-socket` is set it currently *replaces* the TCP listener (mirroring how execution clients keep `--ipcpath` separate from `--http`). Happy to make it additive (serve both) if you'd prefer.

## Testing

- New integration test serves the API over a socket and asserts a `200` from `/eth/v1/node/version` via a raw `UnixStream`.
- New CLI flag tests for the flag being set and unset by default.