### PR TITLE
Remove seen_timestamp tracking from sync

### DIFF
--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -658,22 +658,6 @@ pub static BEACON_BLOB_DELAY_FULL_VERIFICATION: LazyLock<Result<IntGauge>> = Laz
     )
 });
 
-pub static BEACON_BLOB_RPC_SLOT_START_DELAY_TIME: LazyLock<Result<Histogram>> = LazyLock::new(
-    || {
-        try_create_histogram_with_buckets(
-            "beacon_blob_rpc_slot_start_delay_time",
-            "Duration between when a blob is received over rpc and the start of the slot it belongs to.",
-            // Create a custom bucket list for greater granularity in block delay
-            Ok(vec![
-                0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0,
-                6.0, 7.0, 8.0, 9.0, 10.0, 15.0, 20.0,
-            ]), // NOTE: Previous values, which we may want to switch back to.
-                // [0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50]
-                //decimal_buckets(-1,2)
-        )
-    },
-);
-
 /*
  * Light client update reprocessing queue metrics.
  */

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -518,15 +518,11 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self: &Arc<Self>,
         block_root: Hash256,
         block: LookupBlock<T::EthSpec>,
-        seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) -> Result<(), Error<T::EthSpec>> {
-        let process_fn = self.clone().generate_lookup_beacon_block_process_fn(
-            block_root,
-            block,
-            seen_timestamp,
-            process_type,
-        );
+        let process_fn =
+            self.clone()
+                .generate_lookup_beacon_block_process_fn(block_root, block, process_type);
         self.try_send(BeaconWorkEvent {
             drop_during_sync: false,
             work: Work::RpcBlock {
@@ -542,14 +538,13 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self: &Arc<Self>,
         block_root: Hash256,
         envelope: Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>,
-        seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) -> Result<(), Error<T::EthSpec>> {
         let s = self.clone();
         self.try_send(BeaconWorkEvent {
             drop_during_sync: false,
             work: Work::RpcEnvelope(Box::pin(async move {
-                s.process_lookup_envelope(block_root, envelope, seen_timestamp, process_type)
+                s.process_lookup_envelope(block_root, envelope, process_type)
                     .await;
             })),
         })
@@ -561,20 +556,14 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self: &Arc<Self>,
         block_root: Hash256,
         custody_columns: DataColumnSidecarList<T::EthSpec>,
-        seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) -> Result<(), Error<T::EthSpec>> {
         let s = self.clone();
         self.try_send(BeaconWorkEvent {
             drop_during_sync: false,
             work: Work::RpcCustodyColumn(Box::pin(async move {
-                s.process_rpc_custody_columns(
-                    block_root,
-                    custody_columns,
-                    seen_timestamp,
-                    process_type,
-                )
-                .await;
+                s.process_rpc_custody_columns(block_root, custody_columns, process_type)
+                    .await;
             })),
         })
     }

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -14,7 +14,7 @@ use beacon_chain::data_availability_checker::{
 use beacon_chain::historical_data_columns::HistoricalDataColumnError;
 use beacon_chain::{
     AvailabilityProcessingStatus, BeaconChainTypes, BlockError, ChainSegmentResult,
-    HistoricalBlockError, NotifyExecutionLayer, validator_monitor::get_slot_delay_ms,
+    HistoricalBlockError, NotifyExecutionLayer,
 };
 use beacon_processor::{
     AsyncFn, BlockingFn, DuplicateCache,
@@ -26,7 +26,6 @@ use lighthouse_network::PeerId;
 use lighthouse_network::service::api_types::CustodyBackfillBatchId;
 use logging::crit;
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::{debug, debug_span, error, info, instrument, warn};
 use types::{BlockImportSource, DataColumnSidecarList, Epoch, ExecutionBlockHash, Hash256};
 
@@ -56,19 +55,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self: Arc<Self>,
         block_root: Hash256,
         block: LookupBlock<T::EthSpec>,
-        seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) -> AsyncFn {
         let process_fn = async move {
             let duplicate_cache = self.duplicate_cache.clone();
-            self.process_lookup_block(
-                block_root,
-                block,
-                seen_timestamp,
-                process_type,
-                duplicate_cache,
-            )
-            .await;
+            self.process_lookup_block(block_root, block, process_type, duplicate_cache)
+                .await;
         };
         Box::pin(process_fn)
     }
@@ -78,14 +70,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self: Arc<Self>,
         block_root: Hash256,
         block: LookupBlock<T::EthSpec>,
-        seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) -> (AsyncFn, BlockingFn) {
         // An async closure which will import the block.
         let process_fn = self.clone().generate_lookup_beacon_block_process_fn(
             block_root,
             block,
-            seen_timestamp,
             process_type.clone(),
         );
         // A closure which will ignore the block.
@@ -119,7 +109,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self: Arc<NetworkBeaconProcessor<T>>,
         block_root: Hash256,
         block: LookupBlock<T::EthSpec>,
-        seen_timestamp: Duration,
         process_type: BlockProcessType,
         duplicate_cache: DuplicateCache,
     ) {
@@ -133,12 +122,9 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             );
 
             // Send message to work reprocess queue to retry the block
-            let (process_fn, ignore_fn) = self.clone().generate_lookup_beacon_block_fns(
-                block_root,
-                block,
-                seen_timestamp,
-                process_type,
-            );
+            let (process_fn, ignore_fn) =
+                self.clone()
+                    .generate_lookup_beacon_block_fns(block_root, block, process_type);
             let reprocess_msg = ReprocessQueueMessage::RpcBlock(QueuedRpcBlock {
                 beacon_block_root: block_root,
                 process_fn,
@@ -211,13 +197,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "Failed to inform block import"
                     );
                 };
-                self.chain.block_times_cache.write().set_time_observed(
-                    *hash,
-                    slot,
-                    seen_timestamp,
-                    None,
-                    None,
-                );
 
                 self.chain.recompute_head_at_current_slot().await;
             }
@@ -259,20 +238,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self: Arc<NetworkBeaconProcessor<T>>,
         block_root: Hash256,
         custody_columns: DataColumnSidecarList<T::EthSpec>,
-        seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) {
         // custody_columns must always have at least one element
         let Some(slot) = custody_columns.first().map(|d| d.slot()) else {
             return;
         };
-
-        if let Ok(current_slot) = self.chain.slot()
-            && current_slot == slot
-        {
-            let delay = get_slot_delay_ms(seen_timestamp, slot, &self.chain.slot_clock);
-            metrics::observe_duration(&metrics::BEACON_BLOB_RPC_SLOT_START_DELAY_TIME, delay);
-        }
 
         let mut indices = custody_columns
             .iter()
@@ -337,7 +308,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self: Arc<NetworkBeaconProcessor<T>>,
         block_root: Hash256,
         envelope: Arc<types::SignedExecutionPayloadEnvelope<T::EthSpec>>,
-        _seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) {
         debug!(

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -422,7 +422,6 @@ impl TestRig {
             .send_lookup_beacon_block(
                 block_root,
                 LookupBlock::new(self.next_block.clone()),
-                std::time::Duration::default(),
                 BlockProcessType::SingleBlock { id: 0 },
             )
             .unwrap();
@@ -434,7 +433,6 @@ impl TestRig {
             .send_lookup_beacon_block(
                 block_root,
                 LookupBlock::new(self.next_block.clone()),
-                std::time::Duration::default(),
                 BlockProcessType::SingleBlock { id: 1 },
             )
             .unwrap();
@@ -446,7 +444,6 @@ impl TestRig {
                 .send_rpc_custody_columns(
                     self.next_block.canonical_root(),
                     data_columns,
-                    Duration::default(),
                     BlockProcessType::SingleCustodyColumn(1),
                 )
                 .unwrap();

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -659,7 +659,6 @@ impl<T: BeaconChainTypes> Router<T> {
             peer_id,
             sync_request_id,
             beacon_block,
-            seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
         });
     }
 
@@ -679,7 +678,6 @@ impl<T: BeaconChainTypes> Router<T> {
                 peer_id,
                 sync_request_id,
                 blob_sidecar,
-                seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
             });
         } else {
             crit!("All blobs by range responses should belong to sync");
@@ -716,7 +714,6 @@ impl<T: BeaconChainTypes> Router<T> {
             peer_id,
             sync_request_id,
             beacon_block,
-            seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
         });
     }
 
@@ -750,7 +747,6 @@ impl<T: BeaconChainTypes> Router<T> {
             sync_request_id,
             peer_id,
             data_column,
-            seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
         });
     }
 
