### PR TITLE
Range sync: fetch data columns via custody-by-root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,7 +2475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1205,13 +1205,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn cached_data_column_indexes(
         &self,
         block_root: &Hash256,
-        slot: Slot,
+        block_epoch: Epoch,
     ) -> Option<Vec<ColumnIndex>> {
-        if self
-            .spec
-            .fork_name_at_slot::<T::EthSpec>(slot)
-            .gloas_enabled()
-        {
+        if self.spec.fork_name_at_epoch(block_epoch).gloas_enabled() {
             self.pending_payload_cache
                 .cached_data_column_indexes(block_root)
         } else {
@@ -3495,7 +3491,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 return;
             };
             let imported_data_columns = self
-                .cached_data_column_indexes(block_root, slot)
+                .cached_data_column_indexes(block_root, slot.epoch(T::EthSpec::slots_per_epoch()))
                 .unwrap_or_default();
             let new_data_columns =
                 data_columns_iter.filter(|b| !imported_data_columns.contains(b.index()));

--- a/beacon_node/beacon_chain/src/fetch_blobs/fetch_blobs_beacon_adapter.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs/fetch_blobs_beacon_adapter.rs
@@ -10,7 +10,7 @@ use mockall::automock;
 use std::collections::HashSet;
 use std::sync::Arc;
 use task_executor::TaskExecutor;
-use types::{ChainSpec, ColumnIndex, Hash256, Slot};
+use types::{ChainSpec, ColumnIndex, EthSpec, Hash256, Slot};
 
 /// An adapter to the `BeaconChain` functionalities to remove `BeaconChain` from direct dependency to enable testing fetch blobs logic.
 pub(crate) struct FetchBlobsBeaconAdapter<T: BeaconChainTypes> {
@@ -92,7 +92,8 @@ impl<T: BeaconChainTypes> FetchBlobsBeaconAdapter<T> {
         block_root: &Hash256,
         slot: Slot,
     ) -> Option<Vec<u64>> {
-        self.chain.cached_data_column_indexes(block_root, slot)
+        self.chain
+            .cached_data_column_indexes(block_root, slot.epoch(T::EthSpec::slots_per_epoch()))
     }
 
     pub(crate) async fn process_engine_blobs(

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -3,7 +3,7 @@ use libp2p::PeerId;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use types::{
-    BlobSidecar, DataColumnSidecar, Epoch, EthSpec, LightClientBootstrap,
+    BlobSidecar, DataColumnSidecar, Epoch, EthSpec, Hash256, LightClientBootstrap,
     LightClientFinalityUpdate, LightClientOptimisticUpdate, LightClientUpdate, SignedBeaconBlock,
     SignedExecutionPayloadEnvelope,
 };
@@ -80,7 +80,6 @@ pub struct DataColumnsByRangeRequestId {
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum DataColumnsByRangeRequester {
-    ComponentsByRange(ComponentsByRangeRequestId),
     CustodyBackfillSync(CustodyBackFillBatchRequestId),
 }
 
@@ -139,9 +138,17 @@ pub struct CustodyId {
 }
 
 /// Downstream components that perform custody by root requests.
-/// Currently, it's only single block lookups, so not using an enum
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-pub struct CustodyRequester(pub SingleLookupReqId);
+pub enum CustodyRequester {
+    SingleLookup(SingleLookupReqId),
+    RangeSync(RangeSyncCustodyId),
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub struct RangeSyncCustodyId {
+    pub id: ComponentsByRangeRequestId,
+    pub block_root: Hash256,
+}
 
 /// Application level requests sent to the network.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -290,7 +297,16 @@ impl Display for DataColumnsByRootRequester {
 
 impl Display for CustodyRequester {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        match self {
+            Self::SingleLookup(id) => write!(f, "{id}"),
+            Self::RangeSync(id) => write!(f, "RangeSync/{id}"),
+        }
+    }
+}
+
+impl Display for RangeSyncCustodyId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{:?}", self.id, self.block_root)
     }
 }
 
@@ -306,7 +322,6 @@ impl Display for RangeRequestId {
 impl Display for DataColumnsByRangeRequester {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ComponentsByRange(id) => write!(f, "ByRange/{id}"),
             Self::CustodyBackfillSync(id) => write!(f, "CustodyBackfill/{id}"),
         }
     }
@@ -321,7 +336,7 @@ mod tests {
         let id = DataColumnsByRootRequestId {
             id: 123,
             requester: DataColumnsByRootRequester::Custody(CustodyId {
-                requester: CustodyRequester(SingleLookupReqId {
+                requester: CustodyRequester::SingleLookup(SingleLookupReqId {
                     req_id: 121,
                     lookup_id: 101,
                 }),
@@ -334,17 +349,17 @@ mod tests {
     fn display_id_data_columns_by_range() {
         let id = DataColumnsByRangeRequestId {
             id: 123,
-            parent_request_id: DataColumnsByRangeRequester::ComponentsByRange(
-                ComponentsByRangeRequestId {
+            parent_request_id: DataColumnsByRangeRequester::CustodyBackfillSync(
+                CustodyBackFillBatchRequestId {
                     id: 122,
-                    requester: RangeRequestId::RangeSync {
-                        chain_id: 54,
-                        batch_id: Epoch::new(0),
+                    batch_id: CustodyBackfillBatchId {
+                        epoch: Epoch::new(0),
+                        run_id: 54,
                     },
                 },
             ),
             peer: PeerId::random(),
         };
-        assert_eq!(format!("{id}"), "123/ByRange/122/RangeSync/0/54");
+        assert_eq!(format!("{id}"), "123/CustodyBackfill/122/0/54");
     }
 }

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -3,7 +3,7 @@ use libp2p::PeerId;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use types::{
-    BlobSidecar, DataColumnSidecar, Epoch, EthSpec, Hash256, LightClientBootstrap,
+    BlobSidecar, DataColumnSidecar, Epoch, EthSpec, LightClientBootstrap,
     LightClientFinalityUpdate, LightClientOptimisticUpdate, LightClientUpdate, SignedBeaconBlock,
     SignedExecutionPayloadEnvelope,
 };
@@ -137,17 +137,12 @@ pub struct CustodyId {
     pub requester: CustodyRequester,
 }
 
-/// Downstream components that perform custody by root requests.
+/// Downstream components that perform custody by root requests. A range sync request fetches the
+/// custody columns of an entire batch (identified by its `ComponentsByRangeRequestId`) in one go.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum CustodyRequester {
     SingleLookup(SingleLookupReqId),
-    RangeSync(RangeSyncCustodyId),
-}
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-pub struct RangeSyncCustodyId {
-    pub id: ComponentsByRangeRequestId,
-    pub block_root: Hash256,
+    RangeSync(ComponentsByRangeRequestId),
 }
 
 /// Application level requests sent to the network.
@@ -301,12 +296,6 @@ impl Display for CustodyRequester {
             Self::SingleLookup(id) => write!(f, "{id}"),
             Self::RangeSync(id) => write!(f, "RangeSync/{id}"),
         }
-    }
-}
-
-impl Display for RangeSyncCustodyId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{:?}", self.id, self.block_root)
     }
 }
 

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -9,7 +9,8 @@ use libp2p::PeerId;
 use lighthouse_network::rpc::{RequestType, methods::*};
 use lighthouse_network::service::api_types::{
     AppRequestId, BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId,
-    DataColumnsByRangeRequestId, DataColumnsByRangeRequester, RangeRequestId, SyncRequestId,
+    CustodyBackFillBatchRequestId, CustodyBackfillBatchId, DataColumnsByRangeRequestId,
+    DataColumnsByRangeRequester, RangeRequestId, SyncRequestId,
 };
 use lighthouse_network::{NetworkEvent, ReportSource, Response};
 use ssz::Encode;
@@ -1828,12 +1829,12 @@ fn test_request_too_large_data_columns_by_range() {
         AppRequestId::Sync(SyncRequestId::DataColumnsByRange(
             DataColumnsByRangeRequestId {
                 id: 1,
-                parent_request_id: DataColumnsByRangeRequester::ComponentsByRange(
-                    ComponentsByRangeRequestId {
+                parent_request_id: DataColumnsByRangeRequester::CustodyBackfillSync(
+                    CustodyBackFillBatchRequestId {
                         id: 1,
-                        requester: RangeRequestId::RangeSync {
-                            chain_id: 1,
-                            batch_id: Epoch::new(1),
+                        batch_id: CustodyBackfillBatchId {
+                            epoch: Epoch::new(1),
+                            run_id: 1,
                         },
                     },
                 ),

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -478,6 +478,30 @@ pub static SYNCING_CHAIN_BATCHES: LazyLock<Result<IntGaugeVec>> = LazyLock::new(
         &["sync_type", "state"],
     )
 });
+pub static SYNCING_CHAIN_BATCH_DOWNLOADING: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram_with_buckets(
+        "sync_range_chain_batch_downloading_seconds",
+        "Time range sync batches spend downloading",
+        Ok(vec![0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0]),
+    )
+});
+pub static SYNCING_CHAIN_BATCH_PROCESSING: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram_with_buckets(
+        "sync_range_chain_batch_processing_seconds",
+        "Time range sync batches spend in processing",
+        Ok(vec![
+            0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0,
+        ]),
+    )
+});
+pub static SYNCING_CHAIN_BATCH_AWAITING_PROCESSING_COUNT: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram_with_buckets(
+            "sync_range_chain_batch_awaiting_processing_count",
+            "Number of batches in AwaitingProcessing when a batch starts processing",
+            Ok(vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+        )
+    });
 pub static SYNC_SINGLE_BLOCK_LOOKUPS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
     try_create_int_gauge(
         "sync_single_block_lookups",

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -882,11 +882,13 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                 .collect::<HashSet<_>>();
 
             let (request, is_blob_batch) = batch.to_blocks_by_range_request();
+            let failed_peers = batch.failed_peers();
             match network.block_components_by_range_request(
                 is_blob_batch,
                 request,
                 RangeRequestId::BackfillSync { batch_id },
                 &synced_peers,
+                &failed_peers,
             ) {
                 Ok(request_id) => {
                     // inform the batch about the new request

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -35,7 +35,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 use tracing::{debug, error, info, warn};
-use types::{ColumnIndex, Epoch, EthSpec};
+use types::{Epoch, EthSpec};
 
 /// Blocks are downloaded in batches from peers. This constant specifies how many epochs worth of
 /// blocks per batch are requested _at most_. A batch may request less blocks to account for
@@ -315,39 +315,13 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
         &mut self,
         network: &mut SyncNetworkContext<T>,
         batch_id: BatchId,
-        peer_id: &PeerId,
+        peer_id: Option<&PeerId>,
         request_id: Id,
         err: RpcResponseError,
     ) -> Result<(), BackFillError> {
         if let Some(batch) = self.batches.get_mut(&batch_id) {
             if let RpcResponseError::BlockComponentCouplingError(coupling_error) = &err {
                 match coupling_error {
-                    CouplingError::DataColumnPeerFailure {
-                        error,
-                        faulty_peers,
-                        exceeded_retries,
-                    } => {
-                        debug!(?batch_id, error, "Block components coupling error");
-                        // Note: we don't fail the batch here because a `CouplingError` is
-                        // recoverable by requesting from other honest peers.
-                        let mut failed_columns = HashSet::new();
-                        let mut failed_peers = HashSet::new();
-                        for (column, peer) in faulty_peers {
-                            failed_columns.insert(*column);
-                            failed_peers.insert(*peer);
-                        }
-
-                        // Only retry if peer failure **and** retries haven't been exceeded
-                        if !*exceeded_retries {
-                            return self.retry_partial_batch(
-                                network,
-                                batch_id,
-                                request_id,
-                                failed_columns,
-                                failed_peers,
-                            );
-                        }
-                    }
                     CouplingError::BlobPeerFailure(msg) => {
                         debug!(?batch_id, msg, "Blob peer failure");
                     }
@@ -356,6 +330,9 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                     }
                     CouplingError::InternalError(msg) => {
                         error!(?batch_id, msg, "Block components coupling internal error");
+                    }
+                    CouplingError::DataColumnPeerFailure { error, .. } => {
+                        debug!(?batch_id, error, "Data column peer failure");
                     }
                 }
             }
@@ -368,7 +345,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                 return Ok(());
             }
             debug!(batch_epoch = %batch_id, error = ?err, "Batch download failed");
-            match batch.download_failed(Some(*peer_id)) {
+            match batch.download_failed(peer_id.copied()) {
                 Err(e) => self.fail_sync(BackFillError::BatchInvalidState(batch_id, e.0)),
                 Ok(BatchOperationOutcome::Failed { blacklist: _ }) => {
                     self.fail_sync(BackFillError::BatchDownloadFailed(batch_id))
@@ -702,7 +679,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                 // Batches can be in `AwaitingDownload` state if there weren't good data column subnet
                 // peers to send the request to.
                 BatchState::AwaitingDownload => return Ok(ProcessResult::Successful),
-                BatchState::Failed | BatchState::Processing(_) => {
+                BatchState::Failed | BatchState::Processing(..) => {
                     // these are all inconsistent states:
                     // - Failed -> non recoverable batch. Chain should have been removed
                     // - Processing -> `self.current_processing_batch` is None
@@ -808,7 +785,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                     crit!("batch indicates inconsistent chain state while advancing chain")
                 }
                 BatchState::AwaitingProcessing(..) => {}
-                BatchState::Processing(_) => {
+                BatchState::Processing(..) => {
                     debug!(batch = %id, %batch, "Advancing chain while processing a batch");
                     if let Some(processing_id) = self.current_processing_batch
                         && id >= processing_id
@@ -905,14 +882,11 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                 .collect::<HashSet<_>>();
 
             let (request, is_blob_batch) = batch.to_blocks_by_range_request();
-            let failed_peers = batch.failed_peers();
             match network.block_components_by_range_request(
                 is_blob_batch,
                 request,
                 RangeRequestId::BackfillSync { batch_id },
                 &synced_peers,
-                &synced_peers, // All synced peers have imported up to the finalized slot so they must have their custody columns available
-                &failed_peers,
             ) {
                 Ok(request_id) => {
                     // inform the batch about the new request
@@ -957,53 +931,6 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
             }
         }
 
-        Ok(())
-    }
-
-    /// Retries partial column requests within the batch by creating new requests for the failed columns.
-    pub fn retry_partial_batch(
-        &mut self,
-        network: &mut SyncNetworkContext<T>,
-        batch_id: BatchId,
-        id: Id,
-        failed_columns: HashSet<ColumnIndex>,
-        mut failed_peers: HashSet<PeerId>,
-    ) -> Result<(), BackFillError> {
-        if let Some(batch) = self.batches.get_mut(&batch_id) {
-            failed_peers.extend(&batch.failed_peers());
-            let req = batch.to_blocks_by_range_request().0;
-
-            let synced_peers = network
-                .network_globals()
-                .peers
-                .read()
-                .synced_peers_for_epoch(batch_id)
-                .cloned()
-                .collect::<HashSet<_>>();
-
-            match network.retry_columns_by_range(
-                id,
-                &synced_peers,
-                &failed_peers,
-                req,
-                &failed_columns,
-            ) {
-                Ok(_) => {
-                    debug!(
-                        ?batch_id,
-                        id, "Retried column requests from different peers"
-                    );
-                    return Ok(());
-                }
-                Err(e) => {
-                    debug!(?batch_id, id, e, "Failed to retry partial batch");
-                }
-            }
-        } else {
-            return Err(BackFillError::InvalidSyncState(
-                "Batch should exist to be retried".to_string(),
-            ));
-        }
         Ok(())
     }
 

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -315,7 +315,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
         &mut self,
         network: &mut SyncNetworkContext<T>,
         batch_id: BatchId,
-        peer_id: Option<&PeerId>,
+        peer_id: &PeerId,
         request_id: Id,
         err: RpcResponseError,
     ) -> Result<(), BackFillError> {
@@ -345,7 +345,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                 return Ok(());
             }
             debug!(batch_epoch = %batch_id, error = ?err, "Batch download failed");
-            match batch.download_failed(peer_id.copied()) {
+            match batch.download_failed(Some(*peer_id)) {
                 Err(e) => self.fail_sync(BackFillError::BatchInvalidState(batch_id, e.0)),
                 Ok(BatchOperationOutcome::Failed { blacklist: _ }) => {
                     self.fail_sync(BackFillError::BatchDownloadFailed(batch_id))

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -322,6 +322,9 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
         if let Some(batch) = self.batches.get_mut(&batch_id) {
             if let RpcResponseError::BlockComponentCouplingError(coupling_error) = &err {
                 match coupling_error {
+                    CouplingError::DataColumnPeerFailure { error, .. } => {
+                        debug!(?batch_id, error, "Block components coupling error");
+                    }
                     CouplingError::BlobPeerFailure(msg) => {
                         debug!(?batch_id, msg, "Blob peer failure");
                     }
@@ -330,9 +333,6 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                     }
                     CouplingError::InternalError(msg) => {
                         error!(?batch_id, msg, "Block components coupling internal error");
-                    }
-                    CouplingError::DataColumnPeerFailure { error, .. } => {
-                        debug!(?batch_id, error, "Data column peer failure");
                     }
                 }
             }

--- a/beacon_node/network/src/sync/batch.rs
+++ b/beacon_node/network/src/sync/batch.rs
@@ -132,11 +132,11 @@ pub enum BatchState<D: Hash> {
     /// The batch has failed either downloading or processing, but can be requested again.
     AwaitingDownload,
     /// The batch is being downloaded.
-    Downloading(Id),
+    Downloading(Id, Instant),
     /// The batch has been completely downloaded and is ready for processing.
     AwaitingProcessing(PeerId, D, Instant),
     /// The batch is being processed.
-    Processing(Attempt<D>),
+    Processing(Attempt<D>, Instant),
     /// The batch was successfully processed and is waiting to be validated.
     ///
     /// It is not sufficient to process a batch successfully to consider it correct. This is
@@ -160,9 +160,9 @@ impl<D: Hash> BatchState<D> {
     pub fn metrics_state(&self) -> BatchMetricsState {
         match self {
             BatchState::AwaitingDownload => BatchMetricsState::AwaitingDownload,
-            BatchState::Downloading(_) => BatchMetricsState::Downloading,
+            BatchState::Downloading(..) => BatchMetricsState::Downloading,
             BatchState::AwaitingProcessing(..) => BatchMetricsState::AwaitingProcessing,
-            BatchState::Processing(_) => BatchMetricsState::Processing,
+            BatchState::Processing(..) => BatchMetricsState::Processing,
             BatchState::AwaitingValidation(_) => BatchMetricsState::AwaitingValidation,
             BatchState::Poisoned | BatchState::Failed => BatchMetricsState::Failed,
         }
@@ -218,10 +218,28 @@ impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {
 
     /// Verifies if an incoming request id to this batch.
     pub fn is_expecting_request_id(&self, request_id: &Id) -> bool {
-        if let BatchState::Downloading(expected_id) = &self.state {
+        if let BatchState::Downloading(expected_id, _) = &self.state {
             return expected_id == request_id;
         }
         false
+    }
+
+    /// Returns the elapsed time since the batch entered the Downloading state.
+    pub fn time_since_downloading(&self) -> Option<Duration> {
+        if let BatchState::Downloading(_, start) = &self.state {
+            Some(start.elapsed())
+        } else {
+            None
+        }
+    }
+
+    /// Returns the elapsed time since the batch entered the Processing state.
+    pub fn time_since_processing(&self) -> Option<Duration> {
+        if let BatchState::Processing(_, start) = &self.state {
+            Some(start.elapsed())
+        } else {
+            None
+        }
     }
 
     /// Returns the peer that is currently responsible for progressing the state of the batch.
@@ -229,7 +247,7 @@ impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {
         match &self.state {
             BatchState::AwaitingDownload | BatchState::Failed | BatchState::Downloading(..) => None,
             BatchState::AwaitingProcessing(peer_id, _, _)
-            | BatchState::Processing(Attempt { peer_id, .. })
+            | BatchState::Processing(Attempt { peer_id, .. }, _)
             | BatchState::AwaitingValidation(Attempt { peer_id, .. }) => Some(peer_id),
             BatchState::Poisoned => unreachable!("Poisoned batch"),
         }
@@ -265,7 +283,7 @@ impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {
     #[must_use = "Batch may have failed"]
     pub fn download_completed(&mut self, data_columns: D, peer: PeerId) -> Result<(), WrongState> {
         match self.state.poison() {
-            BatchState::Downloading(_) => {
+            BatchState::Downloading(..) => {
                 self.state = BatchState::AwaitingProcessing(peer, data_columns, Instant::now());
                 Ok(())
             }
@@ -285,15 +303,14 @@ impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {
     /// This can happen if a peer disconnects or some error occurred that was not the peers fault.
     /// The `peer` parameter, when set to `None`, still counts toward
     /// `max_batch_download_attempts` (to prevent infinite retries on persistent failures)
-    /// but does not register a peer in `failed_peers()`. Use
-    /// [`Self::downloading_to_awaiting_download`] to retry without counting a failed attempt.
+    /// but does not register a peer in `failed_peers()`.
     #[must_use = "Batch may have failed"]
     pub fn download_failed(
         &mut self,
         peer: Option<PeerId>,
     ) -> Result<BatchOperationOutcome, WrongState> {
         match self.state.poison() {
-            BatchState::Downloading(_) => {
+            BatchState::Downloading(..) => {
                 // register the attempt and check if the batch can be tried again
                 self.failed_download_attempts.push(peer);
 
@@ -317,35 +334,10 @@ impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {
         }
     }
 
-    /// Change the batch state from `Self::Downloading` to `Self::AwaitingDownload` without
-    /// registering a failed attempt.
-    ///
-    /// Note: must use this cautiously with some level of retry protection
-    /// as not registering a failed attempt could lead to requesting in a loop.
-    #[must_use = "Batch may have failed"]
-    pub fn downloading_to_awaiting_download(
-        &mut self,
-    ) -> Result<BatchOperationOutcome, WrongState> {
-        match self.state.poison() {
-            BatchState::Downloading(_) => {
-                self.state = BatchState::AwaitingDownload;
-                Ok(self.outcome())
-            }
-            BatchState::Poisoned => unreachable!("Poisoned batch"),
-            other => {
-                self.state = other;
-                Err(WrongState(format!(
-                    "Download failed for batch in wrong state {:?}",
-                    self.state
-                )))
-            }
-        }
-    }
-
     pub fn start_downloading(&mut self, request_id: Id) -> Result<(), WrongState> {
         match self.state.poison() {
             BatchState::AwaitingDownload => {
-                self.state = BatchState::Downloading(request_id);
+                self.state = BatchState::Downloading(request_id, Instant::now());
                 Ok(())
             }
             BatchState::Poisoned => unreachable!("Poisoned batch"),
@@ -362,7 +354,8 @@ impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {
     pub fn start_processing(&mut self) -> Result<(D, Duration), WrongState> {
         match self.state.poison() {
             BatchState::AwaitingProcessing(peer, data_columns, start_instant) => {
-                self.state = BatchState::Processing(Attempt::new::<B>(peer, &data_columns));
+                self.state =
+                    BatchState::Processing(Attempt::new::<B>(peer, &data_columns), Instant::now());
                 Ok((data_columns, start_instant.elapsed()))
             }
             BatchState::Poisoned => unreachable!("Poisoned batch"),
@@ -381,7 +374,7 @@ impl<E: EthSpec, B: BatchConfig, D: Hash> BatchInfo<E, B, D> {
         processing_result: BatchProcessingResult,
     ) -> Result<BatchOperationOutcome, WrongState> {
         match self.state.poison() {
-            BatchState::Processing(attempt) => {
+            BatchState::Processing(attempt, _start) => {
                 self.state = match processing_result {
                     BatchProcessingResult::Success => BatchState::AwaitingValidation(attempt),
                     BatchProcessingResult::FaultyFailure => {
@@ -519,7 +512,7 @@ impl<D: Hash> Attempt<D> {
 impl<D: Hash> std::fmt::Debug for BatchState<D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BatchState::Processing(Attempt { peer_id, .. }) => {
+            BatchState::Processing(Attempt { peer_id, .. }, _) => {
                 write!(f, "Processing({})", peer_id)
             }
             BatchState::AwaitingValidation(Attempt { peer_id, .. }) => {
@@ -530,7 +523,7 @@ impl<D: Hash> std::fmt::Debug for BatchState<D> {
             BatchState::AwaitingProcessing(peer, ..) => {
                 write!(f, "AwaitingProcessing({})", peer)
             }
-            BatchState::Downloading(request_id) => {
+            BatchState::Downloading(request_id, _) => {
                 write!(f, "Downloading({})", request_id)
             }
             BatchState::Poisoned => f.write_str("Poisoned"),
@@ -544,8 +537,8 @@ impl<D: Hash> BatchState<D> {
     fn visualize(&self) -> char {
         match self {
             BatchState::Downloading(..) => 'D',
-            BatchState::Processing(_) => 'P',
-            BatchState::AwaitingValidation(_) => 'v',
+            BatchState::Processing(..) => 'P',
+            BatchState::AwaitingValidation(..) => 'v',
             BatchState::AwaitingDownload => 'd',
             BatchState::Failed => 'F',
             BatchState::AwaitingProcessing(..) => 'p',
@@ -600,7 +593,7 @@ mod tests {
         assert!(matches!(batch.state(), BatchState::AwaitingDownload));
 
         batch.start_downloading(1).unwrap();
-        assert!(matches!(batch.state(), BatchState::Downloading(1)));
+        assert!(matches!(batch.state(), BatchState::Downloading(1, _)));
 
         batch.download_completed(vec![10, 20], p).unwrap();
         assert!(matches!(batch.state(), BatchState::AwaitingProcessing(..)));

--- a/beacon_node/network/src/sync/batch.rs
+++ b/beacon_node/network/src/sync/batch.rs
@@ -538,7 +538,7 @@ impl<D: Hash> BatchState<D> {
         match self {
             BatchState::Downloading(..) => 'D',
             BatchState::Processing(..) => 'P',
-            BatchState::AwaitingValidation(..) => 'v',
+            BatchState::AwaitingValidation(_) => 'v',
             BatchState::AwaitingDownload => 'd',
             BatchState::Failed => 'F',
             BatchState::AwaitingProcessing(..) => 'p',

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -11,7 +11,7 @@ use crate::sync::network_context::{
 use beacon_chain::BeaconChainTypes;
 use beacon_chain::block_verification_types::AsBlock;
 use educe::Educe;
-use lighthouse_network::service::api_types::Id;
+use lighthouse_network::service::api_types::{CustodyRequester, Id, SingleLookupReqId};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -410,7 +410,18 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
                 }
                 DataRequest::Request { slot, peers, state } => {
                     state.maybe_start_downloading(|| {
-                        cx.custody_lookup_request(self.id, self.block_root, *slot, peers.clone())
+                        let req_id = cx.next_id();
+                        cx.custody_lookup_request(
+                            CustodyRequester::SingleLookup(SingleLookupReqId {
+                                lookup_id: self.id,
+                                req_id,
+                            }),
+                            self.block_root,
+                            *slot,
+                            // single lookups consult the DA cache to skip gossip-imported columns
+                            false,
+                            peers.clone(),
+                        )
                     })?;
                     // Wait for the current block and parent to be imported, data column processing result handle does
                     // not support `ParentUnknown`.

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -416,7 +416,8 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
                                 lookup_id: self.id,
                                 req_id,
                             }),
-                            &[(self.block_root, *slot)],
+                            &[self.block_root],
+                            slot.epoch(<T as BeaconChainTypes>::EthSpec::slots_per_epoch()),
                             // single lookups consult the DA cache to skip gossip-imported columns
                             false,
                             peers.clone(),

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -416,8 +416,7 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
                                 lookup_id: self.id,
                                 req_id,
                             }),
-                            self.block_root,
-                            *slot,
+                            &[(self.block_root, *slot)],
                             // single lookups consult the DA cache to skip gossip-imported columns
                             false,
                             peers.clone(),

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -622,16 +622,18 @@ mod tests {
         expected_custody_columns: &[u64],
     ) {
         info.set_custody_requesting();
-        let custody_columns = blocks
+        let columns = expected_custody_columns
             .iter()
-            .flat_map(|(_, columns, _)| {
-                columns
-                    .iter()
-                    .filter(|column| expected_custody_columns.contains(column.index()))
-                    .cloned()
+            .flat_map(|&column_index| {
+                blocks.iter().flat_map(move |(_, columns, _)| {
+                    columns
+                        .iter()
+                        .filter(move |column| *column.index() == column_index)
+                        .cloned()
+                })
             })
             .collect();
-        info.add_custody_columns(custody_columns, PeerGroup::from_set(Default::default()))
+        info.add_custody_columns(columns, PeerGroup::from_set(Default::default()))
             .unwrap();
     }
 
@@ -753,8 +755,8 @@ mod tests {
         let spec = Arc::new(spec);
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
         // Blobs are no longer required for availability, so the response succeeds without them.
-        let result = info.responses(da_checker, spec).unwrap();
-        assert!(result.0.is_ok())
+        let result = info.responses(da_checker, spec).unwrap().0;
+        assert!(result.is_ok())
     }
 
     #[test]
@@ -797,78 +799,19 @@ mod tests {
         // Assert response is not finished
         assert!(!is_finished(&mut info));
 
-        info.set_custody_requesting();
-        assert!(!is_finished(&mut info));
-
         // Send data columns
-        let custody_columns = expects_custody_columns
-            .iter()
-            .flat_map(|column_index| {
-                blocks
-                    .iter()
-                    .flat_map(|b| b.1.iter().filter(|d| *d.index() == *column_index).cloned())
-            })
-            .collect();
-        info.add_custody_columns(custody_columns, PeerGroup::from_set(Default::default()))
-            .unwrap();
-
-        // All completed construct response
-        info.responses(da_checker, spec).unwrap().0.unwrap();
-    }
-
-    #[test]
-    fn rpc_block_with_custody_columns_batched() {
-        if skip_under_gloas() {
-            return;
-        }
-        let mut spec = test_spec::<E>();
-        spec.deneb_fork_epoch = Some(Epoch::new(0));
-        spec.fulu_fork_epoch = Some(Epoch::new(0));
-        let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expected_sampling_columns = da_checker
-            .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
-            .to_vec();
-
-        let components_id = components_id();
-        let blocks_req_id = blocks_id(components_id);
-
-        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
-
-        let mut u = types::test_utils::test_unstructured();
-        let blocks = (0..4)
-            .map(|_| {
-                generate_rand_block_and_data_columns::<E>(
-                    ForkName::Fulu,
-                    NumBlobs::Number(1),
-                    &mut u,
-                    &spec,
-                )
-                .unwrap()
-            })
-            .collect::<Vec<_>>();
-
-        // Send blocks and complete terminate response
-        info.add_blocks(
-            blocks_req_id,
-            blocks.iter().map(|b| b.0.clone().into()).collect(),
-            PeerId::random(),
-        )
-        .unwrap();
-        // Assert response is not finished
-        assert!(!is_finished(&mut info));
-
         info.set_custody_requesting();
-        let custody_columns = expected_sampling_columns
+        let columns = expects_custody_columns
             .iter()
-            .flat_map(|column_index| {
-                blocks
-                    .iter()
-                    .flat_map(|b| b.1.iter().filter(|d| *d.index() == *column_index).cloned())
+            .flat_map(|&column_index| {
+                blocks.iter().flat_map(move |b| {
+                    b.1.iter()
+                        .filter(move |d| *d.index() == column_index)
+                        .cloned()
+                })
             })
             .collect();
-        info.add_custody_columns(custody_columns, PeerGroup::from_set(Default::default()))
+        info.add_custody_columns(columns, PeerGroup::from_set(Default::default()))
             .unwrap();
 
         // All completed construct response
@@ -973,10 +916,10 @@ mod tests {
         info.add_payload_envelopes(payloads_req_id, vec![Arc::new(bad_envelope)])
             .unwrap();
 
-        let result = info.responses(da_checker, spec).unwrap();
+        let result = info.responses(da_checker, spec).unwrap().0;
         assert!(
             matches!(
-                result.0,
+                result,
                 Err(super::CouplingError::EnvelopePeerFailure(ref error))
                     if error.contains("SlotMismatch")
             ),

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -47,6 +47,8 @@ pub struct RangeBlockComponentsRequest<E: EthSpec> {
             Vec<Arc<SignedExecutionPayloadEnvelope<E>>>,
         >,
     >,
+    /// The peer that provided this batch's blocks; the batch is attributed to it on completion.
+    pub(crate) block_peer: Option<PeerId>,
 }
 
 pub enum ByRangeRequest<I: PartialEq + std::fmt::Display, T> {
@@ -109,6 +111,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             blocks_request: ByRangeRequest::Active(blocks_req_id),
             block_data_request,
             payloads_request: payloads_req_id.map(ByRangeRequest::Active),
+            block_peer: None,
         }
     }
 

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -112,11 +112,6 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         }
     }
 
-    /// Returns true if the blocks component of this request has been received.
-    pub fn blocks_received(&self) -> bool {
-        self.blocks_request.to_finished().is_some()
-    }
-
     /// Adds received blocks to the request.
     ///
     /// Returns an error if the request ID doesn't match the expected blocks request.

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -37,7 +37,8 @@ use crate::sync::network_context::{LookupRequestResult, PeerGroup, SyncNetworkCo
 /// them together and returns complete `RangeSyncBlock`s ready for processing.
 pub struct RangeBlockComponentsRequest<E: EthSpec> {
     /// Blocks we have received awaiting for their corresponding sidecar.
-    blocks_request: ByRangeRequest<BlocksByRangeRequestId, Vec<Arc<SignedBeaconBlock<E>>>>,
+    blocks_request:
+        ByRangeRequest<BlocksByRangeRequestId, (Vec<Arc<SignedBeaconBlock<E>>>, PeerId)>,
     /// Sidecars we have received awaiting for their corresponding block.
     block_data_request: RangeBlockDataRequest<E>,
     /// Payload envelopes for Gloas blocks.
@@ -47,8 +48,6 @@ pub struct RangeBlockComponentsRequest<E: EthSpec> {
             Vec<Arc<SignedExecutionPayloadEnvelope<E>>>,
         >,
     >,
-    /// The peer that provided this batch's blocks; the batch is attributed to it on completion.
-    pub(crate) block_peer: Option<PeerId>,
 }
 
 pub enum ByRangeRequest<I: PartialEq + std::fmt::Display, T> {
@@ -111,7 +110,6 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             blocks_request: ByRangeRequest::Active(blocks_req_id),
             block_data_request,
             payloads_request: payloads_req_id.map(ByRangeRequest::Active),
-            block_peer: None,
         }
     }
 
@@ -122,8 +120,9 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         &mut self,
         req_id: BlocksByRangeRequestId,
         blocks: Vec<Arc<SignedBeaconBlock<E>>>,
+        peer_id: PeerId,
     ) -> Result<(), String> {
-        self.blocks_request.finish(req_id, blocks)
+        self.blocks_request.finish(req_id, (blocks, peer_id))
     }
 
     /// Adds received blobs to the request.
@@ -191,7 +190,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         id: ComponentsByRangeRequestId,
         cx: &mut SyncNetworkContext<T>,
     ) -> Result<(), String> {
-        let Some(blocks) = self.blocks_request.to_finished() else {
+        let Some((blocks, _)) = self.blocks_request.to_finished() else {
             return Ok(());
         };
         let RangeBlockDataRequest::DataColumns(state @ DataColumnsRequest::NotStarted) =
@@ -259,11 +258,11 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         &mut self,
         da_checker: Arc<DataAvailabilityChecker<T>>,
         spec: Arc<ChainSpec>,
-    ) -> Option<Result<Vec<RangeSyncBlock<E>>, CouplingError>>
+    ) -> Option<(Result<Vec<RangeSyncBlock<E>>, CouplingError>, PeerId)>
     where
         T: BeaconChainTypes<EthSpec = E>,
     {
-        let Some(blocks) = self.blocks_request.to_finished() else {
+        let Some((blocks, block_peer)) = self.blocks_request.to_finished() else {
             return None;
         };
 
@@ -273,21 +272,17 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         }
 
         match &self.block_data_request {
-            RangeBlockDataRequest::NoData => Some(Self::responses_with_blobs(
-                blocks.to_vec(),
-                vec![],
-                da_checker,
-                spec,
+            RangeBlockDataRequest::NoData => Some((
+                Self::responses_with_blobs(blocks.to_vec(), vec![], da_checker, spec),
+                *block_peer,
             )),
             RangeBlockDataRequest::Blobs(request) => {
                 let Some(blobs) = request.to_finished() else {
                     return None;
                 };
-                Some(Self::responses_with_blobs(
-                    blocks.to_vec(),
-                    blobs.to_vec(),
-                    da_checker,
-                    spec,
+                Some((
+                    Self::responses_with_blobs(blocks.to_vec(), blobs.to_vec(), da_checker, spec),
+                    *block_peer,
                 ))
             }
             RangeBlockDataRequest::DataColumns(state) => {
@@ -302,12 +297,15 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                         .map(|payload_envelopes| payload_envelopes.to_vec())
                 });
 
-                Some(Self::responses_with_custody_columns(
-                    blocks.to_vec(),
-                    columns.clone(),
-                    da_checker,
-                    spec,
-                    payload_envelopes,
+                Some((
+                    Self::responses_with_custody_columns(
+                        blocks.to_vec(),
+                        columns.clone(),
+                        da_checker,
+                        spec,
+                        payload_envelopes,
+                    ),
+                    *block_peer,
                 ))
             }
         }

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -228,14 +228,11 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                 Ok(())
             }
             Ok(LookupRequestResult::NoRequestNeeded(..)) => {
-                // All columns already available (e.g. arrived via gossip).
-                *state =
-                    DataColumnsRequest::Complete(vec![], PeerGroup::from_set(Default::default()));
-                Ok(())
+                Err("Unexpected custody_lookup_request returned NoRequestNeeded".to_owned())
             }
-            Ok(LookupRequestResult::Pending(reason)) => {
-                Err(format!("Custody request for batch {id} pending: {reason}"))
-            }
+            Ok(LookupRequestResult::Pending(reason)) => Err(format!(
+                "Unexpected custody_lookup_request returned Pending({reason})"
+            )),
             Err(e) => Err(format!("Failed to initiate custody for batch {id}: {e:?}")),
         }
     }
@@ -243,7 +240,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
     /// Marks the custody-by-root request as in flight. Used in tests to simulate the effect of
     /// `continue_requests` without requiring a full network context.
     #[cfg(test)]
-    pub fn set_custody_requesting(&mut self) {
+    fn set_custody_requesting(&mut self) {
         if let RangeBlockDataRequest::DataColumns(state) = &mut self.block_data_request {
             *state = DataColumnsRequest::Requesting;
         }

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -448,6 +448,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         if !columns_by_block_root.is_empty() {
             let remaining_roots = columns_by_block_root.keys().collect::<Vec<_>>();
             // log the error but don't return an error, we can still progress with responses.
+            // this is most likely an internal error with overrequesting or a client bug.
             debug!(?remaining_roots, "Not all columns consumed for block");
         }
 
@@ -496,14 +497,16 @@ mod tests {
         generate_rand_block_and_data_columns, test_da_checker, test_spec,
     };
     use bls::Signature;
-    use lighthouse_network::PeerId;
-    use lighthouse_network::service::api_types::{
-        BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId,
-        PayloadEnvelopesByRangeRequestId, RangeRequestId,
+    use lighthouse_network::{
+        PeerId,
+        service::api_types::{
+            BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId,
+            PayloadEnvelopesByRangeRequestId, RangeRequestId,
+        },
     };
     use std::sync::Arc;
     use types::{
-        ChainSpec, ColumnIndex, DataColumnSidecarList, Epoch, ExecutionPayloadEnvelope, ForkName,
+        ChainSpec, DataColumnSidecarList, Epoch, ExecutionPayloadEnvelope, ForkName,
         MinimalEthSpec as E, SignedBeaconBlock, SignedExecutionPayloadEnvelope,
     };
 
@@ -515,6 +518,15 @@ mod tests {
                 batch_id: Epoch::new(0),
             },
         }
+    }
+
+    /// The custody-column coupling tests below build Fulu data-column sidecars directly, which is
+    /// incompatible with a Gloas genesis (Gloas columns have a different structure). Skip them when
+    /// `FORK_NAME` schedules Gloas at genesis. TODO(gloas): port the harness to build Gloas columns.
+    fn skip_under_gloas() -> bool {
+        test_spec::<E>()
+            .fork_name_at_epoch(Epoch::new(0))
+            .gloas_enabled()
     }
 
     fn blocks_id(parent_request_id: ComponentsByRangeRequestId) -> BlocksByRangeRequestId {
@@ -540,30 +552,82 @@ mod tests {
         }
     }
 
-    /// The custody-column coupling tests below build Fulu data-column sidecars directly, which is
-    /// incompatible with a Gloas genesis (Gloas columns have a different structure). Skip them when
-    /// `FORK_NAME` schedules Gloas at genesis.
-    fn skip_under_gloas() -> bool {
-        test_spec::<E>()
-            .fork_name_at_epoch(Epoch::new(0))
-            .gloas_enabled()
+    fn is_finished(info: &mut RangeBlockComponentsRequest<E>) -> bool {
+        let spec = Arc::new(test_spec::<E>());
+        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
+        info.responses(da_checker, spec).is_some()
     }
 
-    /// Marks the batch's custody-by-root request as in flight, then completes it with the custody
-    /// columns of every data-bearing block (as a single response, as the network layer would).
-    fn complete_custody_by_root(
+    fn gloas_spec() -> ChainSpec {
+        let mut spec = test_spec::<E>();
+        spec.deneb_fork_epoch = Some(Epoch::new(0));
+        spec.fulu_fork_epoch = Some(Epoch::new(0));
+        spec.gloas_fork_epoch = Some(Epoch::new(0));
+        spec
+    }
+
+    fn matching_envelope(block: &SignedBeaconBlock<E>) -> Arc<SignedExecutionPayloadEnvelope<E>> {
+        let bid = &block
+            .message()
+            .body()
+            .signed_execution_payload_bid()
+            .expect("Gloas block should have payload bid")
+            .message;
+        let mut envelope = SignedExecutionPayloadEnvelope {
+            message: ExecutionPayloadEnvelope::empty(),
+            signature: Signature::empty(),
+        };
+        envelope.message.beacon_block_root = block.canonical_root();
+        envelope.message.parent_beacon_block_root = block.parent_root();
+        envelope.message.builder_index = bid.builder_index;
+        envelope.message.payload.slot_number = block.slot();
+        envelope.message.payload.parent_hash = bid.parent_block_hash;
+        envelope.message.payload.block_hash = bid.block_hash;
+        Arc::new(envelope)
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn make_gloas_blocks_and_columns(
+        count: usize,
+        spec: &ChainSpec,
+    ) -> Vec<(
+        Arc<SignedBeaconBlock<E>>,
+        DataColumnSidecarList<E>,
+        Arc<SignedExecutionPayloadEnvelope<E>>,
+    )> {
+        let mut u = types::test_utils::test_unstructured();
+        (0..count)
+            .map(|_| {
+                let (block, data_columns) = generate_rand_block_and_data_columns::<E>(
+                    ForkName::Gloas,
+                    NumBlobs::Number(1),
+                    &mut u,
+                    spec,
+                )
+                .unwrap();
+                let envelope = matching_envelope(&block);
+                (Arc::new(block), data_columns, envelope)
+            })
+            .collect()
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn add_all_columns(
         info: &mut RangeBlockComponentsRequest<E>,
-        blocks_and_columns: &[(Arc<SignedBeaconBlock<E>>, DataColumnSidecarList<E>)],
-        expected_custody_columns: &[ColumnIndex],
+        blocks: &[(
+            Arc<SignedBeaconBlock<E>>,
+            DataColumnSidecarList<E>,
+            Arc<SignedExecutionPayloadEnvelope<E>>,
+        )],
+        expected_custody_columns: &[u64],
     ) {
         info.set_custody_requesting();
-        let custody_columns: DataColumnSidecarList<E> = blocks_and_columns
+        let custody_columns = blocks
             .iter()
-            .filter(|(block, _)| block.num_expected_blobs() > 0)
-            .flat_map(|(_, data_columns)| {
-                data_columns
+            .flat_map(|(_, columns, _)| {
+                columns
                     .iter()
-                    .filter(|d| expected_custody_columns.contains(d.index()))
+                    .filter(|column| expected_custody_columns.contains(column.index()))
                     .cloned()
             })
             .collect();
@@ -571,9 +635,59 @@ mod tests {
             .unwrap();
     }
 
+    #[allow(clippy::type_complexity)]
+    struct GloasSetup {
+        info: RangeBlockComponentsRequest<E>,
+        da_checker: Arc<DataAvailabilityChecker<EphemeralHarnessType<E>>>,
+        spec: Arc<ChainSpec>,
+        blocks: Vec<(
+            Arc<SignedBeaconBlock<E>>,
+            DataColumnSidecarList<E>,
+            Arc<SignedExecutionPayloadEnvelope<E>>,
+        )>,
+        payloads_req_id: PayloadEnvelopesByRangeRequestId,
+        expected_custody_columns: Vec<u64>,
+    }
+
+    /// Builds a Gloas coupling request with `count` blocks and all custody columns added,
+    /// ready for the per-test payload-envelope step.
+    fn setup_gloas_coupling(count: usize) -> GloasSetup {
+        let spec = Arc::new(gloas_spec());
+        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
+        let expected_custody_columns = da_checker
+            .custody_context()
+            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .to_vec();
+        let blocks = make_gloas_blocks_and_columns(count, &spec);
+
+        let components_id = components_id();
+        let blocks_req_id = blocks_id(components_id);
+        let payloads_req_id = payloads_id(components_id);
+        let mut info =
+            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, Some(payloads_req_id));
+
+        info.add_blocks(
+            blocks_req_id,
+            blocks.iter().map(|(block, _, _)| block.clone()).collect(),
+            PeerId::random(),
+        )
+        .unwrap();
+        add_all_columns(&mut info, &blocks, &expected_custody_columns);
+
+        GloasSetup {
+            info,
+            da_checker,
+            spec,
+            blocks,
+            payloads_req_id,
+            expected_custody_columns,
+        }
+    }
+
     #[test]
     fn no_blobs_into_responses() {
-        // This exercises the pre-Gloas blobs/no-data coupling path.
+        // This exercises the pre-Gloas blobs/no-data coupling path. Gloas coupling is covered
+        // by the dedicated `setup_gloas_coupling` tests below.
         if skip_under_gloas() {
             return;
         }
@@ -602,7 +716,7 @@ mod tests {
 
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
 
-        // Assert response is finished and blocks can be constructed
+        // Assert response is finished and RpcBlocks can be constructed
         info.responses(da_checker, spec).unwrap().0.unwrap();
     }
 
@@ -668,58 +782,42 @@ mod tests {
                 )
                 .unwrap()
             })
-            .map(|(block, columns)| (Arc::new(block), columns))
             .collect::<Vec<_>>();
 
         let components_id = components_id();
         let blocks_req_id = blocks_id(components_id);
         let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
-
-        // Send blocks
+        // Send blocks and complete terminate response
         info.add_blocks(
             blocks_req_id,
-            blocks.iter().map(|(b, _)| b.clone()).collect(),
+            blocks.iter().map(|b| b.0.clone().into()).collect(),
             PeerId::random(),
         )
         .unwrap();
-        // Assert response is not finished while custody-by-root is outstanding.
-        info.set_custody_requesting();
-        assert!(info.responses(da_checker.clone(), spec.clone()).is_none());
+        // Assert response is not finished
+        assert!(!is_finished(&mut info));
 
-        // Complete the batch's custody-by-root request with all custody columns.
-        let blocks_and_columns = blocks
+        info.set_custody_requesting();
+        assert!(!is_finished(&mut info));
+
+        // Send data columns
+        let custody_columns = expects_custody_columns
             .iter()
-            .map(|(block, columns)| (block.clone(), columns.clone()))
-            .collect::<Vec<_>>();
-        complete_custody_by_root(&mut info, &blocks_and_columns, &expects_custody_columns);
+            .flat_map(|column_index| {
+                blocks
+                    .iter()
+                    .flat_map(|b| b.1.iter().filter(|d| *d.index() == *column_index).cloned())
+            })
+            .collect();
+        info.add_custody_columns(custody_columns, PeerGroup::from_set(Default::default()))
+            .unwrap();
 
         // All completed construct response
         info.responses(da_checker, spec).unwrap().0.unwrap();
     }
 
     #[test]
-    fn add_custody_columns_rejects_before_requesting() {
-        let blocks_req_id = blocks_id(components_id());
-        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
-        let result = info.add_custody_columns(vec![], PeerGroup::from_set(Default::default()));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("before request was initiated"));
-    }
-
-    #[test]
-    fn add_custody_columns_rejects_duplicate() {
-        let blocks_req_id = blocks_id(components_id());
-        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
-        info.set_custody_requesting();
-        info.add_custody_columns(vec![], PeerGroup::from_set(Default::default()))
-            .unwrap();
-        let result = info.add_custody_columns(vec![], PeerGroup::from_set(Default::default()));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("duplicate"));
-    }
-
-    #[test]
-    fn responses_returns_none_while_custody_requesting() {
+    fn rpc_block_with_custody_columns_batched() {
         if skip_under_gloas() {
             return;
         }
@@ -728,100 +826,22 @@ mod tests {
         spec.fulu_fork_epoch = Some(Epoch::new(0));
         let spec = Arc::new(spec);
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let mut u = types::test_utils::test_unstructured();
-        let (block, _data_columns) = generate_rand_block_and_data_columns::<E>(
-            ForkName::Fulu,
-            NumBlobs::Number(1),
-            &mut u,
-            &spec,
-        )
-        .unwrap();
-
-        let blocks_req_id = blocks_id(components_id());
-        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
-
-        info.add_blocks(blocks_req_id, vec![block.into()], PeerId::random())
-            .unwrap();
-        info.set_custody_requesting();
-
-        // Still requesting — responses should return None
-        assert!(info.responses(da_checker, spec).is_none());
-    }
-
-    #[test]
-    fn mixed_blocks_with_and_without_data() {
-        if skip_under_gloas() {
-            return;
-        }
-        // Mix of blocks: some with blobs (need custody), some without
-        let mut spec = test_spec::<E>();
-        spec.deneb_fork_epoch = Some(Epoch::new(0));
-        spec.fulu_fork_epoch = Some(Epoch::new(0));
-        let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expects_custody_columns = da_checker
+        let expected_sampling_columns = da_checker
             .custody_context()
             .sampling_columns_for_epoch(Epoch::new(0), &spec)
             .to_vec();
-        let mut u = types::test_utils::test_unstructured();
 
-        let (block_with_data, data_columns) = generate_rand_block_and_data_columns::<E>(
-            ForkName::Fulu,
-            NumBlobs::Number(1),
-            &mut u,
-            &spec,
-        )
-        .unwrap();
-        let (block_no_data, _) = generate_rand_block_and_data_columns::<E>(
-            ForkName::Fulu,
-            NumBlobs::None,
-            &mut u,
-            &spec,
-        )
-        .unwrap();
+        let components_id = components_id();
+        let blocks_req_id = blocks_id(components_id);
 
-        let blocks_req_id = blocks_id(components_id());
         let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
 
-        info.add_blocks(
-            blocks_req_id,
-            vec![block_with_data.into(), block_no_data.into()],
-            PeerId::random(),
-        )
-        .unwrap();
-
-        // Complete the batch's custody-by-root request with columns for the data block only.
-        info.set_custody_requesting();
-        let custody_columns: DataColumnSidecarList<E> = data_columns
-            .iter()
-            .filter(|d| expects_custody_columns.contains(d.index()))
-            .cloned()
-            .collect();
-        info.add_custody_columns(custody_columns, PeerGroup::from_set(Default::default()))
-            .unwrap();
-
-        // Both blocks should resolve — one with columns, one with NoData
-        info.responses(da_checker, spec).unwrap().0.unwrap();
-    }
-
-    #[test]
-    fn rpc_block_with_custody_columns_no_data_blocks() {
-        if skip_under_gloas() {
-            return;
-        }
-        // Test blocks that don't have blob commitments don't need custody
-        let mut spec = test_spec::<E>();
-        spec.deneb_fork_epoch = Some(Epoch::new(0));
-        spec.fulu_fork_epoch = Some(Epoch::new(0));
-        let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
         let mut u = types::test_utils::test_unstructured();
-        // Generate blocks with NO blobs
         let blocks = (0..4)
             .map(|_| {
                 generate_rand_block_and_data_columns::<E>(
                     ForkName::Fulu,
-                    NumBlobs::None,
+                    NumBlobs::Number(1),
                     &mut u,
                     &spec,
                 )
@@ -829,134 +849,30 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let blocks_req_id = blocks_id(components_id());
-        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
-
-        // Send blocks
+        // Send blocks and complete terminate response
         info.add_blocks(
             blocks_req_id,
             blocks.iter().map(|b| b.0.clone().into()).collect(),
             PeerId::random(),
         )
         .unwrap();
+        // Assert response is not finished
+        assert!(!is_finished(&mut info));
 
-        // No block in the batch has data, so `continue_requests` completes the custody request
-        // with no columns. Simulate that resolved state.
         info.set_custody_requesting();
-        info.add_custody_columns(vec![], PeerGroup::from_set(Default::default()))
+        let custody_columns = expected_sampling_columns
+            .iter()
+            .flat_map(|column_index| {
+                blocks
+                    .iter()
+                    .flat_map(|b| b.1.iter().filter(|d| *d.index() == *column_index).cloned())
+            })
+            .collect();
+        info.add_custody_columns(custody_columns, PeerGroup::from_set(Default::default()))
             .unwrap();
 
-        // Response should be ready (no blocks need custody columns)
+        // All completed construct response
         info.responses(da_checker, spec).unwrap().0.unwrap();
-    }
-
-    // ===== Gloas payload-envelope coupling tests =====
-
-    fn gloas_spec() -> ChainSpec {
-        let mut spec = test_spec::<E>();
-        spec.deneb_fork_epoch = Some(Epoch::new(0));
-        spec.fulu_fork_epoch = Some(Epoch::new(0));
-        spec.gloas_fork_epoch = Some(Epoch::new(0));
-        spec
-    }
-
-    fn matching_envelope(block: &SignedBeaconBlock<E>) -> Arc<SignedExecutionPayloadEnvelope<E>> {
-        let bid = &block
-            .message()
-            .body()
-            .signed_execution_payload_bid()
-            .expect("Gloas block should have payload bid")
-            .message;
-        let mut envelope = SignedExecutionPayloadEnvelope {
-            message: ExecutionPayloadEnvelope::empty(),
-            signature: Signature::empty(),
-        };
-        envelope.message.beacon_block_root = block.canonical_root();
-        envelope.message.parent_beacon_block_root = block.parent_root();
-        envelope.message.builder_index = bid.builder_index;
-        envelope.message.payload.slot_number = block.slot();
-        envelope.message.payload.parent_hash = bid.parent_block_hash;
-        envelope.message.payload.block_hash = bid.block_hash;
-        Arc::new(envelope)
-    }
-
-    #[allow(clippy::type_complexity)]
-    fn make_gloas_blocks_and_columns(
-        count: usize,
-        spec: &ChainSpec,
-    ) -> Vec<(
-        Arc<SignedBeaconBlock<E>>,
-        DataColumnSidecarList<E>,
-        Arc<SignedExecutionPayloadEnvelope<E>>,
-    )> {
-        let mut u = types::test_utils::test_unstructured();
-        (0..count)
-            .map(|_| {
-                let (block, data_columns) = generate_rand_block_and_data_columns::<E>(
-                    ForkName::Gloas,
-                    NumBlobs::Number(1),
-                    &mut u,
-                    spec,
-                )
-                .unwrap();
-                let envelope = matching_envelope(&block);
-                (Arc::new(block), data_columns, envelope)
-            })
-            .collect()
-    }
-
-    #[allow(clippy::type_complexity)]
-    struct GloasSetup {
-        info: RangeBlockComponentsRequest<E>,
-        da_checker: Arc<DataAvailabilityChecker<EphemeralHarnessType<E>>>,
-        spec: Arc<ChainSpec>,
-        blocks: Vec<(
-            Arc<SignedBeaconBlock<E>>,
-            DataColumnSidecarList<E>,
-            Arc<SignedExecutionPayloadEnvelope<E>>,
-        )>,
-        payloads_req_id: PayloadEnvelopesByRangeRequestId,
-        expected_custody_columns: Vec<ColumnIndex>,
-    }
-
-    /// Builds a Gloas coupling request with `count` blocks and all custody columns added,
-    /// ready for the per-test payload-envelope step.
-    fn setup_gloas_coupling(count: usize) -> GloasSetup {
-        let spec = Arc::new(gloas_spec());
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expected_custody_columns = da_checker
-            .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
-            .to_vec();
-        let blocks = make_gloas_blocks_and_columns(count, &spec);
-
-        let components_id = components_id();
-        let blocks_req_id = blocks_id(components_id);
-        let payloads_req_id = payloads_id(components_id);
-        let mut info =
-            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, Some(payloads_req_id));
-
-        info.add_blocks(
-            blocks_req_id,
-            blocks.iter().map(|(block, _, _)| block.clone()).collect(),
-            PeerId::random(),
-        )
-        .unwrap();
-
-        let blocks_and_columns = blocks
-            .iter()
-            .map(|(block, columns, _)| (block.clone(), columns.clone()))
-            .collect::<Vec<_>>();
-        complete_custody_by_root(&mut info, &blocks_and_columns, &expected_custody_columns);
-
-        GloasSetup {
-            info,
-            da_checker,
-            spec,
-            blocks,
-            payloads_req_id,
-            expected_custody_columns,
-        }
     }
 
     #[test]

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -202,29 +202,32 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             return Ok(());
         };
 
-        // Collect the data-bearing blocks that need custody columns.
-        let data_blocks = blocks
+        // Collect the data-bearing block roots that need custody columns. All blocks in a range
+        // batch share an epoch (EPOCHS_PER_BATCH == 1).
+        let block_roots = blocks
             .iter()
             .filter(|block| block.num_expected_blobs() > 0)
-            .map(|block| (get_block_root(block), block.slot()))
+            .map(|block| get_block_root(block))
             .collect::<Vec<_>>();
 
-        if data_blocks.is_empty() {
+        if block_roots.is_empty() {
             // No block in this batch has data; nothing to fetch.
             *state = DataColumnsRequest::Complete(vec![], PeerGroup::from_set(Default::default()));
             return Ok(());
         }
+        let block_epoch = blocks[0].slot().epoch(E::slots_per_epoch());
 
         match cx.custody_lookup_request(
             CustodyRequester::RangeSync(id),
-            &data_blocks,
+            &block_roots,
+            block_epoch,
             // ignore_cache: range blocks are historical and won't have gossip-imported columns
             true,
             Arc::new(RwLock::new(HashSet::new())),
         ) {
             Ok(LookupRequestResult::RequestSent(_)) => {
                 *state = DataColumnsRequest::Requesting;
-                debug!(%id, blocks = data_blocks.len(), "Initiated custody-by-root for range batch");
+                debug!(%id, blocks = block_roots.len(), "Initiated custody-by-root for range batch");
                 Ok(())
             }
             Ok(LookupRequestResult::NoRequestNeeded(..)) => {

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -108,6 +108,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         blobs_req_id: Option<BlobsByRangeRequestId>,
         expects_custody_columns: bool,
         payloads_req_id: Option<PayloadEnvelopesByRangeRequestId>,
+        request_span: Span,
     ) -> Self {
         let block_data_request = if let Some(blobs_req_id) = blobs_req_id {
             RangeBlockDataRequest::Blobs(ByRangeRequest::Active(blobs_req_id))
@@ -121,7 +122,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             blocks_request: ByRangeRequest::Active(blocks_req_id),
             block_data_request,
             payloads_request: payloads_req_id.map(ByRangeRequest::Active),
-            request_span: Span::none(),
+            request_span,
         }
     }
 
@@ -522,6 +523,7 @@ mod tests {
         },
     };
     use std::sync::Arc;
+    use tracing::Span;
     use types::{
         ChainSpec, DataColumnSidecarList, Epoch, ExecutionPayloadEnvelope, ForkName,
         MinimalEthSpec as E, SignedBeaconBlock, SignedExecutionPayloadEnvelope,
@@ -681,8 +683,13 @@ mod tests {
         let components_id = components_id();
         let blocks_req_id = blocks_id(components_id);
         let payloads_req_id = payloads_id(components_id);
-        let mut info =
-            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, Some(payloads_req_id));
+        let mut info = RangeBlockComponentsRequest::<E>::new(
+            blocks_req_id,
+            None,
+            true,
+            Some(payloads_req_id),
+            Span::none(),
+        );
 
         info.add_blocks(
             blocks_req_id,
@@ -726,7 +733,8 @@ mod tests {
             .collect::<Vec<Arc<SignedBeaconBlock<E>>>>();
 
         let blocks_req_id = blocks_id(components_id());
-        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, false, None);
+        let mut info =
+            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, false, None, Span::none());
 
         // Send blocks and complete terminate response
         info.add_blocks(blocks_req_id, blocks, PeerId::random())
@@ -754,8 +762,13 @@ mod tests {
         let components_id = components_id();
         let blocks_req_id = blocks_id(components_id);
         let blobs_req_id = blobs_id(components_id);
-        let mut info =
-            RangeBlockComponentsRequest::<E>::new(blocks_req_id, Some(blobs_req_id), false, None);
+        let mut info = RangeBlockComponentsRequest::<E>::new(
+            blocks_req_id,
+            Some(blobs_req_id),
+            false,
+            None,
+            Span::none(),
+        );
 
         // Send blocks and complete terminate response
         info.add_blocks(blocks_req_id, blocks, PeerId::random())
@@ -803,7 +816,8 @@ mod tests {
 
         let components_id = components_id();
         let blocks_req_id = blocks_id(components_id);
-        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
+        let mut info =
+            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None, Span::none());
         // Send blocks and complete terminate response
         info.add_blocks(
             blocks_req_id,

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -16,7 +16,7 @@ use parking_lot::RwLock;
 use ssz_types::RuntimeVariableList;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tracing::{debug, warn};
+use tracing::{Span, debug, warn};
 use types::{
     BlobSidecar, ChainSpec, ColumnIndex, DataColumnSidecar, DataColumnSidecarList, EthSpec,
     Hash256, SignedBeaconBlock, SignedExecutionPayloadEnvelope,
@@ -37,6 +37,7 @@ use crate::sync::network_context::{LookupRequestResult, PeerGroup, SyncNetworkCo
 /// them together and returns complete `RangeSyncBlock`s ready for processing.
 pub struct RangeBlockComponentsRequest<E: EthSpec> {
     /// Blocks we have received awaiting for their corresponding sidecar.
+    #[allow(clippy::type_complexity)]
     blocks_request:
         ByRangeRequest<BlocksByRangeRequestId, (Vec<Arc<SignedBeaconBlock<E>>>, PeerId)>,
     /// Sidecars we have received awaiting for their corresponding block.
@@ -48,6 +49,8 @@ pub struct RangeBlockComponentsRequest<E: EthSpec> {
             Vec<Arc<SignedExecutionPayloadEnvelope<E>>>,
         >,
     >,
+    /// Span to track the range request and all children range requests.
+    pub(crate) request_span: Span,
 }
 
 pub enum ByRangeRequest<I: PartialEq + std::fmt::Display, T> {
@@ -110,6 +113,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             blocks_request: ByRangeRequest::Active(blocks_req_id),
             block_data_request,
             payloads_request: payloads_req_id.map(ByRangeRequest::Active),
+            request_span: Span::none(),
         }
     }
 
@@ -190,7 +194,8 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         id: ComponentsByRangeRequestId,
         cx: &mut SyncNetworkContext<T>,
     ) -> Result<(), String> {
-        let Some((blocks, _)) = self.blocks_request.to_finished() else {
+        let _guard = self.request_span.clone().entered();
+        let Some((blocks, block_peer)) = self.blocks_request.to_finished() else {
             return Ok(());
         };
         let RangeBlockDataRequest::DataColumns(state @ DataColumnsRequest::NotStarted) =
@@ -220,7 +225,8 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             block_epoch,
             // ignore_cache: range blocks are historical and won't have gossip-imported columns
             true,
-            Arc::new(RwLock::new(HashSet::new())),
+            // The peer that provided the blocks is a signal that some peer has the block's data.
+            Arc::new(RwLock::new(HashSet::from([*block_peer]))),
         ) {
             Ok(LookupRequestResult::RequestSent(_)) => {
                 *state = DataColumnsRequest::Requesting;
@@ -251,6 +257,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
     /// Returns `None` if not all expected requests have completed.
     /// Returns `Some(Ok(_))` with valid RPC blocks if all data is present and valid.
     /// Returns `Some(Err(_))` if there are issues coupling blocks with their data.
+    #[allow(clippy::type_complexity)]
     pub fn responses<T>(
         &mut self,
         da_checker: Arc<DataAvailabilityChecker<T>>,
@@ -489,6 +496,7 @@ mod tests {
         generate_rand_block_and_data_columns, test_da_checker, test_spec,
     };
     use bls::Signature;
+    use lighthouse_network::PeerId;
     use lighthouse_network::service::api_types::{
         BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId,
         PayloadEnvelopesByRangeRequestId, RangeRequestId,
@@ -589,12 +597,13 @@ mod tests {
         let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, false, None);
 
         // Send blocks and complete terminate response
-        info.add_blocks(blocks_req_id, blocks).unwrap();
+        info.add_blocks(blocks_req_id, blocks, PeerId::random())
+            .unwrap();
 
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
 
         // Assert response is finished and blocks can be constructed
-        info.responses(da_checker, spec).unwrap().unwrap();
+        info.responses(da_checker, spec).unwrap().0.unwrap();
     }
 
     #[test]
@@ -617,7 +626,8 @@ mod tests {
             RangeBlockComponentsRequest::<E>::new(blocks_req_id, Some(blobs_req_id), false, None);
 
         // Send blocks and complete terminate response
-        info.add_blocks(blocks_req_id, blocks).unwrap();
+        info.add_blocks(blocks_req_id, blocks, PeerId::random())
+            .unwrap();
         // Expect no blobs returned
         info.add_blobs(blobs_req_id, vec![]).unwrap();
 
@@ -630,7 +640,7 @@ mod tests {
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
         // Blobs are no longer required for availability, so the response succeeds without them.
         let result = info.responses(da_checker, spec).unwrap();
-        assert!(result.is_ok())
+        assert!(result.0.is_ok())
     }
 
     #[test]
@@ -669,6 +679,7 @@ mod tests {
         info.add_blocks(
             blocks_req_id,
             blocks.iter().map(|(b, _)| b.clone()).collect(),
+            PeerId::random(),
         )
         .unwrap();
         // Assert response is not finished while custody-by-root is outstanding.
@@ -683,7 +694,7 @@ mod tests {
         complete_custody_by_root(&mut info, &blocks_and_columns, &expects_custody_columns);
 
         // All completed construct response
-        info.responses(da_checker, spec).unwrap().unwrap();
+        info.responses(da_checker, spec).unwrap().0.unwrap();
     }
 
     #[test]
@@ -729,7 +740,8 @@ mod tests {
         let blocks_req_id = blocks_id(components_id());
         let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
 
-        info.add_blocks(blocks_req_id, vec![block.into()]).unwrap();
+        info.add_blocks(blocks_req_id, vec![block.into()], PeerId::random())
+            .unwrap();
         info.set_custody_requesting();
 
         // Still requesting — responses should return None
@@ -774,6 +786,7 @@ mod tests {
         info.add_blocks(
             blocks_req_id,
             vec![block_with_data.into(), block_no_data.into()],
+            PeerId::random(),
         )
         .unwrap();
 
@@ -788,7 +801,7 @@ mod tests {
             .unwrap();
 
         // Both blocks should resolve — one with columns, one with NoData
-        info.responses(da_checker, spec).unwrap().unwrap();
+        info.responses(da_checker, spec).unwrap().0.unwrap();
     }
 
     #[test]
@@ -823,6 +836,7 @@ mod tests {
         info.add_blocks(
             blocks_req_id,
             blocks.iter().map(|b| b.0.clone().into()).collect(),
+            PeerId::random(),
         )
         .unwrap();
 
@@ -833,7 +847,7 @@ mod tests {
             .unwrap();
 
         // Response should be ready (no blocks need custody columns)
-        info.responses(da_checker, spec).unwrap().unwrap();
+        info.responses(da_checker, spec).unwrap().0.unwrap();
     }
 
     // ===== Gloas payload-envelope coupling tests =====
@@ -925,6 +939,7 @@ mod tests {
         info.add_blocks(
             blocks_req_id,
             blocks.iter().map(|(block, _, _)| block.clone()).collect(),
+            PeerId::random(),
         )
         .unwrap();
 
@@ -979,7 +994,7 @@ mod tests {
         )
         .unwrap();
 
-        let responses = info.responses(da_checker, spec).unwrap().unwrap();
+        let responses = info.responses(da_checker, spec).unwrap().0.unwrap();
         assert_eq!(responses.len(), blocks.len());
         for response in responses {
             match response {
@@ -1013,7 +1028,7 @@ mod tests {
         info.add_payload_envelopes(payloads_req_id, vec![blocks[0].2.clone()])
             .unwrap();
 
-        let responses = info.responses(da_checker, spec).unwrap().unwrap();
+        let responses = info.responses(da_checker, spec).unwrap().0.unwrap();
         let count_with = |with_envelope: bool| {
             responses
                 .iter()
@@ -1045,7 +1060,7 @@ mod tests {
         let result = info.responses(da_checker, spec).unwrap();
         assert!(
             matches!(
-                result,
+                result.0,
                 Err(super::CouplingError::EnvelopePeerFailure(ref error))
                     if error.contains("SlotMismatch")
             ),

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -9,19 +9,21 @@ use beacon_chain::{
 use lighthouse_network::{
     PeerId,
     service::api_types::{
-        BlobsByRangeRequestId, BlocksByRangeRequestId, DataColumnsByRangeRequestId,
-        PayloadEnvelopesByRangeRequestId,
+        BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId,
+        CustodyRequester, PayloadEnvelopesByRangeRequestId, RangeSyncCustodyId,
     },
 };
+use parking_lot::RwLock;
 use ssz_types::RuntimeVariableList;
-use std::{collections::HashMap, sync::Arc};
-use tracing::{Span, debug, warn};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tracing::{debug, warn};
 use types::{
     BlobSidecar, ChainSpec, ColumnIndex, DataColumnSidecar, DataColumnSidecarList, EthSpec,
     Hash256, SignedBeaconBlock, SignedExecutionPayloadEnvelope,
 };
 
-use crate::sync::network_context::MAX_COLUMN_RETRIES;
+use crate::sync::network_context::{LookupRequestResult, PeerGroup, SyncNetworkContext};
 
 /// Accumulates and couples beacon blocks with their associated data (blobs or data columns)
 /// from range sync network responses.
@@ -29,11 +31,11 @@ use crate::sync::network_context::MAX_COLUMN_RETRIES;
 /// This struct acts as temporary storage while multiple network responses arrive:
 /// - Blocks themselves (always required)
 /// - Blob sidecars (pre-Fulu fork)
-/// - Data columns (Fulu fork and later)
+/// - Data columns (Fulu fork and later, via custody-by-root)
+/// - Payload envelopes (Gloas fork and later)
 ///
 /// It accumulates responses until all expected components are received, then couples
-/// them together and returns complete `RpcBlock`s ready for processing. Handles validation
-/// and peer failure detection during the coupling process.
+/// them together and returns complete `RangeSyncBlock`s ready for processing.
 pub struct RangeBlockComponentsRequest<E: EthSpec> {
     /// Blocks we have received awaiting for their corresponding sidecar.
     blocks_request: ByRangeRequest<BlocksByRangeRequestId, Vec<Arc<SignedBeaconBlock<E>>>>,
@@ -46,8 +48,6 @@ pub struct RangeBlockComponentsRequest<E: EthSpec> {
             Vec<Arc<SignedExecutionPayloadEnvelope<E>>>,
         >,
     >,
-    /// Span to track the range request and all children range requests.
-    pub(crate) request_span: Span,
 }
 
 pub enum ByRangeRequest<I: PartialEq + std::fmt::Display, T> {
@@ -59,15 +59,18 @@ enum RangeBlockDataRequest<E: EthSpec> {
     NoData,
     Blobs(ByRangeRequest<BlobsByRangeRequestId, Vec<Arc<BlobSidecar<E>>>>),
     DataColumns {
-        requests: HashMap<
-            DataColumnsByRangeRequestId,
-            ByRangeRequest<DataColumnsByRangeRequestId, DataColumnSidecarList<E>>,
-        >,
-        /// The column indices corresponding to the request
-        column_peers: HashMap<DataColumnsByRangeRequestId, Vec<ColumnIndex>>,
+        /// Per-block-root custody-by-root state. Populated by `continue_requests` once blocks
+        /// arrive and completed by `add_custody_columns` as each custody-by-root request resolves.
+        custody_columns_by_root: HashMap<Hash256, DataColumnsState<E>>,
+        /// The custody columns we expect for each block with data in this batch.
         expected_custody_columns: Vec<ColumnIndex>,
-        attempt: usize,
     },
+}
+
+#[derive(Clone)]
+enum DataColumnsState<E: EthSpec> {
+    Requesting,
+    Complete(DataColumnSidecarList<E>, PeerGroup),
 }
 
 #[derive(Debug)]
@@ -77,7 +80,6 @@ pub enum CouplingError {
     DataColumnPeerFailure {
         error: String,
         faulty_peers: Vec<(ColumnIndex, PeerId)>,
-        exceeded_retries: bool,
     },
     BlobPeerFailure(String),
     EnvelopePeerFailure(String),
@@ -89,30 +91,20 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
     /// # Arguments
     /// * `blocks_req_id` - Request ID for the blocks
     /// * `blobs_req_id` - Optional request ID for blobs (pre-Fulu fork)
-    /// * `data_columns` - Optional tuple of (request_id->column_indices pairs, expected_custody_columns) for Fulu fork
-    #[allow(clippy::type_complexity)]
+    /// * `expects_custody_columns` - If Some, custody-by-root will be used after blocks arrive
+    /// * `payloads_req_id` - Optional request ID for payload envelopes (Gloas fork)
     pub fn new(
         blocks_req_id: BlocksByRangeRequestId,
         blobs_req_id: Option<BlobsByRangeRequestId>,
-        data_columns: Option<(
-            Vec<(DataColumnsByRangeRequestId, Vec<ColumnIndex>)>,
-            Vec<ColumnIndex>,
-        )>,
+        expects_custody_columns: Option<Vec<ColumnIndex>>,
         payloads_req_id: Option<PayloadEnvelopesByRangeRequestId>,
-        request_span: Span,
     ) -> Self {
         let block_data_request = if let Some(blobs_req_id) = blobs_req_id {
             RangeBlockDataRequest::Blobs(ByRangeRequest::Active(blobs_req_id))
-        } else if let Some((requests, expected_custody_columns)) = data_columns {
-            let column_peers: HashMap<_, _> = requests.into_iter().collect();
+        } else if let Some(expected_custody_columns) = expects_custody_columns {
             RangeBlockDataRequest::DataColumns {
-                requests: column_peers
-                    .keys()
-                    .map(|id| (*id, ByRangeRequest::Active(*id)))
-                    .collect(),
-                column_peers,
+                custody_columns_by_root: HashMap::new(),
                 expected_custody_columns,
-                attempt: 0,
             }
         } else {
             RangeBlockDataRequest::NoData
@@ -122,31 +114,12 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             blocks_request: ByRangeRequest::Active(blocks_req_id),
             block_data_request,
             payloads_request: payloads_req_id.map(ByRangeRequest::Active),
-            request_span,
         }
     }
 
-    /// Modifies `self` by inserting a new `DataColumnsByRangeRequestId` for a formerly failed
-    /// request for some columns.
-    pub fn reinsert_failed_column_requests(
-        &mut self,
-        failed_column_requests: Vec<(DataColumnsByRangeRequestId, Vec<u64>)>,
-    ) -> Result<(), String> {
-        match &mut self.block_data_request {
-            RangeBlockDataRequest::DataColumns {
-                requests,
-                expected_custody_columns: _,
-                column_peers,
-                attempt: _,
-            } => {
-                for (request, columns) in failed_column_requests.into_iter() {
-                    requests.insert(request, ByRangeRequest::Active(request));
-                    column_peers.insert(request, columns);
-                }
-                Ok(())
-            }
-            _ => Err("not a column request".to_string()),
-        }
+    /// Returns true if the blocks component of this request has been received.
+    pub fn blocks_received(&self) -> bool {
+        self.blocks_request.to_finished().is_some()
     }
 
     /// Adds received blocks to the request.
@@ -178,27 +151,34 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         }
     }
 
-    /// Adds received custody columns to the request.
+    /// Adds received custody columns for a specific block root.
     ///
-    /// Returns an error if this request expects blobs instead of data columns,
-    /// or if the request ID is unknown.
+    /// Returns an error if not in DataColumns mode, or if columns for this root
+    /// were already completed or never registered.
     pub fn add_custody_columns(
         &mut self,
-        req_id: DataColumnsByRangeRequestId,
-        columns: Vec<Arc<DataColumnSidecar<E>>>,
+        block_root: Hash256,
+        columns: DataColumnSidecarList<E>,
+        peer_group: PeerGroup,
     ) -> Result<(), String> {
-        match &mut self.block_data_request {
-            RangeBlockDataRequest::NoData => {
-                Err("received data columns but expected no data".to_owned())
-            }
-            RangeBlockDataRequest::Blobs(_) => {
-                Err("received data columns but expected blobs".to_owned())
-            }
-            RangeBlockDataRequest::DataColumns { requests, .. } => {
-                let req = requests
-                    .get_mut(&req_id)
-                    .ok_or(format!("unknown data columns by range req_id {req_id}"))?;
-                req.finish(req_id, columns)
+        let RangeBlockDataRequest::DataColumns {
+            custody_columns_by_root,
+            ..
+        } = &mut self.block_data_request
+        else {
+            return Err("received custody columns but not in DataColumns mode".to_owned());
+        };
+        match custody_columns_by_root.get(&block_root) {
+            Some(DataColumnsState::Complete(..)) => Err(format!(
+                "duplicate custody columns for block root {block_root:?}"
+            )),
+            None => Err(format!(
+                "received custody columns for unregistered block root {block_root:?}"
+            )),
+            Some(DataColumnsState::Requesting) => {
+                custody_columns_by_root
+                    .insert(block_root, DataColumnsState::Complete(columns, peer_group));
+                Ok(())
             }
         }
     }
@@ -211,6 +191,91 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         match &mut self.payloads_request {
             Some(req) => req.finish(req_id, envelopes),
             None => Err("received payload envelopes but none were expected".to_owned()),
+        }
+    }
+
+    /// After blocks arrive, initiates custody-by-root requests for blocks that need data columns.
+    ///
+    /// Only does work when blocks have arrived and we're in DataColumns mode. For each block
+    /// with data, inserts a `Requesting` entry and fires a custody request via the network context.
+    pub fn continue_requests<T: BeaconChainTypes<EthSpec = E>>(
+        &mut self,
+        id: ComponentsByRangeRequestId,
+        cx: &mut SyncNetworkContext<T>,
+    ) -> Result<(), String> {
+        let Some(blocks) = self.blocks_request.to_finished() else {
+            return Ok(());
+        };
+        let RangeBlockDataRequest::DataColumns {
+            custody_columns_by_root,
+            ..
+        } = &mut self.block_data_request
+        else {
+            return Ok(());
+        };
+
+        let mut errors = vec![];
+
+        for block in blocks {
+            if block.num_expected_blobs() == 0 {
+                continue;
+            }
+            let block_root = get_block_root(block);
+            if custody_columns_by_root.contains_key(&block_root) {
+                continue;
+            }
+
+            let requester = CustodyRequester::RangeSync(RangeSyncCustodyId { id, block_root });
+            match cx.custody_lookup_request(
+                requester,
+                block_root,
+                block.slot(),
+                // ignore_cache: range blocks are historical and won't have gossip-imported columns
+                true,
+                Arc::new(RwLock::new(HashSet::new())),
+            ) {
+                Ok(LookupRequestResult::RequestSent(_)) => {
+                    custody_columns_by_root.insert(block_root, DataColumnsState::Requesting);
+                    debug!(?block_root, %id, "Initiated custody-by-root for range block");
+                }
+                Ok(LookupRequestResult::NoRequestNeeded(reason, _)) => {
+                    // All columns already available (e.g. arrived via gossip). Mark as complete.
+                    debug!(?block_root, %id, %reason, "Custody-by-root not needed for range block");
+                    custody_columns_by_root.insert(
+                        block_root,
+                        DataColumnsState::Complete(vec![], PeerGroup::from_set(Default::default())),
+                    );
+                }
+                Ok(LookupRequestResult::Pending(reason)) => {
+                    errors.push(format!(
+                        "Custody request for {block_root:?} pending: {reason}"
+                    ));
+                }
+                Err(e) => {
+                    errors.push(format!(
+                        "Failed to initiate custody for {block_root:?}: {e:?}"
+                    ));
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.join("; "))
+        }
+    }
+
+    /// Registers a block root as awaiting custody columns. Used in tests to simulate
+    /// the effect of `continue_requests` without requiring a full network context.
+    #[cfg(test)]
+    pub fn register_custody_block(&mut self, block_root: Hash256) {
+        if let RangeBlockDataRequest::DataColumns {
+            custody_columns_by_root,
+            ..
+        } = &mut self.block_data_request
+        {
+            custody_columns_by_root.insert(block_root, DataColumnsState::Requesting);
         }
     }
 
@@ -236,8 +301,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             return None;
         }
 
-        // Increment the attempt once this function returns the response or errors
-        match &mut self.block_data_request {
+        match &self.block_data_request {
             RangeBlockDataRequest::NoData => Some(Self::responses_with_blobs(
                 blocks.to_vec(),
                 vec![],
@@ -256,30 +320,15 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                 ))
             }
             RangeBlockDataRequest::DataColumns {
-                requests,
+                custody_columns_by_root,
                 expected_custody_columns,
-                column_peers,
-                attempt,
             } => {
-                let mut data_columns = vec![];
-                let mut column_to_peer_id: HashMap<u64, PeerId> = HashMap::new();
-                for req in requests.values() {
-                    let Some(data) = req.to_finished() else {
-                        return None;
-                    };
-                    data_columns.extend(data.clone())
-                }
-
-                // An "attempt" is complete here after we have received a response for all the
-                // requests we made. i.e. `req.to_finished()` returns Some for all requests.
-                *attempt += 1;
-
-                // Note: this assumes that only 1 peer is responsible for a column
-                // with a batch.
-                for (id, columns) in column_peers {
-                    for column in columns {
-                        column_to_peer_id.insert(*column, id.peer);
-                    }
+                // Wait until every registered custody-by-root request has resolved.
+                if custody_columns_by_root
+                    .values()
+                    .any(|s| matches!(s, DataColumnsState::Requesting))
+                {
+                    return None;
                 }
 
                 let payload_envelopes = self.payloads_request.as_ref().and_then(|request| {
@@ -288,32 +337,14 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                         .map(|payload_envelopes| payload_envelopes.to_vec())
                 });
 
-                let resp = Self::responses_with_custody_columns(
+                Some(Self::responses_with_custody_columns(
                     blocks.to_vec(),
-                    data_columns,
-                    column_to_peer_id,
+                    custody_columns_by_root.clone(),
                     expected_custody_columns,
-                    *attempt,
                     da_checker,
                     spec,
                     payload_envelopes,
-                );
-
-                if let Err(CouplingError::DataColumnPeerFailure {
-                    error: _,
-                    faulty_peers,
-                    exceeded_retries: _,
-                }) = &resp
-                {
-                    for (_, peer) in faulty_peers.iter() {
-                        // find the req id associated with the peer and
-                        // delete it from the entries as we are going to make
-                        // a separate attempt for those components.
-                        requests.retain(|&k, _| k.peer != *peer);
-                    }
-                }
-
-                Some(resp)
+                ))
             }
         }
     }
@@ -390,10 +421,8 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
     #[allow(clippy::too_many_arguments)]
     fn responses_with_custody_columns<T>(
         blocks: Vec<Arc<SignedBeaconBlock<E>>>,
-        data_columns: DataColumnSidecarList<E>,
-        column_to_peer: HashMap<u64, PeerId>,
+        custody_columns_by_root: HashMap<Hash256, DataColumnsState<E>>,
         expects_custody_columns: &[ColumnIndex],
-        attempt: usize,
         da_checker: Arc<DataAvailabilityChecker<T>>,
         spec: Arc<ChainSpec>,
         payload_envelopes: Option<Vec<Arc<SignedExecutionPayloadEnvelope<E>>>>,
@@ -409,78 +438,45 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                 .collect::<HashMap<_, _>>()
         });
 
-        // Group data columns by block_root and index
-        let mut data_columns_by_block =
-            HashMap::<Hash256, HashMap<ColumnIndex, Arc<DataColumnSidecar<E>>>>::new();
-
-        for column in data_columns {
-            let block_root = column.block_root();
-            let index = *column.index();
-            if data_columns_by_block
-                .entry(block_root)
-                .or_default()
-                .insert(index, column)
-                .is_some()
-            {
-                // `DataColumnsByRangeRequestItems` ensures that we do not request any duplicated indices across all peers
-                // we request the data from.
-                // If there are duplicated indices, its likely a peer sending us the same index multiple times.
-                // However we can still proceed even if there are extra columns, just log an error.
-                debug!(?block_root, ?index, "Repeated column for block_root");
-                continue;
-            }
-        }
-
-        // Now iterate all blocks ensuring that the block roots of each block and data column match,
-        // plus we have columns for our custody requirements
+        let mut custody_columns_by_root = custody_columns_by_root;
         let mut range_sync_blocks = Vec::with_capacity(blocks.len());
 
-        let exceeded_retries = attempt >= MAX_COLUMN_RETRIES;
         for block in blocks {
             let block_root = get_block_root(&block);
             let custody_columns = if block.num_expected_blobs() > 0 {
-                let Some(mut data_columns_by_index) = data_columns_by_block.remove(&block_root)
+                let Some(DataColumnsState::Complete(data_columns, _peer_group)) =
+                    custody_columns_by_root.remove(&block_root)
                 else {
-                    let responsible_peers = column_to_peer.iter().map(|c| (*c.0, *c.1)).collect();
-                    return Err(CouplingError::DataColumnPeerFailure {
-                        error: format!("No columns for block {block_root:?} with data"),
-                        faulty_peers: responsible_peers,
-                        exceeded_retries,
-                    });
+                    return Err(CouplingError::InternalError(format!(
+                        "No columns for block {block_root:?} with data"
+                    )));
                 };
 
+                let mut data_columns_by_index =
+                    HashMap::<ColumnIndex, Arc<DataColumnSidecar<E>>>::new();
+                for column in data_columns {
+                    let index = *column.index();
+                    if data_columns_by_index.insert(index, column).is_some() {
+                        debug!(?block_root, ?index, "Repeated column for block_root");
+                    }
+                }
+
                 let mut custody_columns = vec![];
-                let mut naughty_peers = vec![];
                 for index in expects_custody_columns {
-                    // Safe to convert to `CustodyDataColumn`: we have asserted that the index of
-                    // this column is in the set of `expects_custody_columns` and with the expected
-                    // block root, so for the expected epoch of this batch.
+                    // Safe to convert to `CustodyDataColumn`: the custody-by-root request only
+                    // returns columns for the expected block root and custody indices.
                     if let Some(data_column) = data_columns_by_index.remove(index) {
                         custody_columns.push(CustodyDataColumn::from_asserted_custody(data_column));
                     } else {
-                        let Some(responsible_peer) = column_to_peer.get(index) else {
-                            return Err(CouplingError::InternalError(format!(
-                                "Internal error, no request made for column {}",
-                                index
-                            )));
-                        };
-                        naughty_peers.push((*index, *responsible_peer));
+                        return Err(CouplingError::InternalError(format!(
+                            "Missing custody column {index} for block {block_root:?}"
+                        )));
                     }
-                }
-                if !naughty_peers.is_empty() {
-                    return Err(CouplingError::DataColumnPeerFailure {
-                        error: format!(
-                            "Peers did not return column for block_root {block_root:?} {naughty_peers:?}"
-                        ),
-                        faulty_peers: naughty_peers,
-                        exceeded_retries,
-                    });
                 }
 
                 // Assert that there are no columns left
                 if !data_columns_by_index.is_empty() {
                     let remaining_indices = data_columns_by_index.keys().collect::<Vec<_>>();
-                    // log the error but don't return an error, we can still progress with extra columns.
                     debug!(
                         ?block_root,
                         ?remaining_indices,
@@ -495,6 +491,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             } else {
                 vec![]
             };
+
             let range_sync_block = if let Some(envelopes_by_block_root) =
                 envelopes_by_block_root.as_mut()
             {
@@ -516,10 +513,9 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         }
 
         // Assert that there are no columns left for other blocks
-        if !data_columns_by_block.is_empty() {
-            let remaining_roots = data_columns_by_block.keys().collect::<Vec<_>>();
+        if !custody_columns_by_root.is_empty() {
+            let remaining_roots = custody_columns_by_root.keys().collect::<Vec<_>>();
             // log the error but don't return an error, we can still progress with responses.
-            // this is most likely an internal error with overrequesting or a client bug.
             debug!(?remaining_roots, "Not all columns consumed for block");
         }
 
@@ -558,9 +554,8 @@ impl<I: PartialEq + std::fmt::Display, T> ByRangeRequest<I, T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::sync::network_context::MAX_COLUMN_RETRIES;
-
     use super::RangeBlockComponentsRequest;
+    use crate::sync::network_context::PeerGroup;
     use beacon_chain::block_verification_types::RangeSyncBlock;
     use beacon_chain::custody_context::NodeCustodyType;
     use beacon_chain::data_availability_checker::DataAvailabilityChecker;
@@ -569,19 +564,14 @@ mod tests {
         generate_rand_block_and_data_columns, test_da_checker, test_spec,
     };
     use bls::Signature;
-    use lighthouse_network::{
-        PeerId,
-        service::api_types::{
-            BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId,
-            DataColumnsByRangeRequestId, DataColumnsByRangeRequester, Id,
-            PayloadEnvelopesByRangeRequestId, RangeRequestId,
-        },
+    use lighthouse_network::service::api_types::{
+        BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId,
+        PayloadEnvelopesByRangeRequestId, RangeRequestId,
     };
-    use std::{collections::HashMap, sync::Arc};
-    use tracing::Span;
+    use std::sync::Arc;
     use types::{
-        ChainSpec, DataColumnSidecarList, Epoch, ExecutionPayloadEnvelope, ForkName,
-        MinimalEthSpec as E, SignedBeaconBlock, SignedExecutionPayloadEnvelope,
+        ChainSpec, ColumnIndex, DataColumnSidecarList, Epoch, ExecutionPayloadEnvelope, ForkName,
+        Hash256, MinimalEthSpec as E, SignedBeaconBlock, SignedExecutionPayloadEnvelope,
     };
 
     fn components_id() -> ComponentsByRangeRequestId {
@@ -592,15 +582,6 @@ mod tests {
                 batch_id: Epoch::new(0),
             },
         }
-    }
-
-    /// The custody-column coupling tests below build Fulu data-column sidecars directly, which is
-    /// incompatible with a Gloas genesis (Gloas columns have a different structure). Skip them when
-    /// `FORK_NAME` schedules Gloas at genesis. TODO(gloas): port the harness to build Gloas columns.
-    fn skip_under_gloas() -> bool {
-        test_spec::<E>()
-            .fork_name_at_epoch(Epoch::new(0))
-            .gloas_enabled()
     }
 
     fn blocks_id(parent_request_id: ComponentsByRangeRequestId) -> BlocksByRangeRequestId {
@@ -626,22 +607,406 @@ mod tests {
         }
     }
 
-    fn columns_id(
-        id: Id,
-        parent_request_id: DataColumnsByRangeRequester,
-    ) -> DataColumnsByRangeRequestId {
-        DataColumnsByRangeRequestId {
-            id,
-            parent_request_id,
-            peer: PeerId::random(),
+    /// The custody-column coupling tests below build Fulu data-column sidecars directly, which is
+    /// incompatible with a Gloas genesis (Gloas columns have a different structure). Skip them when
+    /// `FORK_NAME` schedules Gloas at genesis.
+    fn skip_under_gloas() -> bool {
+        test_spec::<E>()
+            .fork_name_at_epoch(Epoch::new(0))
+            .gloas_enabled()
+    }
+
+    /// Registers each data-bearing block root as awaiting custody, then completes its custody-by-root
+    /// request with the columns the node is expected to custody.
+    fn complete_custody_by_root(
+        info: &mut RangeBlockComponentsRequest<E>,
+        blocks_and_columns: &[(Arc<SignedBeaconBlock<E>>, DataColumnSidecarList<E>)],
+        expected_custody_columns: &[ColumnIndex],
+    ) {
+        for (block, _) in blocks_and_columns {
+            if block.num_expected_blobs() == 0 {
+                continue;
+            }
+            let block_root = beacon_chain::get_block_root(block);
+            info.register_custody_block(block_root);
+        }
+        for (block, data_columns) in blocks_and_columns {
+            if block.num_expected_blobs() == 0 {
+                continue;
+            }
+            let block_root = beacon_chain::get_block_root(block);
+            let custody_columns: DataColumnSidecarList<E> = data_columns
+                .iter()
+                .filter(|d| expected_custody_columns.contains(d.index()))
+                .cloned()
+                .collect();
+            info.add_custody_columns(
+                block_root,
+                custody_columns,
+                PeerGroup::from_set(Default::default()),
+            )
+            .unwrap();
         }
     }
 
-    fn is_finished(info: &mut RangeBlockComponentsRequest<E>) -> bool {
+    #[test]
+    fn no_blobs_into_responses() {
+        // This exercises the pre-Gloas blobs/no-data coupling path.
+        if skip_under_gloas() {
+            return;
+        }
         let spec = Arc::new(test_spec::<E>());
+
+        let mut u = types::test_utils::test_unstructured();
+        let blocks = (0..4)
+            .map(|_| {
+                generate_rand_block_and_blobs::<E>(
+                    spec.fork_name_at_epoch(Epoch::new(0)),
+                    NumBlobs::None,
+                    &mut u,
+                )
+                .unwrap()
+                .0
+                .into()
+            })
+            .collect::<Vec<Arc<SignedBeaconBlock<E>>>>();
+
+        let blocks_req_id = blocks_id(components_id());
+        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, None, None);
+
+        // Send blocks and complete terminate response
+        info.add_blocks(blocks_req_id, blocks).unwrap();
+
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        info.responses(da_checker, spec).is_some()
+
+        // Assert response is finished and blocks can be constructed
+        info.responses(da_checker, spec).unwrap().unwrap();
     }
+
+    #[test]
+    fn empty_blobs_into_responses() {
+        let mut u = types::test_utils::test_unstructured();
+        let blocks = (0..4)
+            .map(|_| {
+                // Always generate some blobs.
+                generate_rand_block_and_blobs::<E>(ForkName::Deneb, NumBlobs::Number(3), &mut u)
+                    .unwrap()
+                    .0
+                    .into()
+            })
+            .collect::<Vec<Arc<SignedBeaconBlock<E>>>>();
+
+        let components_id = components_id();
+        let blocks_req_id = blocks_id(components_id);
+        let blobs_req_id = blobs_id(components_id);
+        let mut info =
+            RangeBlockComponentsRequest::<E>::new(blocks_req_id, Some(blobs_req_id), None, None);
+
+        // Send blocks and complete terminate response
+        info.add_blocks(blocks_req_id, blocks).unwrap();
+        // Expect no blobs returned
+        info.add_blobs(blobs_req_id, vec![]).unwrap();
+
+        let mut spec = test_spec::<E>();
+        spec.deneb_fork_epoch = Some(Epoch::new(0));
+        // Pin to pre-PeerDAS so this exercises the blob (not custody-column) path under any
+        // FORK_NAME.
+        spec.fulu_fork_epoch = None;
+        let spec = Arc::new(spec);
+        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
+        // Blobs are no longer required for availability, so the response succeeds without them.
+        let result = info.responses(da_checker, spec).unwrap();
+        assert!(result.is_ok())
+    }
+
+    #[test]
+    fn rpc_block_with_custody_columns() {
+        if skip_under_gloas() {
+            return;
+        }
+        let mut spec = test_spec::<E>();
+        spec.deneb_fork_epoch = Some(Epoch::new(0));
+        spec.fulu_fork_epoch = Some(Epoch::new(0));
+        let spec = Arc::new(spec);
+        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
+        let expects_custody_columns = da_checker
+            .custody_context()
+            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .to_vec();
+        let mut u = types::test_utils::test_unstructured();
+        let blocks = (0..4)
+            .map(|_| {
+                generate_rand_block_and_data_columns::<E>(
+                    ForkName::Fulu,
+                    NumBlobs::Number(1),
+                    &mut u,
+                    &spec,
+                )
+                .unwrap()
+            })
+            .map(|(block, columns)| (Arc::new(block), columns))
+            .collect::<Vec<_>>();
+
+        let components_id = components_id();
+        let blocks_req_id = blocks_id(components_id);
+        let mut info = RangeBlockComponentsRequest::<E>::new(
+            blocks_req_id,
+            None,
+            Some(expects_custody_columns.clone()),
+            None,
+        );
+
+        // Send blocks
+        info.add_blocks(
+            blocks_req_id,
+            blocks.iter().map(|(b, _)| b.clone()).collect(),
+        )
+        .unwrap();
+        // Assert response is not finished while custody-by-root is outstanding.
+        for (block, _) in &blocks {
+            info.register_custody_block(beacon_chain::get_block_root(block));
+        }
+        assert!(info.responses(da_checker.clone(), spec.clone()).is_none());
+
+        // Complete each custody-by-root request.
+        for (block, data_columns) in &blocks {
+            let block_root = beacon_chain::get_block_root(block);
+            let custody_columns: DataColumnSidecarList<E> = data_columns
+                .iter()
+                .filter(|d| expects_custody_columns.contains(d.index()))
+                .cloned()
+                .collect();
+            info.add_custody_columns(
+                block_root,
+                custody_columns,
+                PeerGroup::from_set(Default::default()),
+            )
+            .unwrap();
+        }
+
+        // All completed construct response
+        info.responses(da_checker, spec).unwrap().unwrap();
+    }
+
+    #[test]
+    fn add_custody_columns_rejects_unregistered_root() {
+        let blocks_req_id = blocks_id(components_id());
+        let mut info =
+            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, Some(vec![0, 1]), None);
+        let root = Hash256::random();
+        let result =
+            info.add_custody_columns(root, vec![], PeerGroup::from_set(Default::default()));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("unregistered"));
+    }
+
+    #[test]
+    fn add_custody_columns_rejects_duplicate() {
+        let blocks_req_id = blocks_id(components_id());
+        let mut info =
+            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, Some(vec![0, 1]), None);
+        let root = Hash256::random();
+        info.register_custody_block(root);
+        info.add_custody_columns(root, vec![], PeerGroup::from_set(Default::default()))
+            .unwrap();
+        let result =
+            info.add_custody_columns(root, vec![], PeerGroup::from_set(Default::default()));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("duplicate"));
+    }
+
+    #[test]
+    fn responses_returns_none_while_custody_requesting() {
+        if skip_under_gloas() {
+            return;
+        }
+        let mut spec = test_spec::<E>();
+        spec.deneb_fork_epoch = Some(Epoch::new(0));
+        spec.fulu_fork_epoch = Some(Epoch::new(0));
+        let spec = Arc::new(spec);
+        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
+        let expects_custody_columns = da_checker
+            .custody_context()
+            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .to_vec();
+        let mut u = types::test_utils::test_unstructured();
+        let (block, _data_columns) = generate_rand_block_and_data_columns::<E>(
+            ForkName::Fulu,
+            NumBlobs::Number(1),
+            &mut u,
+            &spec,
+        )
+        .unwrap();
+
+        let blocks_req_id = blocks_id(components_id());
+        let mut info = RangeBlockComponentsRequest::<E>::new(
+            blocks_req_id,
+            None,
+            Some(expects_custody_columns),
+            None,
+        );
+
+        info.add_blocks(blocks_req_id, vec![block.into()]).unwrap();
+        let block_root = Hash256::random();
+        info.register_custody_block(block_root);
+
+        // Still requesting — responses should return None
+        assert!(info.responses(da_checker, spec).is_none());
+    }
+
+    #[test]
+    fn responses_error_on_missing_custody_columns() {
+        if skip_under_gloas() {
+            return;
+        }
+        // Block with data but no custody columns registered → error
+        let mut spec = test_spec::<E>();
+        spec.deneb_fork_epoch = Some(Epoch::new(0));
+        spec.fulu_fork_epoch = Some(Epoch::new(0));
+        let spec = Arc::new(spec);
+        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
+        let expects_custody_columns = da_checker
+            .custody_context()
+            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .to_vec();
+        let mut u = types::test_utils::test_unstructured();
+        let (block, _data_columns) = generate_rand_block_and_data_columns::<E>(
+            ForkName::Fulu,
+            NumBlobs::Number(1),
+            &mut u,
+            &spec,
+        )
+        .unwrap();
+
+        let blocks_req_id = blocks_id(components_id());
+        let mut info = RangeBlockComponentsRequest::<E>::new(
+            blocks_req_id,
+            None,
+            Some(expects_custody_columns),
+            None,
+        );
+
+        info.add_blocks(blocks_req_id, vec![block.into()]).unwrap();
+
+        // No custody columns registered or completed — block has data so this should error
+        let result = info.responses(da_checker, spec).unwrap();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn mixed_blocks_with_and_without_data() {
+        if skip_under_gloas() {
+            return;
+        }
+        // Mix of blocks: some with blobs (need custody), some without
+        let mut spec = test_spec::<E>();
+        spec.deneb_fork_epoch = Some(Epoch::new(0));
+        spec.fulu_fork_epoch = Some(Epoch::new(0));
+        let spec = Arc::new(spec);
+        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
+        let expects_custody_columns = da_checker
+            .custody_context()
+            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .to_vec();
+        let mut u = types::test_utils::test_unstructured();
+
+        let (block_with_data, data_columns) = generate_rand_block_and_data_columns::<E>(
+            ForkName::Fulu,
+            NumBlobs::Number(1),
+            &mut u,
+            &spec,
+        )
+        .unwrap();
+        let (block_no_data, _) = generate_rand_block_and_data_columns::<E>(
+            ForkName::Fulu,
+            NumBlobs::None,
+            &mut u,
+            &spec,
+        )
+        .unwrap();
+
+        let blocks_req_id = blocks_id(components_id());
+        let mut info = RangeBlockComponentsRequest::<E>::new(
+            blocks_req_id,
+            None,
+            Some(expects_custody_columns.clone()),
+            None,
+        );
+
+        let block_root_with_data = beacon_chain::get_block_root(&block_with_data);
+        info.add_blocks(
+            blocks_req_id,
+            vec![block_with_data.into(), block_no_data.into()],
+        )
+        .unwrap();
+
+        // Only register and complete custody for the block with data
+        info.register_custody_block(block_root_with_data);
+        let custody_columns: DataColumnSidecarList<E> = data_columns
+            .iter()
+            .filter(|d| expects_custody_columns.contains(d.index()))
+            .cloned()
+            .collect();
+        info.add_custody_columns(
+            block_root_with_data,
+            custody_columns,
+            PeerGroup::from_set(Default::default()),
+        )
+        .unwrap();
+
+        // Both blocks should resolve — one with columns, one with NoData
+        info.responses(da_checker, spec).unwrap().unwrap();
+    }
+
+    #[test]
+    fn rpc_block_with_custody_columns_no_data_blocks() {
+        if skip_under_gloas() {
+            return;
+        }
+        // Test blocks that don't have blob commitments don't need custody
+        let mut spec = test_spec::<E>();
+        spec.deneb_fork_epoch = Some(Epoch::new(0));
+        spec.fulu_fork_epoch = Some(Epoch::new(0));
+        let spec = Arc::new(spec);
+        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
+        let expects_custody_columns = da_checker
+            .custody_context()
+            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .to_vec();
+        let mut u = types::test_utils::test_unstructured();
+        // Generate blocks with NO blobs
+        let blocks = (0..4)
+            .map(|_| {
+                generate_rand_block_and_data_columns::<E>(
+                    ForkName::Fulu,
+                    NumBlobs::None,
+                    &mut u,
+                    &spec,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        let blocks_req_id = blocks_id(components_id());
+        let mut info = RangeBlockComponentsRequest::<E>::new(
+            blocks_req_id,
+            None,
+            Some(expects_custody_columns),
+            None,
+        );
+
+        // Send blocks
+        info.add_blocks(
+            blocks_req_id,
+            blocks.iter().map(|b| b.0.clone().into()).collect(),
+        )
+        .unwrap();
+
+        // Response should be ready immediately (no blocks need custody columns)
+        info.responses(da_checker, spec).unwrap().unwrap();
+    }
+
+    // ===== Gloas payload-envelope coupling tests =====
 
     fn gloas_spec() -> ChainSpec {
         let mut spec = test_spec::<E>();
@@ -697,35 +1062,6 @@ mod tests {
     }
 
     #[allow(clippy::type_complexity)]
-    fn add_all_columns(
-        info: &mut RangeBlockComponentsRequest<E>,
-        blocks: &[(
-            Arc<SignedBeaconBlock<E>>,
-            DataColumnSidecarList<E>,
-            Arc<SignedExecutionPayloadEnvelope<E>>,
-        )],
-        columns_req_id: &[(DataColumnsByRangeRequestId, Vec<u64>)],
-        expected_custody_columns: &[u64],
-    ) {
-        for (i, &column_index) in expected_custody_columns.iter().enumerate() {
-            let (req, _columns) = columns_req_id.get(i).unwrap();
-            info.add_custody_columns(
-                *req,
-                blocks
-                    .iter()
-                    .flat_map(|(_, columns, _)| {
-                        columns
-                            .iter()
-                            .filter(|column| *column.index() == column_index)
-                            .cloned()
-                    })
-                    .collect(),
-            )
-            .unwrap();
-        }
-    }
-
-    #[allow(clippy::type_complexity)]
     struct GloasSetup {
         info: RangeBlockComponentsRequest<E>,
         da_checker: Arc<DataAvailabilityChecker<EphemeralHarnessType<E>>>,
@@ -736,7 +1072,7 @@ mod tests {
             Arc<SignedExecutionPayloadEnvelope<E>>,
         )>,
         payloads_req_id: PayloadEnvelopesByRangeRequestId,
-        expected_custody_columns: Vec<u64>,
+        expected_custody_columns: Vec<ColumnIndex>,
     }
 
     /// Builds a Gloas coupling request with `count` blocks and all custody columns added,
@@ -753,25 +1089,11 @@ mod tests {
         let components_id = components_id();
         let blocks_req_id = blocks_id(components_id);
         let payloads_req_id = payloads_id(components_id);
-        let columns_req_id = expected_custody_columns
-            .iter()
-            .enumerate()
-            .map(|(i, column)| {
-                (
-                    columns_id(
-                        i as Id,
-                        DataColumnsByRangeRequester::ComponentsByRange(components_id),
-                    ),
-                    vec![*column],
-                )
-            })
-            .collect::<Vec<_>>();
         let mut info = RangeBlockComponentsRequest::<E>::new(
             blocks_req_id,
             None,
-            Some((columns_req_id.clone(), expected_custody_columns.clone())),
+            Some(expected_custody_columns.clone()),
             Some(payloads_req_id),
-            Span::none(),
         );
 
         info.add_blocks(
@@ -779,12 +1101,12 @@ mod tests {
             blocks.iter().map(|(block, _, _)| block.clone()).collect(),
         )
         .unwrap();
-        add_all_columns(
-            &mut info,
-            &blocks,
-            &columns_req_id,
-            &expected_custody_columns,
-        );
+
+        let blocks_and_columns = blocks
+            .iter()
+            .map(|(block, columns, _)| (block.clone(), columns.clone()))
+            .collect::<Vec<_>>();
+        complete_custody_by_root(&mut info, &blocks_and_columns, &expected_custody_columns);
 
         GloasSetup {
             info,
@@ -794,263 +1116,6 @@ mod tests {
             payloads_req_id,
             expected_custody_columns,
         }
-    }
-
-    #[test]
-    fn no_blobs_into_responses() {
-        // This exercises the pre-Gloas blobs/no-data coupling path. Gloas coupling is covered
-        // by the dedicated `setup_gloas_coupling` tests below.
-        if skip_under_gloas() {
-            return;
-        }
-        let spec = Arc::new(test_spec::<E>());
-
-        let mut u = types::test_utils::test_unstructured();
-        let blocks = (0..4)
-            .map(|_| {
-                generate_rand_block_and_blobs::<E>(
-                    spec.fork_name_at_epoch(Epoch::new(0)),
-                    NumBlobs::None,
-                    &mut u,
-                )
-                .unwrap()
-                .0
-                .into()
-            })
-            .collect::<Vec<Arc<SignedBeaconBlock<E>>>>();
-
-        let blocks_req_id = blocks_id(components_id());
-        let mut info =
-            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, None, None, Span::none());
-
-        // Send blocks and complete terminate response
-        info.add_blocks(blocks_req_id, blocks).unwrap();
-
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-
-        // Assert response is finished and RpcBlocks can be constructed
-        info.responses(da_checker, spec).unwrap().unwrap();
-    }
-
-    #[test]
-    fn empty_blobs_into_responses() {
-        let mut u = types::test_utils::test_unstructured();
-        let blocks = (0..4)
-            .map(|_| {
-                // Always generate some blobs.
-                generate_rand_block_and_blobs::<E>(ForkName::Deneb, NumBlobs::Number(3), &mut u)
-                    .unwrap()
-                    .0
-                    .into()
-            })
-            .collect::<Vec<Arc<SignedBeaconBlock<E>>>>();
-
-        let components_id = components_id();
-        let blocks_req_id = blocks_id(components_id);
-        let blobs_req_id = blobs_id(components_id);
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            Some(blobs_req_id),
-            None,
-            None,
-            Span::none(),
-        );
-
-        // Send blocks and complete terminate response
-        info.add_blocks(blocks_req_id, blocks).unwrap();
-        // Expect no blobs returned
-        info.add_blobs(blobs_req_id, vec![]).unwrap();
-
-        let mut spec = test_spec::<E>();
-        spec.deneb_fork_epoch = Some(Epoch::new(0));
-        // Pin to pre-PeerDAS so this exercises the blob (not custody-column) path under any
-        // FORK_NAME.
-        spec.fulu_fork_epoch = None;
-        let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        // Blobs are no longer required for availability, so the response succeeds without them.
-        let result = info.responses(da_checker, spec).unwrap();
-        assert!(result.is_ok())
-    }
-
-    #[test]
-    fn rpc_block_with_custody_columns() {
-        if skip_under_gloas() {
-            return;
-        }
-        let mut spec = test_spec::<E>();
-        spec.deneb_fork_epoch = Some(Epoch::new(0));
-        spec.fulu_fork_epoch = Some(Epoch::new(0));
-        let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expects_custody_columns = da_checker
-            .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
-            .to_vec();
-        let mut u = types::test_utils::test_unstructured();
-        let blocks = (0..4)
-            .map(|_| {
-                generate_rand_block_and_data_columns::<E>(
-                    ForkName::Fulu,
-                    NumBlobs::Number(1),
-                    &mut u,
-                    &spec,
-                )
-                .unwrap()
-            })
-            .collect::<Vec<_>>();
-
-        let components_id = components_id();
-        let blocks_req_id = blocks_id(components_id);
-        let columns_req_id = expects_custody_columns
-            .iter()
-            .enumerate()
-            .map(|(i, column)| {
-                (
-                    columns_id(
-                        i as Id,
-                        DataColumnsByRangeRequester::ComponentsByRange(components_id),
-                    ),
-                    vec![*column],
-                )
-            })
-            .collect::<Vec<_>>();
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            None,
-            Some((columns_req_id.clone(), expects_custody_columns.clone())),
-            None,
-            Span::none(),
-        );
-        // Send blocks and complete terminate response
-        info.add_blocks(
-            blocks_req_id,
-            blocks.iter().map(|b| b.0.clone().into()).collect(),
-        )
-        .unwrap();
-        // Assert response is not finished
-        assert!(!is_finished(&mut info));
-
-        // Send data columns
-        for (i, &column_index) in expects_custody_columns.iter().enumerate() {
-            let (req, _columns) = columns_req_id.get(i).unwrap();
-            info.add_custody_columns(
-                *req,
-                blocks
-                    .iter()
-                    .flat_map(|b| b.1.iter().filter(|d| *d.index() == column_index).cloned())
-                    .collect(),
-            )
-            .unwrap();
-
-            if i < expects_custody_columns.len() - 1 {
-                assert!(
-                    !is_finished(&mut info),
-                    "requested should not be finished at loop {i}"
-                );
-            }
-        }
-
-        // All completed construct response
-        info.responses(da_checker, spec).unwrap().unwrap();
-    }
-
-    #[test]
-    fn rpc_block_with_custody_columns_batched() {
-        if skip_under_gloas() {
-            return;
-        }
-        let mut spec = test_spec::<E>();
-        spec.deneb_fork_epoch = Some(Epoch::new(0));
-        spec.fulu_fork_epoch = Some(Epoch::new(0));
-        let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expected_sampling_columns = da_checker
-            .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
-            .to_vec();
-        // Split sampling columns into two batches
-        let mid = expected_sampling_columns.len() / 2;
-        let batched_column_requests = [
-            expected_sampling_columns[..mid].to_vec(),
-            expected_sampling_columns[mid..].to_vec(),
-        ];
-        let custody_column_request_ids =
-            (0..batched_column_requests.len() as u32).collect::<Vec<_>>();
-        let num_of_data_column_requests = custody_column_request_ids.len();
-
-        let components_id = components_id();
-        let blocks_req_id = blocks_id(components_id);
-        let columns_req_id = batched_column_requests
-            .iter()
-            .enumerate()
-            .map(|(i, columns)| {
-                (
-                    columns_id(
-                        i as Id,
-                        DataColumnsByRangeRequester::ComponentsByRange(components_id),
-                    ),
-                    columns.clone(),
-                )
-            })
-            .collect::<Vec<_>>();
-
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            None,
-            Some((columns_req_id.clone(), expected_sampling_columns.clone())),
-            None,
-            Span::none(),
-        );
-
-        let mut u = types::test_utils::test_unstructured();
-        let blocks = (0..4)
-            .map(|_| {
-                generate_rand_block_and_data_columns::<E>(
-                    ForkName::Fulu,
-                    NumBlobs::Number(1),
-                    &mut u,
-                    &spec,
-                )
-                .unwrap()
-            })
-            .collect::<Vec<_>>();
-
-        // Send blocks and complete terminate response
-        info.add_blocks(
-            blocks_req_id,
-            blocks.iter().map(|b| b.0.clone().into()).collect(),
-        )
-        .unwrap();
-        // Assert response is not finished
-        assert!(!is_finished(&mut info));
-
-        for (i, column_indices) in batched_column_requests.iter().enumerate() {
-            let (req, _columns) = columns_req_id.get(i).unwrap();
-            // Send the set of columns in the same batch request
-            info.add_custody_columns(
-                *req,
-                blocks
-                    .iter()
-                    .flat_map(|b| {
-                        b.1.iter()
-                            .filter(|d| column_indices.contains(d.index()))
-                            .cloned()
-                    })
-                    .collect::<Vec<_>>(),
-            )
-            .unwrap();
-
-            if i < num_of_data_column_requests - 1 {
-                assert!(
-                    !is_finished(&mut info),
-                    "requested should not be finished at loop {i}"
-                );
-            }
-        }
-
-        // All completed construct response
-        info.responses(da_checker, spec).unwrap().unwrap();
     }
 
     #[test]
@@ -1160,344 +1225,5 @@ mod tests {
             ),
             "expected envelope slot mismatch, got {result:?}"
         );
-    }
-
-    #[test]
-    fn missing_custody_columns_from_faulty_peers() {
-        if skip_under_gloas() {
-            return;
-        }
-        // GIVEN: A request expecting sampling columns from multiple peers
-        let spec = Arc::new(test_spec::<E>());
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expected_sampling_columns = da_checker
-            .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
-            .to_vec();
-        let mut u = types::test_utils::test_unstructured();
-        let blocks = (0..2)
-            .map(|_| {
-                generate_rand_block_and_data_columns::<E>(
-                    ForkName::Fulu,
-                    NumBlobs::Number(1),
-                    &mut u,
-                    &spec,
-                )
-                .unwrap()
-            })
-            .collect::<Vec<_>>();
-
-        let components_id = components_id();
-        let blocks_req_id = blocks_id(components_id);
-        let columns_req_id = expected_sampling_columns
-            .iter()
-            .enumerate()
-            .map(|(i, column)| {
-                (
-                    columns_id(
-                        i as Id,
-                        DataColumnsByRangeRequester::ComponentsByRange(components_id),
-                    ),
-                    vec![*column],
-                )
-            })
-            .collect::<Vec<_>>();
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            None,
-            Some((columns_req_id.clone(), expected_sampling_columns.clone())),
-            None,
-            Span::none(),
-        );
-
-        // AND: All blocks are received successfully
-        info.add_blocks(
-            blocks_req_id,
-            blocks.iter().map(|b| b.0.clone().into()).collect(),
-        )
-        .unwrap();
-
-        // AND: Only the first 2 sampling columns are received successfully
-        for (i, &column_index) in expected_sampling_columns.iter().take(2).enumerate() {
-            let (req, _columns) = columns_req_id.get(i).unwrap();
-            info.add_custody_columns(
-                *req,
-                blocks
-                    .iter()
-                    .flat_map(|b| b.1.iter().filter(|d| *d.index() == column_index).cloned())
-                    .collect(),
-            )
-            .unwrap();
-        }
-
-        // AND: Remaining column requests are completed with empty data (simulating faulty peers)
-        for i in 2..expected_sampling_columns.len() {
-            let (req, _columns) = columns_req_id.get(i).unwrap();
-            info.add_custody_columns(*req, vec![]).unwrap();
-        }
-
-        // WHEN: Attempting to construct RPC blocks
-        let result = info.responses(da_checker, spec).unwrap();
-
-        // THEN: Should fail with PeerFailure identifying the faulty peers
-        assert!(result.is_err());
-        if let Err(super::CouplingError::DataColumnPeerFailure {
-            error,
-            faulty_peers,
-            exceeded_retries,
-        }) = result
-        {
-            assert!(error.contains("Peers did not return column"));
-            // All columns after the first 2 should be reported as faulty
-            let expected_faulty_count = expected_sampling_columns.len() - 2;
-            assert_eq!(faulty_peers.len(), expected_faulty_count);
-            // Verify the faulty column indices match
-            for (i, (column_index, _peer)) in faulty_peers.iter().enumerate() {
-                assert_eq!(*column_index, expected_sampling_columns[i + 2]);
-            }
-            assert!(!exceeded_retries); // First attempt, should be false
-        } else {
-            panic!("Expected PeerFailure error");
-        }
-    }
-
-    #[test]
-    fn retry_logic_after_peer_failures() {
-        if skip_under_gloas() {
-            return;
-        }
-        // GIVEN: A request expecting sampling columns where some peers initially fail
-        let mut spec = test_spec::<E>();
-        spec.deneb_fork_epoch = Some(Epoch::new(0));
-        spec.fulu_fork_epoch = Some(Epoch::new(0));
-        let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expected_sampling_columns = da_checker
-            .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
-            .to_vec();
-        let mut u = types::test_utils::test_unstructured();
-        let blocks = (0..2)
-            .map(|_| {
-                generate_rand_block_and_data_columns::<E>(
-                    ForkName::Fulu,
-                    NumBlobs::Number(1),
-                    &mut u,
-                    &spec,
-                )
-                .unwrap()
-            })
-            .collect::<Vec<_>>();
-
-        let components_id = components_id();
-        let blocks_req_id = blocks_id(components_id);
-        let columns_req_id = expected_sampling_columns
-            .iter()
-            .enumerate()
-            .map(|(i, column)| {
-                (
-                    columns_id(
-                        i as Id,
-                        DataColumnsByRangeRequester::ComponentsByRange(components_id),
-                    ),
-                    vec![*column],
-                )
-            })
-            .collect::<Vec<_>>();
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            None,
-            Some((columns_req_id.clone(), expected_sampling_columns.clone())),
-            None,
-            Span::none(),
-        );
-
-        // AND: All blocks are received
-        info.add_blocks(
-            blocks_req_id,
-            blocks.iter().map(|b| b.0.clone().into()).collect(),
-        )
-        .unwrap();
-
-        // AND: Only partial sampling columns are received (first column but not others)
-        let (req0, _) = columns_req_id.first().unwrap();
-        info.add_custody_columns(
-            *req0,
-            blocks
-                .iter()
-                .flat_map(|b| {
-                    b.1.iter()
-                        .filter(|d| *d.index() == expected_sampling_columns[0])
-                        .cloned()
-                })
-                .collect(),
-        )
-        .unwrap();
-
-        // AND: The remaining column requests are completed with empty data (peer failure)
-        for i in 1..expected_sampling_columns.len() {
-            let (req, _) = columns_req_id.get(i).unwrap();
-            info.add_custody_columns(*req, vec![]).unwrap();
-        }
-
-        let result: Result<
-            Vec<beacon_chain::block_verification_types::RangeSyncBlock<E>>,
-            crate::sync::block_sidecar_coupling::CouplingError,
-        > = info.responses(da_checker.clone(), spec.clone()).unwrap();
-        assert!(result.is_err());
-
-        // AND: We retry with a new peer for the failed columns
-        let new_columns_req_id = columns_id(
-            10 as Id,
-            DataColumnsByRangeRequester::ComponentsByRange(components_id),
-        );
-        for column in &expected_sampling_columns[1..] {
-            let failed_column_requests = vec![(new_columns_req_id, vec![*column])];
-            info.reinsert_failed_column_requests(failed_column_requests)
-                .unwrap();
-        }
-
-        // AND: The new peer provides the missing column data
-        let failed_column_indices: Vec<_> = expected_sampling_columns[1..].to_vec();
-        info.add_custody_columns(
-            new_columns_req_id,
-            blocks
-                .iter()
-                .flat_map(|b| {
-                    b.1.iter()
-                        .filter(|d| failed_column_indices.contains(d.index()))
-                        .cloned()
-                })
-                .collect(),
-        )
-        .unwrap();
-
-        // WHEN: Attempting to get responses again
-        let result = info.responses(da_checker, spec).unwrap();
-
-        // THEN: Should succeed with complete RangeSync blocks
-        assert!(result.is_ok());
-        let range_sync_blocks = result.unwrap();
-        assert_eq!(range_sync_blocks.len(), 2);
-    }
-
-    #[test]
-    fn max_retries_exceeded_behavior() {
-        if skip_under_gloas() {
-            return;
-        }
-        // GIVEN: A request where peers consistently fail to provide required columns
-        let mut spec = test_spec::<E>();
-        spec.deneb_fork_epoch = Some(Epoch::new(0));
-        spec.fulu_fork_epoch = Some(Epoch::new(0));
-        let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expected_sampling_columns = da_checker
-            .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
-            .to_vec();
-        let mut u = types::test_utils::test_unstructured();
-        let blocks = (0..1)
-            .map(|_| {
-                generate_rand_block_and_data_columns::<E>(
-                    ForkName::Fulu,
-                    NumBlobs::Number(1),
-                    &mut u,
-                    &spec,
-                )
-                .unwrap()
-            })
-            .collect::<Vec<_>>();
-
-        let components_id = components_id();
-        let blocks_req_id = blocks_id(components_id);
-        let columns_req_id = expected_sampling_columns
-            .iter()
-            .enumerate()
-            .map(|(i, column)| {
-                (
-                    columns_id(
-                        i as Id,
-                        DataColumnsByRangeRequester::ComponentsByRange(components_id),
-                    ),
-                    vec![*column],
-                )
-            })
-            .collect::<Vec<_>>();
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            None,
-            Some((columns_req_id.clone(), expected_sampling_columns.clone())),
-            None,
-            Span::none(),
-        );
-
-        // AND: All blocks are received
-        info.add_blocks(
-            blocks_req_id,
-            blocks.iter().map(|b| b.0.clone().into()).collect(),
-        )
-        .unwrap();
-
-        // AND: Only the first sampling column is provided successfully
-        let (req0, _) = columns_req_id.first().unwrap();
-        info.add_custody_columns(
-            *req0,
-            blocks
-                .iter()
-                .flat_map(|b| {
-                    b.1.iter()
-                        .filter(|d| *d.index() == expected_sampling_columns[0])
-                        .cloned()
-                })
-                .collect(),
-        )
-        .unwrap();
-
-        // AND: All other column requests complete with empty data (persistent peer failure)
-        for i in 1..expected_sampling_columns.len() {
-            let (req, _) = columns_req_id.get(i).unwrap();
-            info.add_custody_columns(*req, vec![]).unwrap();
-        }
-
-        // WHEN: Multiple retry attempts are made (up to max retries)
-        for _ in 0..MAX_COLUMN_RETRIES {
-            let result = info.responses(da_checker.clone(), spec.clone()).unwrap();
-            assert!(result.is_err());
-
-            if let Err(super::CouplingError::DataColumnPeerFailure {
-                exceeded_retries, ..
-            }) = &result
-                && *exceeded_retries
-            {
-                break;
-            }
-        }
-
-        // AND: One final attempt after exceeding max retries
-        let result = info.responses(da_checker, spec).unwrap();
-
-        // THEN: Should fail with exceeded_retries = true
-        assert!(result.is_err());
-        if let Err(super::CouplingError::DataColumnPeerFailure {
-            error: _,
-            faulty_peers,
-            exceeded_retries,
-        }) = result
-        {
-            // All columns except the first one should be faulty
-            let expected_faulty_count = expected_sampling_columns.len() - 1;
-            assert_eq!(faulty_peers.len(), expected_faulty_count);
-
-            let mut faulty_peers = faulty_peers.into_iter().collect::<HashMap<u64, PeerId>>();
-            // Only the columns that failed (indices 1..N) should be in faulty_peers
-            for column in &expected_sampling_columns[1..] {
-                faulty_peers.remove(column);
-            }
-            assert!(faulty_peers.is_empty());
-            assert!(exceeded_retries); // Should be true after max retries
-        } else {
-            panic!("Expected PeerFailure error with exceeded_retries=true");
-        }
     }
 }

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -3,14 +3,13 @@ use beacon_chain::{
     BeaconChainTypes,
     block_verification_types::{AvailableBlockData, RangeSyncBlock},
     data_availability_checker::DataAvailabilityChecker,
-    data_column_verification::CustodyDataColumn,
     get_block_root,
 };
 use lighthouse_network::{
     PeerId,
     service::api_types::{
         BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId,
-        CustodyRequester, PayloadEnvelopesByRangeRequestId, RangeSyncCustodyId,
+        CustodyRequester, PayloadEnvelopesByRangeRequestId,
     },
 };
 use parking_lot::RwLock;
@@ -58,18 +57,17 @@ pub enum ByRangeRequest<I: PartialEq + std::fmt::Display, T> {
 enum RangeBlockDataRequest<E: EthSpec> {
     NoData,
     Blobs(ByRangeRequest<BlobsByRangeRequestId, Vec<Arc<BlobSidecar<E>>>>),
-    DataColumns {
-        /// Per-block-root custody-by-root state. Populated by `continue_requests` once blocks
-        /// arrive and completed by `add_custody_columns` as each custody-by-root request resolves.
-        custody_columns_by_root: HashMap<Hash256, DataColumnsState<E>>,
-        /// The custody columns we expect for each block with data in this batch.
-        expected_custody_columns: Vec<ColumnIndex>,
-    },
+    /// A single custody-by-root request fetches the custody columns of every data-bearing block
+    /// in this batch.
+    DataColumns(DataColumnsRequest<E>),
 }
 
-#[derive(Clone)]
-enum DataColumnsState<E: EthSpec> {
+enum DataColumnsRequest<E: EthSpec> {
+    /// Blocks have not arrived yet, so no custody-by-root request has been initiated.
+    NotStarted,
+    /// A custody-by-root request is in flight for the batch's data blocks.
     Requesting,
+    /// All custody columns for the batch have been downloaded.
     Complete(DataColumnSidecarList<E>, PeerGroup),
 }
 
@@ -91,21 +89,18 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
     /// # Arguments
     /// * `blocks_req_id` - Request ID for the blocks
     /// * `blobs_req_id` - Optional request ID for blobs (pre-Fulu fork)
-    /// * `expects_custody_columns` - If Some, custody-by-root will be used after blocks arrive
+    /// * `expects_custody_columns` - If true, custody-by-root will be used after blocks arrive
     /// * `payloads_req_id` - Optional request ID for payload envelopes (Gloas fork)
     pub fn new(
         blocks_req_id: BlocksByRangeRequestId,
         blobs_req_id: Option<BlobsByRangeRequestId>,
-        expects_custody_columns: Option<Vec<ColumnIndex>>,
+        expects_custody_columns: bool,
         payloads_req_id: Option<PayloadEnvelopesByRangeRequestId>,
     ) -> Self {
         let block_data_request = if let Some(blobs_req_id) = blobs_req_id {
             RangeBlockDataRequest::Blobs(ByRangeRequest::Active(blobs_req_id))
-        } else if let Some(expected_custody_columns) = expects_custody_columns {
-            RangeBlockDataRequest::DataColumns {
-                custody_columns_by_root: HashMap::new(),
-                expected_custody_columns,
-            }
+        } else if expects_custody_columns {
+            RangeBlockDataRequest::DataColumns(DataColumnsRequest::NotStarted)
         } else {
             RangeBlockDataRequest::NoData
         };
@@ -151,34 +146,28 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         }
     }
 
-    /// Adds received custody columns for a specific block root.
+    /// Adds the custody columns downloaded for the whole batch via custody-by-root.
     ///
-    /// Returns an error if not in DataColumns mode, or if columns for this root
-    /// were already completed or never registered.
+    /// Returns an error if not in DataColumns mode, or if the request was already completed or
+    /// was never initiated.
     pub fn add_custody_columns(
         &mut self,
-        block_root: Hash256,
         columns: DataColumnSidecarList<E>,
         peer_group: PeerGroup,
     ) -> Result<(), String> {
-        let RangeBlockDataRequest::DataColumns {
-            custody_columns_by_root,
-            ..
-        } = &mut self.block_data_request
-        else {
+        let RangeBlockDataRequest::DataColumns(state) = &mut self.block_data_request else {
             return Err("received custody columns but not in DataColumns mode".to_owned());
         };
-        match custody_columns_by_root.get(&block_root) {
-            Some(DataColumnsState::Complete(..)) => Err(format!(
-                "duplicate custody columns for block root {block_root:?}"
-            )),
-            None => Err(format!(
-                "received custody columns for unregistered block root {block_root:?}"
-            )),
-            Some(DataColumnsState::Requesting) => {
-                custody_columns_by_root
-                    .insert(block_root, DataColumnsState::Complete(columns, peer_group));
+        match state {
+            DataColumnsRequest::Requesting => {
+                *state = DataColumnsRequest::Complete(columns, peer_group);
                 Ok(())
+            }
+            DataColumnsRequest::Complete(..) => {
+                Err("duplicate custody columns for batch".to_owned())
+            }
+            DataColumnsRequest::NotStarted => {
+                Err("received custody columns before request was initiated".to_owned())
             }
         }
     }
@@ -194,10 +183,11 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         }
     }
 
-    /// After blocks arrive, initiates custody-by-root requests for blocks that need data columns.
+    /// After blocks arrive, initiates a single custody-by-root request for all data-bearing blocks
+    /// in the batch.
     ///
-    /// Only does work when blocks have arrived and we're in DataColumns mode. For each block
-    /// with data, inserts a `Requesting` entry and fires a custody request via the network context.
+    /// Only does work when blocks have arrived and we're in DataColumns mode and haven't started
+    /// yet. Fires one custody request covering every block with data via the network context.
     pub fn continue_requests<T: BeaconChainTypes<EthSpec = E>>(
         &mut self,
         id: ComponentsByRangeRequestId,
@@ -206,76 +196,56 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         let Some(blocks) = self.blocks_request.to_finished() else {
             return Ok(());
         };
-        let RangeBlockDataRequest::DataColumns {
-            custody_columns_by_root,
-            ..
-        } = &mut self.block_data_request
+        let RangeBlockDataRequest::DataColumns(state @ DataColumnsRequest::NotStarted) =
+            &mut self.block_data_request
         else {
             return Ok(());
         };
 
-        let mut errors = vec![];
+        // Collect the data-bearing blocks that need custody columns.
+        let data_blocks = blocks
+            .iter()
+            .filter(|block| block.num_expected_blobs() > 0)
+            .map(|block| (get_block_root(block), block.slot()))
+            .collect::<Vec<_>>();
 
-        for block in blocks {
-            if block.num_expected_blobs() == 0 {
-                continue;
-            }
-            let block_root = get_block_root(block);
-            if custody_columns_by_root.contains_key(&block_root) {
-                continue;
-            }
-
-            let requester = CustodyRequester::RangeSync(RangeSyncCustodyId { id, block_root });
-            match cx.custody_lookup_request(
-                requester,
-                block_root,
-                block.slot(),
-                // ignore_cache: range blocks are historical and won't have gossip-imported columns
-                true,
-                Arc::new(RwLock::new(HashSet::new())),
-            ) {
-                Ok(LookupRequestResult::RequestSent(_)) => {
-                    custody_columns_by_root.insert(block_root, DataColumnsState::Requesting);
-                    debug!(?block_root, %id, "Initiated custody-by-root for range block");
-                }
-                Ok(LookupRequestResult::NoRequestNeeded(reason, _)) => {
-                    // All columns already available (e.g. arrived via gossip). Mark as complete.
-                    debug!(?block_root, %id, %reason, "Custody-by-root not needed for range block");
-                    custody_columns_by_root.insert(
-                        block_root,
-                        DataColumnsState::Complete(vec![], PeerGroup::from_set(Default::default())),
-                    );
-                }
-                Ok(LookupRequestResult::Pending(reason)) => {
-                    errors.push(format!(
-                        "Custody request for {block_root:?} pending: {reason}"
-                    ));
-                }
-                Err(e) => {
-                    errors.push(format!(
-                        "Failed to initiate custody for {block_root:?}: {e:?}"
-                    ));
-                }
-            }
+        if data_blocks.is_empty() {
+            // No block in this batch has data; nothing to fetch.
+            *state = DataColumnsRequest::Complete(vec![], PeerGroup::from_set(Default::default()));
+            return Ok(());
         }
 
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors.join("; "))
+        match cx.custody_lookup_request(
+            CustodyRequester::RangeSync(id),
+            &data_blocks,
+            // ignore_cache: range blocks are historical and won't have gossip-imported columns
+            true,
+            Arc::new(RwLock::new(HashSet::new())),
+        ) {
+            Ok(LookupRequestResult::RequestSent(_)) => {
+                *state = DataColumnsRequest::Requesting;
+                debug!(%id, blocks = data_blocks.len(), "Initiated custody-by-root for range batch");
+                Ok(())
+            }
+            Ok(LookupRequestResult::NoRequestNeeded(..)) => {
+                // All columns already available (e.g. arrived via gossip).
+                *state =
+                    DataColumnsRequest::Complete(vec![], PeerGroup::from_set(Default::default()));
+                Ok(())
+            }
+            Ok(LookupRequestResult::Pending(reason)) => {
+                Err(format!("Custody request for batch {id} pending: {reason}"))
+            }
+            Err(e) => Err(format!("Failed to initiate custody for batch {id}: {e:?}")),
         }
     }
 
-    /// Registers a block root as awaiting custody columns. Used in tests to simulate
-    /// the effect of `continue_requests` without requiring a full network context.
+    /// Marks the custody-by-root request as in flight. Used in tests to simulate the effect of
+    /// `continue_requests` without requiring a full network context.
     #[cfg(test)]
-    pub fn register_custody_block(&mut self, block_root: Hash256) {
-        if let RangeBlockDataRequest::DataColumns {
-            custody_columns_by_root,
-            ..
-        } = &mut self.block_data_request
-        {
-            custody_columns_by_root.insert(block_root, DataColumnsState::Requesting);
+    pub fn set_custody_requesting(&mut self) {
+        if let RangeBlockDataRequest::DataColumns(state) = &mut self.block_data_request {
+            *state = DataColumnsRequest::Requesting;
         }
     }
 
@@ -319,17 +289,11 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                     spec,
                 ))
             }
-            RangeBlockDataRequest::DataColumns {
-                custody_columns_by_root,
-                expected_custody_columns,
-            } => {
-                // Wait until every registered custody-by-root request has resolved.
-                if custody_columns_by_root
-                    .values()
-                    .any(|s| matches!(s, DataColumnsState::Requesting))
-                {
+            RangeBlockDataRequest::DataColumns(state) => {
+                // Wait until the batch's custody-by-root request has resolved.
+                let DataColumnsRequest::Complete(columns, _peer_group) = state else {
                     return None;
-                }
+                };
 
                 let payload_envelopes = self.payloads_request.as_ref().and_then(|request| {
                     request
@@ -339,8 +303,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
 
                 Some(Self::responses_with_custody_columns(
                     blocks.to_vec(),
-                    custody_columns_by_root.clone(),
-                    expected_custody_columns,
+                    columns.clone(),
                     da_checker,
                     spec,
                     payload_envelopes,
@@ -418,11 +381,9 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         Ok(responses)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn responses_with_custody_columns<T>(
         blocks: Vec<Arc<SignedBeaconBlock<E>>>,
-        custody_columns_by_root: HashMap<Hash256, DataColumnsState<E>>,
-        expects_custody_columns: &[ColumnIndex],
+        columns: DataColumnSidecarList<E>,
         da_checker: Arc<DataAvailabilityChecker<T>>,
         spec: Arc<ChainSpec>,
         payload_envelopes: Option<Vec<Arc<SignedExecutionPayloadEnvelope<E>>>>,
@@ -438,56 +399,24 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                 .collect::<HashMap<_, _>>()
         });
 
-        let mut custody_columns_by_root = custody_columns_by_root;
+        // Group the downloaded custody columns by block root. The custody-by-root request only
+        // returns the requested custody columns, so we can couple them directly.
+        let mut columns_by_block_root = HashMap::<Hash256, Vec<Arc<DataColumnSidecar<E>>>>::new();
+        for column in columns {
+            columns_by_block_root
+                .entry(column.block_root())
+                .or_default()
+                .push(column);
+        }
+
         let mut range_sync_blocks = Vec::with_capacity(blocks.len());
 
         for block in blocks {
             let block_root = get_block_root(&block);
             let custody_columns = if block.num_expected_blobs() > 0 {
-                let Some(DataColumnsState::Complete(data_columns, _peer_group)) =
-                    custody_columns_by_root.remove(&block_root)
-                else {
-                    return Err(CouplingError::InternalError(format!(
-                        "No columns for block {block_root:?} with data"
-                    )));
-                };
-
-                let mut data_columns_by_index =
-                    HashMap::<ColumnIndex, Arc<DataColumnSidecar<E>>>::new();
-                for column in data_columns {
-                    let index = *column.index();
-                    if data_columns_by_index.insert(index, column).is_some() {
-                        debug!(?block_root, ?index, "Repeated column for block_root");
-                    }
-                }
-
-                let mut custody_columns = vec![];
-                for index in expects_custody_columns {
-                    // Safe to convert to `CustodyDataColumn`: the custody-by-root request only
-                    // returns columns for the expected block root and custody indices.
-                    if let Some(data_column) = data_columns_by_index.remove(index) {
-                        custody_columns.push(CustodyDataColumn::from_asserted_custody(data_column));
-                    } else {
-                        return Err(CouplingError::InternalError(format!(
-                            "Missing custody column {index} for block {block_root:?}"
-                        )));
-                    }
-                }
-
-                // Assert that there are no columns left
-                if !data_columns_by_index.is_empty() {
-                    let remaining_indices = data_columns_by_index.keys().collect::<Vec<_>>();
-                    debug!(
-                        ?block_root,
-                        ?remaining_indices,
-                        "Not all columns consumed for block"
-                    );
-                }
-
-                custody_columns
-                    .iter()
-                    .map(|c| c.as_data_column().clone())
-                    .collect::<Vec<_>>()
+                columns_by_block_root
+                    .remove(&block_root)
+                    .unwrap_or_default()
             } else {
                 vec![]
             };
@@ -513,8 +442,8 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         }
 
         // Assert that there are no columns left for other blocks
-        if !custody_columns_by_root.is_empty() {
-            let remaining_roots = custody_columns_by_root.keys().collect::<Vec<_>>();
+        if !columns_by_block_root.is_empty() {
+            let remaining_roots = columns_by_block_root.keys().collect::<Vec<_>>();
             // log the error but don't return an error, we can still progress with responses.
             debug!(?remaining_roots, "Not all columns consumed for block");
         }
@@ -571,7 +500,7 @@ mod tests {
     use std::sync::Arc;
     use types::{
         ChainSpec, ColumnIndex, DataColumnSidecarList, Epoch, ExecutionPayloadEnvelope, ForkName,
-        Hash256, MinimalEthSpec as E, SignedBeaconBlock, SignedExecutionPayloadEnvelope,
+        MinimalEthSpec as E, SignedBeaconBlock, SignedExecutionPayloadEnvelope,
     };
 
     fn components_id() -> ComponentsByRangeRequestId {
@@ -616,37 +545,26 @@ mod tests {
             .gloas_enabled()
     }
 
-    /// Registers each data-bearing block root as awaiting custody, then completes its custody-by-root
-    /// request with the columns the node is expected to custody.
+    /// Marks the batch's custody-by-root request as in flight, then completes it with the custody
+    /// columns of every data-bearing block (as a single response, as the network layer would).
     fn complete_custody_by_root(
         info: &mut RangeBlockComponentsRequest<E>,
         blocks_and_columns: &[(Arc<SignedBeaconBlock<E>>, DataColumnSidecarList<E>)],
         expected_custody_columns: &[ColumnIndex],
     ) {
-        for (block, _) in blocks_and_columns {
-            if block.num_expected_blobs() == 0 {
-                continue;
-            }
-            let block_root = beacon_chain::get_block_root(block);
-            info.register_custody_block(block_root);
-        }
-        for (block, data_columns) in blocks_and_columns {
-            if block.num_expected_blobs() == 0 {
-                continue;
-            }
-            let block_root = beacon_chain::get_block_root(block);
-            let custody_columns: DataColumnSidecarList<E> = data_columns
-                .iter()
-                .filter(|d| expected_custody_columns.contains(d.index()))
-                .cloned()
-                .collect();
-            info.add_custody_columns(
-                block_root,
-                custody_columns,
-                PeerGroup::from_set(Default::default()),
-            )
+        info.set_custody_requesting();
+        let custody_columns: DataColumnSidecarList<E> = blocks_and_columns
+            .iter()
+            .filter(|(block, _)| block.num_expected_blobs() > 0)
+            .flat_map(|(_, data_columns)| {
+                data_columns
+                    .iter()
+                    .filter(|d| expected_custody_columns.contains(d.index()))
+                    .cloned()
+            })
+            .collect();
+        info.add_custody_columns(custody_columns, PeerGroup::from_set(Default::default()))
             .unwrap();
-        }
     }
 
     #[test]
@@ -672,7 +590,7 @@ mod tests {
             .collect::<Vec<Arc<SignedBeaconBlock<E>>>>();
 
         let blocks_req_id = blocks_id(components_id());
-        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, None, None);
+        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, false, None);
 
         // Send blocks and complete terminate response
         info.add_blocks(blocks_req_id, blocks).unwrap();
@@ -700,7 +618,7 @@ mod tests {
         let blocks_req_id = blocks_id(components_id);
         let blobs_req_id = blobs_id(components_id);
         let mut info =
-            RangeBlockComponentsRequest::<E>::new(blocks_req_id, Some(blobs_req_id), None, None);
+            RangeBlockComponentsRequest::<E>::new(blocks_req_id, Some(blobs_req_id), false, None);
 
         // Send blocks and complete terminate response
         info.add_blocks(blocks_req_id, blocks).unwrap();
@@ -749,12 +667,7 @@ mod tests {
 
         let components_id = components_id();
         let blocks_req_id = blocks_id(components_id);
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            None,
-            Some(expects_custody_columns.clone()),
-            None,
-        );
+        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
 
         // Send blocks
         info.add_blocks(
@@ -763,54 +676,37 @@ mod tests {
         )
         .unwrap();
         // Assert response is not finished while custody-by-root is outstanding.
-        for (block, _) in &blocks {
-            info.register_custody_block(beacon_chain::get_block_root(block));
-        }
+        info.set_custody_requesting();
         assert!(info.responses(da_checker.clone(), spec.clone()).is_none());
 
-        // Complete each custody-by-root request.
-        for (block, data_columns) in &blocks {
-            let block_root = beacon_chain::get_block_root(block);
-            let custody_columns: DataColumnSidecarList<E> = data_columns
-                .iter()
-                .filter(|d| expects_custody_columns.contains(d.index()))
-                .cloned()
-                .collect();
-            info.add_custody_columns(
-                block_root,
-                custody_columns,
-                PeerGroup::from_set(Default::default()),
-            )
-            .unwrap();
-        }
+        // Complete the batch's custody-by-root request with all custody columns.
+        let blocks_and_columns = blocks
+            .iter()
+            .map(|(block, columns)| (block.clone(), columns.clone()))
+            .collect::<Vec<_>>();
+        complete_custody_by_root(&mut info, &blocks_and_columns, &expects_custody_columns);
 
         // All completed construct response
         info.responses(da_checker, spec).unwrap().unwrap();
     }
 
     #[test]
-    fn add_custody_columns_rejects_unregistered_root() {
+    fn add_custody_columns_rejects_before_requesting() {
         let blocks_req_id = blocks_id(components_id());
-        let mut info =
-            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, Some(vec![0, 1]), None);
-        let root = Hash256::random();
-        let result =
-            info.add_custody_columns(root, vec![], PeerGroup::from_set(Default::default()));
+        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
+        let result = info.add_custody_columns(vec![], PeerGroup::from_set(Default::default()));
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("unregistered"));
+        assert!(result.unwrap_err().contains("before request was initiated"));
     }
 
     #[test]
     fn add_custody_columns_rejects_duplicate() {
         let blocks_req_id = blocks_id(components_id());
-        let mut info =
-            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, Some(vec![0, 1]), None);
-        let root = Hash256::random();
-        info.register_custody_block(root);
-        info.add_custody_columns(root, vec![], PeerGroup::from_set(Default::default()))
+        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
+        info.set_custody_requesting();
+        info.add_custody_columns(vec![], PeerGroup::from_set(Default::default()))
             .unwrap();
-        let result =
-            info.add_custody_columns(root, vec![], PeerGroup::from_set(Default::default()));
+        let result = info.add_custody_columns(vec![], PeerGroup::from_set(Default::default()));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("duplicate"));
     }
@@ -825,10 +721,6 @@ mod tests {
         spec.fulu_fork_epoch = Some(Epoch::new(0));
         let spec = Arc::new(spec);
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expects_custody_columns = da_checker
-            .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
-            .to_vec();
         let mut u = types::test_utils::test_unstructured();
         let (block, _data_columns) = generate_rand_block_and_data_columns::<E>(
             ForkName::Fulu,
@@ -839,58 +731,13 @@ mod tests {
         .unwrap();
 
         let blocks_req_id = blocks_id(components_id());
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            None,
-            Some(expects_custody_columns),
-            None,
-        );
+        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
 
         info.add_blocks(blocks_req_id, vec![block.into()]).unwrap();
-        let block_root = Hash256::random();
-        info.register_custody_block(block_root);
+        info.set_custody_requesting();
 
         // Still requesting — responses should return None
         assert!(info.responses(da_checker, spec).is_none());
-    }
-
-    #[test]
-    fn responses_error_on_missing_custody_columns() {
-        if skip_under_gloas() {
-            return;
-        }
-        // Block with data but no custody columns registered → error
-        let mut spec = test_spec::<E>();
-        spec.deneb_fork_epoch = Some(Epoch::new(0));
-        spec.fulu_fork_epoch = Some(Epoch::new(0));
-        let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expects_custody_columns = da_checker
-            .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
-            .to_vec();
-        let mut u = types::test_utils::test_unstructured();
-        let (block, _data_columns) = generate_rand_block_and_data_columns::<E>(
-            ForkName::Fulu,
-            NumBlobs::Number(1),
-            &mut u,
-            &spec,
-        )
-        .unwrap();
-
-        let blocks_req_id = blocks_id(components_id());
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            None,
-            Some(expects_custody_columns),
-            None,
-        );
-
-        info.add_blocks(blocks_req_id, vec![block.into()]).unwrap();
-
-        // No custody columns registered or completed — block has data so this should error
-        let result = info.responses(da_checker, spec).unwrap();
-        assert!(result.is_err());
     }
 
     #[test]
@@ -926,33 +773,23 @@ mod tests {
         .unwrap();
 
         let blocks_req_id = blocks_id(components_id());
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            None,
-            Some(expects_custody_columns.clone()),
-            None,
-        );
+        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
 
-        let block_root_with_data = beacon_chain::get_block_root(&block_with_data);
         info.add_blocks(
             blocks_req_id,
             vec![block_with_data.into(), block_no_data.into()],
         )
         .unwrap();
 
-        // Only register and complete custody for the block with data
-        info.register_custody_block(block_root_with_data);
+        // Complete the batch's custody-by-root request with columns for the data block only.
+        info.set_custody_requesting();
         let custody_columns: DataColumnSidecarList<E> = data_columns
             .iter()
             .filter(|d| expects_custody_columns.contains(d.index()))
             .cloned()
             .collect();
-        info.add_custody_columns(
-            block_root_with_data,
-            custody_columns,
-            PeerGroup::from_set(Default::default()),
-        )
-        .unwrap();
+        info.add_custody_columns(custody_columns, PeerGroup::from_set(Default::default()))
+            .unwrap();
 
         // Both blocks should resolve — one with columns, one with NoData
         info.responses(da_checker, spec).unwrap().unwrap();
@@ -969,10 +806,6 @@ mod tests {
         spec.fulu_fork_epoch = Some(Epoch::new(0));
         let spec = Arc::new(spec);
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expects_custody_columns = da_checker
-            .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
-            .to_vec();
         let mut u = types::test_utils::test_unstructured();
         // Generate blocks with NO blobs
         let blocks = (0..4)
@@ -988,12 +821,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let blocks_req_id = blocks_id(components_id());
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            None,
-            Some(expects_custody_columns),
-            None,
-        );
+        let mut info = RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, None);
 
         // Send blocks
         info.add_blocks(
@@ -1002,7 +830,13 @@ mod tests {
         )
         .unwrap();
 
-        // Response should be ready immediately (no blocks need custody columns)
+        // No block in the batch has data, so `continue_requests` completes the custody request
+        // with no columns. Simulate that resolved state.
+        info.set_custody_requesting();
+        info.add_custody_columns(vec![], PeerGroup::from_set(Default::default()))
+            .unwrap();
+
+        // Response should be ready (no blocks need custody columns)
         info.responses(da_checker, spec).unwrap().unwrap();
     }
 
@@ -1089,12 +923,8 @@ mod tests {
         let components_id = components_id();
         let blocks_req_id = blocks_id(components_id);
         let payloads_req_id = payloads_id(components_id);
-        let mut info = RangeBlockComponentsRequest::<E>::new(
-            blocks_req_id,
-            None,
-            Some(expected_custody_columns.clone()),
-            Some(payloads_req_id),
-        );
+        let mut info =
+            RangeBlockComponentsRequest::<E>::new(blocks_req_id, None, true, Some(payloads_req_id));
 
         info.add_blocks(
             blocks_req_id,

--- a/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
@@ -598,7 +598,6 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
                     && let CouplingError::DataColumnPeerFailure {
                         error,
                         faulty_peers,
-                        exceeded_retries: _,
                     } = coupling_error
                 {
                     let mut failed_peers = HashSet::new();
@@ -862,7 +861,7 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
                     // The batch is validated
                 }
                 BatchState::Poisoned => unreachable!("Poisoned batch"),
-                BatchState::Failed | BatchState::Processing(_) => {
+                BatchState::Failed | BatchState::Processing(..) => {
                     // these are all inconsistent states:
                     // - Failed -> non recoverable batch. Columns should have been removed
                     // - AwaitingDownload -> A recoverable failed batch should have been
@@ -912,7 +911,7 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
                     crit!("Batch indicates inconsistent data columns while advancing custody sync")
                 }
                 BatchState::AwaitingProcessing(..) => {}
-                BatchState::Processing(_) => {
+                BatchState::Processing(..) => {
                     debug!(batch = %id, %batch, "Advancing custody sync while processing a batch");
                     if let Some(processing_id) = self.current_processing_batch
                         && id >= processing_id

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -1236,7 +1236,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         {
             self.on_range_components_response(
                 id.parent_request_id,
-                peer_id,
+                Some(peer_id),
                 RangeBlockComponent::PayloadEnvelope(id, resp),
             );
         }
@@ -1274,7 +1274,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         if let Some(resp) = self.network.on_blocks_by_range_response(id, peer_id, block) {
             self.on_range_components_response(
                 id.parent_request_id,
-                peer_id,
+                Some(peer_id),
                 RangeBlockComponent::Block(id, resp),
             );
         }
@@ -1289,7 +1289,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         if let Some(resp) = self.network.on_blobs_by_range_response(id, peer_id, blob) {
             self.on_range_components_response(
                 id.parent_request_id,
-                peer_id,
+                Some(peer_id),
                 RangeBlockComponent::Blob(id, resp),
             );
         }
@@ -1305,22 +1305,9 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             .network
             .on_data_columns_by_range_response(id, peer_id, data_column)
         {
-            match id.parent_request_id {
-                DataColumnsByRangeRequester::ComponentsByRange(components_by_range_req_id) => {
-                    self.on_range_components_response(
-                        components_by_range_req_id,
-                        peer_id,
-                        RangeBlockComponent::CustodyColumns(id, resp),
-                    );
-                }
-                DataColumnsByRangeRequester::CustodyBackfillSync(custody_backfill_req_id) => self
-                    .on_custody_backfill_columns_response(
-                        custody_backfill_req_id,
-                        id,
-                        peer_id,
-                        resp,
-                    ),
-            }
+            let DataColumnsByRangeRequester::CustodyBackfillSync(custody_backfill_req_id) =
+                id.parent_request_id;
+            self.on_custody_backfill_columns_response(custody_backfill_req_id, id, peer_id, resp);
         }
     }
 
@@ -1329,8 +1316,27 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         requester: CustodyRequester,
         response: CustodyByRootResult<T::EthSpec>,
     ) {
-        self.block_lookups
-            .on_custody_download_response(requester.0, response, &mut self.network);
+        match requester {
+            CustodyRequester::SingleLookup(id) => {
+                self.block_lookups
+                    .on_custody_download_response(id, response, &mut self.network);
+            }
+            CustodyRequester::RangeSync(range_id) => {
+                // Route custody-by-root results through the standard range components
+                // response path, reusing the same dispatch to range_sync / backfill.
+                let peer_group = response
+                    .as_ref()
+                    .ok()
+                    .map(|dl| dl.peer_group.clone())
+                    .unwrap_or_else(|| PeerGroup::from_set(Default::default()));
+                let peer_id = peer_group.all().next().copied();
+                self.on_range_components_response(
+                    range_id.id,
+                    peer_id,
+                    RangeBlockComponent::CustodyResult(range_id.block_root, response, peer_group),
+                );
+            }
+        }
     }
 
     /// Handles receiving a response for a range sync request that should have both blocks and
@@ -1338,15 +1344,19 @@ impl<T: BeaconChainTypes> SyncManager<T> {
     fn on_range_components_response(
         &mut self,
         range_request_id: ComponentsByRangeRequestId,
-        peer_id: PeerId,
+        peer_id: Option<PeerId>,
         range_block_component: RangeBlockComponent<T::EthSpec>,
     ) {
+        let is_block_response = matches!(range_block_component, RangeBlockComponent::Block(..));
+
         if let Some(resp) = self
             .network
             .range_block_component_response(range_request_id, range_block_component)
         {
             match resp {
                 Ok(blocks) => {
+                    // Success path: peer_id should always be available
+                    let peer_id = peer_id.unwrap_or(PeerId::random());
                     match range_request_id.requester {
                         RangeRequestId::RangeSync { chain_id, batch_id } => {
                             self.range_sync.blocks_by_range_response(
@@ -1394,7 +1404,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         match self.backfill_sync.inject_error(
                             &mut self.network,
                             batch_id,
-                            &peer_id,
+                            peer_id.as_ref(),
                             range_request_id.id,
                             e,
                         ) {
@@ -1403,6 +1413,13 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         }
                     }
                 },
+            }
+        } else if is_block_response {
+            // Blocks arrived but columns are still pending. Notify the chain so it can
+            // start downloading the next batch (the block download gate is now lifted).
+            if let RangeRequestId::RangeSync { chain_id, .. } = range_request_id.requester {
+                self.range_sync
+                    .trigger_batch_downloads(&mut self.network, chain_id);
             }
         }
     }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -1347,8 +1347,6 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         peer_id: Option<PeerId>,
         range_block_component: RangeBlockComponent<T::EthSpec>,
     ) {
-        let is_block_response = matches!(range_block_component, RangeBlockComponent::Block(..));
-
         if let Some(resp) = self
             .network
             .range_block_component_response(range_request_id, range_block_component)
@@ -1413,13 +1411,6 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         }
                     }
                 },
-            }
-        } else if is_block_response {
-            // Blocks arrived but columns are still pending. Notify the chain so it can
-            // start downloading the next batch (the block download gate is now lifted).
-            if let RangeRequestId::RangeSync { chain_id, .. } = range_request_id.requester {
-                self.range_sync
-                    .trigger_batch_downloads(&mut self.network, chain_id);
             }
         }
     }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -1236,7 +1236,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         {
             self.on_range_components_response(
                 id.parent_request_id,
-                Some(peer_id),
+                peer_id,
                 RangeBlockComponent::PayloadEnvelope(id, resp),
             );
         }
@@ -1274,8 +1274,8 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         if let Some(resp) = self.network.on_blocks_by_range_response(id, peer_id, block) {
             self.on_range_components_response(
                 id.parent_request_id,
-                Some(peer_id),
-                RangeBlockComponent::Block(id, resp),
+                peer_id,
+                RangeBlockComponent::Block(id, resp, peer_id),
             );
         }
     }
@@ -1289,7 +1289,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         if let Some(resp) = self.network.on_blobs_by_range_response(id, peer_id, blob) {
             self.on_range_components_response(
                 id.parent_request_id,
-                Some(peer_id),
+                peer_id,
                 RangeBlockComponent::Blob(id, resp),
             );
         }
@@ -1329,10 +1329,10 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     .ok()
                     .map(|dl| dl.peer_group.clone())
                     .unwrap_or_else(|| PeerGroup::from_set(Default::default()));
-                let peer_id = peer_group.all().next().copied();
                 self.on_range_components_response(
                     components_by_range_id,
-                    peer_id,
+                    // Peer attributability is broken in range sync :)
+                    PeerId::random(),
                     RangeBlockComponent::CustodyResult(response, peer_group),
                 );
             }
@@ -1344,14 +1344,13 @@ impl<T: BeaconChainTypes> SyncManager<T> {
     fn on_range_components_response(
         &mut self,
         range_request_id: ComponentsByRangeRequestId,
-        peer_id: Option<PeerId>,
+        peer_id: PeerId,
         range_block_component: RangeBlockComponent<T::EthSpec>,
     ) {
-        if let Some(resp) = self.network.range_block_component_response(
-            range_request_id,
-            peer_id,
-            range_block_component,
-        ) {
+        if let Some(resp) = self
+            .network
+            .range_block_component_response(range_request_id, range_block_component)
+        {
             match resp {
                 // On success the batch is attributed to the peer that provided its blocks.
                 Ok((peer_id, blocks)) => {
@@ -1390,7 +1389,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     RangeRequestId::RangeSync { chain_id, batch_id } => {
                         self.range_sync.inject_error(
                             &mut self.network,
-                            peer_id,
+                            Some(peer_id),
                             batch_id,
                             chain_id,
                             range_request_id.id,
@@ -1402,7 +1401,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         match self.backfill_sync.inject_error(
                             &mut self.network,
                             batch_id,
-                            peer_id.as_ref(),
+                            &peer_id,
                             range_request_id.id,
                             e,
                         ) {

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -1347,14 +1347,14 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         peer_id: Option<PeerId>,
         range_block_component: RangeBlockComponent<T::EthSpec>,
     ) {
-        if let Some(resp) = self
-            .network
-            .range_block_component_response(range_request_id, range_block_component)
-        {
+        if let Some(resp) = self.network.range_block_component_response(
+            range_request_id,
+            peer_id,
+            range_block_component,
+        ) {
             match resp {
-                Ok(blocks) => {
-                    // Success path: peer_id should always be available
-                    let peer_id = peer_id.unwrap_or(PeerId::random());
+                // On success the batch is attributed to the peer that provided its blocks.
+                Ok((peer_id, blocks)) => {
                     match range_request_id.requester {
                         RangeRequestId::RangeSync { chain_id, batch_id } => {
                             self.range_sync.blocks_by_range_response(

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -1321,7 +1321,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 self.block_lookups
                     .on_custody_download_response(id, response, &mut self.network);
             }
-            CustodyRequester::RangeSync(range_id) => {
+            CustodyRequester::RangeSync(components_by_range_id) => {
                 // Route custody-by-root results through the standard range components
                 // response path, reusing the same dispatch to range_sync / backfill.
                 let peer_group = response
@@ -1331,9 +1331,9 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     .unwrap_or_else(|| PeerGroup::from_set(Default::default()));
                 let peer_id = peer_group.all().next().copied();
                 self.on_range_components_response(
-                    range_id.id,
+                    components_by_range_id,
                     peer_id,
-                    RangeBlockComponent::CustodyResult(range_id.block_root, response, peer_group),
+                    RangeBlockComponent::CustodyResult(response, peer_group),
                 );
             }
         }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -589,17 +589,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         Ok(id.id)
     }
 
-    /// Returns true if there is a pending range sync request for the given chain where
-    /// blocks have not yet been received. Used to serialize block downloads for PeerDAS.
-    pub fn has_pending_block_range_download(&self, chain_id: Id) -> bool {
-        self.components_by_range_requests.iter().any(|(id, req)| {
-            matches!(
-                id.requester,
-                RangeRequestId::RangeSync { chain_id: cid, .. } if cid == chain_id
-            ) && !req.blocks_received()
-        })
-    }
-
     fn select_columns_by_range_peers_to_request(
         &self,
         custody_indexes: &HashSet<ColumnIndex>,

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -75,9 +75,6 @@ macro_rules! new_range_request_span {
     }};
 }
 
-/// Max retries for block components after which we fail the batch.
-pub const MAX_COLUMN_RETRIES: usize = 3;
-
 #[derive(Debug)]
 pub enum RpcEvent<T> {
     StreamTermination,
@@ -258,10 +255,9 @@ pub enum RangeBlockComponent<E: EthSpec> {
         BlobsByRangeRequestId,
         RpcResponseResult<Vec<Arc<BlobSidecar<E>>>>,
     ),
-    CustodyColumns(
-        DataColumnsByRangeRequestId,
-        RpcResponseResult<Vec<Arc<DataColumnSidecar<E>>>>,
-    ),
+    /// Custody-by-root result for a specific block root. Arrives after blocks and carries
+    /// the columns fetched via ActiveCustodyRequest.
+    CustodyResult(Hash256, CustodyByRootResult<E>, PeerGroup),
     PayloadEnvelope(
         PayloadEnvelopesByRangeRequestId,
         RpcResponseResult<Vec<Arc<SignedExecutionPayloadEnvelope<E>>>>,
@@ -481,104 +477,21 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         active_request_count_by_peer
     }
 
-    /// Retries only the specified failed columns by requesting them again.
-    ///
-    /// Note: This function doesn't retry the whole batch, but retries specific requests within
-    /// the batch.
-    pub fn retry_columns_by_range(
-        &mut self,
-        id: Id,
-        peers: &HashSet<PeerId>,
-        peers_to_deprioritize: &HashSet<PeerId>,
-        request: BlocksByRangeRequest,
-        failed_columns: &HashSet<ColumnIndex>,
-    ) -> Result<(), String> {
-        let Some((requester, parent_request_span)) = self
-            .components_by_range_requests
-            .iter()
-            .find_map(|(key, value)| {
-                if key.id == id {
-                    Some((key.requester, value.request_span.clone()))
-                } else {
-                    None
-                }
-            })
-        else {
-            return Err("request id not present".to_string());
-        };
-
-        let active_request_count_by_peer = self.active_request_count_by_peer();
-
-        debug!(
-            ?failed_columns,
-            ?id,
-            ?requester,
-            "Retrying only failed column requests from other peers"
-        );
-
-        // Attempt to find all required custody peers to request the failed columns from
-        let columns_by_range_peers_to_request = self
-            .select_columns_by_range_peers_to_request(
-                failed_columns,
-                peers,
-                active_request_count_by_peer,
-                peers_to_deprioritize,
-            )
-            .map_err(|e| format!("{:?}", e))?;
-
-        // Reuse the id for the request that received partially correct responses
-        let id = ComponentsByRangeRequestId { id, requester };
-
-        let data_column_requests = columns_by_range_peers_to_request
-            .into_iter()
-            .map(|(peer_id, columns)| {
-                self.send_data_columns_by_range_request(
-                    peer_id,
-                    DataColumnsByRangeRequest {
-                        start_slot: *request.start_slot(),
-                        count: *request.count(),
-                        columns,
-                    },
-                    DataColumnsByRangeRequester::ComponentsByRange(id),
-                    new_range_request_span!(
-                        self,
-                        "outgoing_columns_by_range_retry",
-                        parent_request_span.clone(),
-                        peer_id
-                    ),
-                )
-            })
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| format!("{:?}", e))?;
-
-        // instead of creating a new `RangeBlockComponentsRequest`, we reinsert
-        // the new requests created for the failed requests
-        let Some(range_request) = self.components_by_range_requests.get_mut(&id) else {
-            return Err(
-                "retrying custody request for range request that does not exist".to_string(),
-            );
-        };
-
-        range_request.reinsert_failed_column_requests(data_column_requests)?;
-        Ok(())
-    }
-
-    /// A blocks by range request sent by the range sync algorithm
+    /// A blocks by range request sent by the range sync algorithm.
+    /// For Fulu+ epochs (BlocksAndColumns), only sends BlocksByRange upfront.
+    /// Custody-by-root requests for columns are initiated after blocks arrive.
     pub fn block_components_by_range_request(
         &mut self,
         batch_type: ByRangeRequestType,
         request: BlocksByRangeRequest,
         requester: RangeRequestId,
         block_peers: &HashSet<PeerId>,
-        column_peers: &HashSet<PeerId>,
-        peers_to_deprioritize: &HashSet<PeerId>,
     ) -> Result<Id, RpcRequestSendError> {
         let range_request_span = debug_span!(
             parent: None,
             "lh_outgoing_range_request",
             range_req_id = %requester,
             block_peers = block_peers.len(),
-            column_peers = column_peers.len()
         );
         let _guard = range_request_span.clone().entered();
         let active_request_count_by_peer = self.active_request_count_by_peer();
@@ -587,8 +500,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .iter()
             .map(|peer| {
                 (
-                    // If contains -> 1 (order after), not contains -> 0 (order first)
-                    peers_to_deprioritize.contains(peer),
                     // Prefer peers with less overall requests
                     active_request_count_by_peer.get(peer).copied().unwrap_or(0),
                     // Random factor to break ties, otherwise the PeerID breaks ties
@@ -597,34 +508,12 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 )
             })
             .min()
-            .map(|(_, _, _, peer)| *peer)
+            .map(|(_, _, peer)| *peer)
         else {
             // Backfill and forward sync handle this condition gracefully.
             // - Backfill sync: will pause waiting for more peers to join
             // - Forward sync: can never happen as the chain is dropped when removing the last peer.
             return Err(RpcRequestSendError::NoPeer(NoPeerError::BlockPeer));
-        };
-
-        // Attempt to find all required custody peers before sending any request or creating an ID
-        let columns_by_range_peers_to_request = if matches!(
-            batch_type,
-            ByRangeRequestType::BlocksAndColumns | ByRangeRequestType::BlocksAndEnvelopesAndColumns
-        ) {
-            let epoch = Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch());
-            let column_indexes = self
-                .chain
-                .sampling_columns_for_epoch(epoch)
-                .iter()
-                .cloned()
-                .collect();
-            Some(self.select_columns_by_range_peers_to_request(
-                &column_indexes,
-                column_peers,
-                active_request_count_by_peer,
-                peers_to_deprioritize,
-            )?)
-        } else {
-            None
         };
 
         // Create the overall components_by_range request ID before its individual components
@@ -664,30 +553,17 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             None
         };
 
-        let data_column_requests = columns_by_range_peers_to_request
-            .map(|columns_by_range_peers_to_request| {
-                columns_by_range_peers_to_request
-                    .into_iter()
-                    .map(|(peer_id, columns)| {
-                        self.send_data_columns_by_range_request(
-                            peer_id,
-                            DataColumnsByRangeRequest {
-                                start_slot: *request.start_slot(),
-                                count: *request.count(),
-                                columns,
-                            },
-                            DataColumnsByRangeRequester::ComponentsByRange(id),
-                            new_range_request_span!(
-                                self,
-                                "outgoing_columns_by_range",
-                                range_request_span.clone(),
-                                peer_id
-                            ),
-                        )
-                    })
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .transpose()?;
+        // For BlocksAndColumns, compute expected custody columns but don't send requests yet.
+        // Custody-by-root requests will be initiated after blocks arrive.
+        let expects_custody_columns = if matches!(
+            batch_type,
+            ByRangeRequestType::BlocksAndColumns | ByRangeRequestType::BlocksAndEnvelopesAndColumns
+        ) {
+            let epoch = Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch());
+            Some(self.chain.sampling_columns_for_epoch(epoch).to_vec())
+        } else {
+            None
+        };
 
         let payloads_req_id =
             if matches!(batch_type, ByRangeRequestType::BlocksAndEnvelopesAndColumns) {
@@ -709,22 +585,26 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 None
             };
 
-        let epoch = Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch());
         let info = RangeBlockComponentsRequest::new(
             blocks_req_id,
             blobs_req_id,
-            data_column_requests.map(|data_column_requests| {
-                (
-                    data_column_requests,
-                    self.chain.sampling_columns_for_epoch(epoch).to_vec(),
-                )
-            }),
+            expects_custody_columns,
             payloads_req_id,
-            range_request_span,
         );
         self.components_by_range_requests.insert(id, info);
 
         Ok(id.id)
+    }
+
+    /// Returns true if there is a pending range sync request for the given chain where
+    /// blocks have not yet been received. Used to serialize block downloads for PeerDAS.
+    pub fn has_pending_block_range_download(&self, chain_id: Id) -> bool {
+        self.components_by_range_requests.iter().any(|(id, req)| {
+            matches!(
+                id.requester,
+                RangeRequestId::RangeSync { chain_id: cid, .. } if cid == chain_id
+            ) && !req.blocks_received()
+        })
     }
 
     fn select_columns_by_range_peers_to_request(
@@ -782,91 +662,72 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         Ok(columns_to_request_by_peer)
     }
 
-    /// Received a blocks by range or blobs by range response for a request that couples blocks '
-    /// and blobs.
+    /// Received a blocks by range, blobs by range, or custody-by-root response for a request
+    /// that couples blocks with their data. The coupling struct handles initiating custody-by-root
+    /// requests when blocks arrive.
     pub fn range_block_component_response(
         &mut self,
         id: ComponentsByRangeRequestId,
         range_block_component: RangeBlockComponent<T::EthSpec>,
     ) -> Option<Result<Vec<RangeSyncBlock<T::EthSpec>>, RpcResponseError>> {
-        let Entry::Occupied(mut entry) = self.components_by_range_requests.entry(id) else {
-            metrics::inc_counter_vec(&metrics::SYNC_UNKNOWN_NETWORK_REQUESTS, &["range_blocks"]);
-            return None;
-        };
+        // Remove from map to allow passing &mut self to continue_requests
+        let mut request = self.components_by_range_requests.remove(&id)?;
 
-        if let Err(e) = {
-            let request = entry.get_mut();
-            match range_block_component {
-                RangeBlockComponent::Block(req_id, resp) => resp.and_then(|(blocks, _)| {
-                    request.add_blocks(req_id, blocks).map_err(|e| {
-                        RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(
-                            e,
-                        ))
-                    })
-                }),
-                RangeBlockComponent::Blob(req_id, resp) => resp.and_then(|(blobs, _)| {
-                    request.add_blobs(req_id, blobs).map_err(|e| {
-                        RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(
-                            e,
-                        ))
-                    })
-                }),
-                RangeBlockComponent::CustodyColumns(req_id, resp) => {
-                    resp.and_then(|(custody_columns, _)| {
-                        request
-                            .add_custody_columns(req_id, custody_columns)
-                            .map_err(|e| {
-                                RpcResponseError::BlockComponentCouplingError(
-                                    CouplingError::InternalError(e),
-                                )
-                            })
-                    })
-                }
-                RangeBlockComponent::PayloadEnvelope(req_id, resp) => {
-                    resp.and_then(|(envelopes, _)| {
-                        request
-                            .add_payload_envelopes(req_id, envelopes)
-                            .map_err(|e| {
-                                RpcResponseError::BlockComponentCouplingError(
-                                    CouplingError::InternalError(e),
-                                )
-                            })
-                    })
-                }
+        // Add the incoming component
+        let add_result = match range_block_component {
+            RangeBlockComponent::Block(req_id, resp) => resp.and_then(|(blocks, _)| {
+                request.add_blocks(req_id, blocks).map_err(|e| {
+                    RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(e))
+                })
+            }),
+            RangeBlockComponent::Blob(req_id, resp) => resp.and_then(|(blobs, _)| {
+                request.add_blobs(req_id, blobs).map_err(|e| {
+                    RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(e))
+                })
+            }),
+            RangeBlockComponent::CustodyResult(block_root, resp, peer_group) => {
+                resp.and_then(|dl| {
+                    request
+                        .add_custody_columns(block_root, dl.value, peer_group)
+                        .map_err(|e| {
+                            RpcResponseError::BlockComponentCouplingError(
+                                CouplingError::InternalError(e),
+                            )
+                        })
+                })
             }
-        } {
-            entry.remove();
+            RangeBlockComponent::PayloadEnvelope(req_id, resp) => {
+                resp.and_then(|(envelopes, _)| {
+                    request
+                        .add_payload_envelopes(req_id, envelopes)
+                        .map_err(|e| {
+                            RpcResponseError::BlockComponentCouplingError(
+                                CouplingError::InternalError(e),
+                            )
+                        })
+                })
+            }
+        };
+        if let Err(e) = add_result {
             return Some(Err(e));
         }
 
-        let range_req = entry.get_mut();
-        if let Some(blocks_result) = range_req.responses(
+        // Let the coupling struct initiate any follow-up requests (custody-by-root)
+        if let Err(e) = request.continue_requests(id, self) {
+            return Some(Err(RpcResponseError::BlockComponentCouplingError(
+                CouplingError::InternalError(e),
+            )));
+        }
+
+        // Check if all components have arrived
+        if let Some(blocks_result) = request.responses(
             self.chain.data_availability_checker.clone(),
             self.chain.spec.clone(),
         ) {
-            if let Err(CouplingError::DataColumnPeerFailure {
-                error,
-                faulty_peers: _,
-                exceeded_retries,
-            }) = &blocks_result
-            {
-                // Remove the entry if it's a peer failure **and** retry counter is exceeded
-                if *exceeded_retries {
-                    debug!(
-                        entry=?entry.key(),
-                        msg = error,
-                        "Request exceeded max retries, failing batch"
-                    );
-                    entry.remove();
-                };
-            } else {
-                // also remove the entry only if it coupled successfully
-                // or if it isn't a column peer failure.
-                entry.remove();
-            }
-            // If the request is finished, dequeue everything
             Some(blocks_result.map_err(RpcResponseError::BlockComponentCouplingError))
         } else {
+            // Re-insert — still waiting for more components
+            self.components_by_range_requests.insert(id, request);
             None
         }
     }
@@ -1109,26 +970,40 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     /// any request to the network if no columns have to be fetched based on the import state of the
     /// node. A custody request is a "super request" that may trigger 0 or more `data_columns_by_root`
     /// requests.
+    ///
+    /// The caller provides `custody_indexes_to_fetch` — the set of column indices needed. For
+    /// single lookups this should be derived from the current epoch minus already-imported columns.
+    /// For range sync this should use the batch epoch columns (already computed at request creation).
+    /// Initiate a custody-by-root request for the given block root.
+    ///
+    /// When `ignore_cache` is true, the DA checker cache is not consulted and all custody
+    /// columns are fetched. This is used by range sync where blocks are historical and
+    /// won't have gossip-imported columns in the cache.
     pub fn custody_lookup_request(
         &mut self,
-        lookup_id: SingleLookupId,
+        requester: CustodyRequester,
         block_root: Hash256,
         block_slot: Slot,
+        ignore_cache: bool,
         lookup_peers: Arc<RwLock<HashSet<PeerId>>>,
     ) -> Result<LookupRequestResult<DataColumnSidecarList<T::EthSpec>>, RpcRequestSendError> {
-        // Code below will issue column requests even if `lookup_peers` is empty. This is not okay,
-        // as we want to have at least one signal that some of our peers has already seen the
-        // block's data.
-        if lookup_peers.read().is_empty() {
+        // For single lookups we want at least one signal that some peer has seen the block's data
+        // before issuing column requests. Range sync legitimately passes empty `lookup_peers` and
+        // relies on the global custody peer set, so only apply this check to single lookups.
+        if matches!(requester, CustodyRequester::SingleLookup(_)) && lookup_peers.read().is_empty()
+        {
             return Ok(LookupRequestResult::Pending("no peers"));
         }
 
-        let custody_indexes_imported = self
-            .chain
-            .cached_data_column_indexes(&block_root, block_slot)
-            .unwrap_or_default();
+        let custody_indexes_imported = if ignore_cache {
+            Default::default()
+        } else {
+            self.chain
+                .cached_data_column_indexes(&block_root, block_slot)
+                .unwrap_or_default()
+        };
 
-        // Include only the blob indexes not yet imported (received through gossip)
+        // Include only the column indexes not yet imported (received through gossip)
         let mut custody_indexes_to_fetch = self
             .chain
             .sampling_columns_for_epoch(block_slot.epoch(T::EthSpec::slots_per_epoch()))
@@ -1146,19 +1021,21 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             ));
         }
 
-        let id = SingleLookupReqId {
-            lookup_id,
-            req_id: self.next_id(),
-        };
-
         debug!(
             ?block_root,
             indices = ?custody_indexes_to_fetch,
-            %id,
+            %requester,
             "Starting custody columns request"
         );
 
-        let requester = CustodyRequester(id);
+        // Extract the caller-allocated req_id before continue_requests() increments
+        // self.request_id internally. For single lookups, the caller stores this req_id in
+        // State::Downloading and later matches it against response req_ids.
+        let caller_req_id = match &requester {
+            CustodyRequester::SingleLookup(id) => id.req_id,
+            CustodyRequester::RangeSync(id) => id.id.id,
+        };
+
         let mut request = ActiveCustodyRequest::new(
             block_root,
             CustodyId { requester },
@@ -1173,7 +1050,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 // created cannot return data immediately, it must send some request to the network
                 // first. And there must exist some request, `custody_indexes_to_fetch` is not empty.
                 self.custody_by_root_requests.insert(requester, request);
-                Ok(LookupRequestResult::RequestSent(id.req_id))
+                Ok(LookupRequestResult::RequestSent(caller_req_id))
             }
             Err(e) => Err(match e {
                 CustodyRequestError::NoPeer(column_index) => {

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -566,13 +566,13 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 None
             };
 
-        let mut info = RangeBlockComponentsRequest::new(
+        let info = RangeBlockComponentsRequest::new(
             blocks_req_id,
             blobs_req_id,
             expects_custody_columns,
             payloads_req_id,
+            range_request_span,
         );
-        info.request_span = range_request_span;
         self.components_by_range_requests.insert(id, info);
 
         Ok(id.id)

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -3,8 +3,7 @@
 
 use self::custody::{ActiveCustodyRequest, Error as CustodyRequestError};
 pub use self::requests::{
-    BlocksByRootSingleRequest, DataColumnsByRootSingleBlockRequest,
-    PayloadEnvelopesByRootSingleRequest,
+    BlocksByRootSingleRequest, DataColumnsByRootRequestParams, PayloadEnvelopesByRootSingleRequest,
 };
 use super::SyncMessage;
 use super::block_sidecar_coupling::RangeBlockComponentsRequest;
@@ -255,9 +254,9 @@ pub enum RangeBlockComponent<E: EthSpec> {
         BlobsByRangeRequestId,
         RpcResponseResult<Vec<Arc<BlobSidecar<E>>>>,
     ),
-    /// Custody-by-root result for a specific block root. Arrives after blocks and carries
-    /// the columns fetched via ActiveCustodyRequest.
-    CustodyResult(Hash256, CustodyByRootResult<E>, PeerGroup),
+    /// Custody-by-root result for a whole range batch. Arrives after blocks and carries the
+    /// custody columns of every data-bearing block, fetched via a single ActiveCustodyRequest.
+    CustodyResult(CustodyByRootResult<E>, PeerGroup),
     PayloadEnvelope(
         PayloadEnvelopesByRangeRequestId,
         RpcResponseResult<Vec<Arc<SignedExecutionPayloadEnvelope<E>>>>,
@@ -553,17 +552,11 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             None
         };
 
-        // For BlocksAndColumns, compute expected custody columns but don't send requests yet.
-        // Custody-by-root requests will be initiated after blocks arrive.
-        let expects_custody_columns = if matches!(
+        // For Fulu+ batches, custody columns are fetched via custody-by-root after blocks arrive.
+        let expects_custody_columns = matches!(
             batch_type,
             ByRangeRequestType::BlocksAndColumns | ByRangeRequestType::BlocksAndEnvelopesAndColumns
-        ) {
-            let epoch = Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch());
-            Some(self.chain.sampling_columns_for_epoch(epoch).to_vec())
-        } else {
-            None
-        };
+        );
 
         let payloads_req_id =
             if matches!(batch_type, ByRangeRequestType::BlocksAndEnvelopesAndColumns) {
@@ -685,17 +678,15 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                     RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(e))
                 })
             }),
-            RangeBlockComponent::CustodyResult(block_root, resp, peer_group) => {
-                resp.and_then(|dl| {
-                    request
-                        .add_custody_columns(block_root, dl.value, peer_group)
-                        .map_err(|e| {
-                            RpcResponseError::BlockComponentCouplingError(
-                                CouplingError::InternalError(e),
-                            )
-                        })
-                })
-            }
+            RangeBlockComponent::CustodyResult(resp, peer_group) => resp.and_then(|dl| {
+                request
+                    .add_custody_columns(dl.value, peer_group)
+                    .map_err(|e| {
+                        RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(
+                            e,
+                        ))
+                    })
+            }),
             RangeBlockComponent::PayloadEnvelope(req_id, resp) => {
                 resp.and_then(|(envelopes, _)| {
                     request
@@ -920,12 +911,13 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
         Ok(LookupRequestResult::RequestSent(id.req_id))
     }
-    /// Request to send a single `data_columns_by_root` request to the network.
+    /// Request to send a `data_columns_by_root` request to the network. The request may cover the
+    /// custody columns of one or more block roots.
     pub fn data_column_lookup_request(
         &mut self,
         requester: DataColumnsByRootRequester,
         peer_id: PeerId,
-        request: DataColumnsByRootSingleBlockRequest,
+        request: DataColumnsByRootRequestParams,
         expect_max_responses: bool,
     ) -> Result<LookupRequestResult<(), DataColumnsByRootRequestId>, &'static str> {
         let id = DataColumnsByRootRequestId {
@@ -946,7 +938,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
         debug!(
             method = "DataColumnsByRoot",
-            block_root = ?request.block_root,
+            block_roots = ?request.block_roots,
             indices = ?request.indices,
             peer = %peer_id,
             %id,
@@ -966,15 +958,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         Ok(LookupRequestResult::RequestSent(id))
     }
 
-    /// Request to fetch all needed custody columns of a specific block. This function may not send
-    /// any request to the network if no columns have to be fetched based on the import state of the
-    /// node. A custody request is a "super request" that may trigger 0 or more `data_columns_by_root`
-    /// requests.
-    ///
-    /// The caller provides `custody_indexes_to_fetch` — the set of column indices needed. For
-    /// single lookups this should be derived from the current epoch minus already-imported columns.
-    /// For range sync this should use the batch epoch columns (already computed at request creation).
-    /// Initiate a custody-by-root request for the given block root.
+    /// Request to fetch all needed custody columns of one or more blocks via a single custody
+    /// request (which may fan out into multiple `data_columns_by_root` requests). This function may
+    /// not send any request to the network if no columns have to be fetched based on the import
+    /// state of the node.
     ///
     /// When `ignore_cache` is true, the DA checker cache is not consulted and all custody
     /// columns are fetched. This is used by range sync where blocks are historical and
@@ -982,8 +969,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     pub fn custody_lookup_request(
         &mut self,
         requester: CustodyRequester,
-        block_root: Hash256,
-        block_slot: Slot,
+        blocks: &[(Hash256, Slot)],
         ignore_cache: bool,
         lookup_peers: Arc<RwLock<HashSet<PeerId>>>,
     ) -> Result<LookupRequestResult<DataColumnSidecarList<T::EthSpec>>, RpcRequestSendError> {
@@ -995,25 +981,29 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             return Ok(LookupRequestResult::Pending("no peers"));
         }
 
+        // All blocks in a single custody request share an epoch and (for range sync) ignore the
+        // cache, so they need the same custody column set. Compute it once; for single lookups the
+        // cache trims columns already imported via gossip.
+        let Some((first_root, first_slot)) = blocks.first() else {
+            return Ok(LookupRequestResult::NoRequestNeeded("no blocks", vec![]));
+        };
         let custody_indexes_imported = if ignore_cache {
             Default::default()
         } else {
             self.chain
-                .cached_data_column_indexes(&block_root, block_slot)
+                .cached_data_column_indexes(first_root, *first_slot)
                 .unwrap_or_default()
         };
-
-        // Include only the column indexes not yet imported (received through gossip)
-        let mut custody_indexes_to_fetch = self
+        let mut column_indices = self
             .chain
-            .sampling_columns_for_epoch(block_slot.epoch(T::EthSpec::slots_per_epoch()))
+            .sampling_columns_for_epoch(first_slot.epoch(T::EthSpec::slots_per_epoch()))
             .iter()
             .copied()
             .filter(|index| !custody_indexes_imported.contains(index))
             .collect::<Vec<_>>();
-        custody_indexes_to_fetch.sort_unstable();
+        column_indices.sort_unstable();
 
-        if custody_indexes_to_fetch.is_empty() {
+        if column_indices.is_empty() {
             // No indexes required, do not issue any request
             return Ok(LookupRequestResult::NoRequestNeeded(
                 "no indices to fetch",
@@ -1021,9 +1011,11 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             ));
         }
 
+        let block_roots = blocks.iter().map(|(root, _)| *root).collect::<Vec<_>>();
+
         debug!(
-            ?block_root,
-            indices = ?custody_indexes_to_fetch,
+            blocks = block_roots.len(),
+            indices = ?column_indices,
             %requester,
             "Starting custody columns request"
         );
@@ -1033,13 +1025,13 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         // State::Downloading and later matches it against response req_ids.
         let caller_req_id = match &requester {
             CustodyRequester::SingleLookup(id) => id.req_id,
-            CustodyRequester::RangeSync(id) => id.id.id,
+            CustodyRequester::RangeSync(id) => id.id,
         };
 
         let mut request = ActiveCustodyRequest::new(
-            block_root,
+            block_roots,
             CustodyId { requester },
-            &custody_indexes_to_fetch,
+            &column_indices,
             lookup_peers,
         );
 

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -249,6 +249,7 @@ pub enum RangeBlockComponent<E: EthSpec> {
     Block(
         BlocksByRangeRequestId,
         RpcResponseResult<Vec<Arc<SignedBeaconBlock<E>>>>,
+        PeerId,
     ),
     Blob(
         BlobsByRangeRequestId,
@@ -651,7 +652,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     pub fn range_block_component_response(
         &mut self,
         id: ComponentsByRangeRequestId,
-        peer_id: Option<PeerId>,
         range_block_component: RangeBlockComponent<T::EthSpec>,
     ) -> Option<Result<(PeerId, Vec<RangeSyncBlock<T::EthSpec>>), RpcResponseError>> {
         // Remove from map to allow passing &mut self to continue_requests
@@ -659,12 +659,11 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
         // Add the incoming component
         let add_result = match range_block_component {
-            RangeBlockComponent::Block(req_id, resp) => resp.and_then(|(blocks, _)| {
-                request.add_blocks(req_id, blocks).map_err(|e| {
+            RangeBlockComponent::Block(req_id, resp, peer_id) => resp.and_then(|(blocks, _)| {
+                request.add_blocks(req_id, blocks, peer_id).map_err(|e| {
                     RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(e))
                 })?;
                 // Record the peer that provided the blocks for batch attribution.
-                request.block_peer = peer_id;
                 Ok(())
             }),
             RangeBlockComponent::Blob(req_id, resp) => resp.and_then(|(blobs, _)| {
@@ -705,16 +704,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         }
 
         // Check if all components have arrived
-        if let Some(blocks_result) = request.responses(
+        if let Some((blocks_result, block_peer)) = request.responses(
             self.chain.data_availability_checker.clone(),
             self.chain.spec.clone(),
         ) {
-            // The blocks have been received for `responses` to return `Some`, so `block_peer` is
-            // set; attribute the batch to it.
-            let Some(block_peer) = request.block_peer else {
-                self.components_by_range_requests.insert(id, request);
-                return None;
-            };
             Some(
                 blocks_result
                     .map(|blocks| (block_peer, blocks))

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -477,15 +477,14 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         active_request_count_by_peer
     }
 
-    /// A blocks by range request sent by the range sync algorithm.
-    /// For Fulu+ epochs (BlocksAndColumns), only sends BlocksByRange upfront.
-    /// Custody-by-root requests for columns are initiated after blocks arrive.
+    /// A blocks by range request sent by the range sync algorithm
     pub fn block_components_by_range_request(
         &mut self,
         batch_type: ByRangeRequestType,
         request: BlocksByRangeRequest,
         requester: RangeRequestId,
         block_peers: &HashSet<PeerId>,
+        peers_to_deprioritize: &HashSet<PeerId>,
     ) -> Result<Id, RpcRequestSendError> {
         let range_request_span = debug_span!(
             parent: None,
@@ -500,6 +499,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .iter()
             .map(|peer| {
                 (
+                    // If contains -> 1 (order after), not contains -> 0 (order first)
+                    peers_to_deprioritize.contains(peer),
                     // Prefer peers with less overall requests
                     active_request_count_by_peer.get(peer).copied().unwrap_or(0),
                     // Random factor to break ties, otherwise the PeerID breaks ties
@@ -508,7 +509,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 )
             })
             .min()
-            .map(|(_, _, peer)| *peer)
+            .map(|(_, _, _, peer)| *peer)
         else {
             // Backfill and forward sync handle this condition gracefully.
             // - Backfill sync: will pause waiting for more peers to join
@@ -579,12 +580,13 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 None
             };
 
-        let info = RangeBlockComponentsRequest::new(
+        let mut info = RangeBlockComponentsRequest::new(
             blocks_req_id,
             blobs_req_id,
             expects_custody_columns,
             payloads_req_id,
         );
+        info.request_span = range_request_span;
         self.components_by_range_requests.insert(id, info);
 
         Ok(id.id)
@@ -974,10 +976,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     ) -> Result<LookupRequestResult<DataColumnSidecarList<T::EthSpec>>, RpcRequestSendError> {
         // Code below will issue column requests even if `lookup_peers` is empty. This is not okay,
         // as we want to have at least one signal that some of our peers has already seen the
-        // block's data. Range sync passes empty `lookup_peers` and relies on the global custody
-        // peer set, so only apply this check to single lookups.
-        if matches!(requester, CustodyRequester::SingleLookup(_)) && lookup_peers.read().is_empty()
-        {
+        // block's data.
+        if lookup_peers.read().is_empty() {
             return Ok(LookupRequestResult::Pending("no peers"));
         }
 

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -647,11 +647,13 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     /// Received a blocks by range, blobs by range, or custody-by-root response for a request
     /// that couples blocks with their data. The coupling struct handles initiating custody-by-root
     /// requests when blocks arrive.
+    #[allow(clippy::type_complexity)]
     pub fn range_block_component_response(
         &mut self,
         id: ComponentsByRangeRequestId,
+        peer_id: Option<PeerId>,
         range_block_component: RangeBlockComponent<T::EthSpec>,
-    ) -> Option<Result<Vec<RangeSyncBlock<T::EthSpec>>, RpcResponseError>> {
+    ) -> Option<Result<(PeerId, Vec<RangeSyncBlock<T::EthSpec>>), RpcResponseError>> {
         // Remove from map to allow passing &mut self to continue_requests
         let mut request = self.components_by_range_requests.remove(&id)?;
 
@@ -660,7 +662,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             RangeBlockComponent::Block(req_id, resp) => resp.and_then(|(blocks, _)| {
                 request.add_blocks(req_id, blocks).map_err(|e| {
                     RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(e))
-                })
+                })?;
+                // Record the peer that provided the blocks for batch attribution.
+                request.block_peer = peer_id;
+                Ok(())
             }),
             RangeBlockComponent::Blob(req_id, resp) => resp.and_then(|(blobs, _)| {
                 request.add_blobs(req_id, blobs).map_err(|e| {
@@ -704,7 +709,17 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             self.chain.data_availability_checker.clone(),
             self.chain.spec.clone(),
         ) {
-            Some(blocks_result.map_err(RpcResponseError::BlockComponentCouplingError))
+            // The blocks have been received for `responses` to return `Some`, so `block_peer` is
+            // set; attribute the batch to it.
+            let Some(block_peer) = request.block_peer else {
+                self.components_by_range_requests.insert(id, request);
+                return None;
+            };
+            Some(
+                blocks_result
+                    .map(|blocks| (block_peer, blocks))
+                    .map_err(RpcResponseError::BlockComponentCouplingError),
+            )
         } else {
             // Re-insert — still waiting for more components
             self.components_by_range_requests.insert(id, request);

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -55,7 +55,7 @@ use task_executor::TaskExecutor;
 use tokio::sync::mpsc;
 use tracing::{Span, debug, debug_span, error, warn};
 use types::{
-    BlobSidecar, ChainSpec, ColumnIndex, DataColumnSidecar, DataColumnSidecarList, EthSpec,
+    BlobSidecar, ChainSpec, ColumnIndex, DataColumnSidecar, DataColumnSidecarList, Epoch, EthSpec,
     ForkContext, Hash256, SignedBeaconBlock, SignedExecutionPayloadEnvelope, Slot,
 };
 
@@ -958,52 +958,55 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         Ok(LookupRequestResult::RequestSent(id))
     }
 
-    /// Request to fetch all needed custody columns of one or more blocks via a single custody
-    /// request (which may fan out into multiple `data_columns_by_root` requests). This function may
-    /// not send any request to the network if no columns have to be fetched based on the import
-    /// state of the node.
+    /// Request to fetch all needed custody columns of a specific block. This function may not send
+    /// any request to the network if no columns have to be fetched based on the import state of the
+    /// node. A custody request is a "super request" that may trigger 0 or more `data_columns_by_root`
+    /// requests.
     ///
-    /// When `ignore_cache` is true, the DA checker cache is not consulted and all custody
-    /// columns are fetched. This is used by range sync where blocks are historical and
+    /// A single request may span multiple `block_roots`; callers must ensure all of them are within
+    /// `block_epoch`. When `ignore_cache` is true, the DA checker cache is not consulted and all
+    /// custody columns are fetched. This is used by range sync where blocks are historical and
     /// won't have gossip-imported columns in the cache.
     pub fn custody_lookup_request(
         &mut self,
         requester: CustodyRequester,
-        blocks: &[(Hash256, Slot)],
+        block_roots: &[Hash256],
+        block_epoch: Epoch,
         ignore_cache: bool,
         lookup_peers: Arc<RwLock<HashSet<PeerId>>>,
     ) -> Result<LookupRequestResult<DataColumnSidecarList<T::EthSpec>>, RpcRequestSendError> {
-        // For single lookups we want at least one signal that some peer has seen the block's data
-        // before issuing column requests. Range sync legitimately passes empty `lookup_peers` and
-        // relies on the global custody peer set, so only apply this check to single lookups.
+        // Code below will issue column requests even if `lookup_peers` is empty. This is not okay,
+        // as we want to have at least one signal that some of our peers has already seen the
+        // block's data. Range sync passes empty `lookup_peers` and relies on the global custody
+        // peer set, so only apply this check to single lookups.
         if matches!(requester, CustodyRequester::SingleLookup(_)) && lookup_peers.read().is_empty()
         {
             return Ok(LookupRequestResult::Pending("no peers"));
         }
 
-        // All blocks in a single custody request share an epoch and (for range sync) ignore the
-        // cache, so they need the same custody column set. Compute it once; for single lookups the
-        // cache trims columns already imported via gossip.
-        let Some((first_root, first_slot)) = blocks.first() else {
-            return Ok(LookupRequestResult::NoRequestNeeded("no blocks", vec![]));
-        };
         let custody_indexes_imported = if ignore_cache {
             Default::default()
         } else {
-            self.chain
-                .cached_data_column_indexes(first_root, *first_slot)
+            block_roots
+                .first()
+                .and_then(|block_root| {
+                    self.chain
+                        .cached_data_column_indexes(block_root, block_epoch)
+                })
                 .unwrap_or_default()
         };
-        let mut column_indices = self
+
+        // Include only the column indexes not yet imported (received through gossip)
+        let mut custody_indexes_to_fetch = self
             .chain
-            .sampling_columns_for_epoch(first_slot.epoch(T::EthSpec::slots_per_epoch()))
+            .sampling_columns_for_epoch(block_epoch)
             .iter()
             .copied()
             .filter(|index| !custody_indexes_imported.contains(index))
             .collect::<Vec<_>>();
-        column_indices.sort_unstable();
+        custody_indexes_to_fetch.sort_unstable();
 
-        if column_indices.is_empty() {
+        if block_roots.is_empty() || custody_indexes_to_fetch.is_empty() {
             // No indexes required, do not issue any request
             return Ok(LookupRequestResult::NoRequestNeeded(
                 "no indices to fetch",
@@ -1011,11 +1014,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             ));
         }
 
-        let block_roots = blocks.iter().map(|(root, _)| *root).collect::<Vec<_>>();
-
         debug!(
             blocks = block_roots.len(),
-            indices = ?column_indices,
+            indices = ?custody_indexes_to_fetch,
             %requester,
             "Starting custody columns request"
         );
@@ -1029,9 +1030,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         };
 
         let mut request = ActiveCustodyRequest::new(
-            block_roots,
+            block_roots.to_vec(),
             CustodyId { requester },
-            &column_indices,
+            &custody_indexes_to_fetch,
             lookup_peers,
         );
 

--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -46,8 +46,8 @@ pub enum Error {
     /// There should only exist a single request at a time. Having multiple requests is a bug and
     /// can result in undefined state, so it's treated as a hard error and the lookup is dropped.
     UnexpectedRequestId {
-        expected_req_id: DataColumnsByRootRequestId,
-        req_id: DataColumnsByRootRequestId,
+        expected_req_id: Box<DataColumnsByRootRequestId>,
+        req_id: Box<DataColumnsByRootRequestId>,
     },
 }
 
@@ -452,8 +452,8 @@ impl<E: EthSpec> ColumnRequest<E> {
             Status::Downloading(expected_req_id) => {
                 if req_id != *expected_req_id {
                     return Err(Error::UnexpectedRequestId {
-                        expected_req_id: *expected_req_id,
-                        req_id,
+                        expected_req_id: Box::new(*expected_req_id),
+                        req_id: Box::new(req_id),
                     });
                 }
                 self.status = Status::NotStarted(Instant::now());
@@ -485,8 +485,8 @@ impl<E: EthSpec> ColumnRequest<E> {
             Status::Downloading(expected_req_id) => {
                 if req_id != *expected_req_id {
                     return Err(Error::UnexpectedRequestId {
-                        expected_req_id: *expected_req_id,
-                        req_id,
+                        expected_req_id: Box::new(*expected_req_id),
+                        req_id: Box::new(req_id),
                     });
                 }
                 self.status = Status::Downloaded(peer_id, data_column, seen_timestamp);

--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -1,7 +1,5 @@
 use crate::sync::block_lookups::DownloadResult;
-use crate::sync::network_context::{
-    DataColumnsByRootRequestId, DataColumnsByRootSingleBlockRequest,
-};
+use crate::sync::network_context::{DataColumnsByRootRequestId, DataColumnsByRootRequestParams};
 use beacon_chain::BeaconChainTypes;
 use fnv::FnvHashMap;
 use lighthouse_network::PeerId;
@@ -21,7 +19,7 @@ use super::{LookupRequestResult, PeerGroup, RpcResponseResult, SyncNetworkContex
 const MAX_STALE_NO_PEERS_DURATION: Duration = Duration::from_secs(30);
 
 pub struct ActiveCustodyRequest<T: BeaconChainTypes> {
-    block_root: Hash256,
+    block_roots: Vec<Hash256>,
     custody_id: CustodyId,
     /// List of column indices this request needs to download to complete successfully
     column_requests: FnvHashMap<ColumnIndex, ColumnRequest<T::EthSpec>>,
@@ -46,8 +44,8 @@ pub enum Error {
     /// There should only exist a single request at a time. Having multiple requests is a bug and
     /// can result in undefined state, so it's treated as a hard error and the lookup is dropped.
     UnexpectedRequestId {
-        expected_req_id: Box<DataColumnsByRootRequestId>,
-        req_id: Box<DataColumnsByRootRequestId>,
+        expected_req_id: DataColumnsByRootRequestId,
+        req_id: DataColumnsByRootRequestId,
     },
 }
 
@@ -61,7 +59,7 @@ pub type CustodyRequestResult<E> = Result<Option<DownloadResult<DataColumnSideca
 
 impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
     pub(crate) fn new(
-        block_root: Hash256,
+        block_roots: Vec<Hash256>,
         custody_id: CustodyId,
         column_indices: &[ColumnIndex],
         lookup_peers: Arc<RwLock<HashSet<PeerId>>>,
@@ -69,10 +67,10 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
         let span = debug_span!(
             parent: Span::current(),
             "lh_outgoing_custody_request",
-            %block_root,
+            blocks = block_roots.len(),
         );
         Self {
-            block_root,
+            block_roots,
             custody_id,
             column_requests: HashMap::from_iter(
                 column_indices
@@ -104,7 +102,6 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
     ) -> CustodyRequestResult<T::EthSpec> {
         let Some(batch_request) = self.active_batch_columns_requests.get_mut(&req_id) else {
             warn!(
-                block_root = ?self.block_root,
                 %req_id,
                 "Received custody column response for unrequested index"
             );
@@ -116,7 +113,6 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
         match resp {
             Ok((data_columns, seen_timestamp)) => {
                 debug!(
-                    block_root = ?self.block_root,
                     %req_id,
                     %peer_id,
                     count = data_columns.len(),
@@ -126,8 +122,10 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                 // Map columns by index as an optimization to not loop the returned list on each
                 // requested index. The worse case is 128 loops over a 128 item vec + mutation to
                 // drop the consumed columns.
-                let mut data_columns = HashMap::<ColumnIndex, _>::from_iter(
-                    data_columns.into_iter().map(|d| (*d.index(), d)),
+                let mut data_columns = HashMap::<(Hash256, ColumnIndex), _>::from_iter(
+                    data_columns
+                        .into_iter()
+                        .map(|d| ((d.block_root(), *d.index()), d)),
                 );
                 // Accumulate columns that the peer does not have to issue a single log per request
                 let mut missing_column_indexes = vec![];
@@ -138,11 +136,16 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                         .get_mut(column_index)
                         .ok_or(Error::BadState("unknown column_index".to_owned()))?;
 
-                    if let Some(data_column) = data_columns.remove(column_index) {
+                    if let Some(columns) = self
+                        .block_roots
+                        .iter()
+                        .map(|block_root| data_columns.remove(&(*block_root, *column_index)))
+                        .collect::<Option<Vec<_>>>()
+                    {
                         column_request.on_download_success(
                             req_id,
                             peer_id,
-                            data_column,
+                            columns,
                             seen_timestamp,
                         )?;
                     } else {
@@ -163,7 +166,6 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                 if !missing_column_indexes.is_empty() {
                     // Note: Batch logging that columns are missing to not spam logger
                     debug!(
-                        block_root = ?self.block_root,
                         %req_id,
                         %peer_id,
                         ?missing_column_indexes,
@@ -173,7 +175,6 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
             }
             Err(err) => {
                 debug!(
-                    block_root = ?self.block_root,
                     %req_id,
                    %peer_id,
                    error = ?err,
@@ -212,15 +213,20 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
             let columns = std::mem::take(&mut self.column_requests)
                 .into_values()
                 .map(|request| {
-                    let (peer, data_column, seen_timestamp) = request.complete()?;
-                    peers
-                        .entry(peer)
-                        .or_default()
-                        .push(*data_column.index() as usize);
+                    let (peer, data_columns, seen_timestamp) = request.complete()?;
+                    if let Some(data_column) = data_columns.first() {
+                        peers
+                            .entry(peer)
+                            .or_default()
+                            .push(*data_column.index() as usize);
+                    }
                     seen_timestamps.push(seen_timestamp);
-                    Ok(data_column)
+                    Ok(data_columns)
                 })
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .flatten()
+                .collect();
 
             let peer_group = PeerGroup::from_set(peers);
             let max_seen_timestamp = seen_timestamps
@@ -301,8 +307,8 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                 .data_column_lookup_request(
                     DataColumnsByRootRequester::Custody(self.custody_id),
                     peer_id,
-                    DataColumnsByRootSingleBlockRequest {
-                        block_root: self.block_root,
+                    DataColumnsByRootRequestParams {
+                        block_roots: self.block_roots.clone(),
                         indices: indices.clone(),
                     },
                     // If peer is in the lookup peer set, it claims to have imported the block and
@@ -410,7 +416,7 @@ struct ColumnRequest<E: EthSpec> {
 enum Status<E: EthSpec> {
     NotStarted(Instant),
     Downloading(DataColumnsByRootRequestId),
-    Downloaded(PeerId, Arc<DataColumnSidecar<E>>, Duration),
+    Downloaded(PeerId, Vec<Arc<DataColumnSidecar<E>>>, Duration),
 }
 
 impl<E: EthSpec> ColumnRequest<E> {
@@ -452,8 +458,8 @@ impl<E: EthSpec> ColumnRequest<E> {
             Status::Downloading(expected_req_id) => {
                 if req_id != *expected_req_id {
                     return Err(Error::UnexpectedRequestId {
-                        expected_req_id: Box::new(*expected_req_id),
-                        req_id: Box::new(req_id),
+                        expected_req_id: *expected_req_id,
+                        req_id,
                     });
                 }
                 self.status = Status::NotStarted(Instant::now());
@@ -478,18 +484,18 @@ impl<E: EthSpec> ColumnRequest<E> {
         &mut self,
         req_id: DataColumnsByRootRequestId,
         peer_id: PeerId,
-        data_column: Arc<DataColumnSidecar<E>>,
+        data_columns: Vec<Arc<DataColumnSidecar<E>>>,
         seen_timestamp: Duration,
     ) -> Result<(), Error> {
         match &self.status {
             Status::Downloading(expected_req_id) => {
                 if req_id != *expected_req_id {
                     return Err(Error::UnexpectedRequestId {
-                        expected_req_id: Box::new(*expected_req_id),
-                        req_id: Box::new(req_id),
+                        expected_req_id: *expected_req_id,
+                        req_id,
                     });
                 }
-                self.status = Status::Downloaded(peer_id, data_column, seen_timestamp);
+                self.status = Status::Downloaded(peer_id, data_columns, seen_timestamp);
                 Ok(())
             }
             other => Err(Error::BadState(format!(
@@ -498,10 +504,11 @@ impl<E: EthSpec> ColumnRequest<E> {
         }
     }
 
-    fn complete(self) -> Result<(PeerId, Arc<DataColumnSidecar<E>>, Duration), Error> {
+    #[allow(clippy::type_complexity)]
+    fn complete(self) -> Result<(PeerId, Vec<Arc<DataColumnSidecar<E>>>, Duration), Error> {
         match self.status {
-            Status::Downloaded(peer_id, data_column, seen_timestamp) => {
-                Ok((peer_id, data_column, seen_timestamp))
+            Status::Downloaded(peer_id, data_columns, seen_timestamp) => {
+                Ok((peer_id, data_columns, seen_timestamp))
             }
             other => Err(Error::BadState(format!(
                 "bad state complete expected Downloaded got {other:?}"

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -12,9 +12,7 @@ pub use blobs_by_range::BlobsByRangeRequestItems;
 pub use blocks_by_range::BlocksByRangeRequestItems;
 pub use blocks_by_root::{BlocksByRootRequestItems, BlocksByRootSingleRequest};
 pub use data_columns_by_range::DataColumnsByRangeRequestItems;
-pub use data_columns_by_root::{
-    DataColumnsByRootRequestItems, DataColumnsByRootSingleBlockRequest,
-};
+pub use data_columns_by_root::{DataColumnsByRootRequestItems, DataColumnsByRootRequestParams};
 pub use payload_envelopes_by_range::PayloadEnvelopesByRangeRequestItems;
 pub use payload_envelopes_by_root::{
     PayloadEnvelopesByRootRequestItems, PayloadEnvelopesByRootSingleRequest,

--- a/beacon_node/network/src/sync/network_context/requests/data_columns_by_root.rs
+++ b/beacon_node/network/src/sync/network_context/requests/data_columns_by_root.rs
@@ -88,3 +88,58 @@ impl<E: EthSpec> ActiveRequestItems for DataColumnsByRootRequestItems<E> {
         std::mem::take(&mut self.items)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use beacon_chain::test_utils::{NumBlobs, generate_rand_block_and_data_columns, test_spec};
+    use types::{Epoch, ForkName, MinimalEthSpec as E};
+
+    /// A response missing any requested `(block_root, index)` must not report the request complete,
+    /// whether it covers all roots but misses an index, or all indices but misses a root.
+    #[test]
+    fn partial_response_does_not_complete() {
+        let mut spec = test_spec::<E>();
+        spec.fulu_fork_epoch = Some(Epoch::new(0));
+        let mut u = types::test_utils::test_unstructured();
+        let a = generate_rand_block_and_data_columns::<E>(
+            ForkName::Fulu,
+            NumBlobs::Number(1),
+            &mut u,
+            &spec,
+        )
+        .unwrap()
+        .1;
+        let b = generate_rand_block_and_data_columns::<E>(
+            ForkName::Fulu,
+            NumBlobs::Number(1),
+            &mut u,
+            &spec,
+        )
+        .unwrap()
+        .1;
+
+        // Request columns [0, 1] for two block roots: 4 items expected.
+        let params = DataColumnsByRootRequestParams {
+            block_roots: vec![a[0].block_root(), b[0].block_root()],
+            indices: vec![0, 1],
+        };
+
+        // All block roots, but index 1 missing.
+        let mut items = DataColumnsByRootRequestItems::<E>::new(params.clone());
+        assert_eq!(items.add(a[0].clone()), Ok(false));
+        assert_eq!(items.add(b[0].clone()), Ok(false));
+
+        // All indices, but block root `b` missing.
+        let mut items = DataColumnsByRootRequestItems::<E>::new(params.clone());
+        assert_eq!(items.add(a[0].clone()), Ok(false));
+        assert_eq!(items.add(a[1].clone()), Ok(false));
+
+        // The complete set resolves the request.
+        let mut items = DataColumnsByRootRequestItems::<E>::new(params);
+        assert_eq!(items.add(a[0].clone()), Ok(false));
+        assert_eq!(items.add(a[1].clone()), Ok(false));
+        assert_eq!(items.add(b[0].clone()), Ok(false));
+        assert_eq!(items.add(b[1].clone()), Ok(true));
+    }
+}

--- a/beacon_node/network/src/sync/network_context/requests/data_columns_by_root.rs
+++ b/beacon_node/network/src/sync/network_context/requests/data_columns_by_root.rs
@@ -8,12 +8,12 @@ use types::{
 use super::{ActiveRequestItems, LookupVerifyError};
 
 #[derive(Debug, Clone)]
-pub struct DataColumnsByRootSingleBlockRequest {
-    pub block_root: Hash256,
+pub struct DataColumnsByRootRequestParams {
+    pub block_roots: Vec<Hash256>,
     pub indices: Vec<u64>,
 }
 
-impl DataColumnsByRootSingleBlockRequest {
+impl DataColumnsByRootRequestParams {
     pub fn try_into_request<E: EthSpec>(
         self,
         fork_name: ForkName,
@@ -21,23 +21,25 @@ impl DataColumnsByRootSingleBlockRequest {
     ) -> Result<DataColumnsByRootRequest<E>, &'static str> {
         let columns = VariableList::new(self.indices)
             .map_err(|_| "Number of indices exceeds total number of columns")?;
-        DataColumnsByRootRequest::new(
-            vec![DataColumnsByRootIdentifier {
-                block_root: self.block_root,
-                columns,
-            }],
-            spec.max_request_blocks(fork_name),
-        )
+        let data_column_ids = self
+            .block_roots
+            .into_iter()
+            .map(|block_root| DataColumnsByRootIdentifier {
+                block_root,
+                columns: columns.clone(),
+            })
+            .collect();
+        DataColumnsByRootRequest::new(data_column_ids, spec.max_request_blocks(fork_name))
     }
 }
 
 pub struct DataColumnsByRootRequestItems<E: EthSpec> {
-    request: DataColumnsByRootSingleBlockRequest,
+    request: DataColumnsByRootRequestParams,
     items: Vec<Arc<DataColumnSidecar<E>>>,
 }
 
 impl<E: EthSpec> DataColumnsByRootRequestItems<E> {
-    pub fn new(request: DataColumnsByRootSingleBlockRequest) -> Self {
+    pub fn new(request: DataColumnsByRootRequestParams) -> Self {
         Self {
             request,
             items: vec![],
@@ -53,7 +55,7 @@ impl<E: EthSpec> ActiveRequestItems for DataColumnsByRootRequestItems<E> {
     /// The active request SHOULD be dropped after `add_response` returns an error
     fn add(&mut self, data_column: Self::Item) -> Result<bool, LookupVerifyError> {
         let block_root = data_column.block_root();
-        if self.request.block_root != block_root {
+        if !self.request.block_roots.contains(&block_root) {
             return Err(LookupVerifyError::UnrequestedBlockRoot(block_root));
         }
 
@@ -69,7 +71,7 @@ impl<E: EthSpec> ActiveRequestItems for DataColumnsByRootRequestItems<E> {
         if self
             .items
             .iter()
-            .any(|d| *d.index() == *data_column.index())
+            .any(|d| d.block_root() == block_root && *d.index() == *data_column.index())
         {
             return Err(LookupVerifyError::DuplicatedData(
                 data_column.slot(),
@@ -79,7 +81,7 @@ impl<E: EthSpec> ActiveRequestItems for DataColumnsByRootRequestItems<E> {
 
         self.items.push(data_column);
 
-        Ok(self.items.len() >= self.request.indices.len())
+        Ok(self.items.len() >= self.request.block_roots.len() * self.request.indices.len())
     }
 
     fn consume(&mut self) -> Vec<Self::Item> {

--- a/beacon_node/network/src/sync/network_context/requests/data_columns_by_root.rs
+++ b/beacon_node/network/src/sync/network_context/requests/data_columns_by_root.rs
@@ -99,6 +99,13 @@ mod tests {
     /// whether it covers all roots but misses an index, or all indices but misses a root.
     #[test]
     fn partial_response_does_not_complete() {
+        // This test builds Fulu data columns, which is incompatible with a Gloas genesis.
+        if test_spec::<E>()
+            .fork_name_at_epoch(Epoch::new(0))
+            .gloas_enabled()
+        {
+            return;
+        }
         let mut spec = test_spec::<E>();
         spec.fulu_fork_epoch = Some(Epoch::new(0));
         let mut u = types::test_utils::test_unstructured();

--- a/beacon_node/network/src/sync/range_data_column_batch_request.rs
+++ b/beacon_node/network/src/sync/range_data_column_batch_request.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::sync::block_sidecar_coupling::{ByRangeRequest, CouplingError};
-use crate::sync::network_context::MAX_COLUMN_RETRIES;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use itertools::Itertools;
 use lighthouse_network::PeerId;
@@ -105,7 +104,6 @@ impl<T: BeaconChainTypes> RangeDataColumnBatchRequest<T> {
         if let Err(CouplingError::DataColumnPeerFailure {
             error: _,
             faulty_peers,
-            exceeded_retries: _,
         }) = &resp
         {
             for (_, peer) in faulty_peers.iter() {
@@ -123,7 +121,7 @@ impl<T: BeaconChainTypes> RangeDataColumnBatchRequest<T> {
         mut received_columns_for_slot: HashMap<Slot, DataColumnSidecarList<T::EthSpec>>,
         column_to_peer: HashMap<ColumnIndex, PeerId>,
         expected_custody_columns: &HashSet<ColumnIndex>,
-        attempt: usize,
+        _attempt: usize,
     ) -> Result<DataColumnSidecarList<T::EthSpec>, CouplingError> {
         let mut naughty_peers = vec![];
         let mut result: DataColumnSidecarList<T::EthSpec> = vec![];
@@ -297,7 +295,6 @@ impl<T: BeaconChainTypes> RangeDataColumnBatchRequest<T> {
             return Err(CouplingError::DataColumnPeerFailure {
                 error: "Bad or missing columns for some slots".to_string(),
                 faulty_peers: naughty_peers,
-                exceeded_retries: attempt >= MAX_COLUMN_RETRIES,
             });
         }
 

--- a/beacon_node/network/src/sync/range_data_column_batch_request.rs
+++ b/beacon_node/network/src/sync/range_data_column_batch_request.rs
@@ -98,7 +98,6 @@ impl<T: BeaconChainTypes> RangeDataColumnBatchRequest<T> {
             received_columns_for_slot,
             column_to_peer_id,
             &self.expected_custody_columns,
-            self.attempt,
         );
 
         if let Err(CouplingError::DataColumnPeerFailure {
@@ -121,7 +120,6 @@ impl<T: BeaconChainTypes> RangeDataColumnBatchRequest<T> {
         mut received_columns_for_slot: HashMap<Slot, DataColumnSidecarList<T::EthSpec>>,
         column_to_peer: HashMap<ColumnIndex, PeerId>,
         expected_custody_columns: &HashSet<ColumnIndex>,
-        _attempt: usize,
     ) -> Result<DataColumnSidecarList<T::EthSpec>, CouplingError> {
         let mut naughty_peers = vec![];
         let mut result: DataColumnSidecarList<T::EthSpec> = vec![];

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -1116,10 +1116,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
 
     /// Attempts to request the next required batches from the peer pool if the chain is syncing. It will exhaust the peer
     /// pool and left over batches until the batch buffer is reached or all peers are exhausted.
-    pub(super) fn request_batches(
-        &mut self,
-        network: &mut SyncNetworkContext<T>,
-    ) -> ProcessingResult {
+    fn request_batches(&mut self, network: &mut SyncNetworkContext<T>) -> ProcessingResult {
         if !matches!(self.state, ChainSyncingState::Syncing) {
             return Ok(KeepChain);
         }
@@ -1209,13 +1206,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             .count()
             >= BATCH_BUFFER_SIZE as usize
         {
-            return None;
-        }
-
-        // Don't start downloading the next batch until the previous batch's blocks have
-        // arrived. This serializes the block download phase while allowing custody-by-root
-        // requests to run in parallel across batches.
-        if network.has_pending_block_range_download(self.id) {
             return None;
         }
 

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -1032,6 +1032,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         let batch_state = self.visualize_batch_state();
         if let Some(batch) = self.batches.get_mut(&batch_id) {
             let (request, batch_type) = batch.to_blocks_by_range_request();
+            let failed_peers = batch.failed_peers();
 
             match network.block_components_by_range_request(
                 batch_type,
@@ -1042,6 +1043,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 },
                 // Request blocks only from peers of this specific chain
                 &self.peers,
+                &failed_peers,
             ) {
                 Ok(request_id) => {
                     // inform the batch about the new request

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -926,6 +926,9 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         if let Some(batch) = self.batches.get_mut(&batch_id) {
             if let RpcResponseError::BlockComponentCouplingError(coupling_error) = &err {
                 match coupling_error {
+                    CouplingError::DataColumnPeerFailure { error, .. } => {
+                        debug!(?batch_id, error, "Block components coupling error");
+                    }
                     CouplingError::BlobPeerFailure(msg) => {
                         debug!(?batch_id, msg, "Blob peer failure");
                     }
@@ -934,9 +937,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                     }
                     CouplingError::InternalError(msg) => {
                         error!(?batch_id, msg, "Block components coupling internal error");
-                    }
-                    CouplingError::DataColumnPeerFailure { error, .. } => {
-                        debug!(?batch_id, error, "Data column peer failure");
                     }
                 }
             }

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -19,7 +19,7 @@ use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use strum::IntoStaticStr;
 use tracing::{Span, debug, error, instrument, warn};
-use types::{ColumnIndex, Epoch, EthSpec, Hash256, Slot};
+use types::{Epoch, EthSpec, Hash256, Slot};
 
 /// Blocks are downloaded in batches from peers. This constant specifies how many epochs worth of
 /// blocks per batch are requested _at most_. A batch may request less blocks to account for
@@ -302,6 +302,9 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
 
         // TODO(das): should use peer group here https://github.com/sigp/lighthouse/issues/6258
         let received = blocks.len();
+        if let Some(duration) = batch.time_since_downloading() {
+            metrics::observe_duration(&metrics::SYNCING_CHAIN_BATCH_DOWNLOADING, duration);
+        }
         batch.download_completed(blocks, *peer_id)?;
         let awaiting_batches = batch_id
             .saturating_sub(self.optimistic_start.unwrap_or(self.processing_target))
@@ -352,6 +355,15 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             &metrics::SYNCING_CHAIN_BATCH_AWAITING_PROCESSING,
             duration_in_awaiting_processing,
         );
+        let awaiting_processing_count = self
+            .batches
+            .values()
+            .filter(|b| matches!(b.state(), BatchState::AwaitingProcessing(..)))
+            .count();
+        metrics::observe(
+            &metrics::SYNCING_CHAIN_BATCH_AWAITING_PROCESSING_COUNT,
+            awaiting_processing_count as f64,
+        );
 
         let process_id = ChainSegmentProcessId::RangeBatchId(self.id, batch_id);
         self.current_processing_batch = Some(batch_id);
@@ -401,7 +413,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 // Batches can be in `AwaitingDownload` state if there weren't good data column subnet
                 // peers to send the request to.
                 BatchState::AwaitingDownload => return Ok(KeepChain),
-                BatchState::Processing(_) | BatchState::Failed => {
+                BatchState::Processing(..) | BatchState::Failed => {
                     // these are all inconsistent states:
                     // - Processing -> `self.current_processing_batch` is None
                     // - Failed -> non recoverable batch. For an optimistic batch, it should
@@ -438,7 +450,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 // Batches can be in `AwaitingDownload` state if there weren't good data column subnet
                 // peers to send the request to.
                 BatchState::AwaitingDownload => return Ok(KeepChain),
-                BatchState::Failed | BatchState::Processing(_) => {
+                BatchState::Failed | BatchState::Processing(..) => {
                     // these are all inconsistent states:
                     // - Failed -> non recoverable batch. Chain should have been removed
                     // - AwaitingDownload -> A recoverable failed batch should have been
@@ -523,6 +535,10 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 batch.state(),
             ))
         })?;
+
+        if let Some(duration) = batch.time_since_processing() {
+            metrics::observe_duration(&metrics::SYNCING_CHAIN_BATCH_PROCESSING, duration);
+        }
 
         // Log the process result and the batch for debugging purposes.
         debug!(
@@ -741,7 +757,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                     crit!("batch indicates inconsistent chain state while advancing chain")
                 }
                 BatchState::AwaitingProcessing(..) => {}
-                BatchState::Processing(_) => {
+                BatchState::Processing(..) => {
                     debug!(batch = %id, %batch, "Advancing chain while processing a batch");
                     if let Some(processing_id) = self.current_processing_batch
                         && id <= processing_id
@@ -901,7 +917,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         &mut self,
         network: &mut SyncNetworkContext<T>,
         batch_id: BatchId,
-        peer_id: &PeerId,
+        peer_id: Option<&PeerId>,
         request_id: Id,
         err: RpcResponseError,
     ) -> ProcessingResult {
@@ -910,45 +926,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         if let Some(batch) = self.batches.get_mut(&batch_id) {
             if let RpcResponseError::BlockComponentCouplingError(coupling_error) = &err {
                 match coupling_error {
-                    CouplingError::DataColumnPeerFailure {
-                        error,
-                        faulty_peers,
-                        exceeded_retries,
-                    } => {
-                        debug!(?batch_id, error, "Block components coupling error");
-                        // Note: we don't fail the batch here because a `CouplingError` is
-                        // recoverable by requesting from other honest peers.
-                        let mut failed_columns = HashSet::new();
-                        let mut failed_peers = HashSet::new();
-                        for (column, peer) in faulty_peers {
-                            failed_columns.insert(*column);
-                            failed_peers.insert(*peer);
-                        }
-                        // Retry the failed columns if the column requests haven't exceeded the
-                        // max retries. Otherwise, remove treat it as a failed batch below.
-                        if !*exceeded_retries {
-                            // Set the batch back to `AwaitingDownload` before retrying.
-                            // This is to ensure that the batch doesn't get stuck in `Downloading` state.
-                            //
-                            // DataColumn retries has a retry limit so calling `downloading_to_awaiting_download`
-                            // is safe.
-                            if let BatchOperationOutcome::Failed { blacklist } =
-                                batch.downloading_to_awaiting_download()?
-                            {
-                                return Err(RemoveChain::ChainFailed {
-                                    blacklist,
-                                    failing_batch: batch_id,
-                                });
-                            }
-                            return self.retry_partial_batch(
-                                network,
-                                batch_id,
-                                request_id,
-                                failed_columns,
-                                failed_peers,
-                            );
-                        }
-                    }
                     CouplingError::BlobPeerFailure(msg) => {
                         debug!(?batch_id, msg, "Blob peer failure");
                     }
@@ -957,6 +934,9 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                     }
                     CouplingError::InternalError(msg) => {
                         error!(?batch_id, msg, "Block components coupling internal error");
+                    }
+                    CouplingError::DataColumnPeerFailure { error, .. } => {
+                        debug!(?batch_id, error, "Data column peer failure");
                     }
                 }
             }
@@ -967,7 +947,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 debug!(
                     batch_epoch = %batch_id,
                     batch_state = ?batch.state(),
-                    %peer_id,
+                    ?peer_id,
                     %request_id,
                     ?batch_state,
                     "Batch not expecting block"
@@ -978,13 +958,12 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 batch_epoch = %batch_id,
                 batch_state = ?batch.state(),
                 error = ?err,
-                %peer_id,
+                ?peer_id,
                 %request_id,
                 "Batch download error"
             );
-            if let BatchOperationOutcome::Failed { blacklist } =
-                batch.download_failed(Some(*peer_id))?
-            {
+            let dl_outcome = batch.download_failed(peer_id.copied())?;
+            if let BatchOperationOutcome::Failed { blacklist } = dl_outcome {
                 return Err(RemoveChain::ChainFailed {
                     blacklist,
                     failing_batch: batch_id,
@@ -997,7 +976,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         } else {
             debug!(
                 batch_epoch = %batch_id,
-                %peer_id,
+                ?peer_id,
                 %request_id,
                 batch_state,
                 "Batch not found"
@@ -1053,15 +1032,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         let batch_state = self.visualize_batch_state();
         if let Some(batch) = self.batches.get_mut(&batch_id) {
             let (request, batch_type) = batch.to_blocks_by_range_request();
-            let failed_peers = batch.failed_peers();
-
-            let synced_column_peers = network
-                .network_globals()
-                .peers
-                .read()
-                .synced_peers_for_epoch(batch_id)
-                .cloned()
-                .collect::<HashSet<_>>();
 
             match network.block_components_by_range_request(
                 batch_type,
@@ -1072,12 +1042,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 },
                 // Request blocks only from peers of this specific chain
                 &self.peers,
-                // Request column from all synced peers, even if they are not part of this chain.
-                // This is to avoid splitting of good column peers across many head chains in a heavy forking
-                // environment. If the column peers and block peer are on different chains, then we return
-                // a coupling error and retry only the columns that failed to couple. See `Self::retry_partial_batch`.
-                &synced_column_peers,
-                &failed_peers,
             ) {
                 Ok(request_id) => {
                     // inform the batch about the new request
@@ -1125,55 +1089,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         Ok(KeepChain)
     }
 
-    /// Retries partial column requests within the batch by creating new requests for the failed columns.
-    fn retry_partial_batch(
-        &mut self,
-        network: &mut SyncNetworkContext<T>,
-        batch_id: BatchId,
-        id: Id,
-        failed_columns: HashSet<ColumnIndex>,
-        mut failed_peers: HashSet<PeerId>,
-    ) -> ProcessingResult {
-        let _guard = self.span.clone().entered();
-        debug!(%batch_id, %id, ?failed_columns, "Retrying partial batch");
-        if let Some(batch) = self.batches.get_mut(&batch_id) {
-            failed_peers.extend(&batch.failed_peers());
-            let req = batch.to_blocks_by_range_request().0;
-
-            let synced_peers = network
-                .network_globals()
-                .peers
-                .read()
-                .synced_peers_for_epoch(batch_id)
-                .cloned()
-                .collect::<HashSet<_>>();
-
-            match network.retry_columns_by_range(
-                id,
-                &synced_peers,
-                &failed_peers,
-                req,
-                &failed_columns,
-            ) {
-                Ok(_) => {
-                    // inform the batch about the new request
-                    batch.start_downloading(id)?;
-                    debug!(
-                        ?batch_id,
-                        id, "Retried column requests from different peers"
-                    );
-                    return Ok(KeepChain);
-                }
-                Err(e) => {
-                    // No need to explicitly fail the batch since its in `AwaitingDownload` state
-                    // before we attempted to retry.
-                    debug!(?batch_id, id, e, "Failed to retry partial batch");
-                }
-            }
-        }
-        Ok(KeepChain)
-    }
-
     /// Returns true if this chain is currently syncing.
     pub fn is_syncing(&self) -> bool {
         match self.state {
@@ -1201,7 +1116,10 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
 
     /// Attempts to request the next required batches from the peer pool if the chain is syncing. It will exhaust the peer
     /// pool and left over batches until the batch buffer is reached or all peers are exhausted.
-    fn request_batches(&mut self, network: &mut SyncNetworkContext<T>) -> ProcessingResult {
+    pub(super) fn request_batches(
+        &mut self,
+        network: &mut SyncNetworkContext<T>,
+    ) -> ProcessingResult {
         if !matches!(self.state, ChainSyncingState::Syncing) {
             return Ok(KeepChain);
         }
@@ -1291,6 +1209,13 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             .count()
             >= BATCH_BUFFER_SIZE as usize
         {
+            return None;
+        }
+
+        // Don't start downloading the next batch until the previous batch's blocks have
+        // arrived. This serializes the block download phase while allowing custody-by-root
+        // requests to run in parallel across batches.
+        if network.has_pending_block_range_download(self.id) {
             return None;
         }
 

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -380,33 +380,6 @@ where
         self.chains.register_metrics();
     }
 
-    /// Notifies the chain that a block download has completed (blocks received, columns may still
-    /// be pending). This allows the chain to start downloading the next batch immediately.
-    pub fn trigger_batch_downloads(
-        &mut self,
-        network: &mut SyncNetworkContext<T>,
-        chain_id: ChainId,
-    ) {
-        match self
-            .chains
-            .call_by_id(chain_id, |chain| chain.request_batches(network))
-        {
-            Ok((None, _)) => {}
-            Ok((Some((removed_chain, remove_reason)), sync_type)) => {
-                self.on_chain_removed(
-                    removed_chain,
-                    sync_type,
-                    remove_reason,
-                    network,
-                    "trigger_batch_downloads",
-                );
-            }
-            Err(_) => {
-                debug!(%chain_id, "trigger_batch_downloads for removed chain");
-            }
-        }
-    }
-
     /// Kickstarts sync.
     pub fn resume(&mut self, network: &mut SyncNetworkContext<T>) {
         for (removed_chain, sync_type, remove_reason) in

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -301,7 +301,7 @@ where
     pub fn inject_error(
         &mut self,
         network: &mut SyncNetworkContext<T>,
-        peer_id: PeerId,
+        peer_id: Option<PeerId>,
         batch_id: BatchId,
         chain_id: ChainId,
         request_id: Id,
@@ -309,7 +309,7 @@ where
     ) {
         // check that this request is pending
         match self.chains.call_by_id(chain_id, |chain| {
-            chain.inject_error(network, batch_id, &peer_id, request_id, err)
+            chain.inject_error(network, batch_id, peer_id.as_ref(), request_id, err)
         }) {
             Ok((removed_chain, sync_type)) => {
                 if let Some((removed_chain, remove_reason)) = removed_chain {
@@ -378,6 +378,33 @@ where
 
     pub fn register_metrics(&self) {
         self.chains.register_metrics();
+    }
+
+    /// Notifies the chain that a block download has completed (blocks received, columns may still
+    /// be pending). This allows the chain to start downloading the next batch immediately.
+    pub fn trigger_batch_downloads(
+        &mut self,
+        network: &mut SyncNetworkContext<T>,
+        chain_id: ChainId,
+    ) {
+        match self
+            .chains
+            .call_by_id(chain_id, |chain| chain.request_batches(network))
+        {
+            Ok((None, _)) => {}
+            Ok((Some((removed_chain, remove_reason)), sync_type)) => {
+                self.on_chain_removed(
+                    removed_chain,
+                    sync_type,
+                    remove_reason,
+                    network,
+                    "trigger_batch_downloads",
+                );
+            }
+            Err(_) => {
+                debug!(%chain_id, "trigger_batch_downloads for removed chain");
+            }
+        }
     }
 
     /// Kickstarts sync.


### PR DESCRIPTION
## Description

Range sync currently fetches data columns with `data_columns_by_range`. This PR switches range sync to fetch a node's custody columns via `data_columns_by_root`, requesting the custody columns for every data-bearing block in a batch with a single custody-by-root request (reusing the `ActiveCustodyRequest` machinery shared with lookup sync).

This replaces the columns-by-range coupling path, per-column requests plus per-column retry / faulty-peer bookkeeping with the generic custody-by-root request, and attributes the completed batch to the block peer.

- Prototype and previous reviews: https://github.com/dapplion/lighthouse/pull/67

## Proposed Changes

- Generalize the custody-by-root request to accept a `Vec<Hash256>` of block roots so a whole batch is fetched in one request; `DataColumnsByRootRequestParams { block_roots, indices }` completes at `block_roots.len() * indices.len()`.
- `custody_lookup_request` takes `block_roots: &[Hash256]` + `block_epoch`; `cached_data_column_indexes` takes `block_epoch`.
- `block_sidecar_coupling.rs`: couple a batch's blocks with the columns returned by the single custody-by-root request; drop the per-column request map and retry/faulty-peer machinery.
- Remove the now-unused columns-by-range range-sync path and the serialize-downloads gate.
