### PR TITLE
deprecate `disallowed-offsets` config for re-orgs

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5245,13 +5245,16 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Only attempt a re-org if we have a proposer registered for the re-org slot.
         let proposing_at_re_org_slot = {
-            // We know our re-org block is not on the epoch boundary, so it has the same proposer
-            // shuffling as the head (but not necessarily the parent which may lie in the previous
-            // epoch).
+            // Since Fulu, proposer shuffling is computed one epoch in advance, so the shuffling
+            // for the re-org block's epoch is always decided by an ancestor of the head, even
+            // when the re-org block lies in the epoch after the head (epoch boundary re-org).
+            let proposal_in_head_epoch = re_org_block_slot.epoch(T::EthSpec::slots_per_epoch())
+                == head_slot.epoch(T::EthSpec::slots_per_epoch());
             let shuffling_decision_root = if self
                 .spec
                 .fork_name_at_slot::<T::EthSpec>(re_org_block_slot)
                 .fulu_enabled()
+                && proposal_in_head_epoch
             {
                 info.head_node.current_epoch_shuffling_id()
             } else {
@@ -5259,18 +5262,33 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
             .shuffling_decision_block;
             let proposer_index = self
-                .beacon_proposer_cache
-                .lock()
-                .get_slot::<T::EthSpec>(shuffling_decision_root, re_org_block_slot)
-                .ok_or_else(|| {
-                    debug!(
-                        slot = %re_org_block_slot,
-                        decision_root = ?shuffling_decision_root,
-                        "Fork choice override proposer shuffling miss"
-                    );
-                    Box::new(DoNotReOrg::NotProposing.into())
-                })?
-                .index as u64;
+                .with_proposer_cache::<u64, Error>(
+                    shuffling_decision_root,
+                    re_org_block_slot.epoch(T::EthSpec::slots_per_epoch()),
+                    |proposers| {
+                        proposers
+                            .get_slot::<T::EthSpec>(re_org_block_slot)
+                            .map(|proposer| proposer.index as u64)
+                    },
+                    || {
+                        debug!(
+                            slot = %re_org_block_slot,
+                            decision_root = ?shuffling_decision_root,
+                            "Fork choice override proposer shuffling miss"
+                        );
+                        let head = self.canonical_head.cached_head();
+                        Ok((head.head_state_root(), head.snapshot.beacon_state.clone()))
+                    },
+                )
+                .map_err(|e| match e {
+                    Error::ProposerCacheIncorrectState { .. } => {
+                        // The head changed while we were computing the proposer shuffling.
+                        // Decline the re-org rather than erroring out.
+                        warn!("Head changed during fork choice override check");
+                        Box::new(ProposerHeadError::from(DoNotReOrg::NotProposing))
+                    }
+                    e => Box::new(ProposerHeadError::Error(e)),
+                })?;
 
             self.execution_layer
                 .as_ref()

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5243,7 +5243,52 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Err(Box::new(DoNotReOrg::HeadDistance.into()));
         }
 
-        // Only attempt a re-org if we have a proposer registered for the re-org slot.
+        // TODO(gloas): reorg weight logic needs updating for Gloas. For now use
+        // total weight which is correct for pre-Gloas and conservative for post-Gloas.
+        let head_weight = info.head_node.weight();
+        let parent_weight = info.parent_node.weight();
+
+        let (head_weak, parent_strong) = if fork_choice_slot == re_org_block_slot {
+            (
+                head_weight < info.re_org_head_weight_threshold,
+                parent_weight > info.re_org_parent_weight_threshold,
+            )
+        } else {
+            (true, true)
+        };
+        if !head_weak {
+            return Err(Box::new(
+                DoNotReOrg::HeadNotWeak {
+                    head_weight,
+                    re_org_head_weight_threshold: info.re_org_head_weight_threshold,
+                }
+                .into(),
+            ));
+        }
+        if !parent_strong {
+            return Err(Box::new(
+                DoNotReOrg::ParentNotStrong {
+                    parent_weight,
+                    re_org_parent_weight_threshold: info.re_org_parent_weight_threshold,
+                }
+                .into(),
+            ));
+        }
+
+        // Check that the head block arrived late and is vulnerable to a re-org. This check is only
+        // a heuristic compared to the proper weight check in `get_state_for_re_org`, the reason
+        // being that we may have only *just* received the block and not yet processed any
+        // attestations for it. We also can't dequeue attestations for the block during the
+        // current slot, which would be necessary for determining its weight.
+        let head_block_late =
+            self.block_observed_after_attestation_deadline(head_block_root, head_slot);
+        if !head_block_late {
+            return Err(Box::new(DoNotReOrg::HeadNotLate.into()));
+        }
+
+        // Only attempt a re-org if we have a proposer registered for the re-org slot. This check
+        // runs after the cheaper checks above because it may compute (and cache) the proposer
+        // shuffling for the re-org slot's epoch on a cache miss.
         let proposing_at_re_org_slot = {
             // Since Fulu, proposer shuffling is computed one epoch in advance, so the shuffling
             // for the re-org block's epoch is always decided by an ancestor of the head, even
@@ -5297,49 +5342,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         };
         if !proposing_at_re_org_slot {
             return Err(Box::new(DoNotReOrg::NotProposing.into()));
-        }
-
-        // TODO(gloas): reorg weight logic needs updating for Gloas. For now use
-        // total weight which is correct for pre-Gloas and conservative for post-Gloas.
-        let head_weight = info.head_node.weight();
-        let parent_weight = info.parent_node.weight();
-
-        let (head_weak, parent_strong) = if fork_choice_slot == re_org_block_slot {
-            (
-                head_weight < info.re_org_head_weight_threshold,
-                parent_weight > info.re_org_parent_weight_threshold,
-            )
-        } else {
-            (true, true)
-        };
-        if !head_weak {
-            return Err(Box::new(
-                DoNotReOrg::HeadNotWeak {
-                    head_weight,
-                    re_org_head_weight_threshold: info.re_org_head_weight_threshold,
-                }
-                .into(),
-            ));
-        }
-        if !parent_strong {
-            return Err(Box::new(
-                DoNotReOrg::ParentNotStrong {
-                    parent_weight,
-                    re_org_parent_weight_threshold: info.re_org_parent_weight_threshold,
-                }
-                .into(),
-            ));
-        }
-
-        // Check that the head block arrived late and is vulnerable to a re-org. This check is only
-        // a heuristic compared to the proper weight check in `get_state_for_re_org`, the reason
-        // being that we may have only *just* received the block and not yet processed any
-        // attestations for it. We also can't dequeue attestations for the block during the
-        // current slot, which would be necessary for determining its weight.
-        let head_block_late =
-            self.block_observed_after_attestation_deadline(head_block_root, head_slot);
-        if !head_block_late {
-            return Err(Box::new(DoNotReOrg::HeadNotLate.into()));
         }
 
         // TODO(gloas): V29 nodes don't carry execution_status, so this returns

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5207,7 +5207,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 head_block_root,
                 re_org_head_threshold,
                 re_org_parent_threshold,
-                &self.config.re_org_disallowed_offsets,
                 re_org_max_epochs_since_finalization,
             )
             .map_err(|e| e.map_inner_error(Error::ProposerHeadForkChoiceError))?;