@@ -770,7 +766,6 @@ impl<T: BeaconChainTypes> Router<T> {
                 peer_id,
                 sync_request_id,
                 data_column,
-                seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
             });
         } else {
             crit!("All data columns by range responses should belong to sync");
@@ -796,7 +791,6 @@ impl<T: BeaconChainTypes> Router<T> {
             sync_request_id,
             peer_id,
             envelope,
-            seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
         });
     }
 
@@ -819,7 +813,6 @@ impl<T: BeaconChainTypes> Router<T> {
             sync_request_id,
             peer_id,
             envelope,
-            seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
         });
     }
 

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -381,7 +381,7 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         if self.awaiting_parent.is_none()
             && let Some(data) = self.block_request.state.maybe_start_processing()
         {
-            cx.send_block_for_processing(self.id, self.block_root, data.value, data.seen_timestamp)
+            cx.send_block_for_processing(self.id, self.block_root, data.value)
                 .map_err(LookupRequestError::SendFailedProcessor)?;
         }
 
@@ -422,7 +422,6 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
                             self.id,
                             self.block_root,
                             data.value,
-                            data.seen_timestamp,
                             BlockProcessType::SingleCustodyColumn(self.id),
                         )
                         .map_err(LookupRequestError::SendFailedProcessor)?;
