### PR TITLE
Expose process CPU seconds as counter

### DIFF
--- a/common/health_metrics/src/metrics.rs
+++ b/common/health_metrics/src/metrics.rs
@@ -1,7 +1,7 @@
 use crate::observe::Observe;
 use eth2::lighthouse::{ProcessHealth, SystemHealth};
 use metrics::*;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, atomic::AtomicU64};
 
 pub static PROCESS_NUM_THREADS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
     try_create_int_gauge(
@@ -33,6 +33,7 @@ pub static PROCESS_SECONDS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
         "Total cpu time taken by the current process",
     )
 });
+static PROCESS_SECONDS_LAST_OBSERVED: AtomicU64 = AtomicU64::new(0);
 pub static SYSTEM_VIRT_MEM_TOTAL: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
     try_create_int_gauge("system_virt_mem_total_bytes", "Total system virtual memory")
 });
@@ -135,7 +136,11 @@ pub fn scrape_process_health_metrics() {
         set_gauge(&PROCESS_RES_MEM, health.pid_mem_resident_set_size as i64);
         set_gauge(&PROCESS_VIRT_MEM, health.pid_mem_virtual_memory_size as i64);
         set_gauge(&PROCESS_SHR_MEM, health.pid_mem_shared_memory_size as i64);
-        set_counter_from_absolute(&PROCESS_SECONDS, health.pid_process_seconds_total);
+        set_counter_from_absolute(
+            &PROCESS_SECONDS,
+            &PROCESS_SECONDS_LAST_OBSERVED,
+            health.pid_process_seconds_total,
+        );
     }
 }
 

--- a/common/health_metrics/src/metrics.rs
+++ b/common/health_metrics/src/metrics.rs
@@ -27,8 +27,8 @@ pub static PROCESS_SHR_MEM: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
         "Shared memory used by the current process",
     )
 });
-pub static PROCESS_SECONDS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
-    try_create_int_gauge(
+pub static PROCESS_SECONDS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
         "process_cpu_seconds_total",
         "Total cpu time taken by the current process",
     )
@@ -135,7 +135,7 @@ pub fn scrape_process_health_metrics() {
         set_gauge(&PROCESS_RES_MEM, health.pid_mem_resident_set_size as i64);
         set_gauge(&PROCESS_VIRT_MEM, health.pid_mem_virtual_memory_size as i64);
         set_gauge(&PROCESS_SHR_MEM, health.pid_mem_shared_memory_size as i64);
-        set_gauge(&PROCESS_SECONDS, health.pid_process_seconds_total as i64);
+        set_counter_from_absolute(&PROCESS_SECONDS, health.pid_process_seconds_total);
     }
 }
 
@@ -186,5 +186,24 @@ pub fn scrape_system_health_metrics() {
             &NETWORK_BYTES_SENT,
             health.network_node_bytes_total_transmit as i64,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_cpu_seconds_total_is_registered_as_counter() {
+        PROCESS_SECONDS
+            .as_ref()
+            .expect("process CPU seconds metric should initialize");
+
+        let metric = gather()
+            .into_iter()
+            .find(|metric| metric.get_name() == "process_cpu_seconds_total")
+            .expect("process CPU seconds metric should be registered");
+
+        assert_eq!(metric.get_field_type(), MetricType::COUNTER);
     }
 }

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -308,6 +308,19 @@ pub fn inc_counter_by(counter: &Result<IntCounter>, value: u64) {
     }
 }
 
