### PR TITLE
Only bake warpbuild snapshot from stable

### DIFF
--- a/.github/workflows/warpbuild-ubuntu-latest-snapshot.yml
+++ b/.github/workflows/warpbuild-ubuntu-latest-snapshot.yml
@@ -5,8 +5,11 @@ on:
   schedule:
     # Every week (Sunday at 00:00 UTC)
     - cron: "0 0 * * 0"
-  pull_request:
-    branches: [stable, unstable]
+  push:
+    # The warpbuild snapshot is global across all branches, so only `stable`
+    # bakes it. This avoids non-stable branches (and Mergify merge-queue PRs)
+    # clobbering the shared snapshot and racking up duplicate bakes.
+    branches: [stable]
     paths:
       - '.github/workflows/warpbuild-ubuntu-latest-snapshot.yml'
 


### PR DESCRIPTION
The snapshot is global across all branches. Triggering the bake from
`pull_request` (on stable + unstable) meant any branch could clobber the
shared snapshot, and Mergify merge-queue PRs re-fired the event, causing
duplicate bakes. Switch to `push` on `stable` only so a single branch owns
the bake.