### PR TITLE
fix(http_api): ignore committee_index in attestation data endpoint

### DIFF
--- a/beacon_node/http_api/src/validator/mod.rs
+++ b/beacon_node/http_api/src/validator/mod.rs
@@ -278,7 +278,7 @@ pub fn get_validator_attestation_data<T: BeaconChainTypes>(
                     }
 
                     chain
-                        .produce_unaggregated_attestation(query.slot, query.committee_index)
+                        .produce_unaggregated_attestation(query.slot, 0)
                         .map(|attestation| attestation.data().clone())
                         .map(GenericResponse::from)
                         .map_err(warp_utils::reject::unhandled_error)

--- a/beacon_node/http_api/src/validator/mod.rs
+++ b/beacon_node/http_api/src/validator/mod.rs
@@ -278,7 +278,7 @@ pub fn get_validator_attestation_data<T: BeaconChainTypes>(
                     }
 
                     // Always use committee_index 0 regardless of the query parameter, since
-                    // attestation data does not depend on the committee index.
+                    // attestation data does not depend on the committee index post-Electra.
                     chain
                         .produce_unaggregated_attestation(query.slot, 0)
                         .map(|attestation| attestation.data().clone())

--- a/beacon_node/http_api/src/validator/mod.rs
+++ b/beacon_node/http_api/src/validator/mod.rs
@@ -277,6 +277,8 @@ pub fn get_validator_attestation_data<T: BeaconChainTypes>(
                         )));
                     }
 
+                    // Always use committee_index 0 regardless of the query parameter, since
+                    // attestation data does not depend on the committee index.
                     chain
                         .produce_unaggregated_attestation(query.slot, 0)
                         .map(|attestation| attestation.data().clone())

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -4856,11 +4856,10 @@ impl ApiTester {
             assert_eq!(result, expected);
         }
 
-        // The committee_index in the response must always be 0,
-        // regardless of the query parameter. This ensures the API ignores the
-        // committee_index query parameter as specified.
+        // The committee_index in the response must always be 0 post-Electra,
+        // regardless of the query parameter.
         let committee_count = state.get_committee_count_at_slot(slot).unwrap();
-        if committee_count > 1 {
+        if committee_count > 0 {
             let result = self
                 .client
                 .get_validator_attestation_data(slot, 1)

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -4856,6 +4856,20 @@ impl ApiTester {
             assert_eq!(result, expected);
         }
 
+        // The committee_index in the response must always be 0,
+        // regardless of the query parameter. This ensures the API ignores the
+        // committee_index query parameter as specified.
+        let committee_count = state.get_committee_count_at_slot(slot).unwrap();
+        if committee_count > 1 {
+            let result = self
+                .client
+                .get_validator_attestation_data(slot, 1)
+                .await
+                .unwrap()
+                .data;
+            assert_eq!(result.index, 0);
+        }
+
         self
     }
 


### PR DESCRIPTION
Post-Electra there is only one committee per slot, so `committee_index` is always 0. The beacon-APIs spec was updated to say the parameter should be ignored, and other CL clients (Prysm, Nimbus, Lodestar, Grandine) already behave this way.

Currently, passing an out-of-bounds `committee_index` causes a 500 error:
```
BeaconStateError(NoCommittee { slot: Slot(36), index: 4 })
```

This changes the handler to always use index 0 when calling `produce_unaggregated_attestation`, matching what `Attestation::empty_for_signing` already does post-Electra.

Closes #8252