### PR TITLE
Update warp snapshot build job

### DIFF
--- a/.github/workflows/warpbuild-ubuntu-latest-snapshot.yml
+++ b/.github/workflows/warpbuild-ubuntu-latest-snapshot.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   bake:
-    runs-on: warp-ubuntu-latest-x64-8x
+    runs-on: warp-ubuntu-latest-x64-8x;snapshot.enabled=true
     steps:
       - name: Install system deps
         run: |


### PR DESCRIPTION
## Issue Addressed

There's a recent breaking change that deprecated dashboard-based snapshot enablement, and is breaking our CI:
https://www.warpbuild.com/docs/ci/changelog/2026-june#june-8-2026

> Legacy dashboard-based snapshot enablement has been removed. Runners previously configured with snapshots enabled from the dashboard will no longer use snapshots. To continue using snapshot runners, migrate to the label-based configuration by adding snapshot.enabled=true or snapshot.key=<alias> to your runs-on labels. See the [Snapshot Runners docs](https://www.warpbuild.com/docs/ci/features/snapshot-runners) for migration details.