@@ -463,7 +462,6 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
                         cx.send_payload_for_processing(
                             self.block_root,
                             data.value,
-                            data.seen_timestamp,
                             BlockProcessType::SinglePayloadEnvelope(self.id),
                         )
                         .map_err(LookupRequestError::SendFailedProcessor)?;
@@ -711,17 +709,12 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
 #[derive(Debug, Clone)]
 pub struct DownloadResult<T: Clone> {
     pub value: T,
-    pub seen_timestamp: Duration,
     pub peer_group: PeerGroup,
 }
 
 impl<T: Clone> DownloadResult<T> {
-    pub fn new(value: T, peer_group: PeerGroup, seen_timestamp: Duration) -> Self {
-        Self {
-            value,
-            seen_timestamp,
-            peer_group,
-        }
+    pub fn new(value: T, peer_group: PeerGroup) -> Self {
+        Self { value, peer_group }
     }
 }
 

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -113,7 +113,6 @@ pub enum SyncMessage<E: EthSpec> {
         sync_request_id: SyncRequestId,
         peer_id: PeerId,
         beacon_block: Option<Arc<SignedBeaconBlock<E>>>,
-        seen_timestamp: Duration,
     },
 
     /// A blob has been received from the RPC.
@@ -121,7 +120,6 @@ pub enum SyncMessage<E: EthSpec> {
         sync_request_id: SyncRequestId,
         peer_id: PeerId,
         blob_sidecar: Option<Arc<BlobSidecar<E>>>,
-        seen_timestamp: Duration,
     },
 
     /// A data columns has been received from the RPC
@@ -129,7 +127,6 @@ pub enum SyncMessage<E: EthSpec> {
         sync_request_id: SyncRequestId,
         peer_id: PeerId,
         data_column: Option<Arc<DataColumnSidecar<E>>>,
-        seen_timestamp: Duration,
     },
 
     /// A payload envelope has been received from the RPC.
@@ -137,7 +134,6 @@ pub enum SyncMessage<E: EthSpec> {
         sync_request_id: SyncRequestId,
         peer_id: PeerId,
         envelope: Option<Arc<SignedExecutionPayloadEnvelope<E>>>,
-        seen_timestamp: Duration,
     },
 
     /// A block with an unknown parent has been received.
@@ -823,35 +819,24 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 sync_request_id,
                 peer_id,
                 beacon_block,
-                seen_timestamp,
             } => {
-                self.rpc_block_received(sync_request_id, peer_id, beacon_block, seen_timestamp);
+                self.rpc_block_received(sync_request_id, peer_id, beacon_block);
             }
             SyncMessage::RpcBlob {
                 sync_request_id,
                 peer_id,
                 blob_sidecar,
-                seen_timestamp,
-            } => self.rpc_blob_received(sync_request_id, peer_id, blob_sidecar, seen_timestamp),
+            } => self.rpc_blob_received(sync_request_id, peer_id, blob_sidecar),
             SyncMessage::RpcDataColumn {
                 sync_request_id,
                 peer_id,
                 data_column,
-                seen_timestamp,
-            } => {
-                self.rpc_data_column_received(sync_request_id, peer_id, data_column, seen_timestamp)
-            }
+            } => self.rpc_data_column_received(sync_request_id, peer_id, data_column),
             SyncMessage::RpcPayloadEnvelope {
                 sync_request_id,
                 peer_id,
                 envelope,
-                seen_timestamp,
-            } => self.rpc_payload_envelope_received(
-                sync_request_id,
-                peer_id,
-                envelope,
-                seen_timestamp,
-            ),
+            } => self.rpc_payload_envelope_received(sync_request_id, peer_id, envelope),
             SyncMessage::UnknownParentBlock(peer_id, block, block_root) => {
                 let block_slot = block.slot();
                 let parent_root = block.parent_root();
@@ -865,7 +850,6 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     block_slot,
                     BlockComponent::Block(DownloadResult {
                         value: block.block_cloned(),
-                        seen_timestamp: self.chain.slot_clock.now_duration().unwrap_or_default(),
                         peer_group: PeerGroup::from_single(peer_id),
                     }),
                 );
