### PR TITLE
fix: reject non-empty request bodies for light-client no-body protocols

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/codec.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec.rs
@@ -167,6 +167,12 @@ impl<E: EthSpec> Decoder for SSZSnappyInboundCodec<E> {
         if self.protocol.versioned_protocol == SupportedProtocol::MetaDataV3 {
             return Ok(Some(RequestType::MetaData(MetadataRequest::new_v3())));
         }
+        if self.protocol.versioned_protocol == SupportedProtocol::LightClientOptimisticUpdateV1 {
+            return Ok(Some(RequestType::LightClientOptimisticUpdate));
+        }
+        if self.protocol.versioned_protocol == SupportedProtocol::LightClientFinalityUpdateV1 {
+            return Ok(Some(RequestType::LightClientFinalityUpdate));
+        }
         let Some(length) = handle_length(&mut self.inner, &mut self.len, src)? else {
             return Ok(None);
         };
@@ -602,11 +608,25 @@ fn handle_rpc_request<E: EthSpec>(
                 root: Hash256::from_ssz_bytes(decoded_buffer)?,
             },
         ))),
+        // LightClientOptimisticUpdate and LightClientFinalityUpdate requests
+        // return early from InboundUpgrade and do not reach the decoder.
         SupportedProtocol::LightClientOptimisticUpdateV1 => {
-            Ok(Some(RequestType::LightClientOptimisticUpdate))
+            if !decoded_buffer.is_empty() {
+                Err(RPCError::InvalidData(
+                    "LightClientOptimisticUpdate request should be empty".to_string(),
+                ))
+            } else {
+                Ok(Some(RequestType::LightClientOptimisticUpdate))
+            }
         }
         SupportedProtocol::LightClientFinalityUpdateV1 => {
-            Ok(Some(RequestType::LightClientFinalityUpdate))
+            if !decoded_buffer.is_empty() {
+                Err(RPCError::InvalidData(
+                    "LightClientFinalityUpdate request should be empty".to_string(),
+                ))
+            } else {
+                Ok(Some(RequestType::LightClientFinalityUpdate))
+            }
         }
         SupportedProtocol::LightClientUpdatesByRangeV1 => {
             Ok(Some(RequestType::LightClientUpdatesByRange(


### PR DESCRIPTION
The consensus spec defines `light_client_finality_update` and `light_client_optimistic_update` as **No Request Content** protocols so any bytes sent on the request stream must be rejected with `InvalidRequest`. Currently, Lighthouse silently ignores extra bytes instead of rejecting them

## Fix

Added checkes for light-client update protocols, following the exact same pattern already used by `MetaDataV1`/`V2`/`V3` in `decode()` where we now skip body parsing entirely for light-client protocols preventing the codec from attempting to read a body and if the decoder path is somehow reached with a non-empty buffer then we return `RPCError::InvalidData` which is consistent with the `MetaDataV1` handling

## Testing
All 12 existing codec tests pass

Closes #9448