### PR TITLE
Better partial diagnosics

### DIFF
--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -1711,21 +1711,21 @@ pub static PARTIAL_DATA_COLUMN_SIDECAR_HEADER_PROCESSING_REQUESTS: LazyLock<Resu
     LazyLock::new(|| {
         try_create_int_counter(
             "beacon_partial_data_column_sidecar_header_processing_requests_total",
-            "Count of all partial data column sidecars submitted for processing",
+            "Count of all partial data column sidecar headers submitted for processing",
         )
     });
 pub static PARTIAL_DATA_COLUMN_SIDECAR_HEADER_PROCESSING_DUPES: LazyLock<Result<IntCounter>> =
     LazyLock::new(|| {
         try_create_int_counter(
             "beacon_partial_data_column_sidecar_header_processing_dupes_total",
-            "Number of partial data column sidecars verified for gossip (excluding dupes)",
+            "Number of partial data column sidecar headers received that matched a cached header",
         )
     });
 pub static PARTIAL_DATA_COLUMN_SIDECAR_HEADER_PROCESSING_SUCCESSES: LazyLock<Result<IntCounter>> =
     LazyLock::new(|| {
         try_create_int_counter(
             "beacon_partial_data_column_sidecar_header_processing_successes_total",
-            "Number of partial data column sidecar headers verified for gossip (excluding dupes)",
+            "Number of partial data column sidecar headers verified for gossip",
         )
     });
 pub static PARTIAL_DATA_COLUMN_SIDECAR_HEADER_GOSSIP_VERIFICATION_TIMES: LazyLock<

