### PR TITLE
chore: fix typos in comments

### DIFF
--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -425,7 +425,7 @@ where
     }
 
     /// Initializes the BLS withdrawal keypairs for `num_keypairs` validators to
-    /// the "determistic" values, regardless of wether or not the validator has
+    /// the "deterministic" values, regardless of whether or not the validator has
     /// a BLS or execution address in the genesis deposits.
     ///
     /// This aligns with the withdrawal commitments used in the "interop"

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -129,7 +129,7 @@ impl<E: EthSpec> InteractiveTester<E> {
 
         tokio::spawn(server);
 
-        // Late-initalize the mock builder now that the mock execution node and beacon API ports
+        // Late-initialize the mock builder now that the mock execution node and beacon API ports
         // have been allocated.
         let beacon_api_ip = listening_socket.ip();
         let beacon_api_port = listening_socket.port();

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -699,7 +699,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                         peers_to_deprioritize.contains(peer),
                         // Prefer peers with less overall requests
                         // Also account for requests that are not yet issued tracked in peer_id_to_request_map
-                        // We batch requests to the same peer, so count existance in the
+                        // We batch requests to the same peer, so count existence in the
                         // `columns_to_request_by_peer` as a single 1 request.
                         active_request_count_by_peer.get(peer).copied().unwrap_or(0)
                             + columns_to_request_by_peer.get(peer).map(|_| 1).unwrap_or(0),

--- a/consensus/state_processing/src/per_epoch_processing/single_pass.rs
+++ b/consensus/state_processing/src/per_epoch_processing/single_pass.rs
@@ -1212,7 +1212,7 @@ fn process_single_dummy_effective_balance_update(
     state_ctxt: &StateContext,
 ) -> Result<(), Error> {
     // Populate the effective balance cache with the current effective balance. This will be
-    // overriden when `process_single_effective_balance_update` is called.
+    // overridden when `process_single_effective_balance_update` is called.
     let is_active_next_epoch = validator.is_active_at(state_ctxt.next_epoch);
     let temporary_effective_balance = validator.effective_balance;
     next_epoch_cache.update_effective_balance(

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -867,7 +867,7 @@ async fn poll_beacon_attesters<S: ValidatorStore + 'static, T: SlotClock + 'stat
     );
 
     // This vector is intentionally oversized by 10% so that it won't reallocate.
-    // Each validator has 2 attestation duties occuring in the current and next epoch, for which
+    // Each validator has 2 attestation duties occurring in the current and next epoch, for which
     // they must send `ATTESTATION_SUBSCRIPTION_OFFSETS.len()` subscriptions. These subscription
     // slots are approximately evenly distributed over the two epochs, usually with a slight lag
     // that balances out (some subscriptions for the current epoch were sent in the previous, and


### PR DESCRIPTION
Fixes spelling mistakes in code comments. Comment-only — no functional changes.

| File | Before | After |
|---|---|---|
| `beacon_node/network/src/sync/network_context.rs` | existance | existence |
| `consensus/state_processing/src/per_epoch_processing/single_pass.rs` | overriden | overridden |
| `validator_client/validator_services/src/duties_service.rs` | occuring | occurring |
| `beacon_node/beacon_chain/src/test_utils.rs` | determistic / wether | deterministic / whether |
| `beacon_node/http_api/src/test_utils.rs` | initalize | initialize |

🤖 Generated with [Claude Code](https://claude.com/claude-code)