--- a/beacon_node/beacon_chain/src/block_production/mod.rs
+++ b/beacon_node/beacon_chain/src/block_production/mod.rs
@@ -220,7 +220,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 canonical_head,
                 re_org_head_threshold,
                 re_org_parent_threshold,
-                &self.config.re_org_disallowed_offsets,
                 re_org_max_epochs_since_finalization,
             )
             .map_err(|e| match e {

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -30,7 +30,6 @@ use kzg::Kzg;
 use logging::crit;
 use operation_pool::{OperationPool, PersistedOperationPool};
 use parking_lot::{Mutex, RwLock};
-use proto_array::DisallowedReOrgOffsets;
 use rand::RngCore;
 use rayon::prelude::*;
 use slasher::Slasher;
@@ -173,15 +172,6 @@ where
     /// Set to `None` for no limit.
     pub fn import_max_skip_slots(mut self, n: Option<u64>) -> Self {
         self.chain_config.import_max_skip_slots = n;
-        self
-    }
-
-    /// Sets the proposer re-org disallowed offsets list.
-    pub fn proposer_re_org_disallowed_offsets(
-        mut self,
-        disallowed_offsets: DisallowedReOrgOffsets,
-    ) -> Self {
-        self.chain_config.re_org_disallowed_offsets = disallowed_offsets;
         self
     }
 

--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -1,5 +1,4 @@
 use crate::custody_context::NodeCustodyType;
-pub use proto_array::DisallowedReOrgOffsets;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::{collections::HashSet, sync::LazyLock, time::Duration};
@@ -36,11 +35,6 @@ pub struct ChainConfig {
     pub archive: bool,
     /// The max size of a message that can be sent over the network.
     pub max_network_size: usize,
-    /// Additional epoch offsets at which re-orging block proposals are not permitted.
-    ///
-    /// By default this list is empty, but it can be useful for reacting to network conditions, e.g.
-    /// slow gossip of re-org blocks at slot 1 in the epoch.
-    pub re_org_disallowed_offsets: DisallowedReOrgOffsets,
     /// Number of milliseconds to wait for fork choice before proposing a block.
     ///
     /// If set to 0 then block proposal will not wait for fork choice at all.
@@ -123,7 +117,6 @@ impl Default for ChainConfig {
             weak_subjectivity_checkpoint: None,
             archive: false,
             max_network_size: 10 * 1_048_576, // 10M
-            re_org_disallowed_offsets: DisallowedReOrgOffsets::default(),
             fork_choice_before_proposal_timeout_ms: DEFAULT_FORK_CHOICE_BEFORE_PROPOSAL_TIMEOUT,
             // Builder fallback configs that are set in `clap` will override these.
             builder_fallback_skips: 3,

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -2,7 +2,6 @@
 use beacon_chain::custody_context::NodeCustodyType;
 use beacon_chain::{
     ChainConfig,
-    chain_config::DisallowedReOrgOffsets,
     test_utils::{
         AttestationStrategy, BlockStrategy, LightClientStrategy, SyncCommitteeStrategy, test_spec,
     },
@@ -188,8 +187,6 @@ pub struct ReOrgTest {
     misprediction: bool,
     /// Whether to expect withdrawals to change on epoch boundaries.
     expect_withdrawals_change_on_epoch: bool,
-    /// Epoch offsets to avoid proposing reorg blocks at.
-    disallowed_offsets: Vec<u64>,
 }
 
 impl Default for ReOrgTest {
@@ -205,7 +202,6 @@ impl Default for ReOrgTest {
             should_re_org: true,
             misprediction: false,
             expect_withdrawals_change_on_epoch: false,
-            disallowed_offsets: vec![],
         }
     }
 }
@@ -217,11 +213,13 @@ pub async fn proposer_boost_re_org_zero_weight() {
     proposer_boost_re_org_test(ReOrgTest::default()).await;
 }
 
+// Since Fulu, proposer shuffling is stable across epoch boundaries, so re-orgs of the last block
+// in an epoch are permitted.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 pub async fn proposer_boost_re_org_epoch_boundary() {
     proposer_boost_re_org_test(ReOrgTest {
         head_slot: Slot::new(E::slots_per_epoch() - 1),
-        should_re_org: false,
+        should_re_org: true,
         ..Default::default()
     })
     .await;
@@ -317,32 +315,6 @@ pub async fn proposer_boost_re_org_head_distance() {
     .await;
 }
 
-// Check that a re-org at a disallowed offset fails.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-pub async fn proposer_boost_re_org_disallowed_offset() {
-    let offset = 4;
-    proposer_boost_re_org_test(ReOrgTest {
-        head_slot: Slot::new(E::slots_per_epoch() + offset - 1),
-        disallowed_offsets: vec![offset],
-        should_re_org: false,
-        ..Default::default()
-    })
-    .await;
-}
-
-// Check that a re-org at the *only* allowed offset succeeds.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-pub async fn proposer_boost_re_org_disallowed_offset_exact() {
-    let offset = 4;
-    let disallowed_offsets = (0..E::slots_per_epoch()).filter(|o| *o != offset).collect();
-    proposer_boost_re_org_test(ReOrgTest {
-        head_slot: Slot::new(E::slots_per_epoch() + offset - 1),
-        disallowed_offsets,
-        ..Default::default()
-    })
-    .await;
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 pub async fn proposer_boost_re_org_very_unhealthy() {
     proposer_boost_re_org_test(ReOrgTest {
@@ -390,7 +362,6 @@ pub async fn proposer_boost_re_org_test(
         should_re_org,
         misprediction,
         expect_withdrawals_change_on_epoch,
-        disallowed_offsets,
     }: ReOrgTest,
 ) {
     assert!(head_slot > 0);
@@ -419,11 +390,7 @@ pub async fn proposer_boost_re_org_test(
         Some(spec),
         validator_count,
         None,
-        Some(Box::new(move |builder| {
-            builder.proposer_re_org_disallowed_offsets(
-                DisallowedReOrgOffsets::new::<E>(disallowed_offsets).unwrap(),
-            )
-        })),
+        None,
         Default::default(),
         false,
         NodeCustodyType::Fullnode,

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1375,12 +1375,7 @@ pub fn cli_app() -> Command {
                 .long("proposer-reorg-disallowed-offsets")
                 .action(ArgAction::Set)
                 .value_name("N1,N2,...")
-                .help("Comma-separated list of integer offsets which can be used to avoid \
-                       proposing reorging blocks at certain slots. An offset of N means that \
-                       reorging proposals will not be attempted at any slot such that \
-                       `slot % SLOTS_PER_EPOCH == N`. By default only re-orgs at offset 0 will be \
-                       avoided. Any offsets supplied with this flag will impose additional \
-                       restrictions.")
+                .help("DEPRECATED. This flag has no effect.")
                 .conflicts_with("disable-proposer-reorgs")
                 .display_order(0)
         )

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1,6 +1,6 @@
 use account_utils::{STDIN_INPUTS_FLAG, read_input_from_user};
 use beacon_chain::chain_config::{
-    DEFAULT_PREPARE_PAYLOAD_LOOKAHEAD_FACTOR, DisallowedReOrgOffsets, INVALID_HOLESKY_BLOCK_ROOT,
+    DEFAULT_PREPARE_PAYLOAD_LOOKAHEAD_FACTOR, INVALID_HOLESKY_BLOCK_ROOT,
 };
 use beacon_chain::custody_context::NodeCustodyType;
 use beacon_chain::graffiti_calculator::GraffitiOrigin;
@@ -771,19 +771,10 @@ pub fn get_config<E: EthSpec>(
         warn!("The proposer-reorg-parent-threshold flag is deprecated");
     }
 
-    if let Some(disallowed_offsets_str) =
-        clap_utils::parse_optional::<String>(cli_args, "proposer-reorg-disallowed-offsets")?
+    if clap_utils::parse_optional::<String>(cli_args, "proposer-reorg-disallowed-offsets")?
+        .is_some()
     {
-        let disallowed_offsets = disallowed_offsets_str
-            .split(',')
-            .map(|s| {
-                s.parse()
-                    .map_err(|e| format!("invalid disallowed-offsets: {e:?}"))
-            })
-            .collect::<Result<Vec<u64>, _>>()?;
-        client_config.chain.re_org_disallowed_offsets =
-            DisallowedReOrgOffsets::new::<E>(disallowed_offsets)
-                .map_err(|e| format!("invalid disallowed-offsets: {e:?}"))?;
+        warn!("The proposer-reorg-disallowed-offsets flag is deprecated");
     }
 
     client_config.chain.prepare_payload_lookahead =

--- a/book/src/advanced_re-orgs.md
+++ b/book/src/advanced_re-orgs.md
@@ -11,15 +11,11 @@ attestations and transactions that can be included.
 
 ## Command line flags
 
-There are three flags which control the re-orging behaviour:
+There is one flag which controls the re-orging behaviour:
 
 * `--disable-proposer-reorgs`: turn re-orging off (it's on by default).
-* `--proposer-reorg-disallowed-offsets N1,N2,N3...`: Prohibit Lighthouse from attempting to reorg at
-  specific offsets in each epoch. A disallowed offset `N` prevents reorging blocks from being
-  proposed at any `slot` such that `slot % SLOTS_PER_EPOCH == N`. The value to this flag is a
-  comma-separated list of integer offsets.
 
-All flags should be applied to `lighthouse bn`. The default configuration is recommended as it
+This flag should be applied to `lighthouse bn`. The default configuration is recommended as it
 balances the chance of the re-org succeeding against the chance of failure due to attestations
 arriving late and making the re-org block non-viable.
 
@@ -32,8 +28,6 @@ The full conditions are described in [the spec][] but the most important ones ar
 
 * Only single-slot re-orgs: Lighthouse will build a block at N + 1 to re-org N by building on the
   parent N - 1. The result is a chain with exactly one skipped slot.
-* No epoch boundaries: to ensure that the selected proposer does not change, Lighthouse will
-  not propose a re-orging block in the 0th slot of an epoch.
 
 ## Logs
 

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -308,12 +308,7 @@ Options:
       --proposer-reorg-cutoff <MILLISECONDS>
           DEPRECATED. This flag has no effect.
       --proposer-reorg-disallowed-offsets <N1,N2,...>
-          Comma-separated list of integer offsets which can be used to avoid
-          proposing reorging blocks at certain slots. An offset of N means that
-          reorging proposals will not be attempted at any slot such that `slot %
-          SLOTS_PER_EPOCH == N`. By default only re-orgs at offset 0 will be
-          avoided. Any offsets supplied with this flag will impose additional
-          restrictions.
+          DEPRECATED. This flag has no effect.
       --proposer-reorg-epochs-since-finalization <EPOCHS>
           DEPRECATED. This flag has no effect.
       --proposer-reorg-parent-threshold <PERCENT>

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -3,7 +3,7 @@ use crate::{ForkChoiceStore, InvalidationOperation};
 use fixed_bytes::FixedBytesExtended;
 use logging::crit;
 use proto_array::{
-    Block as ProtoBlock, DisallowedReOrgOffsets, ExecutionStatus, JustifiedBalances, LatestMessage,
+    Block as ProtoBlock, ExecutionStatus, JustifiedBalances, LatestMessage,
     PayloadStatus, ProposerHeadError, ProposerHeadInfo, ProtoArrayForkChoice, ReOrgThreshold,
 };
 use ssz_derive::{Decode, Encode};
@@ -622,7 +622,6 @@ where
         canonical_head: Hash256,
         re_org_head_threshold: ReOrgThreshold,
         re_org_parent_threshold: ReOrgThreshold,
-        disallowed_offsets: &DisallowedReOrgOffsets,
         max_epochs_since_finalization: Epoch,
     ) -> Result<ProposerHeadInfo, ProposerHeadError<Error<proto_array::Error>>> {
         // Ensure that fork choice has already been updated for the current slot. This prevents
@@ -655,7 +654,6 @@ where
                 self.fc_store.justified_balances(),
                 re_org_head_threshold,
                 re_org_parent_threshold,
-                disallowed_offsets,
                 max_epochs_since_finalization,
             )
             .map_err(ProposerHeadError::convert_inner_error)
@@ -666,7 +664,6 @@ where
         canonical_head: Hash256,
         re_org_head_threshold: ReOrgThreshold,
         re_org_parent_threshold: ReOrgThreshold,
-        disallowed_offsets: &DisallowedReOrgOffsets,
         max_epochs_since_finalization: Epoch,
     ) -> Result<ProposerHeadInfo, ProposerHeadError<Error<proto_array::Error>>> {
         let current_slot = self.fc_store.get_current_slot();
@@ -677,7 +674,6 @@ where
                 self.fc_store.justified_balances(),
                 re_org_head_threshold,
                 re_org_parent_threshold,
-                disallowed_offsets,
                 max_epochs_since_finalization,
             )
             .map_err(ProposerHeadError::convert_inner_error)

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -3,8 +3,8 @@ use crate::{ForkChoiceStore, InvalidationOperation};
 use fixed_bytes::FixedBytesExtended;
 use logging::crit;
 use proto_array::{
-    Block as ProtoBlock, ExecutionStatus, JustifiedBalances, LatestMessage,
-    PayloadStatus, ProposerHeadError, ProposerHeadInfo, ProtoArrayForkChoice, ReOrgThreshold,
+    Block as ProtoBlock, ExecutionStatus, JustifiedBalances, LatestMessage, PayloadStatus,
+    ProposerHeadError, ProposerHeadInfo, ProtoArrayForkChoice, ReOrgThreshold,
 };
 use ssz_derive::{Decode, Encode};
 use state_processing::{

--- a/consensus/proto_array/src/error.rs
+++ b/consensus/proto_array/src/error.rs
@@ -50,7 +50,6 @@ pub enum Error {
         block_root: Hash256,
         parent_root: Hash256,
     },
-    InvalidEpochOffset(u64),
     Arith(ArithError),
     InvalidNodeVariant {
         block_root: Hash256,

--- a/consensus/proto_array/src/lib.rs
+++ b/consensus/proto_array/src/lib.rs
@@ -8,7 +8,7 @@ mod ssz_container;
 pub use crate::justified_balances::JustifiedBalances;
 pub use crate::proto_array::{InvalidationOperation, calculate_committee_fraction};
 pub use crate::proto_array_fork_choice::{
-    Block, DisallowedReOrgOffsets, DoNotReOrg, ExecutionStatus, LatestMessage, PayloadStatus,
+    Block, DoNotReOrg, ExecutionStatus, LatestMessage, PayloadStatus,
     ProposerHeadError, ProposerHeadInfo, ProtoArrayForkChoice, ReOrgThreshold,
 };
 pub use error::Error;

--- a/consensus/proto_array/src/lib.rs
+++ b/consensus/proto_array/src/lib.rs
@@ -8,8 +8,8 @@ mod ssz_container;
 pub use crate::justified_balances::JustifiedBalances;
 pub use crate::proto_array::{InvalidationOperation, calculate_committee_fraction};
 pub use crate::proto_array_fork_choice::{
-    Block, DoNotReOrg, ExecutionStatus, LatestMessage, PayloadStatus,
-    ProposerHeadError, ProposerHeadInfo, ProtoArrayForkChoice, ReOrgThreshold,
+    Block, DoNotReOrg, ExecutionStatus, LatestMessage, PayloadStatus, ProposerHeadError,
+    ProposerHeadInfo, ProtoArrayForkChoice, ReOrgThreshold,
 };
 pub use error::Error;
 

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -385,10 +385,6 @@ pub enum DoNotReOrg {
     MissingHeadFinalizedCheckpoint,
     ParentDistance,
     HeadDistance,
-    ShufflingUnstable,
-    DisallowedOffset {
-        offset: u64,
-    },
     JustificationAndFinalizationNotCompetitive,
     ChainNotFinalizing {
         epochs_since_finalization: u64,
@@ -413,10 +409,6 @@ impl std::fmt::Display for DoNotReOrg {
             Self::MissingHeadFinalizedCheckpoint => write!(f, "finalized checkpoint missing"),
             Self::ParentDistance => write!(f, "parent too far from head"),
             Self::HeadDistance => write!(f, "head too far from current slot"),
-            Self::ShufflingUnstable => write!(f, "shuffling unstable at epoch boundary"),
-            Self::DisallowedOffset { offset } => {
-                write!(f, "re-orgs disabled at offset {offset}")
-            }
             Self::JustificationAndFinalizationNotCompetitive => {
                 write!(f, "justification or finalization not competitive")
             }
@@ -461,31 +453,6 @@ impl std::fmt::Display for DoNotReOrg {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct ReOrgThreshold(pub u64);
-
-/// New-type for disallowed re-org slots.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct DisallowedReOrgOffsets {
-    // Vecs are faster than hashmaps for small numbers of items.
-    offsets: Vec<u64>,
-}
-
-impl Default for DisallowedReOrgOffsets {
-    fn default() -> Self {
-        DisallowedReOrgOffsets { offsets: vec![0] }
-    }
-}
-
-impl DisallowedReOrgOffsets {
-    pub fn new<E: EthSpec>(offsets: Vec<u64>) -> Result<Self, Error> {
-        for &offset in &offsets {
-            if offset >= E::slots_per_epoch() {
-                return Err(Error::InvalidEpochOffset(offset));
-            }
-        }
-        Ok(Self { offsets })
-    }
-}
 
 #[derive(PartialEq)]
 pub struct ProtoArrayForkChoice {
@@ -724,7 +691,6 @@ impl ProtoArrayForkChoice {
         justified_balances: &JustifiedBalances,
         re_org_head_threshold: ReOrgThreshold,
         re_org_parent_threshold: ReOrgThreshold,
-        disallowed_offsets: &DisallowedReOrgOffsets,
         max_epochs_since_finalization: Epoch,
     ) -> Result<ProposerHeadInfo, ProposerHeadError<Error>> {
         let info = self.get_proposer_head_info::<E>(
@@ -733,7 +699,6 @@ impl ProtoArrayForkChoice {
             justified_balances,
             re_org_head_threshold,
             re_org_parent_threshold,
-            disallowed_offsets,
             max_epochs_since_finalization,
         )?;
 
@@ -784,7 +749,6 @@ impl ProtoArrayForkChoice {
         justified_balances: &JustifiedBalances,
         re_org_head_threshold: ReOrgThreshold,
         re_org_parent_threshold: ReOrgThreshold,
-        disallowed_offsets: &DisallowedReOrgOffsets,
         max_epochs_since_finalization: Epoch,
     ) -> Result<ProposerHeadInfo, ProposerHeadError<Error>> {
         let mut nodes = self
@@ -821,18 +785,6 @@ impl ProtoArrayForkChoice {
         let parent_slot_ok = parent_slot + 1 == head_slot;
         if !parent_slot_ok {
             return Err(DoNotReOrg::ParentDistance.into());
-        }
-
-        // Check shuffling stability.
-        let shuffling_stable = re_org_block_slot % E::slots_per_epoch() != 0;
-        if !shuffling_stable {
-            return Err(DoNotReOrg::ShufflingUnstable.into());
-        }
-
-        // Check allowed slot offsets.
-        let offset = (re_org_block_slot % E::slots_per_epoch()).as_u64();
-        if disallowed_offsets.offsets.contains(&offset) {
-            return Err(DoNotReOrg::DisallowedOffset { offset }.into());
         }
 
         // Check FFG.

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1,7 +1,5 @@
 use crate::exec::{CommandLineTestExec, CompletedTest};
-use beacon_node::beacon_chain::chain_config::{
-    DEFAULT_SYNC_TOLERANCE_EPOCHS, DisallowedReOrgOffsets,
-};
+use beacon_node::beacon_chain::chain_config::DEFAULT_SYNC_TOLERANCE_EPOCHS;
 use beacon_node::beacon_chain::custody_context::NodeCustodyType;
 use beacon_node::{
     ClientConfig as Config, beacon_chain::graffiti_calculator::GraffitiOrigin,
@@ -2361,35 +2359,10 @@ fn disable_proposer_re_orgs() {
 }
 
 #[test]
-fn proposer_re_org_disallowed_offsets_default() {
-    CommandLineTest::new()
-        .run_with_zero_port()
-        .with_config(|config| {
-            assert_eq!(
-                config.chain.re_org_disallowed_offsets,
-                DisallowedReOrgOffsets::new::<MainnetEthSpec>(vec![0]).unwrap()
-            )
-        });
-}
-
-#[test]
-fn proposer_re_org_disallowed_offsets_override() {
+fn proposer_re_org_disallowed_offsets_deprecated() {
+    // The deprecated flag should be accepted but have no effect.
     CommandLineTest::new()
         .flag("proposer-reorg-disallowed-offsets", Some("1,2,3"))
-        .run_with_zero_port()
-        .with_config(|config| {
-            assert_eq!(
-                config.chain.re_org_disallowed_offsets,
-                DisallowedReOrgOffsets::new::<MainnetEthSpec>(vec![1, 2, 3]).unwrap()
-            )
-        });
-}
-
-#[test]
-#[should_panic]
-fn proposer_re_org_disallowed_offsets_invalid() {
-    CommandLineTest::new()
-        .flag("proposer-reorg-disallowed-offsets", Some("32,33,34"))
         .run_with_zero_port();
 }
 

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -3,7 +3,6 @@ use crate::decode::{ssz_decode_file, ssz_decode_file_with, ssz_decode_state, yam
 use ::fork_choice::{AttestationFromBlock, PayloadVerificationStatus, ProposerHeadError};
 use beacon_chain::beacon_proposer_cache::compute_proposer_duties_from_head;
 use beacon_chain::block_verification_types::LookupBlock;
-use beacon_chain::chain_config::DisallowedReOrgOffsets;
 use beacon_chain::data_column_verification::GossipVerifiedDataColumn;
 use beacon_chain::slot_clock::SlotClock;
 use beacon_chain::{
@@ -1040,7 +1039,6 @@ impl<E: EthSpec> Tester<E> {
             canonical_head,
             ReOrgThreshold(self.spec.reorg_head_weight_threshold),
             ReOrgThreshold(self.spec.reorg_parent_weight_threshold),
-            &DisallowedReOrgOffsets::default(),
             Epoch::new(self.spec.reorg_max_epochs_since_finalization),
         );
         let proposer_head = match proposer_head_result {


### PR DESCRIPTION
## Issue Addressed

https://github.com/ethereum/consensus-specs/pull/5348. As per discussions in issue we no longer need to support `disallowed-offsets` for pre-Fulu forks. 