--- a/beacon_node/beacon_chain/src/partial_data_column_assembler.rs
+++ b/beacon_node/beacon_chain/src/partial_data_column_assembler.rs
@@ -106,7 +106,7 @@ impl<E: EthSpec> PartialDataColumnAssembler<E> {
                 let merged = match existing.merge(&partial) {
                     Ok(merged) => merged,
                     Err(err) => {
-                        error!("Unexpected error merging partial data column: {:?}", err);
+                        error!(error = ?err, "Unexpected error merging partial data column");
                         continue;
                     }
                 };

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -2040,11 +2040,11 @@ mod tests {
             .peer_info_mut(&peer0)
             .unwrap()
             .set_meta_data(MetaData::V3(metadata));
-        peer_manager
-            .network_globals
-            .peers
-            .write()
-            .add_subscription(&peer0, Subnet::Attestation(1.into()));
+        peer_manager.network_globals.peers.write().add_subscription(
+            &peer0,
+            Subnet::Attestation(1.into()),
+            false,
+        );
 
         let mut attnets = crate::types::EnrAttestationBitfield::<E>::new();
         attnets.set(10, true).unwrap();
@@ -2061,11 +2061,11 @@ mod tests {
             .peer_info_mut(&peer2)
             .unwrap()
             .set_meta_data(MetaData::V3(metadata));
-        peer_manager
-            .network_globals
-            .peers
-            .write()
-            .add_subscription(&peer2, Subnet::Attestation(10.into()));
+        peer_manager.network_globals.peers.write().add_subscription(
+            &peer2,
+            Subnet::Attestation(10.into()),
+            false,
+        );
 
         let mut syncnets = crate::types::EnrSyncCommitteeBitfield::<E>::new();
         syncnets.set(3, true).unwrap();
@@ -2082,11 +2082,11 @@ mod tests {
             .peer_info_mut(&peer4)
             .unwrap()
             .set_meta_data(MetaData::V3(metadata));
-        peer_manager
-            .network_globals
-            .peers
-            .write()
-            .add_subscription(&peer4, Subnet::SyncCommittee(3.into()));
+        peer_manager.network_globals.peers.write().add_subscription(
+            &peer4,
+            Subnet::SyncCommittee(3.into()),
+            false,
+        );
 
         // Perform the heartbeat.
         peer_manager.heartbeat();
@@ -2183,11 +2183,11 @@ mod tests {
                 peer_info.update_sync_status(empty_synced_status());
             }
 
-            peer_manager
-                .network_globals
-                .peers
-                .write()
-                .add_subscription(&peer, Subnet::DataColumn(subnet.into()));
+            peer_manager.network_globals.peers.write().add_subscription(
+                &peer,
+                Subnet::DataColumn(subnet.into()),
+                false,
+            );
             println!("{},{},{}", x, subnet, peer);
             peers.push(peer);
         }
@@ -2304,7 +2304,7 @@ mod tests {
                     .network_globals
                     .peers
                     .write()
-                    .add_subscription(&peer, subnet);
+                    .add_subscription(&peer, subnet, false);
             }
             println!("{},{}", x, peer);
             peers.push(peer);
@@ -2408,7 +2408,7 @@ mod tests {
                     .network_globals
                     .peers
                     .write()
-                    .add_subscription(&peer, subnet);
+                    .add_subscription(&peer, subnet, false);
             }
             peers.push(peer);
         }
@@ -2507,7 +2507,7 @@ mod tests {
                     .network_globals
                     .peers
                     .write()
-                    .add_subscription(&peer, subnet);
+                    .add_subscription(&peer, subnet, false);
             }
             println!("{},{}", peer_idx, peer);
             peers.push(peer);
@@ -2679,7 +2679,7 @@ mod tests {
                     .network_globals
                     .peers
                     .write()
-                    .add_subscription(&peer, subnet);
+                    .add_subscription(&peer, subnet, false);
             }
             peers.push(peer);
         }
@@ -2746,11 +2746,11 @@ mod tests {
                 .unwrap()
                 .set_meta_data(MetaData::V3(metadata));
 
-            peer_manager
-                .network_globals
-                .peers
-                .write()
-                .add_subscription(&peer, Subnet::Attestation((subnet as u64).into()));
+            peer_manager.network_globals.peers.write().add_subscription(
+                &peer,
+                Subnet::Attestation((subnet as u64).into()),
+                false,
+            );
 
             peers.push(peer);
         }
@@ -2851,7 +2851,7 @@ mod tests {
                     .network_globals
                     .peers
                     .write()
-                    .add_subscription(&peer, subnet);
+                    .add_subscription(&peer, subnet, false);
             }
 
             peers.push(peer);
@@ -2937,7 +2937,7 @@ mod tests {
                 }
 
                 for subnet in peer_info.long_lived_subnets() {
-                    peers_db.add_subscription(&peer, subnet);
+                    peers_db.add_subscription(&peer, subnet, false);
                 }
 
                 peers.push(peer);
@@ -3158,7 +3158,7 @@ mod tests {
                         peer_info.set_custody_subnets(condition.custody_subnets.clone());
 
                         for subnet in peer_info.long_lived_subnets() {
-                            peer_db.add_subscription(&condition.peer_id, subnet);
+                            peer_db.add_subscription(&condition.peer_id, subnet, false);
                         }
                     }
 

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -714,9 +714,14 @@ impl<E: EthSpec> PeerDB<E> {
 
     /// Adds a gossipsub subscription to a peer in the peerdb.
     // VISIBILITY: The behaviour is able to adjust subscriptions.
-    pub(crate) fn add_subscription(&mut self, peer_id: &PeerId, subnet: Subnet) {
+    pub(crate) fn add_subscription(
+        &mut self,
+        peer_id: &PeerId,
+        subnet: Subnet,
+        supports_partials: bool,
+    ) {
         if let Some(info) = self.peers.get_mut(peer_id) {
-            info.insert_subnet(subnet);
+            info.insert_subnet(subnet, supports_partials);
         }
     }
 

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -41,6 +41,8 @@ pub struct PeerInfo<E: EthSpec> {
     meta_data: Option<MetaData<E>>,
     /// Subnets the peer is connected to.
     subnets: HashSet<Subnet>,
+    /// Subnets the peer is connected to, requesting partial messages.
+    partial_message_subnets: HashSet<Subnet>,
     /// This is computed from either metadata or the ENR, and contains the subnets that the peer
     /// is *assigned* to custody, rather than *connected* to (different to `self.subnets`).
     /// Note: Another reason to keep this separate to `self.subnets` is an upcoming change to
@@ -68,6 +70,7 @@ impl<E: EthSpec> Default for PeerInfo<E> {
             listening_addresses: Vec::new(),
             seen_multiaddrs: HashSet::new(),
             subnets: HashSet::new(),
+            partial_message_subnets: HashSet::new(),
             custody_subnets: HashSet::new(),
             sync_status: SyncStatus::Unknown,
             meta_data: None,
@@ -428,18 +431,23 @@ impl<E: EthSpec> PeerInfo<E> {
     }
 
     /// Adds a known subnet for the peer.
-    pub(super) fn insert_subnet(&mut self, subnet: Subnet) {
+    pub(super) fn insert_subnet(&mut self, subnet: Subnet, supports_partials: bool) {
         self.subnets.insert(subnet);
+        if supports_partials {
+            self.partial_message_subnets.insert(subnet);
+        }
     }
 
     /// Removes a subnet from the peer.
     pub(super) fn remove_subnet(&mut self, subnet: &Subnet) {
         self.subnets.remove(subnet);
+        self.partial_message_subnets.remove(subnet);
     }
 
     /// Removes all subnets from the peer.
     pub(super) fn clear_subnets(&mut self) {
-        self.subnets.clear()
+        self.subnets.clear();
+        self.partial_message_subnets.clear()
     }
 
     /// Applies decay rates to a non-trusted peer's score.

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -1456,13 +1456,19 @@ impl<E: EthSpec> Network<E> {
                     }
                 }
             }
-            Event::Subscribed { peer_id, topic, .. } => {
+            Event::Subscribed {
+                peer_id,
+                topic,
+                supports_partial,
+                ..
+            } => {
                 if let Ok(topic) = GossipTopic::decode(topic.as_str()) {
                     if let Some(subnet_id) = topic.subnet_id() {
-                        self.network_globals
-                            .peers
-                            .write()
-                            .add_subscription(&peer_id, subnet_id);
+                        self.network_globals.peers.write().add_subscription(
+                            &peer_id,
+                            subnet_id,
+                            supports_partial,
+                        );
                     }
                     // Try to send the cached messages for this topic
                     if let Some(msgs) = self.gossip_cache.retrieve(&topic) {

--- a/beacon_node/lighthouse_network/src/types/partial.rs
+++ b/beacon_node/lighthouse_network/src/types/partial.rs
@@ -6,7 +6,7 @@ use ssz::{Decode, Encode};
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::Arc;
-use tracing::{debug, error};
+use tracing::{error, trace};
 use types::core::{EthSpec, Hash256};
 use types::data::{
     PartialDataColumn, PartialDataColumnHeader, PartialDataColumnPartsMetadata,
@@ -168,7 +168,7 @@ impl<E: EthSpec> Partial for OutgoingPartialColumn<E> {
                         Box::new(MaybeKnownMetadata::<E>::Unknown) as Box<dyn Metadata>,
                     )
                 });
-                debug!(
+                trace!(
                     peer=%peer_id,
                     group_id=%self.partial_column.block_root,
                     column_index=self.partial_column.index,
@@ -209,7 +209,7 @@ impl<E: EthSpec> Partial for OutgoingPartialColumn<E> {
                         PartialError::InvalidFormat
                     })?
                     .map(|sidecar| {
-                        debug!(
+                        trace!(
                             peer=%peer_id,
                             group_id=%self.partial_column.block_root,
                             column_index=self.partial_column.index,
@@ -233,7 +233,7 @@ impl<E: EthSpec> Partial for OutgoingPartialColumn<E> {
                     });
 
                 if send.is_none() {
-                    debug!(
+                    trace!(
                         peer=%peer_id,
                         group_id=%self.partial_column.block_root,
                         column_index=self.partial_column.index,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1155,7 +1155,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 metrics::inc_counter(
                     &metrics::BEACON_PROCESSOR_GOSSIP_PARTIAL_DATA_COLUMN_SIDECAR_MISSING_HEADER_TOTAL,
                 );
-                warn!(
+                debug!(
                     error = ?err,
                     %block_root,
                     %index,


### PR DESCRIPTION
## Issue Addressed

Small collection of improved diagnostics for partials. 

## Proposed Changes

- In the peer info struct (exposing peer data via `/lighthouse/peers`), add a new field to indicate on which subnets the peer supports partials.
- Fix the description of several metrics.
- Downgrade some noisy logging when sending partials to trace, and downgrade one warning that should not worry the user.

## Additional Info

To avoid excessive logging in v8.2.0, I recommend merge this before the release.
