### PR TITLE
Allow release branches to target stable in target-branch-check

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -71,9 +71,13 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
         - name: Check that the pull request is not targeting the stable branch
+          env:
+            BASE_REF: ${{ github.base_ref }}
+            HEAD_REF: ${{ github.head_ref }}
+            HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           run: |
-            if [[ "${{ github.base_ref }}" == "stable" && "${{ github.head_ref }}" != release-* ]]; then
-              echo "::error::Pull requests must target unstable, not stable (release-* branches excepted)."
+            if [[ "$BASE_REF" == "stable" && ! ( "$HEAD_REF" == release-* && "$HEAD_REPO" == "sigp/lighthouse" ) ]]; then
+              echo "::error::Pull requests must target unstable, not stable (sigp/lighthouse release-* branches excepted)."
               exit 1
             fi
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -71,7 +71,11 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
         - name: Check that the pull request is not targeting the stable branch
-          run: test ${{ github.base_ref }} != "stable"
+          run: |
+            if [[ "${{ github.base_ref }}" == "stable" && "${{ github.head_ref }}" != release-* ]]; then
+              echo "::error::Pull requests must target unstable, not stable (release-* branches excepted)."
+              exit 1
+            fi
 
   forbidden-files-check:
     name: forbidden-files-check


### PR DESCRIPTION
The target-branch-check job fails any PR that targets stable, which is meant to stop contributors from accidentally opening PRs there instead of unstable. The problem is it also fails our own release PRs, since those go from a release-vX.Y branch straight into stable, so every release shows up red even though it merged fine. This adds an exception for release-* head branches so the release flow stays green while everything else still gets blocked from targeting stable.