@@ -1094,19 +1078,14 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         sync_request_id: SyncRequestId,
         peer_id: PeerId,
         block: Option<Arc<SignedBeaconBlock<T::EthSpec>>>,
-        seen_timestamp: Duration,
     ) {
         match sync_request_id {
-            SyncRequestId::SingleBlock { id } => self.on_single_block_response(
-                id,
-                peer_id,
-                RpcEvent::from_chunk(block, seen_timestamp),
-            ),
-            SyncRequestId::BlocksByRange(id) => self.on_blocks_by_range_response(
-                id,
-                peer_id,
-                RpcEvent::from_chunk(block, seen_timestamp),
-            ),
+            SyncRequestId::SingleBlock { id } => {
+                self.on_single_block_response(id, peer_id, RpcEvent::from_chunk(block))
+            }
+            SyncRequestId::BlocksByRange(id) => {
+                self.on_blocks_by_range_response(id, peer_id, RpcEvent::from_chunk(block))
+            }
             _ => {
                 crit!(%peer_id, "bad request id for block");
             }
@@ -1122,9 +1101,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         if let Some(resp) = self.network.on_single_block_response(id, peer_id, block) {
             self.block_lookups.on_block_download_response(
                 id,
-                resp.map(|(value, seen_timestamp)| {
-                    DownloadResult::new(value, PeerGroup::from_single(peer_id), seen_timestamp)
-                }),
+                resp.map(|value| DownloadResult::new(value, PeerGroup::from_single(peer_id))),
                 &mut self.network,
             )
         }
@@ -1135,14 +1112,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         sync_request_id: SyncRequestId,
         peer_id: PeerId,
         blob: Option<Arc<BlobSidecar<T::EthSpec>>>,
-        seen_timestamp: Duration,
     ) {
         match sync_request_id {
-            SyncRequestId::BlobsByRange(id) => self.on_blobs_by_range_response(
-                id,
-                peer_id,
-                RpcEvent::from_chunk(blob, seen_timestamp),
-            ),
+            SyncRequestId::BlobsByRange(id) => {
+                self.on_blobs_by_range_response(id, peer_id, RpcEvent::from_chunk(blob))
+            }
             _ => {
                 crit!(%peer_id, "bad request id for blob");
             }
@@ -1154,20 +1128,15 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         sync_request_id: SyncRequestId,
         peer_id: PeerId,
         envelope: Option<Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>>,
-        seen_timestamp: Duration,
     ) {
         match sync_request_id {
             SyncRequestId::SinglePayloadEnvelope { id } => self
-                .on_single_payload_envelope_response(
-                    id,
-                    peer_id,
-                    RpcEvent::from_chunk(envelope, seen_timestamp),
-                ),
+                .on_single_payload_envelope_response(id, peer_id, RpcEvent::from_chunk(envelope)),
             SyncRequestId::PayloadEnvelopesByRange(req_id) => {
                 self.on_payload_envelopes_by_range_response(
                     req_id,
                     peer_id,
-                    RpcEvent::from_chunk(envelope, seen_timestamp),
+                    RpcEvent::from_chunk(envelope),
                 );
             }
             _ => {
@@ -1181,21 +1150,20 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         sync_request_id: SyncRequestId,
         peer_id: PeerId,
         data_column: Option<Arc<DataColumnSidecar<T::EthSpec>>>,
-        seen_timestamp: Duration,
     ) {
         match sync_request_id {
             SyncRequestId::DataColumnsByRoot(req_id) => {
                 self.on_data_columns_by_root_response(
                     req_id,
                     peer_id,
-                    RpcEvent::from_chunk(data_column, seen_timestamp),
+                    RpcEvent::from_chunk(data_column),
                 );
             }
             SyncRequestId::DataColumnsByRange(req_id) => {
                 self.on_data_columns_by_range_response(
                     req_id,
                     peer_id,
-                    RpcEvent::from_chunk(data_column, seen_timestamp),
+                    RpcEvent::from_chunk(data_column),
                 );
             }
             _ => {
@@ -1216,9 +1184,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         {
             self.block_lookups.on_payload_download_response(
                 id,
-                resp.map(|(value, seen_timestamp)| {
-                    DownloadResult::new(value, PeerGroup::from_single(peer_id), seen_timestamp)
-                }),
+                resp.map(|value| DownloadResult::new(value, PeerGroup::from_single(peer_id))),
                 &mut self.network,
             )
         }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -50,7 +50,6 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::Arc;
-use std::time::Duration;
 #[cfg(test)]
 use task_executor::TaskExecutor;
 use tokio::sync::mpsc;
@@ -81,22 +80,21 @@ pub const MAX_COLUMN_RETRIES: usize = 3;
 #[derive(Debug)]
 pub enum RpcEvent<T> {
     StreamTermination,
-    Response(T, Duration),
+    Response(T),
     RPCError(RPCError),
 }
 
 impl<T> RpcEvent<T> {
-    pub fn from_chunk(chunk: Option<T>, seen_timestamp: Duration) -> Self {
+    pub fn from_chunk(chunk: Option<T>) -> Self {
         match chunk {
-            Some(item) => RpcEvent::Response(item, seen_timestamp),
+            Some(item) => RpcEvent::Response(item),
             None => RpcEvent::StreamTermination,
         }
     }
 }
 
-pub type RpcResponseResult<T> = Result<(T, Duration), RpcResponseError>;
+pub type RpcResponseResult<T> = Result<T, RpcResponseError>;
 
-/// Duration = latest seen timestamp of all received data columns
 pub type CustodyByRootResult<T> =
     Result<DownloadResult<DataColumnSidecarList<T>>, RpcResponseError>;
 
@@ -797,14 +795,14 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         if let Err(e) = {
             let request = entry.get_mut();
             match range_block_component {
-                RangeBlockComponent::Block(req_id, resp) => resp.and_then(|(blocks, _)| {
+                RangeBlockComponent::Block(req_id, resp) => resp.and_then(|blocks| {
                     request.add_blocks(req_id, blocks).map_err(|e| {
                         RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(
                             e,
                         ))
                     })
                 }),
-                RangeBlockComponent::Blob(req_id, resp) => resp.and_then(|(blobs, _)| {
+                RangeBlockComponent::Blob(req_id, resp) => resp.and_then(|blobs| {
                     request.add_blobs(req_id, blobs).map_err(|e| {
                         RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(
                             e,
@@ -812,7 +810,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                     })
                 }),
                 RangeBlockComponent::CustodyColumns(req_id, resp) => {
-                    resp.and_then(|(custody_columns, _)| {
+                    resp.and_then(|custody_columns| {
                         request
                             .add_custody_columns(req_id, custody_columns)
                             .map_err(|e| {
@@ -822,17 +820,15 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                             })
                     })
                 }
-                RangeBlockComponent::PayloadEnvelope(req_id, resp) => {
-                    resp.and_then(|(envelopes, _)| {
-                        request
-                            .add_payload_envelopes(req_id, envelopes)
-                            .map_err(|e| {
-                                RpcResponseError::BlockComponentCouplingError(
-                                    CouplingError::InternalError(e),
-                                )
-                            })
-                    })
-                }
+                RangeBlockComponent::PayloadEnvelope(req_id, resp) => resp.and_then(|envelopes| {
+                    request
+                        .add_payload_envelopes(req_id, envelopes)
+                        .map_err(|e| {
+                            RpcResponseError::BlockComponentCouplingError(
+                                CouplingError::InternalError(e),
+                            )
+                        })
+                }),
             }
         } {
             entry.remove();
@@ -1497,11 +1493,11 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     ) -> Option<RpcResponseResult<Arc<SignedBeaconBlock<T::EthSpec>>>> {
         let resp = self.blocks_by_root_requests.on_response(id, rpc_event);
         let resp = resp.map(|res| {
-            res.and_then(|(mut blocks, seen_timestamp)| {
+            res.and_then(|mut blocks| {
                 // Enforce that exactly one chunk = one block is returned. ReqResp behavior limits the
                 // response count to at most 1.
                 match blocks.pop() {
-                    Some(block) => Ok((block, seen_timestamp)),
+                    Some(block) => Ok(block),
                     // Should never happen, `blocks_by_root_requests` enforces that we receive at least
                     // 1 chunk.
                     None => Err(LookupVerifyError::NotEnoughResponsesReturned { actual: 0 }.into()),
@@ -1521,9 +1517,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .payload_envelopes_by_root_requests
             .on_response(id, rpc_event);
         let resp = resp.map(|res| {
-            res.and_then(|(mut envelopes, seen_timestamp)| {
+            res.and_then(|mut envelopes| {
                 match envelopes.pop() {
-                    Some(envelope) => Ok((envelope, seen_timestamp)),
+                    Some(envelope) => Ok(envelope),
                     // Should never happen, we enforce at least 1 chunk.
                     None => Err(LookupVerifyError::NotEnoughResponsesReturned { actual: 0 }.into()),
                 }
@@ -1664,7 +1660,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         id: Id,
         block_root: Hash256,
         block: Arc<SignedBeaconBlock<T::EthSpec>>,
-        seen_timestamp: Duration,
     ) -> Result<(), SendErrorProcessor> {
         let beacon_processor = self
             .beacon_processor_if_enabled()
@@ -1679,7 +1674,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .send_lookup_beacon_block(
                 block_root,
                 lookup_block,
-                seen_timestamp,
                 BlockProcessType::SingleBlock { id },
             )
             .map_err(|e| {
@@ -1695,7 +1689,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         &self,
         block_root: Hash256,
         envelope: Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>,
-        seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) -> Result<(), SendErrorProcessor> {
         let beacon_processor = self
@@ -1709,7 +1702,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         );
 
         beacon_processor
-            .send_lookup_envelope(block_root, envelope, seen_timestamp, process_type)
+            .send_lookup_envelope(block_root, envelope, process_type)
             .map_err(|e| {
                 error!(
                     error = ?e,
@@ -1724,7 +1717,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         _id: Id,
         block_root: Hash256,
         custody_columns: DataColumnSidecarList<T::EthSpec>,
-        seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) -> Result<(), SendErrorProcessor> {
         let beacon_processor = self
@@ -1738,7 +1730,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         );
 
         beacon_processor
-            .send_rpc_custody_columns(block_root, custody_columns, seen_timestamp, process_type)
+            .send_rpc_custody_columns(block_root, custody_columns, process_type)
             .map_err(|e| {
                 error!(
                     error = ?e,
@@ -1826,7 +1818,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
         if let Err(e) = {
             let request = entry.get_mut();
-            data_columns.and_then(|(data_columns, _)| {
+            data_columns.and_then(|data_columns| {
                 request
                     .add_custody_columns(req_id, data_columns.clone())
                     .map_err(|e| {

--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -7,7 +7,6 @@ use fnv::FnvHashMap;
 use lighthouse_network::PeerId;
 use lighthouse_network::service::api_types::{CustodyId, DataColumnsByRootRequester};
 use parking_lot::RwLock;
-use slot_clock::SlotClock;
 use std::collections::HashSet;
 use std::hash::{BuildHasher, RandomState};
 use std::time::{Duration, Instant};
@@ -114,7 +113,7 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
         let _guard = batch_request.span.clone().entered();
 
         match resp {
-            Ok((data_columns, seen_timestamp)) => {
+            Ok(data_columns) => {
                 debug!(
                     block_root = ?self.block_root,
                     %req_id,
@@ -139,12 +138,7 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                         .ok_or(Error::BadState("unknown column_index".to_owned()))?;
 
                     if let Some(data_column) = data_columns.remove(column_index) {
-                        column_request.on_download_success(
-                            req_id,
-                            peer_id,
-                            data_column,
-                            seen_timestamp,
-                        )?;
+                        column_request.on_download_success(req_id, peer_id, data_column)?;
                     } else {
                         // Peer does not have the requested data.
                         // TODO(das) do not consider this case a success. We know for sure the block has
@@ -208,30 +202,20 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
         if completed_requests >= total_requests {
             // All requests have completed successfully.
             let mut peers = HashMap::<PeerId, Vec<usize>>::new();
-            let mut seen_timestamps = vec![];
             let columns = std::mem::take(&mut self.column_requests)
                 .into_values()
                 .map(|request| {
-                    let (peer, data_column, seen_timestamp) = request.complete()?;
+                    let (peer, data_column) = request.complete()?;
                     peers
                         .entry(peer)
                         .or_default()
                         .push(*data_column.index() as usize);
-                    seen_timestamps.push(seen_timestamp);
                     Ok(data_column)
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
             let peer_group = PeerGroup::from_set(peers);
-            let max_seen_timestamp = seen_timestamps
-                .into_iter()
-                .max()
-                .unwrap_or_else(|| cx.chain.slot_clock.now_duration().unwrap_or_default());
-            return Ok(Some(DownloadResult::new(
-                columns,
-                peer_group,
-                max_seen_timestamp,
-            )));
+            return Ok(Some(DownloadResult::new(columns, peer_group)));
         }
 
         let active_request_count_by_peer = cx.active_request_count_by_peer();
@@ -410,7 +394,7 @@ struct ColumnRequest<E: EthSpec> {
 enum Status<E: EthSpec> {
     NotStarted(Instant),
     Downloading(DataColumnsByRootRequestId),
-    Downloaded(PeerId, Arc<DataColumnSidecar<E>>, Duration),
+    Downloaded(PeerId, Arc<DataColumnSidecar<E>>),
 }
 
 impl<E: EthSpec> ColumnRequest<E> {
@@ -479,7 +463,6 @@ impl<E: EthSpec> ColumnRequest<E> {
         req_id: DataColumnsByRootRequestId,
         peer_id: PeerId,
         data_column: Arc<DataColumnSidecar<E>>,
-        seen_timestamp: Duration,
     ) -> Result<(), Error> {
         match &self.status {
             Status::Downloading(expected_req_id) => {
@@ -489,7 +472,7 @@ impl<E: EthSpec> ColumnRequest<E> {
                         req_id,
                     });
                 }
-                self.status = Status::Downloaded(peer_id, data_column, seen_timestamp);
+                self.status = Status::Downloaded(peer_id, data_column);
                 Ok(())
             }
             other => Err(Error::BadState(format!(
@@ -498,11 +481,9 @@ impl<E: EthSpec> ColumnRequest<E> {
         }
     }
 
-    fn complete(self) -> Result<(PeerId, Arc<DataColumnSidecar<E>>, Duration), Error> {
+    fn complete(self) -> Result<(PeerId, Arc<DataColumnSidecar<E>>), Error> {
         match self.status {
-            Status::Downloaded(peer_id, data_column, seen_timestamp) => {
-                Ok((peer_id, data_column, seen_timestamp))
-            }
+            Status::Downloaded(peer_id, data_column) => Ok((peer_id, data_column)),
             other => Err(Error::BadState(format!(
                 "bad state complete expected Downloaded got {other:?}"
             ))),

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -3,7 +3,6 @@ use std::{collections::hash_map::Entry, hash::Hash};
 
 use fnv::FnvHashMap;
 use lighthouse_network::PeerId;
-use slot_clock::timestamp_now;
 use strum::IntoStaticStr;
 use tracing::{Span, debug};
 use types::{Hash256, Slot};
@@ -122,7 +121,7 @@ impl<K: Copy + Eq + Hash + std::fmt::Display, T: ActiveRequestItems> ActiveReque
         let result = match rpc_event {
             // Handler of a success ReqResp chunk. Adds the item to the request accumulator.
             // `ActiveRequestItems` validates the item before appending to its internal state.
-            RpcEvent::Response(item, seen_timestamp) => {
+            RpcEvent::Response(item) => {
                 let request = &mut entry.get_mut();
                 let _guard = request.span.clone().entered();
                 match &mut request.state {
@@ -133,7 +132,7 @@ impl<K: Copy + Eq + Hash + std::fmt::Display, T: ActiveRequestItems> ActiveReque
                             Ok(true) => {
                                 let items = items.consume();
                                 request.state = State::CompletedEarly;
-                                Some(Ok((items, seen_timestamp, request.start_instant.elapsed())))
+                                Some(Ok((items, request.start_instant.elapsed())))
                             }
                             // Received item, but we are still expecting more
                             Ok(false) => None,
@@ -170,11 +169,7 @@ impl<K: Copy + Eq + Hash + std::fmt::Display, T: ActiveRequestItems> ActiveReque
                             }
                             .into()))
                         } else {
-                            Some(Ok((
-                                items.consume(),
-                                timestamp_now(),
-                                request.start_instant.elapsed(),
-                            )))
+                            Some(Ok((items.consume(), request.start_instant.elapsed())))
                         }
                     }
                     // Items already returned, ignore stream termination
@@ -202,7 +197,7 @@ impl<K: Copy + Eq + Hash + std::fmt::Display, T: ActiveRequestItems> ActiveReque
         };
 
         result.map(|result| match result {
-            Ok((items, seen_timestamp, duration)) => {
+            Ok((items, duration)) => {
                 metrics::inc_counter_vec(&metrics::SYNC_RPC_REQUEST_SUCCESSES, &[self.name]);
                 metrics::observe_timer_vec(&metrics::SYNC_RPC_REQUEST_TIME, &[self.name], duration);
                 debug!(
@@ -212,7 +207,7 @@ impl<K: Copy + Eq + Hash + std::fmt::Display, T: ActiveRequestItems> ActiveReque
                     "Sync RPC request completed"
                 );
 
-                Ok((items, seen_timestamp))
+                Ok(items)
             }
             Err(e) => {
                 let err_str: &'static str = match &e {

--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -43,8 +43,6 @@ use types::{
     SignedExecutionPayloadEnvelope, Slot,
 };
 
-const D: Duration = Duration::new(0, 0);
-
 /// Gloas genesis needs enough validators to populate `proposer_lookahead`.
 const TEST_RIG_VALIDATOR_COUNT: usize = 8;
 
@@ -873,14 +871,12 @@ impl TestRig {
                 sync_request_id,
                 peer_id,
                 beacon_block: Some(block.clone()),
-                seen_timestamp: D,
             });
         }
         self.push_sync_message(SyncMessage::RpcBlock {
             sync_request_id,
             peer_id,
             beacon_block: None,
-            seen_timestamp: D,
         });
     }
 
@@ -904,14 +900,12 @@ impl TestRig {
                 sync_request_id,
                 peer_id,
                 blob_sidecar: Some(blob.clone()),
-                seen_timestamp: D,
             });
         }
         self.push_sync_message(SyncMessage::RpcBlob {
             sync_request_id,
             peer_id,
             blob_sidecar: None,
-            seen_timestamp: D,
         });
     }
 
@@ -940,14 +934,12 @@ impl TestRig {
                 sync_request_id,
                 peer_id,
                 data_column: Some(column.clone()),
-                seen_timestamp: D,
             });
         }
         self.push_sync_message(SyncMessage::RpcDataColumn {
             sync_request_id,
             peer_id,
             data_column: None,
-            seen_timestamp: D,
         });
     }
 
@@ -966,14 +958,12 @@ impl TestRig {
             sync_request_id,
             peer_id,
             envelope: envelope.clone(),
-            seen_timestamp: D,
         });
         // Stream termination
         self.push_sync_message(SyncMessage::RpcPayloadEnvelope {
             sync_request_id,
             peer_id,
             envelope: None,
-            seen_timestamp: D,
         });
     }
 
@@ -993,7 +983,6 @@ impl TestRig {
                 sync_request_id,
                 peer_id,
                 envelope: Some(envelope.clone()),
-                seen_timestamp: D,
             });
         }
         // Stream termination
@@ -1001,7 +990,6 @@ impl TestRig {
             sync_request_id,
             peer_id,
             envelope: None,
-            seen_timestamp: D,
         });
     }
 


### PR DESCRIPTION
Sync requests are initiated by us, so a response's receipt timestamp measures our own request scheduling and RTT, not network propagation lateness. Unlike gossip — where `seen_timestamp` measures real propagation delay — tracking it through the lookup/range sync stack is meaningless. This removes it from sync entirely (keeping it only for gossip) and drops the `beacon_blob_rpc_slot_start_delay_time` metric, which was fed exclusively by RPC-fetched columns.

### AI disclosure
Implemented by Claude Code, reviewed by me.