### PR TITLE
Forbid removed `execution_payload_envelope.rs` file

### DIFF
--- a/.github/forbidden-files.txt
+++ b/.github/forbidden-files.txt
@@ -9,6 +9,7 @@ beacon_node/beacon_chain/src/block_reward.rs
 beacon_node/http_api/src/attestation_performance.rs
 beacon_node/http_api/src/block_packing_efficiency.rs
 beacon_node/http_api/src/block_rewards.rs
+beacon_node/http_api/src/beacon/execution_payload_envelope.rs
 common/eth2/src/lighthouse/attestation_performance.rs
 common/eth2/src/lighthouse/block_packing_efficiency.rs
 common/eth2/src/lighthouse/block_rewards.rs


### PR DESCRIPTION
## Issue Addressed

I noticed that `beacon_node/http_api/src/beacon/execution_payload_envelope.rs` was recently removed but not added to the forbidden-files.txt.

## Proposed Changes

Add the removed file to the forbidden list to ensure it isn't accidentally re-added by a merge or rebase. 