+/// Updates a counter from an observed absolute value.
+///
+/// If `value` is ahead of the current counter value, increments by the positive
+/// delta. Decreases are ignored so the counter never moves backwards.
+pub fn set_counter_from_absolute(counter: &Result<IntCounter>, value: u64) {
+    if let Ok(counter) = counter {
+        let current = counter.get();
+        if value > current {
+            counter.inc_by(value - current);
+        }
+    }
+}
+
 pub fn set_gauge_vec(int_gauge_vec: &Result<IntGaugeVec>, name: &[&str], value: i64) {
     if let Some(gauge) = get_int_gauge(int_gauge_vec, name) {
         gauge.set(value);
@@ -439,5 +452,31 @@ impl<T> TryExt for Option<T> {
             timer.stop_and_discard();
         }
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_counter_from_absolute_only_applies_positive_deltas() {
+        let counter = Ok(IntCounter::new(
+            "set_counter_from_absolute_test_total",
+            "counter helper test",
+        )
+        .expect("should create counter"));
+
+        set_counter_from_absolute(&counter, 10);
+        assert_eq!(counter.as_ref().expect("counter should exist").get(), 10);
+
+        set_counter_from_absolute(&counter, 15);
+        assert_eq!(counter.as_ref().expect("counter should exist").get(), 15);
+
+        set_counter_from_absolute(&counter, 15);
+        assert_eq!(counter.as_ref().expect("counter should exist").get(), 15);
+
+        set_counter_from_absolute(&counter, 12);
+        assert_eq!(counter.as_ref().expect("counter should exist").get(), 15);
     }
 }

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -51,7 +51,10 @@
 //! ```
 
 use prometheus::{Error, HistogramOpts, Opts};
-use std::time::Duration;
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
 
 use prometheus::core::{Atomic, GenericGauge, GenericGaugeVec};
 pub use prometheus::{
@@ -310,13 +313,35 @@ pub fn inc_counter_by(counter: &Result<IntCounter>, value: u64) {
 
 /// Updates a counter from an observed absolute value.
 ///
-/// If `value` is ahead of the current counter value, increments by the positive
-/// delta. Decreases are ignored so the counter never moves backwards.
-pub fn set_counter_from_absolute(counter: &Result<IntCounter>, value: u64) {
+/// If `value` is ahead of the last observed absolute value, increments by the
+/// positive delta. Decreases are ignored so the counter never moves backwards.
+///
+/// `last_observed` should be dedicated to the same source value as `counter`.
+pub fn set_counter_from_absolute(
+    counter: &Result<IntCounter>,
+    last_observed: &AtomicU64,
+    value: u64,
+) {
     if let Ok(counter) = counter {
-        let current = counter.get();
-        if value > current {
-            counter.inc_by(value - current);
+        let mut current = last_observed.load(Ordering::Relaxed);
+
+        loop {
+            if value <= current {
+                return;
+            }
+
+            match last_observed.compare_exchange_weak(
+                current,
+                value,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    counter.inc_by(value - current);
+                    return;
+                }
+                Err(observed) => current = observed,
+            }
         }
     }
 }
@@ -458,6 +483,7 @@ impl<T> TryExt for Option<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{sync::Barrier, thread};
 
     #[test]
     fn set_counter_from_absolute_only_applies_positive_deltas() {
@@ -466,17 +492,46 @@ mod tests {
             "counter helper test",
         )
         .expect("should create counter"));
+        let last_observed = AtomicU64::new(0);
 
-        set_counter_from_absolute(&counter, 10);
+        set_counter_from_absolute(&counter, &last_observed, 10);
         assert_eq!(counter.as_ref().expect("counter should exist").get(), 10);
 
-        set_counter_from_absolute(&counter, 15);
+        set_counter_from_absolute(&counter, &last_observed, 15);
         assert_eq!(counter.as_ref().expect("counter should exist").get(), 15);
 
-        set_counter_from_absolute(&counter, 15);
+        set_counter_from_absolute(&counter, &last_observed, 15);
         assert_eq!(counter.as_ref().expect("counter should exist").get(), 15);
 
-        set_counter_from_absolute(&counter, 12);
+        set_counter_from_absolute(&counter, &last_observed, 12);
+        assert_eq!(counter.as_ref().expect("counter should exist").get(), 15);
+    }
+
+    #[test]
+    fn set_counter_from_absolute_deduplicates_concurrent_updates() {
+        let counter = Ok(IntCounter::new(
+            "set_counter_from_absolute_concurrent_test_total",
+            "counter helper concurrency test",
+        )
+        .expect("should create counter"));
+        let last_observed = AtomicU64::new(10);
+        counter.as_ref().expect("counter should exist").inc_by(10);
+
+        let barrier = Barrier::new(2);
+        thread::scope(|scope| {
+            for _ in 0..2 {
+                let barrier = &barrier;
+                let counter = &counter;
+                let last_observed = &last_observed;
+
+                scope.spawn(move || {
+                    barrier.wait();
+                    set_counter_from_absolute(counter, last_observed, 15);
+                });
+            }
+        });
+
+        assert_eq!(last_observed.load(Ordering::Acquire), 15);
         assert_eq!(counter.as_ref().expect("counter should exist").get(), 15);
     }
 }


### PR DESCRIPTION
## Issue Addressed

Closes #3108

`process_cpu_seconds_total` is registered as a gauge today, even though the underlying value is cumulative CPU time reported by the OS. That leaves the metric with the wrong Prometheus type, and PromQL functions like `rate()` and `irate()` do not treat it as a counter series.

## Proposed Changes

- register `process_cpu_seconds_total` as an `IntCounter`
- add `set_counter_from_absolute` in `common/metrics` so callers can update a counter from an observed absolute value by incrementing only the positive delta
- track the last observed absolute CPU total with an `AtomicU64` so concurrent `/metrics` scrapes cannot count the same observation twice
- use that helper in `scrape_process_health_metrics`
- add focused regression tests for the helper behavior, concurrent deduplication, and the metric type

## Additional Info

This keeps the scope to `process_cpu_seconds_total`. If the observed CPU total goes backwards, the helper ignores the decrease instead of trying to move the Prometheus counter backwards.

### Tests

- `rustup run nightly-2026-06-01-x86_64-unknown-linux-gnu cargo fmt --all --check`
- `rustup run nightly-2026-06-01-x86_64-unknown-linux-gnu cargo test -p metrics --lib`
- `rustup run nightly-2026-06-01-x86_64-unknown-linux-gnu cargo test -p health_metrics --lib`
- `rustup run nightly-2026-06-01-x86_64-unknown-linux-gnu cargo check -p metrics -p health_metrics -p monitoring_api`
