### PR TITLE
Refactor Custody Context Availability Checks

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3316,8 +3316,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         );
 
         // Check if we have custody of this column
-        let sampling_columns =
-            self.sampling_columns_for_epoch(slot.epoch(T::EthSpec::slots_per_epoch()));
+        let sampling_columns = self
+            .custody_context
+            .sampling_columns_for_epoch(slot.epoch(T::EthSpec::slots_per_epoch()));
         let verified_partial = if sampling_columns.contains(&partial.index) {
             KzgVerifiedCustodyPartialDataColumn::from_asserted_custody(verified_partial)
         } else {
@@ -7477,7 +7478,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 Some(StoreOp::PutBlobs(block_root, blobs))
             }
             AvailableBlockData::DataColumns(mut data_columns) => {
-                let columns_to_custody = self.custody_columns_for_epoch(Some(
+                let columns_to_custody = self.custody_context.custody_columns_for_epoch(Some(
                     block_slot.epoch(T::EthSpec::slots_per_epoch()),
                 ));
                 // Supernodes need to persist all sampled custody columns
@@ -7522,23 +7523,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // return in ascending slot order
         roots.reverse();
         roots
-    }
-
-    /// Returns a list of column indices that should be sampled for a given epoch.
-    /// Used for data availability sampling in PeerDAS.
-    pub fn sampling_columns_for_epoch(&self, epoch: Epoch) -> &[ColumnIndex] {
-        // TODO: remove?
-        self.custody_context.sampling_columns_for_epoch(epoch)
-    }
-
-    /// Returns a list of column indices that the node is expected to custody for a given epoch.
-    /// i.e. the node must have validated and persisted the column samples and should be able to
-    /// serve them to peers.
-    ///
-    /// If epoch is `None`, this function computes the custody columns at head.
-    pub fn custody_columns_for_epoch(&self, epoch_opt: Option<Epoch>) -> &[ColumnIndex] {
-        // TODO: remove?
-        self.custody_context.custody_columns_for_epoch(epoch_opt)
     }
 }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -16,7 +16,7 @@ use crate::block_verification_types::{
 };
 pub use crate::canonical_head::CanonicalHead;
 use crate::chain_config::ChainConfig;
-use crate::custody_context::CustodyContextSsz;
+use crate::custody_context::{CustodyContext, CustodyContextSsz};
 use crate::data_availability_checker::{
     Availability as BlockAvailability, AvailabilityCheckError, AvailableBlock, AvailableBlockData,
     DataColumnReconstructionResult as DataColumnReconstructionResultV1,
@@ -500,6 +500,8 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     pub validator_monitor: RwLock<ValidatorMonitor<T::EthSpec>>,
     /// The slot at which blocks are downloaded back to.
     pub genesis_backfill_slot: Slot,
+    /// Contains all the information the node requires to calculate which columns to custody
+    pub custody_context: Arc<CustodyContext<T>>,
     /// Provides KZG verification and temporary storage for pre-Gloas blocks and blobs.
     pub data_availability_checker: Arc<DataAvailabilityChecker<T>>,
     /// Provides KZG verification and temporary storage for post-Gloas payload envelopes.
@@ -682,11 +684,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Ok(());
         }
 
-        let custody_context: CustodyContextSsz = self
-            .data_availability_checker
-            .custody_context()
-            .as_ref()
-            .into();
+        let custody_context: CustodyContextSsz = self.custody_context.as_ref().into();
 
         // Pattern match to avoid accidentally missing fields and to ignore deprecated fields.
         let CustodyContextSsz {
@@ -7170,25 +7168,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             })
     }
 
-    /// The data availability boundary for custodying columns. It will just be the
-    /// regular data availability boundary unless we are near the Fulu fork epoch.
-    pub fn column_data_availability_boundary(&self) -> Option<Epoch> {
-        match self.data_availability_boundary() {
-            Some(da_boundary_epoch) => {
-                if let Some(fulu_fork_epoch) = self.spec.fulu_fork_epoch {
-                    if da_boundary_epoch < fulu_fork_epoch {
-                        Some(fulu_fork_epoch)
-                    } else {
-                        Some(da_boundary_epoch)
-                    }
-                } else {
-                    None // Fulu hasn't been enabled
-                }
-            }
-            None => None, // Deneb hasn't been enabled
-        }
-    }
-
     /// Safely update data column custody info by ensuring that:
     /// - cgc values at the updated epoch and the earliest custodied column epoch are equal
     /// - we are only decrementing the earliest custodied data column epoch by one epoch
@@ -7206,13 +7185,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         let cgc_at_effective_epoch = self
-            .data_availability_checker
-            .custody_context()
+            .custody_context
             .custody_group_count_at_epoch(effective_epoch, &self.spec);
 
         let cgc_at_earliest_data_colum_epoch = self
-            .data_availability_checker
-            .custody_context()
+            .custody_context
             .custody_group_count_at_epoch(earliest_data_column_epoch, &self.spec);
 
         let can_update_data_column_custody_info = cgc_at_effective_epoch
@@ -7240,15 +7217,15 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Compare columns custodied for `epoch` versus columns custodied for the head of the chain
     /// and return any column indices that are missing.
     pub fn get_missing_columns_for_epoch(&self, epoch: Epoch) -> HashSet<ColumnIndex> {
-        let custody_context = self.data_availability_checker.custody_context();
-
-        let columns_required = custody_context
+        let columns_required = self
+            .custody_context
             .custody_columns_for_epoch(None, &self.spec)
             .iter()
             .cloned()
             .collect::<HashSet<_>>();
 
-        let current_columns_at_epoch = custody_context
+        let current_columns_at_epoch = self
+            .custody_context
             .custody_columns_for_epoch(Some(epoch), &self.spec)
             .iter()
             .cloned()
@@ -7258,24 +7235,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .difference(&current_columns_at_epoch)
             .cloned()
             .collect::<HashSet<_>>()
-    }
-
-    /// The da boundary for custodying columns. It will just be the DA boundary unless we are near the Fulu fork epoch.
-    pub fn get_column_da_boundary(&self) -> Option<Epoch> {
-        match self.data_availability_boundary() {
-            Some(da_boundary_epoch) => {
-                if let Some(fulu_fork_epoch) = self.spec.fulu_fork_epoch {
-                    if da_boundary_epoch < fulu_fork_epoch {
-                        Some(fulu_fork_epoch)
-                    } else {
-                        Some(da_boundary_epoch)
-                    }
-                } else {
-                    None
-                }
-            }
-            None => None, // If no DA boundary set, dont try to custody backfill
-        }
     }
 
     /// This method serves to get a sense of the current chain health. It is used in block proposal
@@ -7480,33 +7439,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         gossip_attested || block_attested || aggregated || produced_block
     }
 
-    /// The epoch at which we require a data availability check in block processing.
-    /// `None` if the `Deneb` fork is disabled.
-    pub fn data_availability_boundary(&self) -> Option<Epoch> {
-        self.data_availability_checker
-            .custody_context()
-            .data_availability_boundary()
-    }
-
-    /// Returns true if epoch is within the data availability boundary
-    pub fn da_check_required_for_epoch(&self, epoch: Epoch) -> bool {
-        self.data_availability_checker
-            .custody_context()
-            .da_check_required_for_epoch(epoch)
-    }
-
-    /// Returns true if we should fetch blobs for this block
-    pub fn should_fetch_blobs(&self, block_epoch: Epoch) -> bool {
-        self.da_check_required_for_epoch(block_epoch)
-            && !self.spec.is_peer_das_enabled_for_epoch(block_epoch)
-    }
-
-    /// Returns true if we should fetch custody columns for this block
-    pub fn should_fetch_custody_columns(&self, block_epoch: Epoch) -> bool {
-        self.da_check_required_for_epoch(block_epoch)
-            && self.spec.is_peer_das_enabled_for_epoch(block_epoch)
-    }
-
     /// Gets the `LightClientBootstrap` object for a requested block root.
     ///
     /// Returns `None` when the state or block is not found in the database.
@@ -7595,8 +7527,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Returns a list of column indices that should be sampled for a given epoch.
     /// Used for data availability sampling in PeerDAS.
     pub fn sampling_columns_for_epoch(&self, epoch: Epoch) -> &[ColumnIndex] {
-        self.data_availability_checker
-            .custody_context()
+        // TODO: remove?
+        self.custody_context
             .sampling_columns_for_epoch(epoch, &self.spec)
     }
 
@@ -7606,8 +7538,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// If epoch is `None`, this function computes the custody columns at head.
     pub fn custody_columns_for_epoch(&self, epoch_opt: Option<Epoch>) -> &[ColumnIndex] {
-        self.data_availability_checker
-            .custody_context()
+        // TODO: remove?
+        self.custody_context
             .custody_columns_for_epoch(epoch_opt, &self.spec)
     }
 }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -7186,11 +7186,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let cgc_at_effective_epoch = self
             .custody_context
-            .custody_group_count_at_epoch(effective_epoch, &self.spec);
+            .custody_group_count_at_epoch(effective_epoch);
 
         let cgc_at_earliest_data_colum_epoch = self
             .custody_context
-            .custody_group_count_at_epoch(earliest_data_column_epoch, &self.spec);
+            .custody_group_count_at_epoch(earliest_data_column_epoch);
 
         let can_update_data_column_custody_info = cgc_at_effective_epoch
             == cgc_at_earliest_data_colum_epoch
@@ -7219,14 +7219,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn get_missing_columns_for_epoch(&self, epoch: Epoch) -> HashSet<ColumnIndex> {
         let columns_required = self
             .custody_context
-            .custody_columns_for_epoch(None, &self.spec)
+            .custody_columns_for_epoch(None)
             .iter()
             .cloned()
             .collect::<HashSet<_>>();
 
         let current_columns_at_epoch = self
             .custody_context
-            .custody_columns_for_epoch(Some(epoch), &self.spec)
+            .custody_columns_for_epoch(Some(epoch))
             .iter()
             .cloned()
             .collect::<HashSet<_>>();
@@ -7528,8 +7528,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Used for data availability sampling in PeerDAS.
     pub fn sampling_columns_for_epoch(&self, epoch: Epoch) -> &[ColumnIndex] {
         // TODO: remove?
-        self.custody_context
-            .sampling_columns_for_epoch(epoch, &self.spec)
+        self.custody_context.sampling_columns_for_epoch(epoch)
     }
 
     /// Returns a list of column indices that the node is expected to custody for a given epoch.
@@ -7539,8 +7538,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// If epoch is `None`, this function computes the custody columns at head.
     pub fn custody_columns_for_epoch(&self, epoch_opt: Option<Epoch>) -> &[ColumnIndex] {
         // TODO: remove?
-        self.custody_context
-            .custody_columns_for_epoch(epoch_opt, &self.spec)
+        self.custody_context.custody_columns_for_epoch(epoch_opt)
     }
 }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3981,7 +3981,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         )?;
         let availability = self
             .data_availability_checker
-            .put_rpc_blobs(block_root, blobs)
+            .put_rpc_blobs(block_root, blobs, &self.slot_clock)
             .map_err(BlockError::from)?;
 
         self.process_availability(slot, availability, || Ok(()))
@@ -7483,12 +7483,15 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// The epoch at which we require a data availability check in block processing.
     /// `None` if the `Deneb` fork is disabled.
     pub fn data_availability_boundary(&self) -> Option<Epoch> {
-        self.data_availability_checker.data_availability_boundary()
+        self.data_availability_checker
+            .custody_context()
+            .data_availability_boundary()
     }
 
     /// Returns true if epoch is within the data availability boundary
     pub fn da_check_required_for_epoch(&self, epoch: Epoch) -> bool {
         self.data_availability_checker
+            .custody_context()
             .da_check_required_for_epoch(epoch)
     }
 

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1246,8 +1246,7 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
                         AvailableBlock::new(
                             block,
                             AvailableBlockData::NoData,
-                            &chain.data_availability_checker,
-                            chain.spec.clone(),
+                            &chain.custody_context,
                         )
                         .map_err(BlockError::AvailabilityCheck)?,
                     )

--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -1,18 +1,18 @@
-use crate::data_availability_checker::{AvailabilityCheckError, DataAvailabilityChecker};
+use crate::data_availability_checker::AvailabilityCheckError;
 pub use crate::data_availability_checker::{
     AvailableBlock, AvailableBlockData, MaybeAvailableBlock,
 };
 use crate::payload_envelope_verification::AvailableEnvelope;
 use crate::payload_envelope_verification::gossip_verified_envelope::verify_envelope_consistency;
-use crate::{BeaconChainTypes, PayloadVerificationOutcome};
+use crate::{BeaconChainTypes, CustodyContext, PayloadVerificationOutcome};
 use state_processing::ConsensusContext;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use types::data::BlobIdentifier;
 use types::{
-    BeaconBlockRef, BeaconState, BlindedPayload, ChainSpec, Epoch, EthSpec, Hash256,
-    SignedBeaconBlock, SignedBeaconBlockHeader, Slot,
+    BeaconBlockRef, BeaconState, BlindedPayload, Epoch, EthSpec, Hash256, SignedBeaconBlock,
+    SignedBeaconBlockHeader, Slot,
 };
 
 /// A wrapper around a `SignedBeaconBlock`. This varaint is constructed
@@ -118,8 +118,7 @@ impl<E: EthSpec> RangeSyncBlock<E> {
     pub fn new<T>(
         block: Arc<SignedBeaconBlock<E>>,
         block_data: AvailableBlockData<E>,
-        da_checker: &DataAvailabilityChecker<T>,
-        spec: Arc<ChainSpec>,
+        custody_context: &CustodyContext<T>,
     ) -> Result<Self, AvailabilityCheckError>
     where
         T: BeaconChainTypes<EthSpec = E>,
@@ -127,7 +126,7 @@ impl<E: EthSpec> RangeSyncBlock<E> {
         if block.fork_name_unchecked().gloas_enabled() {
             return Err(AvailabilityCheckError::InvalidVariant);
         }
-        let available_block = AvailableBlock::new(block, block_data, da_checker, spec)?;
+        let available_block = AvailableBlock::new(block, block_data, custody_context)?;
         Ok(Self::Base(available_block))
     }
 
@@ -144,6 +143,7 @@ impl<E: EthSpec> RangeSyncBlock<E> {
         block: Arc<SignedBeaconBlock<E>>,
         envelope: Option<AvailableEnvelope<E>>,
     ) -> Result<Self, String> {
+        // TODO: add verification with custody context
         if let Some(envelope) = envelope.as_ref() {
             let execution_bid = &block
                 .message()

--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -143,7 +143,6 @@ impl<E: EthSpec> RangeSyncBlock<E> {
         block: Arc<SignedBeaconBlock<E>>,
         envelope: Option<AvailableEnvelope<E>>,
     ) -> Result<Self, String> {
-        // TODO: add verification with custody context
         if let Some(envelope) = envelope.as_ref() {
             let execution_bid = &block
                 .message()

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -951,6 +951,7 @@ where
                 self.node_custody_type,
                 head_epoch,
                 ordered_custody_column_indices,
+                slot_clock.clone(),
                 complete_blob_backfill,
                 &self.spec,
             )
@@ -959,6 +960,7 @@ where
                 CustodyContext::new(
                     self.node_custody_type,
                     ordered_custody_column_indices,
+                    slot_clock.clone(),
                     complete_blob_backfill,
                     &self.spec,
                 ),

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1042,7 +1042,6 @@ where
             genesis_backfill_slot,
             data_availability_checker: Arc::new(
                 DataAvailabilityChecker::new(
-                    complete_blob_backfill,
                     slot_clock.clone(),
                     self.kzg.clone(),
                     custody_context.clone(),

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -951,6 +951,7 @@ where
                 self.node_custody_type,
                 head_epoch,
                 ordered_custody_column_indices,
+                complete_blob_backfill,
                 &self.spec,
             )
         } else {
@@ -958,6 +959,7 @@ where
                 CustodyContext::new(
                     self.node_custody_type,
                     ordered_custody_column_indices,
+                    complete_blob_backfill,
                     &self.spec,
                 ),
                 None,

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -953,7 +953,7 @@ where
                 ordered_custody_column_indices,
                 slot_clock.clone(),
                 complete_blob_backfill,
-                &self.spec,
+                self.spec.clone(),
             )
         } else {
             (
@@ -962,7 +962,7 @@ where
                     ordered_custody_column_indices,
                     slot_clock.clone(),
                     complete_blob_backfill,
-                    &self.spec,
+                    self.spec.clone(),
                 ),
                 None,
             )

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1040,6 +1040,7 @@ where
             slasher: self.slasher.clone(),
             validator_monitor: RwLock::new(validator_monitor),
             genesis_backfill_slot,
+            custody_context: custody_context.clone(),
             data_availability_checker: Arc::new(
                 DataAvailabilityChecker::new(
                     self.kzg.clone(),
@@ -1051,12 +1052,8 @@ where
                 .map_err(|e| format!("Error initializing DataAvailabilityChecker: {:?}", e))?,
             ),
             pending_payload_cache: Arc::new(
-                PendingPayloadCache::new(
-                    self.kzg.clone(),
-                    custody_context.clone(),
-                    self.spec.clone(),
-                )
-                .map_err(|e| format!("Error initializing PendingPayloadCache: {:?}", e))?,
+                PendingPayloadCache::new(self.kzg.clone(), custody_context, self.spec.clone())
+                    .map_err(|e| format!("Error initializing PendingPayloadCache: {:?}", e))?,
             ),
             kzg: self.kzg.clone(),
             rng: Arc::new(Mutex::new(rng)),
@@ -1127,7 +1124,9 @@ where
         }
 
         // Prune blobs older than the blob data availability boundary in the background.
-        if let Some(data_availability_boundary) = beacon_chain.data_availability_boundary() {
+        if let Some(data_availability_boundary) =
+            beacon_chain.custody_context.data_availability_boundary()
+        {
             beacon_chain
                 .store_migrator
                 .process_prune_blobs(data_availability_boundary);

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1042,7 +1042,6 @@ where
             genesis_backfill_slot,
             data_availability_checker: Arc::new(
                 DataAvailabilityChecker::new(
-                    slot_clock.clone(),
                     self.kzg.clone(),
                     custody_context.clone(),
                     self.spec.clone(),

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1065,7 +1065,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         )?;
 
         // Prune blobs in the background.
-        if let Some(data_availability_boundary) = self.data_availability_boundary() {
+        if let Some(data_availability_boundary) = self.custody_context.data_availability_boundary()
+        {
             self.store_migrator
                 .process_prune_blobs(data_availability_boundary);
         }

--- a/beacon_node/beacon_chain/src/custody_context.rs
+++ b/beacon_node/beacon_chain/src/custody_context.rs
@@ -10,7 +10,9 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 use tracing::{debug, warn};
-use types::{ChainSpec, ColumnIndex, Epoch, EthSpec, SignedBeaconBlock, Slot};
+use types::{
+    ChainSpec, ColumnIndex, Epoch, EthSpec, SignedBeaconBlock, SignedExecutionPayloadBid, Slot,
+};
 
 /// A delay before making the CGC change effective to the data availability checker.
 pub const CUSTODY_CHANGE_DA_EFFECTIVE_DELAY_SECONDS: u64 = 30;
@@ -584,6 +586,13 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
     /// See `Self::data_columns_required_for_epoch`
     pub fn data_columns_required_for_block(&self, block: &SignedBeaconBlock<T::EthSpec>) -> bool {
         block.num_expected_blobs() > 0 && self.data_columns_required_for_epoch(block.epoch())
+    }
+
+    pub fn data_columns_required_for_bid(
+        &self,
+        bid: &SignedExecutionPayloadBid<T::EthSpec>,
+    ) -> bool {
+        bid.num_blobs_expected() > 0 && self.data_columns_required_for_epoch(bid.epoch())
     }
 
     /// The data availability boundary for custodying columns. It will just be the

--- a/beacon_node/beacon_chain/src/custody_context.rs
+++ b/beacon_node/beacon_chain/src/custody_context.rs
@@ -1,3 +1,5 @@
+use crate::BeaconChainTypes;
+use educe::Educe;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -236,8 +238,9 @@ impl NodeCustodyType {
 
 /// Contains all the information the node requires to calculate the
 /// number of columns to be custodied when checking for DA.
-#[derive(Debug)]
-pub struct CustodyContext<E: EthSpec> {
+#[derive(Educe)]
+#[educe(Debug(bound(T: BeaconChainTypes)))]
+pub struct CustodyContext<T: BeaconChainTypes> {
     /// The Number of custody groups required based on the number of validators
     /// that is attached to this node.
     ///
@@ -250,12 +253,16 @@ pub struct CustodyContext<E: EthSpec> {
     /// Stores an immutable, ordered list of all data column indices as determined by the node's NodeID
     /// on startup. This used to determine the node's custody columns.
     ordered_custody_column_indices: Vec<ColumnIndex>,
+    #[expect(dead_code)]
+    #[educe(Debug(ignore))]
+    slot_clock: T::SlotClock,
     /// backfill blobs and data columns beyond the data availability window.
     complete_blob_backfill: bool,
-    _phantom_data: PhantomData<E>,
+    #[educe(Debug(ignore))]
+    _phantom_data: PhantomData<T>,
 }
 
-impl<E: EthSpec> CustodyContext<E> {
+impl<T: BeaconChainTypes> CustodyContext<T> {
     /// Create a new custody default custody context object when no persisted object
     /// exists.
     ///
@@ -263,6 +270,7 @@ impl<E: EthSpec> CustodyContext<E> {
     pub fn new(
         node_custody_type: NodeCustodyType,
         ordered_custody_column_indices: Vec<ColumnIndex>,
+        slot_clock: T::SlotClock,
         complete_blob_backfill: bool,
         spec: &ChainSpec,
     ) -> Self {
@@ -274,6 +282,7 @@ impl<E: EthSpec> CustodyContext<E> {
             validator_custody_count: AtomicU64::new(cgc_override.unwrap_or(0)),
             validator_registrations: RwLock::new(ValidatorRegistrations::new(cgc_override)),
             ordered_custody_column_indices,
+            slot_clock,
             complete_blob_backfill,
             _phantom_data: PhantomData,
         }
@@ -298,6 +307,7 @@ impl<E: EthSpec> CustodyContext<E> {
         node_custody_type: NodeCustodyType,
         head_epoch: Epoch,
         ordered_custody_column_indices: Vec<ColumnIndex>,
+        slot_clock: T::SlotClock,
         complete_blob_backfill: bool,
         spec: &ChainSpec,
     ) -> (Self, Option<CustodyCountChanged>) {
@@ -365,6 +375,7 @@ impl<E: EthSpec> CustodyContext<E> {
                     .collect(),
             }),
             ordered_custody_column_indices,
+            slot_clock,
             complete_blob_backfill,
             _phantom_data: PhantomData,
         };
@@ -384,10 +395,10 @@ impl<E: EthSpec> CustodyContext<E> {
         current_slot: Slot,
         spec: &ChainSpec,
     ) -> Option<CustodyCountChanged> {
-        let Some((effective_epoch, new_validator_custody)) = self
-            .validator_registrations
-            .write()
-            .register_validators::<E>(validators_and_balance, current_slot, spec)
+        let Some((effective_epoch, new_validator_custody)) =
+            self.validator_registrations
+                .write()
+                .register_validators::<T::EthSpec>(validators_and_balance, current_slot, spec)
         else {
             return None;
         };
@@ -459,13 +470,13 @@ impl<E: EthSpec> CustodyContext<E> {
     /// Returns the count of columns this node must _sample_ for a block at `epoch` to import.
     pub fn num_of_data_columns_to_sample(&self, epoch: Epoch, spec: &ChainSpec) -> usize {
         let custody_group_count = self.custody_group_count_at_epoch(epoch, spec);
-        spec.sampling_size_columns::<E>(custody_group_count)
+        spec.sampling_size_columns::<T::EthSpec>(custody_group_count)
             .expect("should compute node sampling size from valid chain spec")
     }
 
     /// Returns whether the node should attempt reconstruction at a given epoch.
     pub fn should_attempt_reconstruction(&self, epoch: Epoch, spec: &ChainSpec) -> bool {
-        let min_columns_for_reconstruction = E::number_of_columns() / 2;
+        let min_columns_for_reconstruction = T::EthSpec::number_of_columns() / 2;
         // performing reconstruction is not necessary if sampling column count is exactly 50%,
         // because the node doesn't need the remaining columns.
         self.num_of_data_columns_to_sample(epoch, spec) > min_columns_for_reconstruction
@@ -509,7 +520,7 @@ impl<E: EthSpec> CustodyContext<E> {
         };
 
         // This is an unnecessary conversion for spec compliance, basically just multiplying by 1.
-        let columns_per_custody_group = spec.data_columns_per_group::<E>() as usize;
+        let columns_per_custody_group = spec.data_columns_per_group::<T::EthSpec>() as usize;
         let custody_column_count = columns_per_custody_group * custody_group_count;
 
         &self.ordered_custody_column_indices[..custody_column_count]
@@ -559,8 +570,8 @@ pub struct CustodyContextSsz {
     pub epoch_validator_custody_requirements: Vec<(Epoch, u64)>,
 }
 
-impl<E: EthSpec> From<&CustodyContext<E>> for CustodyContextSsz {
-    fn from(context: &CustodyContext<E>) -> Self {
+impl<T: BeaconChainTypes> From<&CustodyContext<T>> for CustodyContextSsz {
+    fn from(context: &CustodyContext<T>) -> Self {
         CustodyContextSsz {
             validator_custody_at_head: context.validator_custody_count.load(Ordering::Relaxed),
             // This field is deprecated and has no effect
@@ -579,16 +590,27 @@ impl<E: EthSpec> From<&CustodyContext<E>> for CustodyContextSsz {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::generate_data_column_indices_rand_order;
+    use crate::test_utils::{EphemeralHarnessType, generate_data_column_indices_rand_order};
+    use slot_clock::{SlotClock, TestingSlotClock};
+    use std::time::Duration;
     use types::MainnetEthSpec;
 
     type E = MainnetEthSpec;
+    type T = EphemeralHarnessType<E>;
+
+    fn testing_slot_clock(spec: &ChainSpec) -> TestingSlotClock {
+        TestingSlotClock::new(
+            Slot::new(0),
+            Duration::from_secs(0),
+            spec.get_slot_duration(),
+        )
+    }
 
     fn setup_custody_context(
         spec: &ChainSpec,
         head_epoch: Epoch,
         epoch_and_cgc_tuples: Vec<(Epoch, u64)>,
-    ) -> CustodyContext<E> {
+    ) -> CustodyContext<T> {
         let cgc_at_head = epoch_and_cgc_tuples.last().unwrap().1;
         let ssz_context = CustodyContextSsz {
             validator_custody_at_head: cgc_at_head,
@@ -597,11 +619,12 @@ mod tests {
         };
 
         let complete_blob_backfill = false;
-        let (custody_context, _) = CustodyContext::<E>::new_from_persisted_custody_context(
+        let (custody_context, _) = CustodyContext::<T>::new_from_persisted_custody_context(
             ssz_context,
             NodeCustodyType::Fullnode,
             head_epoch,
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(spec),
             complete_blob_backfill,
             spec,
         );
@@ -610,7 +633,7 @@ mod tests {
     }
 
     fn complete_backfill_for_epochs(
-        custody_context: &CustodyContext<E>,
+        custody_context: &CustodyContext<T>,
         start_epoch: Epoch,
         end_epoch: Epoch,
         expected_cgc: u64,
@@ -641,11 +664,12 @@ mod tests {
         let complete_blob_backfill = false;
 
         let (custody_context, custody_count_changed) =
-            CustodyContext::<E>::new_from_persisted_custody_context(
+            CustodyContext::<T>::new_from_persisted_custody_context(
                 ssz_context,
                 target_node_custody_type,
                 head_epoch,
                 generate_data_column_indices_rand_order::<E>(),
+                testing_slot_clock(spec),
                 complete_blob_backfill,
                 spec,
             );
@@ -714,11 +738,12 @@ mod tests {
         let complete_blob_backfill = false;
 
         let (custody_context, custody_count_changed) =
-            CustodyContext::<E>::new_from_persisted_custody_context(
+            CustodyContext::<T>::new_from_persisted_custody_context(
                 ssz_context,
                 target_node_custody_type,
                 head_epoch,
                 generate_data_column_indices_rand_order::<E>(),
+                testing_slot_clock(spec),
                 complete_blob_backfill,
                 spec,
             );
@@ -742,9 +767,10 @@ mod tests {
     fn no_validators_supernode_default() {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Supernode,
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -762,9 +788,10 @@ mod tests {
     fn no_validators_semi_supernode_default() {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::SemiSupernode,
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -782,9 +809,10 @@ mod tests {
     fn no_validators_fullnode_default() {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -803,9 +831,10 @@ mod tests {
     fn register_single_validator_should_update_cgc() {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -822,7 +851,7 @@ mod tests {
             (vec![(0, 10 * bal_per_additional_group)], Some(10)),
         ];
 
-        register_validators_and_assert_cgc::<E>(
+        register_validators_and_assert_cgc::<T>(
             &custody_context,
             validators_and_expected_cgc_change,
             &spec,
@@ -833,9 +862,10 @@ mod tests {
     fn register_multiple_validators_should_update_cgc() {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -865,7 +895,7 @@ mod tests {
             ),
         ];
 
-        register_validators_and_assert_cgc::<E>(
+        register_validators_and_assert_cgc::<T>(
             &custody_context,
             validators_and_expected_cgc,
             &spec,
@@ -876,9 +906,10 @@ mod tests {
     fn register_validators_should_not_update_cgc_for_supernode() {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Supernode,
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -904,7 +935,7 @@ mod tests {
             ),
         ];
 
-        register_validators_and_assert_cgc::<E>(
+        register_validators_and_assert_cgc::<T>(
             &custody_context,
             validators_and_expected_cgc,
             &spec,
@@ -920,9 +951,10 @@ mod tests {
     fn cgc_change_should_be_effective_to_sampling_after_delay() {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -957,9 +989,10 @@ mod tests {
     fn validator_dropped_after_no_registrations_within_expiry_should_not_reduce_cgc() {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -1005,9 +1038,10 @@ mod tests {
     fn validator_dropped_after_no_registrations_within_expiry() {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -1058,8 +1092,8 @@ mod tests {
     }
 
     /// Update the validator every epoch and assert cgc against expected values.
-    fn register_validators_and_assert_cgc<E: EthSpec>(
-        custody_context: &CustodyContext<E>,
+    fn register_validators_and_assert_cgc<T: BeaconChainTypes>(
+        custody_context: &CustodyContext<T>,
         validators_and_expected_cgc_changed: Vec<(ValidatorsAndBalances, Option<u64>)>,
         spec: &ChainSpec,
     ) {
@@ -1070,7 +1104,7 @@ mod tests {
             let updated_custody_count_opt = custody_context
                 .register_validators(
                     validators_and_balance,
-                    epoch.start_slot(E::slots_per_epoch()),
+                    epoch.start_slot(T::EthSpec::slots_per_epoch()),
                     spec,
                 )
                 .map(|c| c.new_custody_group_count);
@@ -1084,9 +1118,10 @@ mod tests {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             ordered_custody_column_indices,
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -1102,9 +1137,10 @@ mod tests {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Supernode,
             ordered_custody_column_indices,
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -1120,9 +1156,10 @@ mod tests {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             ordered_custody_column_indices,
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -1148,9 +1185,10 @@ mod tests {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             ordered_custody_column_indices,
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -1175,11 +1213,12 @@ mod tests {
             epoch_validator_custody_requirements: vec![],
         };
 
-        let (custody_context, _) = CustodyContext::<E>::new_from_persisted_custody_context(
+        let (custody_context, _) = CustodyContext::<T>::new_from_persisted_custody_context(
             ssz_context,
             NodeCustodyType::Fullnode,
             Epoch::new(0),
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -1215,9 +1254,10 @@ mod tests {
         let spec = E::default_spec();
         let complete_blob_backfill = false;
         let semi_supernode_cgc = spec.number_of_custody_groups / 2; // 64
-        let custody_context = CustodyContext::<E>::new(
+        let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::SemiSupernode,
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );
@@ -1367,11 +1407,12 @@ mod tests {
         };
 
         let complete_blob_backfill = false;
-        let (custody_context, _) = CustodyContext::<E>::new_from_persisted_custody_context(
+        let (custody_context, _) = CustodyContext::<T>::new_from_persisted_custody_context(
             ssz_context,
             NodeCustodyType::Fullnode,
             Epoch::new(20),
             generate_data_column_indices_rand_order::<E>(),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             &spec,
         );

--- a/beacon_node/beacon_chain/src/custody_context.rs
+++ b/beacon_node/beacon_chain/src/custody_context.rs
@@ -272,9 +272,9 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
         ordered_custody_column_indices: Vec<ColumnIndex>,
         slot_clock: T::SlotClock,
         complete_blob_backfill: bool,
-        spec: &ChainSpec,
+        spec: Arc<ChainSpec>,
     ) -> Self {
-        let cgc_override = node_custody_type.get_custody_count_override(spec);
+        let cgc_override = node_custody_type.get_custody_count_override(&spec);
         // If there's no override, we initialise `validator_custody_count` to 0. This has been the
         // existing behaviour and we maintain this for now to avoid a semantic schema change until
         // a later release.
@@ -284,7 +284,7 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
             ordered_custody_column_indices,
             slot_clock,
             complete_blob_backfill,
-            spec: Arc::new(spec.clone()),
+            spec,
         }
     }
 
@@ -309,7 +309,7 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
         ordered_custody_column_indices: Vec<ColumnIndex>,
         slot_clock: T::SlotClock,
         complete_blob_backfill: bool,
-        spec: &ChainSpec,
+        spec: Arc<ChainSpec>,
     ) -> (Self, Option<CustodyCountChanged>) {
         let CustodyContextSsz {
             mut validator_custody_at_head,
@@ -319,7 +319,7 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
 
         let mut custody_count_changed = None;
 
-        if let Some(cgc_from_cli) = node_custody_type.get_custody_count_override(spec) {
+        if let Some(cgc_from_cli) = node_custody_type.get_custody_count_override(&spec) {
             debug!(
                 ?node_custody_type,
                 persisted_custody_count = validator_custody_at_head,
@@ -377,7 +377,7 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
             ordered_custody_column_indices,
             slot_clock,
             complete_blob_backfill,
-            spec: Arc::new(spec.clone()),
+            spec,
         };
 
         (custody_context, custody_count_changed)
@@ -655,7 +655,7 @@ mod tests {
     }
 
     fn setup_custody_context(
-        spec: &ChainSpec,
+        spec: Arc<ChainSpec>,
         head_epoch: Epoch,
         epoch_and_cgc_tuples: Vec<(Epoch, u64)>,
     ) -> CustodyContext<T> {
@@ -672,7 +672,7 @@ mod tests {
             NodeCustodyType::Fullnode,
             head_epoch,
             generate_data_column_indices_rand_order::<E>(),
-            testing_slot_clock(spec),
+            testing_slot_clock(&spec),
             complete_blob_backfill,
             spec,
         );
@@ -702,7 +702,7 @@ mod tests {
         target_node_custody_type: NodeCustodyType,
         expected_new_cgc: u64,
         head_epoch: Epoch,
-        spec: &ChainSpec,
+        spec: Arc<ChainSpec>,
     ) {
         let ssz_context = CustodyContextSsz {
             validator_custody_at_head: persisted_cgc,
@@ -717,14 +717,14 @@ mod tests {
                 target_node_custody_type,
                 head_epoch,
                 generate_data_column_indices_rand_order::<E>(),
-                testing_slot_clock(spec),
+                testing_slot_clock(&spec),
                 complete_blob_backfill,
-                spec,
+                spec.clone(),
             );
 
         // Verify CGC increased
         assert_eq!(
-            custody_context.custody_group_count_at_head(spec),
+            custody_context.custody_group_count_at_head(&spec),
             expected_new_cgc,
             "cgc should increase from {} to {}",
             persisted_cgc,
@@ -757,13 +757,13 @@ mod tests {
 
         // Verify custody_group_count_at_epoch returns correct values
         assert_eq!(
-            custody_context.custody_group_count_at_epoch(head_epoch, spec),
+            custody_context.custody_group_count_at_epoch(head_epoch, &spec),
             persisted_cgc,
             "current epoch should still use old cgc ({})",
             persisted_cgc
         );
         assert_eq!(
-            custody_context.custody_group_count_at_epoch(head_epoch + 1, spec),
+            custody_context.custody_group_count_at_epoch(head_epoch + 1, &spec),
             expected_new_cgc,
             "next epoch should use new cgc ({})",
             expected_new_cgc
@@ -776,7 +776,7 @@ mod tests {
         persisted_cgc: u64,
         target_node_custody_type: NodeCustodyType,
         head_epoch: Epoch,
-        spec: &ChainSpec,
+        spec: Arc<ChainSpec>,
     ) {
         let ssz_context = CustodyContextSsz {
             validator_custody_at_head: persisted_cgc,
@@ -791,14 +791,14 @@ mod tests {
                 target_node_custody_type,
                 head_epoch,
                 generate_data_column_indices_rand_order::<E>(),
-                testing_slot_clock(spec),
+                testing_slot_clock(&spec),
                 complete_blob_backfill,
-                spec,
+                spec.clone(),
             );
 
         // Verify CGC stays at persisted value (no reduction)
         assert_eq!(
-            custody_context.custody_group_count_at_head(spec),
+            custody_context.custody_group_count_at_head(&spec),
             persisted_cgc,
             "cgc should remain at {} (reduction not supported)",
             persisted_cgc
@@ -813,14 +813,14 @@ mod tests {
 
     #[test]
     fn no_validators_supernode_default() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Supernode,
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
         assert_eq!(
             custody_context.custody_group_count_at_head(&spec),
@@ -834,14 +834,14 @@ mod tests {
 
     #[test]
     fn no_validators_semi_supernode_default() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::SemiSupernode,
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
         assert_eq!(
             custody_context.custody_group_count_at_head(&spec),
@@ -855,14 +855,14 @@ mod tests {
 
     #[test]
     fn no_validators_fullnode_default() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
         assert_eq!(
             custody_context.custody_group_count_at_head(&spec),
@@ -877,14 +877,14 @@ mod tests {
 
     #[test]
     fn register_single_validator_should_update_cgc() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
         let bal_per_additional_group = spec.balance_per_additional_custody_group;
         let min_val_custody_requirement = spec.validator_custody_requirement;
@@ -908,14 +908,14 @@ mod tests {
 
     #[test]
     fn register_multiple_validators_should_update_cgc() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
         let bal_per_additional_group = spec.balance_per_additional_custody_group;
         let min_val_custody_requirement = spec.validator_custody_requirement;
@@ -952,14 +952,14 @@ mod tests {
 
     #[test]
     fn register_validators_should_not_update_cgc_for_supernode() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Supernode,
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
         let bal_per_additional_group = spec.balance_per_additional_custody_group;
 
@@ -997,14 +997,14 @@ mod tests {
 
     #[test]
     fn cgc_change_should_be_effective_to_sampling_after_delay() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
         let current_slot = Slot::new(10);
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
@@ -1035,14 +1035,14 @@ mod tests {
 
     #[test]
     fn validator_dropped_after_no_registrations_within_expiry_should_not_reduce_cgc() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
         let current_slot = Slot::new(10);
         let val_custody_units_1 = 10;
@@ -1084,14 +1084,14 @@ mod tests {
 
     #[test]
     fn validator_dropped_after_no_registrations_within_expiry() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let custody_context = CustodyContext::<T>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
         let current_slot = Slot::new(10);
         let val_custody_units_1 = 10;
@@ -1163,7 +1163,7 @@ mod tests {
 
     #[test]
     fn custody_columns_for_epoch_no_validators_fullnode() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
         let custody_context = CustodyContext::<T>::new(
@@ -1171,7 +1171,7 @@ mod tests {
             ordered_custody_column_indices,
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
 
         assert_eq!(
@@ -1182,7 +1182,7 @@ mod tests {
 
     #[test]
     fn custody_columns_for_epoch_no_validators_supernode() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
         let custody_context = CustodyContext::<T>::new(
@@ -1190,7 +1190,7 @@ mod tests {
             ordered_custody_column_indices,
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
 
         assert_eq!(
@@ -1201,7 +1201,7 @@ mod tests {
 
     #[test]
     fn custody_columns_for_epoch_with_validators_should_match_cgc() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
         let custody_context = CustodyContext::<T>::new(
@@ -1209,7 +1209,7 @@ mod tests {
             ordered_custody_column_indices,
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
         let val_custody_units = 10;
 
@@ -1230,7 +1230,7 @@ mod tests {
 
     #[test]
     fn custody_columns_for_epoch_specific_epoch_uses_epoch_cgc() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
         let custody_context = CustodyContext::<T>::new(
@@ -1238,7 +1238,7 @@ mod tests {
             ordered_custody_column_indices,
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
         let test_epoch = Epoch::new(5);
 
@@ -1253,7 +1253,7 @@ mod tests {
 
     #[test]
     fn restore_from_persisted_fullnode_no_validators() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let ssz_context = CustodyContextSsz {
             validator_custody_at_head: 0, // no validators
@@ -1268,7 +1268,7 @@ mod tests {
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
 
         assert_eq!(
@@ -1282,7 +1282,7 @@ mod tests {
     /// CGC should increase and trigger backfill via CustodyCountChanged.
     #[test]
     fn restore_fullnode_then_switch_to_supernode_increases_cgc() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let head_epoch = Epoch::new(10);
         let supernode_cgc = spec.number_of_custody_groups;
 
@@ -1291,7 +1291,7 @@ mod tests {
             NodeCustodyType::Supernode,
             supernode_cgc,
             head_epoch,
-            &spec,
+            spec,
         );
     }
 
@@ -1299,7 +1299,7 @@ mod tests {
     /// Semi-supernode can exceed 64 when validator effective balance increases CGC.
     #[test]
     fn restore_semi_supernode_with_validators_can_exceed_64() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let complete_blob_backfill = false;
         let semi_supernode_cgc = spec.number_of_custody_groups / 2; // 64
         let custody_context = CustodyContext::<T>::new(
@@ -1307,7 +1307,7 @@ mod tests {
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
 
         // Verify initial CGC is 64 (semi-supernode)
@@ -1356,14 +1356,14 @@ mod tests {
     /// CGC reduction is not supported - persisted value is retained.
     #[test]
     fn restore_supernode_then_switch_to_fullnode_uses_persisted() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let supernode_cgc = spec.number_of_custody_groups;
 
         assert_custody_type_switch_unchanged_cgc(
             supernode_cgc,
             NodeCustodyType::Fullnode,
             Epoch::new(0),
-            &spec,
+            spec,
         );
     }
 
@@ -1371,7 +1371,7 @@ mod tests {
     /// CGC reduction is not supported - persisted value is retained.
     #[test]
     fn restore_supernode_then_switch_to_semi_supernode_keeps_supernode_cgc() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let supernode_cgc = spec.number_of_custody_groups;
         let head_epoch = Epoch::new(10);
 
@@ -1379,7 +1379,7 @@ mod tests {
             supernode_cgc,
             NodeCustodyType::SemiSupernode,
             head_epoch,
-            &spec,
+            spec,
         );
     }
 
@@ -1387,7 +1387,7 @@ mod tests {
     /// CGC should increase and trigger backfill via CustodyCountChanged.
     #[test]
     fn restore_fullnode_with_validators_then_switch_to_semi_supernode() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let persisted_cgc = 32u64;
         let semi_supernode_cgc = spec.number_of_custody_groups / 2;
         let head_epoch = Epoch::new(10);
@@ -1397,7 +1397,7 @@ mod tests {
             NodeCustodyType::SemiSupernode,
             semi_supernode_cgc,
             head_epoch,
-            &spec,
+            spec,
         );
     }
 
@@ -1405,7 +1405,7 @@ mod tests {
     /// CGC should increase and trigger backfill via CustodyCountChanged.
     #[test]
     fn restore_semi_supernode_then_switch_to_supernode() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let semi_supernode_cgc = spec.number_of_custody_groups / 2;
         let supernode_cgc = spec.number_of_custody_groups;
         let head_epoch = Epoch::new(10);
@@ -1415,7 +1415,7 @@ mod tests {
             NodeCustodyType::Supernode,
             supernode_cgc,
             head_epoch,
-            &spec,
+            spec,
         );
     }
 
@@ -1423,7 +1423,7 @@ mod tests {
     /// CGC should increase and trigger backfill via CustodyCountChanged.
     #[test]
     fn restore_with_cli_flag_increases_cgc_from_nonzero() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let persisted_cgc = 32u64;
         let supernode_cgc = spec.number_of_custody_groups;
         let head_epoch = Epoch::new(10);
@@ -1433,13 +1433,13 @@ mod tests {
             NodeCustodyType::Supernode,
             supernode_cgc,
             head_epoch,
-            &spec,
+            spec,
         );
     }
 
     #[test]
     fn restore_with_validator_custody_history_across_epochs() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let initial_cgc = 8u64;
         let increased_cgc = 16u64;
         let final_cgc = 32u64;
@@ -1462,7 +1462,7 @@ mod tests {
             generate_data_column_indices_rand_order::<E>(),
             testing_slot_clock(&spec),
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         );
 
         // Verify head uses latest value
@@ -1503,14 +1503,14 @@ mod tests {
 
     #[test]
     fn backfill_single_cgc_increase_updates_past_epochs() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let final_cgc = 32u64;
         let default_cgc = spec.custody_requirement;
 
         // Setup: Node restart after validators were registered, causing CGC increase to 32 at epoch 20
         let head_epoch = Epoch::new(20);
         let epoch_and_cgc_tuples = vec![(head_epoch, final_cgc)];
-        let custody_context = setup_custody_context(&spec, head_epoch, epoch_and_cgc_tuples);
+        let custody_context = setup_custody_context(spec.clone(), head_epoch, epoch_and_cgc_tuples);
         assert_eq!(
             custody_context.custody_group_count_at_epoch(Epoch::new(15), &spec),
             default_cgc,
@@ -1540,7 +1540,7 @@ mod tests {
 
     #[test]
     fn backfill_with_multiple_cgc_increases_prunes_map_correctly() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let initial_cgc = 8u64;
         let mid_cgc = 16u64;
         let final_cgc = 32u64;
@@ -1552,7 +1552,7 @@ mod tests {
             (Epoch::new(10), mid_cgc),
             (head_epoch, final_cgc),
         ];
-        let custody_context = setup_custody_context(&spec, head_epoch, epoch_and_cgc_tuples);
+        let custody_context = setup_custody_context(spec.clone(), head_epoch, epoch_and_cgc_tuples);
 
         // Backfill to epoch 15 (between the two CGC increases)
         complete_backfill_for_epochs(&custody_context, Epoch::new(20), Epoch::new(15), final_cgc);
@@ -1576,7 +1576,7 @@ mod tests {
 
     #[test]
     fn attempt_backfill_with_invalid_cgc() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let initial_cgc = 8u64;
         let mid_cgc = 16u64;
         let final_cgc = 32u64;
@@ -1588,7 +1588,7 @@ mod tests {
             (Epoch::new(10), mid_cgc),
             (head_epoch, final_cgc),
         ];
-        let custody_context = setup_custody_context(&spec, head_epoch, epoch_and_cgc_tuples);
+        let custody_context = setup_custody_context(spec.clone(), head_epoch, epoch_and_cgc_tuples);
 
         // Backfill to epoch 15 (between the two CGC increases)
         complete_backfill_for_epochs(&custody_context, Epoch::new(20), Epoch::new(15), final_cgc);
@@ -1628,7 +1628,7 @@ mod tests {
 
     #[test]
     fn reset_validator_custody_requirements() {
-        let spec = E::default_spec();
+        let spec = Arc::new(E::default_spec());
         let minimum_cgc = 4u64;
         let initial_cgc = 8u64;
         let mid_cgc = 16u64;
@@ -1641,7 +1641,7 @@ mod tests {
             (Epoch::new(10), mid_cgc),
             (head_epoch, final_cgc),
         ];
-        let custody_context = setup_custody_context(&spec, head_epoch, epoch_and_cgc_tuples);
+        let custody_context = setup_custody_context(spec.clone(), head_epoch, epoch_and_cgc_tuples);
 
         // Backfill from epoch 20 to 9
         complete_backfill_for_epochs(&custody_context, Epoch::new(20), Epoch::new(9), final_cgc);

--- a/beacon_node/beacon_chain/src/custody_context.rs
+++ b/beacon_node/beacon_chain/src/custody_context.rs
@@ -393,13 +393,15 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
         &self,
         validators_and_balance: ValidatorsAndBalances,
         current_slot: Slot,
-        spec: &ChainSpec,
     ) -> Option<CustodyCountChanged> {
-        let Some((effective_epoch, new_validator_custody)) =
-            self.validator_registrations
-                .write()
-                .register_validators::<T::EthSpec>(validators_and_balance, current_slot, spec)
-        else {
+        let Some((effective_epoch, new_validator_custody)) = self
+            .validator_registrations
+            .write()
+            .register_validators::<T::EthSpec>(
+            validators_and_balance,
+            current_slot,
+            &self.spec,
+        ) else {
             return None;
         };
 
@@ -414,7 +416,7 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
             self.validator_custody_count
                 .store(new_validator_custody, Ordering::Relaxed);
 
-            let updated_cgc = self.custody_group_count_at_head(spec);
+            let updated_cgc = self.custody_group_count_at_head();
             // Send the message to network only if there are more columns subnets to subscribe to
             if updated_cgc > current_cgc {
                 debug!(
@@ -424,7 +426,7 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
                 return Some(CustodyCountChanged {
                     new_custody_group_count: updated_cgc,
                     old_custody_group_count: current_cgc,
-                    sampling_count: self.num_of_custody_groups_to_sample(effective_epoch, spec),
+                    sampling_count: self.num_of_custody_groups_to_sample(effective_epoch),
                     effective_epoch,
                 });
             }
@@ -436,14 +438,14 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
     /// This function is used to determine the custody group count at head ONLY.
     /// Do NOT use this directly for data availability check, use `self.sampling_size` instead as
     /// CGC can change over epochs.
-    pub fn custody_group_count_at_head(&self, spec: &ChainSpec) -> u64 {
+    pub fn custody_group_count_at_head(&self) -> u64 {
         let validator_custody_count_at_head = self.validator_custody_count.load(Ordering::Relaxed);
 
         // If there are no validators, return the minimum custody_requirement
         if validator_custody_count_at_head > 0 {
             validator_custody_count_at_head
         } else {
-            spec.custody_requirement
+            self.spec.custody_requirement
         }
     }
 
@@ -453,33 +455,35 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
     /// minimum sampling size which may exceed the custody group count (CGC).
     ///
     /// See also: [`Self::num_of_custody_groups_to_sample`].
-    pub fn custody_group_count_at_epoch(&self, epoch: Epoch, spec: &ChainSpec) -> u64 {
+    pub fn custody_group_count_at_epoch(&self, epoch: Epoch) -> u64 {
         self.validator_registrations
             .read()
             .custody_requirement_at_epoch(epoch)
-            .unwrap_or(spec.custody_requirement)
+            .unwrap_or(self.spec.custody_requirement)
     }
 
     /// Returns the count of custody groups this node must _sample_ for a block at `epoch` to import.
-    pub fn num_of_custody_groups_to_sample(&self, epoch: Epoch, spec: &ChainSpec) -> u64 {
-        let custody_group_count = self.custody_group_count_at_epoch(epoch, spec);
-        spec.sampling_size_custody_groups(custody_group_count)
+    pub fn num_of_custody_groups_to_sample(&self, epoch: Epoch) -> u64 {
+        let custody_group_count = self.custody_group_count_at_epoch(epoch);
+        self.spec
+            .sampling_size_custody_groups(custody_group_count)
             .expect("should compute node sampling size from valid chain spec")
     }
 
     /// Returns the count of columns this node must _sample_ for a block at `epoch` to import.
-    pub fn num_of_data_columns_to_sample(&self, epoch: Epoch, spec: &ChainSpec) -> usize {
-        let custody_group_count = self.custody_group_count_at_epoch(epoch, spec);
-        spec.sampling_size_columns::<T::EthSpec>(custody_group_count)
+    pub fn num_of_data_columns_to_sample(&self, epoch: Epoch) -> usize {
+        let custody_group_count = self.custody_group_count_at_epoch(epoch);
+        self.spec
+            .sampling_size_columns::<T::EthSpec>(custody_group_count)
             .expect("should compute node sampling size from valid chain spec")
     }
 
     /// Returns whether the node should attempt reconstruction at a given epoch.
-    pub fn should_attempt_reconstruction(&self, epoch: Epoch, spec: &ChainSpec) -> bool {
+    pub fn should_attempt_reconstruction(&self, epoch: Epoch) -> bool {
         let min_columns_for_reconstruction = T::EthSpec::number_of_columns() / 2;
         // performing reconstruction is not necessary if sampling column count is exactly 50%,
         // because the node doesn't need the remaining columns.
-        self.num_of_data_columns_to_sample(epoch, spec) > min_columns_for_reconstruction
+        self.num_of_data_columns_to_sample(epoch) > min_columns_for_reconstruction
     }
 
     /// Returns the ordered list of column indices that should be sampled for data availability checking at the given epoch.
@@ -490,8 +494,8 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
     ///
     /// # Returns
     /// A slice of ordered column indices that should be sampled for this epoch based on the node's custody configuration
-    pub fn sampling_columns_for_epoch(&self, epoch: Epoch, spec: &ChainSpec) -> &[ColumnIndex] {
-        let num_of_columns_to_sample = self.num_of_data_columns_to_sample(epoch, spec);
+    pub fn sampling_columns_for_epoch(&self, epoch: Epoch) -> &[ColumnIndex] {
+        let num_of_columns_to_sample = self.num_of_data_columns_to_sample(epoch);
         &self.ordered_custody_column_indices[..num_of_columns_to_sample]
     }
 
@@ -508,19 +512,15 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
     ///
     /// # Returns
     /// A slice of ordered custody column indices for this epoch based on the node's custody configuration
-    pub fn custody_columns_for_epoch(
-        &self,
-        epoch_opt: Option<Epoch>,
-        spec: &ChainSpec,
-    ) -> &[ColumnIndex] {
+    pub fn custody_columns_for_epoch(&self, epoch_opt: Option<Epoch>) -> &[ColumnIndex] {
         let custody_group_count = if let Some(epoch) = epoch_opt {
-            self.custody_group_count_at_epoch(epoch, spec) as usize
+            self.custody_group_count_at_epoch(epoch) as usize
         } else {
-            self.custody_group_count_at_head(spec) as usize
+            self.custody_group_count_at_head() as usize
         };
 
         // This is an unnecessary conversion for spec compliance, basically just multiplying by 1.
-        let columns_per_custody_group = spec.data_columns_per_group::<T::EthSpec>() as usize;
+        let columns_per_custody_group = self.spec.data_columns_per_group::<T::EthSpec>() as usize;
         let custody_column_count = columns_per_custody_group * custody_group_count;
 
         &self.ordered_custody_column_indices[..custody_column_count]
@@ -724,7 +724,7 @@ mod tests {
 
         // Verify CGC increased
         assert_eq!(
-            custody_context.custody_group_count_at_head(&spec),
+            custody_context.custody_group_count_at_head(),
             expected_new_cgc,
             "cgc should increase from {} to {}",
             persisted_cgc,
@@ -757,13 +757,13 @@ mod tests {
 
         // Verify custody_group_count_at_epoch returns correct values
         assert_eq!(
-            custody_context.custody_group_count_at_epoch(head_epoch, &spec),
+            custody_context.custody_group_count_at_epoch(head_epoch),
             persisted_cgc,
             "current epoch should still use old cgc ({})",
             persisted_cgc
         );
         assert_eq!(
-            custody_context.custody_group_count_at_epoch(head_epoch + 1, &spec),
+            custody_context.custody_group_count_at_epoch(head_epoch + 1),
             expected_new_cgc,
             "next epoch should use new cgc ({})",
             expected_new_cgc
@@ -798,7 +798,7 @@ mod tests {
 
         // Verify CGC stays at persisted value (no reduction)
         assert_eq!(
-            custody_context.custody_group_count_at_head(&spec),
+            custody_context.custody_group_count_at_head(),
             persisted_cgc,
             "cgc should remain at {} (reduction not supported)",
             persisted_cgc
@@ -823,11 +823,11 @@ mod tests {
             spec.clone(),
         );
         assert_eq!(
-            custody_context.custody_group_count_at_head(&spec),
+            custody_context.custody_group_count_at_head(),
             spec.number_of_custody_groups
         );
         assert_eq!(
-            custody_context.num_of_custody_groups_to_sample(Epoch::new(0), &spec),
+            custody_context.num_of_custody_groups_to_sample(Epoch::new(0)),
             spec.number_of_custody_groups
         );
     }
@@ -844,11 +844,11 @@ mod tests {
             spec.clone(),
         );
         assert_eq!(
-            custody_context.custody_group_count_at_head(&spec),
+            custody_context.custody_group_count_at_head(),
             spec.number_of_custody_groups / 2
         );
         assert_eq!(
-            custody_context.num_of_custody_groups_to_sample(Epoch::new(0), &spec),
+            custody_context.num_of_custody_groups_to_sample(Epoch::new(0)),
             spec.number_of_custody_groups / 2
         );
     }
@@ -865,12 +865,12 @@ mod tests {
             spec.clone(),
         );
         assert_eq!(
-            custody_context.custody_group_count_at_head(&spec),
+            custody_context.custody_group_count_at_head(),
             spec.custody_requirement,
             "head custody count should be minimum spec custody requirement"
         );
         assert_eq!(
-            custody_context.num_of_custody_groups_to_sample(Epoch::new(0), &spec),
+            custody_context.num_of_custody_groups_to_sample(Epoch::new(0)),
             spec.samples_per_slot
         );
     }
@@ -902,7 +902,6 @@ mod tests {
         register_validators_and_assert_cgc::<T>(
             &custody_context,
             validators_and_expected_cgc_change,
-            &spec,
         );
     }
 
@@ -943,11 +942,7 @@ mod tests {
             ),
         ];
 
-        register_validators_and_assert_cgc::<T>(
-            &custody_context,
-            validators_and_expected_cgc,
-            &spec,
-        );
+        register_validators_and_assert_cgc::<T>(&custody_context, validators_and_expected_cgc);
     }
 
     #[test]
@@ -983,14 +978,10 @@ mod tests {
             ),
         ];
 
-        register_validators_and_assert_cgc::<T>(
-            &custody_context,
-            validators_and_expected_cgc,
-            &spec,
-        );
+        register_validators_and_assert_cgc::<T>(&custody_context, validators_and_expected_cgc);
         let current_epoch = Epoch::new(2);
         assert_eq!(
-            custody_context.num_of_custody_groups_to_sample(current_epoch, &spec),
+            custody_context.num_of_custody_groups_to_sample(current_epoch),
             spec.number_of_custody_groups
         );
     }
@@ -1008,8 +999,7 @@ mod tests {
         );
         let current_slot = Slot::new(10);
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
-        let default_sampling_size =
-            custody_context.num_of_custody_groups_to_sample(current_epoch, &spec);
+        let default_sampling_size = custody_context.num_of_custody_groups_to_sample(current_epoch);
         let validator_custody_units = 10;
 
         let _cgc_changed = custody_context.register_validators(
@@ -1018,17 +1008,16 @@ mod tests {
                 validator_custody_units * spec.balance_per_additional_custody_group,
             )],
             current_slot,
-            &spec,
         );
 
         // CGC update is not applied for `current_epoch`.
         assert_eq!(
-            custody_context.num_of_custody_groups_to_sample(current_epoch, &spec),
+            custody_context.num_of_custody_groups_to_sample(current_epoch),
             default_sampling_size
         );
         // CGC update is applied for the next epoch.
         assert_eq!(
-            custody_context.num_of_custody_groups_to_sample(current_epoch + 1, &spec),
+            custody_context.num_of_custody_groups_to_sample(current_epoch + 1),
             validator_custody_units
         );
     }
@@ -1061,7 +1050,6 @@ mod tests {
                 ),
             ],
             current_slot,
-            &spec,
         );
 
         // WHEN val_1 re-registered, but val_2 did not re-register after `VALIDATOR_REGISTRATION_EXPIRY_SLOTS + 1` slots
@@ -1071,13 +1059,12 @@ mod tests {
                 val_custody_units_1 * spec.balance_per_additional_custody_group,
             )],
             current_slot + VALIDATOR_REGISTRATION_EXPIRY_SLOTS + 1,
-            &spec,
         );
 
         // THEN the reduction from dropping val_2 balance should NOT result in a CGC reduction
         assert!(cgc_changed_opt.is_none(), "CGC should remain unchanged");
         assert_eq!(
-            custody_context.custody_group_count_at_head(&spec),
+            custody_context.custody_group_count_at_head(),
             val_custody_units_1 + val_custody_units_2
         )
     }
@@ -1111,7 +1098,6 @@ mod tests {
                 ),
             ],
             current_slot,
-            &spec,
         );
 
         // WHEN val_1 and val_3 registered, but val_3 did not re-register after `VALIDATOR_REGISTRATION_EXPIRY_SLOTS + 1` slots
@@ -1127,7 +1113,6 @@ mod tests {
                 ),
             ],
             current_slot + VALIDATOR_REGISTRATION_EXPIRY_SLOTS + 1,
-            &spec,
         );
 
         // THEN CGC should increase, BUT val_2 balance should NOT be included in CGC
@@ -1143,7 +1128,6 @@ mod tests {
     fn register_validators_and_assert_cgc<T: BeaconChainTypes>(
         custody_context: &CustodyContext<T>,
         validators_and_expected_cgc_changed: Vec<(ValidatorsAndBalances, Option<u64>)>,
-        spec: &ChainSpec,
     ) {
         for (idx, (validators_and_balance, expected_cgc_change)) in
             validators_and_expected_cgc_changed.into_iter().enumerate()
@@ -1153,7 +1137,6 @@ mod tests {
                 .register_validators(
                     validators_and_balance,
                     epoch.start_slot(T::EthSpec::slots_per_epoch()),
-                    spec,
                 )
                 .map(|c| c.new_custody_group_count);
 
@@ -1175,7 +1158,7 @@ mod tests {
         );
 
         assert_eq!(
-            custody_context.custody_columns_for_epoch(None, &spec).len(),
+            custody_context.custody_columns_for_epoch(None).len(),
             spec.custody_requirement as usize
         );
     }
@@ -1194,7 +1177,7 @@ mod tests {
         );
 
         assert_eq!(
-            custody_context.custody_columns_for_epoch(None, &spec).len(),
+            custody_context.custody_columns_for_epoch(None).len(),
             spec.number_of_custody_groups as usize
         );
     }
@@ -1219,11 +1202,10 @@ mod tests {
                 val_custody_units * spec.balance_per_additional_custody_group,
             )],
             Slot::new(10),
-            &spec,
         );
 
         assert_eq!(
-            custody_context.custody_columns_for_epoch(None, &spec).len(),
+            custody_context.custody_columns_for_epoch(None).len(),
             val_custody_units as usize
         );
     }
@@ -1242,10 +1224,10 @@ mod tests {
         );
         let test_epoch = Epoch::new(5);
 
-        let expected_cgc = custody_context.custody_group_count_at_epoch(test_epoch, &spec);
+        let expected_cgc = custody_context.custody_group_count_at_epoch(test_epoch);
         assert_eq!(
             custody_context
-                .custody_columns_for_epoch(Some(test_epoch), &spec)
+                .custody_columns_for_epoch(Some(test_epoch))
                 .len(),
             expected_cgc as usize
         );
@@ -1272,7 +1254,7 @@ mod tests {
         );
 
         assert_eq!(
-            custody_context.custody_group_count_at_head(&spec),
+            custody_context.custody_group_count_at_head(),
             spec.custody_requirement,
             "restored custody group count should match fullnode default"
         );
@@ -1312,7 +1294,7 @@ mod tests {
 
         // Verify initial CGC is 64 (semi-supernode)
         assert_eq!(
-            custody_context.custody_group_count_at_head(&spec),
+            custody_context.custody_group_count_at_head(),
             semi_supernode_cgc,
             "initial cgc should be 64"
         );
@@ -1326,7 +1308,6 @@ mod tests {
                 validator_custody_units * spec.balance_per_additional_custody_group,
             )],
             current_slot,
-            &spec,
         );
 
         // Verify CGC increased from 64 to 70
@@ -1346,7 +1327,7 @@ mod tests {
 
         // Verify the custody context reflects the new CGC
         assert_eq!(
-            custody_context.custody_group_count_at_head(&spec),
+            custody_context.custody_group_count_at_head(),
             validator_custody_units,
             "custody_group_count_at_head should be 70"
         );
@@ -1466,36 +1447,33 @@ mod tests {
         );
 
         // Verify head uses latest value
-        assert_eq!(
-            custody_context.custody_group_count_at_head(&spec),
-            final_cgc
-        );
+        assert_eq!(custody_context.custody_group_count_at_head(), final_cgc);
 
         // Verify historical epoch lookups work correctly
         assert_eq!(
-            custody_context.custody_group_count_at_epoch(Epoch::new(5), &spec),
+            custody_context.custody_group_count_at_epoch(Epoch::new(5)),
             initial_cgc,
             "epoch 5 should use initial cgc"
         );
         assert_eq!(
-            custody_context.custody_group_count_at_epoch(Epoch::new(15), &spec),
+            custody_context.custody_group_count_at_epoch(Epoch::new(15)),
             increased_cgc,
             "epoch 15 should use increased cgc"
         );
         assert_eq!(
-            custody_context.custody_group_count_at_epoch(Epoch::new(25), &spec),
+            custody_context.custody_group_count_at_epoch(Epoch::new(25)),
             final_cgc,
             "epoch 25 should use final cgc"
         );
 
         // Verify sampling size calculation uses correct historical values
         assert_eq!(
-            custody_context.num_of_custody_groups_to_sample(Epoch::new(5), &spec),
+            custody_context.num_of_custody_groups_to_sample(Epoch::new(5)),
             spec.samples_per_slot,
             "sampling at epoch 5 should use spec minimum since cgc is at minimum"
         );
         assert_eq!(
-            custody_context.num_of_custody_groups_to_sample(Epoch::new(25), &spec),
+            custody_context.num_of_custody_groups_to_sample(Epoch::new(25)),
             final_cgc,
             "sampling at epoch 25 should match final cgc"
         );
@@ -1512,7 +1490,7 @@ mod tests {
         let epoch_and_cgc_tuples = vec![(head_epoch, final_cgc)];
         let custody_context = setup_custody_context(spec.clone(), head_epoch, epoch_and_cgc_tuples);
         assert_eq!(
-            custody_context.custody_group_count_at_epoch(Epoch::new(15), &spec),
+            custody_context.custody_group_count_at_epoch(Epoch::new(15)),
             default_cgc,
         );
 
@@ -1521,19 +1499,19 @@ mod tests {
 
         // After backfilling to epoch 15, it should use latest CGC (32)
         assert_eq!(
-            custody_context.custody_group_count_at_epoch(Epoch::new(15), &spec),
+            custody_context.custody_group_count_at_epoch(Epoch::new(15)),
             final_cgc,
         );
         assert_eq!(
             custody_context
-                .custody_columns_for_epoch(Some(Epoch::new(15)), &spec)
+                .custody_columns_for_epoch(Some(Epoch::new(15)))
                 .len(),
             final_cgc as usize,
         );
 
         // Prior epoch should still return the original CGC
         assert_eq!(
-            custody_context.custody_group_count_at_epoch(Epoch::new(14), &spec),
+            custody_context.custody_group_count_at_epoch(Epoch::new(14)),
             default_cgc,
         );
     }
@@ -1560,7 +1538,7 @@ mod tests {
         // Verify epochs 15 - 20 return latest CGC (32)
         for epoch in 15..=20 {
             assert_eq!(
-                custody_context.custody_group_count_at_epoch(Epoch::new(epoch), &spec),
+                custody_context.custody_group_count_at_epoch(Epoch::new(epoch)),
                 final_cgc,
             );
         }
@@ -1568,7 +1546,7 @@ mod tests {
         // Verify epochs 10-14 still return mid_cgc (16)
         for epoch in 10..14 {
             assert_eq!(
-                custody_context.custody_group_count_at_epoch(Epoch::new(epoch), &spec),
+                custody_context.custody_group_count_at_epoch(Epoch::new(epoch)),
                 mid_cgc,
             );
         }
@@ -1596,7 +1574,7 @@ mod tests {
         // Verify epochs 15 - 20 return latest CGC (32)
         for epoch in 15..=20 {
             assert_eq!(
-                custody_context.custody_group_count_at_epoch(Epoch::new(epoch), &spec),
+                custody_context.custody_group_count_at_epoch(Epoch::new(epoch)),
                 final_cgc,
             );
         }
@@ -1612,7 +1590,7 @@ mod tests {
         // Verify epochs 15 - 20 still return latest CGC (32)
         for epoch in 15..=20 {
             assert_eq!(
-                custody_context.custody_group_count_at_epoch(Epoch::new(epoch), &spec),
+                custody_context.custody_group_count_at_epoch(Epoch::new(epoch)),
                 final_cgc,
             );
         }
@@ -1620,7 +1598,7 @@ mod tests {
         // Verify epochs 10-14 still return mid_cgc (16)
         for epoch in 10..14 {
             assert_eq!(
-                custody_context.custody_group_count_at_epoch(Epoch::new(epoch), &spec),
+                custody_context.custody_group_count_at_epoch(Epoch::new(epoch)),
                 mid_cgc,
             );
         }
@@ -1652,14 +1630,14 @@ mod tests {
         // Verify epochs 0 - 19 return the minimum cgc requirement because of the validator custody requirement reset
         for epoch in 0..=19 {
             assert_eq!(
-                custody_context.custody_group_count_at_epoch(Epoch::new(epoch), &spec),
+                custody_context.custody_group_count_at_epoch(Epoch::new(epoch)),
                 minimum_cgc,
             );
         }
 
         // Verify epoch 20 returns a CGC of 32
         assert_eq!(
-            custody_context.custody_group_count_at_epoch(head_epoch, &spec),
+            custody_context.custody_group_count_at_epoch(head_epoch),
             final_cgc
         );
 
@@ -1669,7 +1647,7 @@ mod tests {
         // Verify epochs 0 - 20 return the final cgc requirements
         for epoch in 0..=20 {
             assert_eq!(
-                custody_context.custody_group_count_at_epoch(Epoch::new(epoch), &spec),
+                custody_context.custody_group_count_at_epoch(Epoch::new(epoch)),
                 final_cgc,
             );
         }

--- a/beacon_node/beacon_chain/src/custody_context.rs
+++ b/beacon_node/beacon_chain/src/custody_context.rs
@@ -2,14 +2,16 @@ use crate::BeaconChainTypes;
 use educe::Educe;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
+use slot_clock::SlotClock;
 use ssz_derive::{Decode, Encode};
 use std::marker::PhantomData;
 use std::{
     collections::{BTreeMap, HashMap},
+    sync::Arc,
     sync::atomic::{AtomicU64, Ordering},
 };
 use tracing::{debug, warn};
-use types::{ChainSpec, ColumnIndex, Epoch, EthSpec, Slot};
+use types::{ChainSpec, ColumnIndex, Epoch, EthSpec, SignedBeaconBlock, Slot};
 
 /// A delay before making the CGC change effective to the data availability checker.
 pub const CUSTODY_CHANGE_DA_EFFECTIVE_DELAY_SECONDS: u64 = 30;
@@ -253,11 +255,12 @@ pub struct CustodyContext<T: BeaconChainTypes> {
     /// Stores an immutable, ordered list of all data column indices as determined by the node's NodeID
     /// on startup. This used to determine the node's custody columns.
     ordered_custody_column_indices: Vec<ColumnIndex>,
-    #[expect(dead_code)]
     #[educe(Debug(ignore))]
     slot_clock: T::SlotClock,
     /// backfill blobs and data columns beyond the data availability window.
     complete_blob_backfill: bool,
+    #[educe(Debug(ignore))]
+    spec: Arc<ChainSpec>,
     #[educe(Debug(ignore))]
     _phantom_data: PhantomData<T>,
 }
@@ -284,6 +287,7 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
             ordered_custody_column_indices,
             slot_clock,
             complete_blob_backfill,
+            spec: Arc::new(spec.clone()),
             _phantom_data: PhantomData,
         }
     }
@@ -377,6 +381,7 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
             ordered_custody_column_indices,
             slot_clock,
             complete_blob_backfill,
+            spec: Arc::new(spec.clone()),
             _phantom_data: PhantomData,
         };
 
@@ -544,6 +549,46 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
         self.validator_registrations
             .write()
             .reset_validator_custody_requirements(effective_epoch);
+    }
+
+    /// The epoch at which we require a data availability check in block processing.
+    /// `None` if the `Deneb` fork is disabled.
+    pub fn data_availability_boundary(&self) -> Option<Epoch> {
+        let fork_epoch = self.spec.deneb_fork_epoch?;
+
+        if self.complete_blob_backfill {
+            Some(fork_epoch)
+        } else {
+            let current_epoch = self.slot_clock.now()?.epoch(T::EthSpec::slots_per_epoch());
+            self.spec
+                .min_epoch_data_availability_boundary(current_epoch)
+        }
+    }
+
+    /// Returns true if the given epoch lies within the da boundary and false otherwise.
+    pub fn da_check_required_for_epoch(&self, block_epoch: Epoch) -> bool {
+        self.data_availability_boundary()
+            .is_some_and(|da_epoch| block_epoch >= da_epoch)
+    }
+
+    /// If the epoch is from prior to the data availability boundary, no blobs are required.
+    pub fn blobs_required_for_epoch(&self, epoch: Epoch) -> bool {
+        self.da_check_required_for_epoch(epoch) && !self.spec.is_peer_das_enabled_for_epoch(epoch)
+    }
+
+    /// If the epoch is from prior to the data availability boundary, no data columns are required.
+    pub fn data_columns_required_for_epoch(&self, epoch: Epoch) -> bool {
+        self.da_check_required_for_epoch(epoch) && self.spec.is_peer_das_enabled_for_epoch(epoch)
+    }
+
+    /// See `Self::blobs_required_for_epoch`
+    pub fn blobs_required_for_block(&self, block: &SignedBeaconBlock<T::EthSpec>) -> bool {
+        block.num_expected_blobs() > 0 && self.blobs_required_for_epoch(block.epoch())
+    }
+
+    /// See `Self::data_columns_required_for_epoch`
+    pub fn data_columns_required_for_block(&self, block: &SignedBeaconBlock<T::EthSpec>) -> bool {
+        block.num_expected_blobs() > 0 && self.data_columns_required_for_epoch(block.epoch())
     }
 }
 

--- a/beacon_node/beacon_chain/src/custody_context.rs
+++ b/beacon_node/beacon_chain/src/custody_context.rs
@@ -585,6 +585,14 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
     pub fn data_columns_required_for_block(&self, block: &SignedBeaconBlock<T::EthSpec>) -> bool {
         block.num_expected_blobs() > 0 && self.data_columns_required_for_epoch(block.epoch())
     }
+
+    /// The data availability boundary for custodying columns. It will just be the
+    /// regular data availability boundary unless we are near the Fulu fork epoch.
+    pub fn column_data_availability_boundary(&self) -> Option<Epoch> {
+        let da_boundary = self.data_availability_boundary()?;
+        let fulu_epoch = self.spec.fulu_fork_epoch?;
+        Some(da_boundary.max(fulu_epoch))
+    }
 }
 
 /// Indicates that the custody group count (CGC) has increased.

--- a/beacon_node/beacon_chain/src/custody_context.rs
+++ b/beacon_node/beacon_chain/src/custody_context.rs
@@ -4,7 +4,6 @@ use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use slot_clock::SlotClock;
 use ssz_derive::{Decode, Encode};
-use std::marker::PhantomData;
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
@@ -261,8 +260,6 @@ pub struct CustodyContext<T: BeaconChainTypes> {
     complete_blob_backfill: bool,
     #[educe(Debug(ignore))]
     spec: Arc<ChainSpec>,
-    #[educe(Debug(ignore))]
-    _phantom_data: PhantomData<T>,
 }
 
 impl<T: BeaconChainTypes> CustodyContext<T> {
@@ -288,7 +285,6 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
             slot_clock,
             complete_blob_backfill,
             spec: Arc::new(spec.clone()),
-            _phantom_data: PhantomData,
         }
     }
 
@@ -382,7 +378,6 @@ impl<T: BeaconChainTypes> CustodyContext<T> {
             slot_clock,
             complete_blob_backfill,
             spec: Arc::new(spec.clone()),
-            _phantom_data: PhantomData,
         };
 
         (custody_context, custody_count_changed)

--- a/beacon_node/beacon_chain/src/custody_context.rs
+++ b/beacon_node/beacon_chain/src/custody_context.rs
@@ -250,6 +250,8 @@ pub struct CustodyContext<E: EthSpec> {
     /// Stores an immutable, ordered list of all data column indices as determined by the node's NodeID
     /// on startup. This used to determine the node's custody columns.
     ordered_custody_column_indices: Vec<ColumnIndex>,
+    /// backfill blobs and data columns beyond the data availability window.
+    complete_blob_backfill: bool,
     _phantom_data: PhantomData<E>,
 }
 
@@ -261,6 +263,7 @@ impl<E: EthSpec> CustodyContext<E> {
     pub fn new(
         node_custody_type: NodeCustodyType,
         ordered_custody_column_indices: Vec<ColumnIndex>,
+        complete_blob_backfill: bool,
         spec: &ChainSpec,
     ) -> Self {
         let cgc_override = node_custody_type.get_custody_count_override(spec);
@@ -271,6 +274,7 @@ impl<E: EthSpec> CustodyContext<E> {
             validator_custody_count: AtomicU64::new(cgc_override.unwrap_or(0)),
             validator_registrations: RwLock::new(ValidatorRegistrations::new(cgc_override)),
             ordered_custody_column_indices,
+            complete_blob_backfill,
             _phantom_data: PhantomData,
         }
     }
@@ -294,6 +298,7 @@ impl<E: EthSpec> CustodyContext<E> {
         node_custody_type: NodeCustodyType,
         head_epoch: Epoch,
         ordered_custody_column_indices: Vec<ColumnIndex>,
+        complete_blob_backfill: bool,
         spec: &ChainSpec,
     ) -> (Self, Option<CustodyCountChanged>) {
         let CustodyContextSsz {
@@ -360,6 +365,7 @@ impl<E: EthSpec> CustodyContext<E> {
                     .collect(),
             }),
             ordered_custody_column_indices,
+            complete_blob_backfill,
             _phantom_data: PhantomData,
         };
 
@@ -590,11 +596,13 @@ mod tests {
             epoch_validator_custody_requirements: epoch_and_cgc_tuples,
         };
 
+        let complete_blob_backfill = false;
         let (custody_context, _) = CustodyContext::<E>::new_from_persisted_custody_context(
             ssz_context,
             NodeCustodyType::Fullnode,
             head_epoch,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             spec,
         );
 
@@ -630,6 +638,7 @@ mod tests {
             persisted_is_supernode: false,
             epoch_validator_custody_requirements: vec![(Epoch::new(0), persisted_cgc)],
         };
+        let complete_blob_backfill = false;
 
         let (custody_context, custody_count_changed) =
             CustodyContext::<E>::new_from_persisted_custody_context(
@@ -637,6 +646,7 @@ mod tests {
                 target_node_custody_type,
                 head_epoch,
                 generate_data_column_indices_rand_order::<E>(),
+                complete_blob_backfill,
                 spec,
             );
 
@@ -701,6 +711,7 @@ mod tests {
             persisted_is_supernode: false,
             epoch_validator_custody_requirements: vec![(Epoch::new(0), persisted_cgc)],
         };
+        let complete_blob_backfill = false;
 
         let (custody_context, custody_count_changed) =
             CustodyContext::<E>::new_from_persisted_custody_context(
@@ -708,6 +719,7 @@ mod tests {
                 target_node_custody_type,
                 head_epoch,
                 generate_data_column_indices_rand_order::<E>(),
+                complete_blob_backfill,
                 spec,
             );
 
@@ -729,9 +741,11 @@ mod tests {
     #[test]
     fn no_validators_supernode_default() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Supernode,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
         assert_eq!(
@@ -747,9 +761,11 @@ mod tests {
     #[test]
     fn no_validators_semi_supernode_default() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::SemiSupernode,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
         assert_eq!(
@@ -765,9 +781,11 @@ mod tests {
     #[test]
     fn no_validators_fullnode_default() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
         assert_eq!(
@@ -784,9 +802,11 @@ mod tests {
     #[test]
     fn register_single_validator_should_update_cgc() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
         let bal_per_additional_group = spec.balance_per_additional_custody_group;
@@ -812,9 +832,11 @@ mod tests {
     #[test]
     fn register_multiple_validators_should_update_cgc() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
         let bal_per_additional_group = spec.balance_per_additional_custody_group;
@@ -853,9 +875,11 @@ mod tests {
     #[test]
     fn register_validators_should_not_update_cgc_for_supernode() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Supernode,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
         let bal_per_additional_group = spec.balance_per_additional_custody_group;
@@ -895,9 +919,11 @@ mod tests {
     #[test]
     fn cgc_change_should_be_effective_to_sampling_after_delay() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
         let current_slot = Slot::new(10);
@@ -930,9 +956,11 @@ mod tests {
     #[test]
     fn validator_dropped_after_no_registrations_within_expiry_should_not_reduce_cgc() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
         let current_slot = Slot::new(10);
@@ -976,9 +1004,11 @@ mod tests {
     #[test]
     fn validator_dropped_after_no_registrations_within_expiry() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
         let current_slot = Slot::new(10);
@@ -1052,10 +1082,12 @@ mod tests {
     #[test]
     fn custody_columns_for_epoch_no_validators_fullnode() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Fullnode,
             ordered_custody_column_indices,
+            complete_blob_backfill,
             &spec,
         );
 
@@ -1068,10 +1100,12 @@ mod tests {
     #[test]
     fn custody_columns_for_epoch_no_validators_supernode() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Supernode,
             ordered_custody_column_indices,
+            complete_blob_backfill,
             &spec,
         );
 
@@ -1084,10 +1118,12 @@ mod tests {
     #[test]
     fn custody_columns_for_epoch_with_validators_should_match_cgc() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Fullnode,
             ordered_custody_column_indices,
+            complete_blob_backfill,
             &spec,
         );
         let val_custody_units = 10;
@@ -1110,10 +1146,12 @@ mod tests {
     #[test]
     fn custody_columns_for_epoch_specific_epoch_uses_epoch_cgc() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::Fullnode,
             ordered_custody_column_indices,
+            complete_blob_backfill,
             &spec,
         );
         let test_epoch = Epoch::new(5);
@@ -1130,6 +1168,7 @@ mod tests {
     #[test]
     fn restore_from_persisted_fullnode_no_validators() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let ssz_context = CustodyContextSsz {
             validator_custody_at_head: 0, // no validators
             persisted_is_supernode: false,
@@ -1141,6 +1180,7 @@ mod tests {
             NodeCustodyType::Fullnode,
             Epoch::new(0),
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
 
@@ -1173,10 +1213,12 @@ mod tests {
     #[test]
     fn restore_semi_supernode_with_validators_can_exceed_64() {
         let spec = E::default_spec();
+        let complete_blob_backfill = false;
         let semi_supernode_cgc = spec.number_of_custody_groups / 2; // 64
         let custody_context = CustodyContext::<E>::new(
             NodeCustodyType::SemiSupernode,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
 
@@ -1324,11 +1366,13 @@ mod tests {
             ],
         };
 
+        let complete_blob_backfill = false;
         let (custody_context, _) = CustodyContext::<E>::new_from_persisted_custody_context(
             ssz_context,
             NodeCustodyType::Fullnode,
             Epoch::new(20),
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         );
 

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -80,7 +80,7 @@ pub struct DataAvailabilityChecker<T: BeaconChainTypes> {
     partial_assembler: Option<Arc<PartialDataColumnAssembler<T::EthSpec>>>,
     slot_clock: T::SlotClock,
     kzg: Arc<Kzg>,
-    custody_context: Arc<CustodyContext<T::EthSpec>>,
+    custody_context: Arc<CustodyContext<T>>,
     spec: Arc<ChainSpec>,
 }
 
@@ -118,7 +118,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         complete_blob_backfill: bool,
         slot_clock: T::SlotClock,
         kzg: Arc<Kzg>,
-        custody_context: Arc<CustodyContext<T::EthSpec>>,
+        custody_context: Arc<CustodyContext<T>>,
         spec: Arc<ChainSpec>,
         enable_partial_columns: bool,
         disable_get_blobs: bool,
@@ -147,7 +147,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         })
     }
 
-    pub fn custody_context(&self) -> &Arc<CustodyContext<T::EthSpec>> {
+    pub fn custody_context(&self) -> &Arc<CustodyContext<T>> {
         &self.custody_context
     }
 
@@ -1425,6 +1425,7 @@ mod test {
         let custody_context = Arc::new(CustodyContext::new(
             NodeCustodyType::Fullnode,
             ordered_custody_column_indices,
+            slot_clock.clone(),
             complete_blob_backfill,
             &spec,
         ));

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -1371,7 +1371,7 @@ mod test {
             ordered_custody_column_indices,
             slot_clock,
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         ));
         DataAvailabilityChecker::new(kzg, custody_context, spec, true, false)
             .expect("should initialise data availability checker")

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -342,9 +342,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         // not be yet effective for data availability check, as CGC changes are only effecive from
         // a new epoch.
         let epoch = slot.epoch(T::EthSpec::slots_per_epoch());
-        let sampling_columns = self
-            .custody_context()
-            .sampling_columns_for_epoch(epoch, &self.spec);
+        let sampling_columns = self.custody_context().sampling_columns_for_epoch(epoch);
         let verified_custody_columns = kzg_verified_columns
             .into_iter()
             .filter(|col| sampling_columns.contains(&col.index()))
@@ -382,9 +380,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         data_columns: I,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
         let epoch = slot.epoch(T::EthSpec::slots_per_epoch());
-        let sampling_columns = self
-            .custody_context()
-            .sampling_columns_for_epoch(epoch, &self.spec);
+        let sampling_columns = self.custody_context().sampling_columns_for_epoch(epoch);
         let custody_columns = data_columns
             .into_iter()
             .filter(|col| sampling_columns.contains(&col.index()))
@@ -568,7 +564,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
 
         let columns_to_sample = self
             .custody_context()
-            .sampling_columns_for_epoch(slot.epoch(T::EthSpec::slots_per_epoch()), &self.spec);
+            .sampling_columns_for_epoch(slot.epoch(T::EthSpec::slots_per_epoch()));
 
         // We only need to import and publish columns that we need to sample
         // and columns that we haven't already received
@@ -826,7 +822,8 @@ impl<E: EthSpec> AvailableBlock<E> {
         block: Arc<SignedBeaconBlock<T::EthSpec>>,
         block_data: AvailableBlockData<T::EthSpec>,
         da_checker: &DataAvailabilityChecker<T>,
-        spec: Arc<ChainSpec>,
+        // TODO: remove spec
+        _spec: Arc<ChainSpec>,
     ) -> Result<Self, AvailabilityCheckError>
     where
         T: BeaconChainTypes<EthSpec = E>,
@@ -880,7 +877,7 @@ impl<E: EthSpec> AvailableBlock<E> {
 
                 let mut column_indices = da_checker
                     .custody_context()
-                    .sampling_columns_for_epoch(block.epoch(), &spec)
+                    .sampling_columns_for_epoch(block.epoch())
                     .iter()
                     .collect::<HashSet<_>>();
 
@@ -1048,10 +1045,9 @@ mod test {
         custody_context.register_validators(
             vec![(validator_0, 32_000_000_000)],
             epoch.start_slot(E::slots_per_epoch()),
-            &spec,
         );
         assert_eq!(
-            custody_context.num_of_data_columns_to_sample(epoch, &spec),
+            custody_context.num_of_data_columns_to_sample(epoch),
             spec.validator_custody_requirement as usize,
             "sampling size should be the minimal custody requirement == 8"
         );
@@ -1059,11 +1055,8 @@ mod test {
         // WHEN additional attached validators result in a CGC increase to 10 at the end slot of the same epoch
         let validator_1 = 1;
         let cgc_change_slot = epoch.end_slot(E::slots_per_epoch());
-        custody_context.register_validators(
-            vec![(validator_1, 32_000_000_000 * 9)],
-            cgc_change_slot,
-            &spec,
-        );
+        custody_context
+            .register_validators(vec![(validator_1, 32_000_000_000 * 9)], cgc_change_slot);
         // AND custody columns (8) and any new extra columns (2) are received via RPC responses.
         // NOTE: block lookup uses the **latest** CGC (10) instead of the effective CGC (8) as the slot is unknown.
         let (_, data_columns) = generate_rand_block_and_data_columns::<E>(
@@ -1078,7 +1071,7 @@ mod test {
         // The CGC change becomes effective after CUSTODY_CHANGE_DA_EFFECTIVE_DELAY_SECONDS,
         // which is typically epoch 2+ for MinimalEthSpec.
         let future_epoch = Epoch::new(10); // Far enough in the future to have the CGC change effective
-        let requested_columns = custody_context.sampling_columns_for_epoch(future_epoch, &spec);
+        let requested_columns = custody_context.sampling_columns_for_epoch(future_epoch);
         assert_eq!(
             requested_columns.len(),
             10,
@@ -1096,7 +1089,7 @@ mod test {
             .expect("should put rpc custody columns");
 
         // THEN the sampling size for the end slot of the same epoch remains unchanged
-        let sampling_columns = custody_context.sampling_columns_for_epoch(epoch, &spec);
+        let sampling_columns = custody_context.sampling_columns_for_epoch(epoch);
         assert_eq!(
             sampling_columns.len(),
             spec.validator_custody_requirement as usize // 8
@@ -1135,10 +1128,9 @@ mod test {
         custody_context.register_validators(
             vec![(validator_0, 32_000_000_000)],
             epoch.start_slot(E::slots_per_epoch()),
-            &spec,
         );
         assert_eq!(
-            custody_context.num_of_data_columns_to_sample(epoch, &spec),
+            custody_context.num_of_data_columns_to_sample(epoch),
             spec.validator_custody_requirement as usize,
             "sampling size should be the minimal custody requirement == 8"
         );
@@ -1146,11 +1138,8 @@ mod test {
         // WHEN additional attached validators result in a CGC increase to 10 at the end slot of the same epoch
         let validator_1 = 1;
         let cgc_change_slot = epoch.end_slot(E::slots_per_epoch());
-        custody_context.register_validators(
-            vec![(validator_1, 32_000_000_000 * 9)],
-            cgc_change_slot,
-            &spec,
-        );
+        custody_context
+            .register_validators(vec![(validator_1, 32_000_000_000 * 9)], cgc_change_slot);
         // AND custody columns (8) and any new extra columns (2) are received via gossip.
         // NOTE: CGC updates results in new topics subscriptions immediately, and extra columns may start to
         // arrive via gossip.
@@ -1166,7 +1155,7 @@ mod test {
         // The CGC change becomes effective after CUSTODY_CHANGE_DA_EFFECTIVE_DELAY_SECONDS,
         // which is typically epoch 2+ for MinimalEthSpec.
         let future_epoch = Epoch::new(10); // Far enough in the future to have the CGC change effective
-        let requested_columns = custody_context.sampling_columns_for_epoch(future_epoch, &spec);
+        let requested_columns = custody_context.sampling_columns_for_epoch(future_epoch);
         assert_eq!(
             requested_columns.len(),
             10,
@@ -1182,7 +1171,7 @@ mod test {
             .expect("should put gossip custody columns");
 
         // THEN the sampling size for the end slot of the same epoch remains unchanged
-        let sampling_columns = custody_context.sampling_columns_for_epoch(epoch, &spec);
+        let sampling_columns = custody_context.sampling_columns_for_epoch(epoch);
         assert_eq!(
             sampling_columns.len(),
             spec.validator_custody_requirement as usize // 8
@@ -1282,9 +1271,8 @@ mod test {
         custody_context.register_validators(
             vec![(0, 2_048_000_000_000), (1, 32_000_000_000)], // 64 + 1
             Slot::new(0),
-            &spec,
         );
-        let sampling_requirement = custody_context.num_of_data_columns_to_sample(epoch, &spec);
+        let sampling_requirement = custody_context.num_of_data_columns_to_sample(epoch);
         assert_eq!(
             sampling_requirement, 65,
             "sampling requirement should be 65"
@@ -1306,7 +1294,7 @@ mod test {
 
         // Add 64 columns to the da checker (enough to be able to reconstruct)
         // Order by all_column_indices_ordered, then take first 64
-        let custody_columns = custody_context.sampling_columns_for_epoch(epoch, &spec);
+        let custody_columns = custody_context.sampling_columns_for_epoch(epoch);
         let custody_columns = custody_columns
             .iter()
             .filter_map(|&col_idx| data_columns.iter().find(|d| *d.index() == col_idx).cloned())
@@ -1344,7 +1332,7 @@ mod test {
         );
 
         // Only the columns required for custody (65) should be imported into the cache
-        let sampling_columns = custody_context.sampling_columns_for_epoch(epoch, &spec);
+        let sampling_columns = custody_context.sampling_columns_for_epoch(epoch);
         let actual_cached: HashSet<ColumnIndex> = da_checker
             .cached_data_column_indexes(&block_root)
             .expect("should have cached data columns")

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -1421,12 +1421,13 @@ mod test {
         );
         let kzg = get_kzg(&spec);
         let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
+        let complete_blob_backfill = false;
         let custody_context = Arc::new(CustodyContext::new(
             NodeCustodyType::Fullnode,
             ordered_custody_column_indices,
+            complete_blob_backfill,
             &spec,
         ));
-        let complete_blob_backfill = false;
         DataAvailabilityChecker::new(
             complete_blob_backfill,
             slot_clock,

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -139,7 +139,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         })
     }
 
-    pub fn custody_context(&self) -> &Arc<CustodyContext<T>> {
+    fn custody_context(&self) -> &Arc<CustodyContext<T>> {
         self.availability_cache.custody_context()
     }
 
@@ -821,20 +821,14 @@ impl<E: EthSpec> AvailableBlock<E> {
     pub fn new<T>(
         block: Arc<SignedBeaconBlock<T::EthSpec>>,
         block_data: AvailableBlockData<T::EthSpec>,
-        da_checker: &DataAvailabilityChecker<T>,
-        // TODO: remove spec
-        _spec: Arc<ChainSpec>,
+        custody_context: &CustodyContext<T>,
     ) -> Result<Self, AvailabilityCheckError>
     where
         T: BeaconChainTypes<EthSpec = E>,
     {
         // Ensure block availability
-        let blobs_required = da_checker
-            .custody_context()
-            .blobs_required_for_block(&block);
-        let columns_required = da_checker
-            .custody_context()
-            .data_columns_required_for_block(&block);
+        let blobs_required = custody_context.blobs_required_for_block(&block);
+        let columns_required = custody_context.data_columns_required_for_block(&block);
 
         match &block_data {
             AvailableBlockData::NoData => {
@@ -875,8 +869,7 @@ impl<E: EthSpec> AvailableBlock<E> {
                     return Err(AvailabilityCheckError::InvalidAvailableBlockData);
                 }
 
-                let mut column_indices = da_checker
-                    .custody_context()
+                let mut column_indices = custody_context
                     .sampling_columns_for_epoch(block.epoch())
                     .iter()
                     .collect::<HashSet<_>>();
@@ -1238,8 +1231,7 @@ mod test {
                 };
 
                 let block_data = AvailableBlockData::new_with_data_columns(custody_columns);
-                let da_checker = Arc::new(new_da_checker(spec.clone()));
-                RangeSyncBlock::new(Arc::new(block), block_data, &da_checker, spec.clone())
+                RangeSyncBlock::new(Arc::new(block), block_data, da_checker.custody_context())
                     .expect("should create RPC block with custody columns")
             })
             .collect::<Vec<_>>();

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -18,7 +18,7 @@ use tracing::{debug, error, instrument};
 use types::data::{BlobIdentifier, FixedBlobSidecarList, PartialDataColumn};
 use types::{
     BlobSidecar, BlobSidecarList, BlockImportSource, ChainSpec, DataColumnSidecar,
-    DataColumnSidecarList, Epoch, EthSpec, Hash256, PartialDataColumnSidecarError,
+    DataColumnSidecarList, EthSpec, Hash256, PartialDataColumnSidecarError,
     PartialDataColumnSidecarRef, SignedBeaconBlock, Slot,
 };
 
@@ -75,7 +75,6 @@ const OVERFLOW_LRU_CAPACITY: usize = 32;
 /// proposer. Having a capacity > 1 is an optimization to prevent sync lookup from having re-fetch
 /// data during moments of unstable network conditions.
 pub struct DataAvailabilityChecker<T: BeaconChainTypes> {
-    complete_blob_backfill: bool,
     availability_cache: Arc<DataAvailabilityCheckerInner<T>>,
     partial_assembler: Option<Arc<PartialDataColumnAssembler<T::EthSpec>>>,
     slot_clock: T::SlotClock,
@@ -115,7 +114,6 @@ impl<E: EthSpec> Debug for Availability<E> {
 
 impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
     pub fn new(
-        complete_blob_backfill: bool,
         slot_clock: T::SlotClock,
         kzg: Arc<Kzg>,
         custody_context: Arc<CustodyContext<T>>,
@@ -137,7 +135,6 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
             None
         };
         Ok(Self {
-            complete_blob_backfill,
             partial_assembler,
             availability_cache: Arc::new(inner),
             slot_clock,
@@ -310,9 +307,9 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         &self,
         block_root: Hash256,
         blobs: FixedBlobSidecarList<T::EthSpec>,
+        slot_clock: &T::SlotClock,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
-        let seen_timestamp = self
-            .slot_clock
+        let seen_timestamp = slot_clock
             .now_duration()
             .ok_or(AvailabilityCheckError::SlotClockError)?;
 
@@ -505,59 +502,6 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         }
 
         Ok(())
-    }
-
-    /// Determines the blob requirements for a block. If the block is pre-deneb, no blobs are required.
-    /// If the epoch is from prior to the data availability boundary, no blobs are required.
-    pub fn blobs_required_for_epoch(&self, epoch: Epoch) -> bool {
-        self.da_check_required_for_epoch(epoch) && !self.spec.is_peer_das_enabled_for_epoch(epoch)
-    }
-
-    /// Determines the data column requirements for an epoch.
-    /// - If the epoch is pre-peerdas, no data columns are required.
-    /// - If the epoch is from prior to the data availability boundary, no data columns are required.
-    pub fn data_columns_required_for_epoch(&self, epoch: Epoch) -> bool {
-        self.da_check_required_for_epoch(epoch) && self.spec.is_peer_das_enabled_for_epoch(epoch)
-    }
-
-    /// See `Self::blobs_required_for_epoch`
-    fn blobs_required_for_block(&self, block: &SignedBeaconBlock<T::EthSpec>) -> bool {
-        block.num_expected_blobs() > 0 && self.blobs_required_for_epoch(block.epoch())
-    }
-
-    /// See `Self::data_columns_required_for_epoch`
-    fn data_columns_required_for_block(&self, block: &SignedBeaconBlock<T::EthSpec>) -> bool {
-        block.num_expected_blobs() > 0 && self.data_columns_required_for_epoch(block.epoch())
-    }
-
-    /// The epoch at which we require a data availability check in block processing.
-    /// `None` if the `Deneb` fork is disabled.
-    pub fn data_availability_boundary(&self) -> Option<Epoch> {
-        let fork_epoch = self.spec.deneb_fork_epoch?;
-
-        if self.complete_blob_backfill {
-            Some(fork_epoch)
-        } else {
-            let current_epoch = self.slot_clock.now()?.epoch(T::EthSpec::slots_per_epoch());
-            self.spec
-                .min_epoch_data_availability_boundary(current_epoch)
-        }
-    }
-
-    /// Returns true if the given epoch lies within the da boundary and false otherwise.
-    pub fn da_check_required_for_epoch(&self, block_epoch: Epoch) -> bool {
-        self.data_availability_boundary()
-            .is_some_and(|da_epoch| block_epoch >= da_epoch)
-    }
-
-    /// Returns `true` if the current epoch is greater than or equal to the `Deneb` epoch.
-    pub fn is_deneb(&self) -> bool {
-        self.slot_clock.now().is_some_and(|slot| {
-            self.spec.deneb_fork_epoch.is_some_and(|deneb_epoch| {
-                let now_epoch = slot.epoch(T::EthSpec::slots_per_epoch());
-                now_epoch >= deneb_epoch
-            })
-        })
     }
 
     /// Collects metrics from the data availability checker.
@@ -893,8 +837,12 @@ impl<E: EthSpec> AvailableBlock<E> {
         T: BeaconChainTypes<EthSpec = E>,
     {
         // Ensure block availability
-        let blobs_required = da_checker.blobs_required_for_block(&block);
-        let columns_required = da_checker.data_columns_required_for_block(&block);
+        let blobs_required = da_checker
+            .custody_context()
+            .blobs_required_for_block(&block);
+        let columns_required = da_checker
+            .custody_context()
+            .data_columns_required_for_block(&block);
 
         match &block_data {
             AvailableBlockData::NoData => {
@@ -1081,7 +1029,8 @@ mod test {
     use std::time::Duration;
     use types::data::DataColumn;
     use types::{
-        ChainSpec, ColumnIndex, DataColumnSidecarFulu, EthSpec, ForkName, MainnetEthSpec, Slot,
+        ChainSpec, ColumnIndex, DataColumnSidecarFulu, Epoch, EthSpec, ForkName, MainnetEthSpec,
+        Slot,
     };
 
     type E = MainnetEthSpec;
@@ -1429,15 +1378,7 @@ mod test {
             complete_blob_backfill,
             &spec,
         ));
-        DataAvailabilityChecker::new(
-            complete_blob_backfill,
-            slot_clock,
-            kzg,
-            custody_context,
-            spec,
-            true,
-            false,
-        )
-        .expect("should initialise data availability checker")
+        DataAvailabilityChecker::new(slot_clock, kzg, custody_context, spec, true, false)
+            .expect("should initialise data availability checker")
     }
 }

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -77,9 +77,7 @@ const OVERFLOW_LRU_CAPACITY: usize = 32;
 pub struct DataAvailabilityChecker<T: BeaconChainTypes> {
     availability_cache: Arc<DataAvailabilityCheckerInner<T>>,
     partial_assembler: Option<Arc<PartialDataColumnAssembler<T::EthSpec>>>,
-    slot_clock: T::SlotClock,
     kzg: Arc<Kzg>,
-    custody_context: Arc<CustodyContext<T>>,
     spec: Arc<ChainSpec>,
 }
 
@@ -114,7 +112,6 @@ impl<E: EthSpec> Debug for Availability<E> {
 
 impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
     pub fn new(
-        slot_clock: T::SlotClock,
         kzg: Arc<Kzg>,
         custody_context: Arc<CustodyContext<T>>,
         spec: Arc<ChainSpec>,
@@ -137,15 +134,13 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         Ok(Self {
             partial_assembler,
             availability_cache: Arc::new(inner),
-            slot_clock,
             kzg,
-            custody_context,
             spec,
         })
     }
 
     pub fn custody_context(&self) -> &Arc<CustodyContext<T>> {
-        &self.custody_context
+        self.availability_cache.custody_context()
     }
 
     pub fn partial_assembler(&self) -> Option<&Arc<PartialDataColumnAssembler<T::EthSpec>>> {
@@ -348,7 +343,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         // a new epoch.
         let epoch = slot.epoch(T::EthSpec::slots_per_epoch());
         let sampling_columns = self
-            .custody_context
+            .custody_context()
             .sampling_columns_for_epoch(epoch, &self.spec);
         let verified_custody_columns = kzg_verified_columns
             .into_iter()
@@ -388,7 +383,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
         let epoch = slot.epoch(T::EthSpec::slots_per_epoch());
         let sampling_columns = self
-            .custody_context
+            .custody_context()
             .sampling_columns_for_epoch(epoch, &self.spec);
         let custody_columns = data_columns
             .into_iter()
@@ -884,7 +879,7 @@ impl<E: EthSpec> AvailableBlock<E> {
                 }
 
                 let mut column_indices = da_checker
-                    .custody_context
+                    .custody_context()
                     .sampling_columns_for_epoch(block.epoch(), &spec)
                     .iter()
                     .collect::<HashSet<_>>();
@@ -1045,7 +1040,7 @@ mod test {
         let mut u = types::test_utils::test_unstructured();
 
         let da_checker = new_da_checker(spec.clone());
-        let custody_context = &da_checker.custody_context;
+        let custody_context = da_checker.custody_context();
 
         // GIVEN a single 32 ETH validator is attached slot 0
         let epoch = Epoch::new(0);
@@ -1132,7 +1127,7 @@ mod test {
         let mut u = types::test_utils::test_unstructured();
 
         let da_checker = new_da_checker(spec.clone());
-        let custody_context = &da_checker.custody_context;
+        let custody_context = da_checker.custody_context();
 
         // GIVEN a single 32 ETH validator is attached slot 0
         let epoch = Epoch::new(0);
@@ -1280,7 +1275,7 @@ mod test {
         let mut u = types::test_utils::test_unstructured();
 
         let da_checker = new_da_checker(spec.clone());
-        let custody_context = &da_checker.custody_context;
+        let custody_context = da_checker.custody_context();
 
         // Set custody requirement to 65 columns (enough to trigger reconstruction)
         let epoch = Epoch::new(1);
@@ -1374,11 +1369,11 @@ mod test {
         let custody_context = Arc::new(CustodyContext::new(
             NodeCustodyType::Fullnode,
             ordered_custody_column_indices,
-            slot_clock.clone(),
+            slot_clock,
             complete_blob_backfill,
             &spec,
         ));
-        DataAvailabilityChecker::new(slot_clock, kzg, custody_context, spec, true, false)
+        DataAvailabilityChecker::new(kzg, custody_context, spec, true, false)
             .expect("should initialise data availability checker")
     }
 }

--- a/beacon_node/beacon_chain/src/data_availability_checker/error.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/error.rs
@@ -25,7 +25,6 @@ pub enum Error {
     RebuildingStateCaches(BeaconStateError),
     SlotClockError,
     InvalidAvailableBlockData,
-    UnnecessaryCustodyColumns,
     InvalidVariant,
 }
 
@@ -52,7 +51,6 @@ impl Error {
             | Error::RebuildingStateCaches(_)
             | Error::SlotClockError
             | Error::InvalidAvailableBlockData
-            | Error::UnnecessaryCustodyColumns
             | Error::InvalidVariant => ErrorCategory::Internal,
             Error::InvalidBlobs { .. }
             | Error::InvalidColumn { .. }

--- a/beacon_node/beacon_chain/src/data_availability_checker/error.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/error.rs
@@ -25,6 +25,7 @@ pub enum Error {
     RebuildingStateCaches(BeaconStateError),
     SlotClockError,
     InvalidAvailableBlockData,
+    UnnecessaryCustodyColumns,
     InvalidVariant,
 }
 
@@ -51,6 +52,7 @@ impl Error {
             | Error::RebuildingStateCaches(_)
             | Error::SlotClockError
             | Error::InvalidAvailableBlockData
+            | Error::UnnecessaryCustodyColumns
             | Error::InvalidVariant => ErrorCategory::Internal,
             Error::InvalidBlobs { .. }
             | Error::InvalidColumn { .. }

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -349,7 +349,7 @@ impl<E: EthSpec> PendingComponents<E> {
 pub struct DataAvailabilityCheckerInner<T: BeaconChainTypes> {
     /// Contains all the data we keep in memory, protected by an RwLock
     critical: RwLock<LruCache<Hash256, PendingComponents<T::EthSpec>>>,
-    custody_context: Arc<CustodyContext<T::EthSpec>>,
+    custody_context: Arc<CustodyContext<T>>,
     spec: Arc<ChainSpec>,
 }
 
@@ -365,7 +365,7 @@ pub(crate) enum ReconstructColumnsDecision<E: EthSpec> {
 impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
     pub fn new(
         capacity: usize,
-        custody_context: Arc<CustodyContext<T::EthSpec>>,
+        custody_context: Arc<CustodyContext<T>>,
         spec: Arc<ChainSpec>,
     ) -> Result<Self, AvailabilityCheckError> {
         Ok(Self {
@@ -760,6 +760,7 @@ mod test {
     };
     use fork_choice::PayloadVerificationStatus;
     use logging::create_test_tracing_subscriber;
+    use slot_clock::TestingSlotClock;
     use state_processing::ConsensusContext;
     use store::{HotColdDB, ItemStore, StoreConfig, database::interface::BeaconNodeBackend};
     use tempfile::{TempDir, tempdir};
@@ -922,6 +923,7 @@ mod test {
                 HotStore = BeaconNodeBackend,
                 ColdStore = BeaconNodeBackend,
                 EthSpec = E,
+                SlotClock = TestingSlotClock,
             >,
     {
         create_test_tracing_subscriber();
@@ -929,9 +931,12 @@ mod test {
         let harness = get_fulu_chain(&chain_db_path).await;
         let spec = harness.spec.clone();
         let complete_blob_backfill = false;
+        let slot_clock = harness.chain.slot_clock.clone();
+
         let custody_context = Arc::new(CustodyContext::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            slot_clock,
             complete_blob_backfill,
             &spec,
         ));

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -928,13 +928,15 @@ mod test {
         let chain_db_path = tempdir().expect("should get temp dir");
         let harness = get_fulu_chain(&chain_db_path).await;
         let spec = harness.spec.clone();
+        let complete_blob_backfill = false;
         let custody_context = Arc::new(CustodyContext::new(
             NodeCustodyType::Fullnode,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         ));
         let cache = Arc::new(
-            DataAvailabilityCheckerInner::<T>::new(capacity, custody_context, spec.clone())
+            DataAvailabilityCheckerInner::<T>::new(capacity, custody_context, spec)
                 .expect("should create cache"),
         );
         (harness, cache, chain_db_path)

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -942,7 +942,7 @@ mod test {
             generate_data_column_indices_rand_order::<E>(),
             slot_clock,
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         ));
         let cache = Arc::new(
             DataAvailabilityCheckerInner::<T>::new(capacity, custody_context, spec)

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -434,6 +434,10 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         f(self.critical.read().peek(block_root))
     }
 
+    pub fn custody_context(&self) -> &Arc<CustodyContext<T>> {
+        &self.custody_context
+    }
+
     /// Puts the KZG verified blobs into the availability cache as pending components.
     pub fn put_kzg_verified_blobs<I: IntoIterator<Item = KzgVerifiedBlob<T::EthSpec>>>(
         &self,

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -504,9 +504,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
                 pending_components.merge_data_columns(kzg_verified_data_columns)
             })?;
 
-        let num_expected_columns = self
-            .custody_context
-            .num_of_data_columns_to_sample(epoch, &self.spec);
+        let num_expected_columns = self.custody_context.num_of_data_columns_to_sample(epoch);
 
         pending_components.span.in_scope(|| {
             debug!(
@@ -610,9 +608,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
         };
 
         let total_column_count = T::EthSpec::number_of_columns();
-        let sampling_column_count = self
-            .custody_context
-            .num_of_data_columns_to_sample(epoch, &self.spec);
+        let sampling_column_count = self.custody_context.num_of_data_columns_to_sample(epoch);
         let received_column_count = pending_components.verified_data_columns.len();
 
         if pending_components.reconstruction_started {
@@ -713,9 +709,7 @@ impl<T: BeaconChainTypes> DataAvailabilityCheckerInner<T> {
 
     fn get_num_expected_columns(&self, epoch: Epoch) -> Option<usize> {
         if self.spec.is_peer_das_enabled_for_epoch(epoch) {
-            let num_of_column_samples = self
-                .custody_context
-                .num_of_data_columns_to_sample(epoch, &self.spec);
+            let num_of_column_samples = self.custody_context.num_of_data_columns_to_sample(epoch);
             Some(num_of_column_samples)
         } else {
             None
@@ -963,9 +957,7 @@ mod test {
         let epoch = pending_block.block.epoch();
 
         let num_blobs_expected = pending_block.num_blobs_expected();
-        let columns_expected = cache
-            .custody_context
-            .num_of_data_columns_to_sample(epoch, &harness.spec);
+        let columns_expected = cache.custody_context.num_of_data_columns_to_sample(epoch);
 
         // All columns are returned from availability_pending_block (E::number_of_columns())
         // but we only need custody columns
@@ -1005,9 +997,7 @@ mod test {
         }
 
         // Get sampling column indices for this epoch
-        let sampling_column_indices = cache
-            .custody_context
-            .sampling_columns_for_epoch(epoch, &harness.spec);
+        let sampling_column_indices = cache.custody_context.sampling_columns_for_epoch(epoch);
 
         // Filter to only sampling columns
         let sampling_columns: Vec<_> = columns
@@ -1043,9 +1033,7 @@ mod test {
         let root = pending_block.import_data.block_root;
 
         // Get sampling column indices for this epoch
-        let sampling_column_indices = cache
-            .custody_context
-            .sampling_columns_for_epoch(epoch, &harness.spec);
+        let sampling_column_indices = cache.custody_context.sampling_columns_for_epoch(epoch);
 
         // Filter to only sampling columns
         let sampling_columns: Vec<_> = columns

--- a/beacon_node/beacon_chain/src/historical_data_columns.rs
+++ b/beacon_node/beacon_chain/src/historical_data_columns.rs
@@ -131,8 +131,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             );
         }
 
-        self.data_availability_checker
-            .custody_context()
+        self.custody_context
             .update_and_backfill_custody_count_at_epoch(epoch, expected_cgc);
 
         self.safely_backfill_data_column_custody_info(epoch)

--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -29,7 +29,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .collect()
         };
 
-        let custody_context = self.data_availability_checker.custody_context();
+        let custody_context = self.custody_context.clone();
 
         let ctx = InvariantContext {
             fork_choice_blocks,

--- a/beacon_node/beacon_chain/src/invariants.rs
+++ b/beacon_node/beacon_chain/src/invariants.rs
@@ -34,9 +34,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let ctx = InvariantContext {
             fork_choice_blocks,
             state_cache_roots: self.store.state_cache.lock().state_roots(),
-            custody_columns: custody_context
-                .custody_columns_for_epoch(None, &self.spec)
-                .to_vec(),
+            custody_columns: custody_context.custody_columns_for_epoch(None).to_vec(),
             pubkey_cache_pubkeys: {
                 let cache = self.validator_pubkey_cache.read();
                 (0..cache.len())

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
@@ -23,12 +23,11 @@ use crate::{
     ExecutionPayloadError, PayloadVerificationError, PayloadVerificationOutcome,
 };
 use state_processing::envelope_processing::EnvelopeProcessingError;
-use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::sync::Arc;
 use store::Error as DBError;
 use strum::AsRefStr;
-use tracing::instrument;
+use tracing::{instrument, warn};
 use types::{
     BeaconState, BeaconStateError, DataColumnSidecarList, EthSpec, ExecutionBlockHash,
     ExecutionPayloadEnvelope, Hash256, SignedExecutionPayloadBid, SignedExecutionPayloadEnvelope,
@@ -52,12 +51,12 @@ impl<E: EthSpec> AvailableEnvelope<E> {
     /// Constructs an `AvailableEnvelope` from an envelope and custody column data.
     ///
     /// This function validates that:
-    /// - Columns are not provided when not required
-    /// - Required custody columns are present in the expected quantity
-    /// - Required custody columns match the expected sampling indices for the bid's epoch
+    /// - All required custody columns are present
+    ///
+    /// If more columns are provided than necessary, a warning is logged and the extra
+    /// columns are filtered out of the list.
     ///
     /// Returns `AvailabilityCheckError` if:
-    /// - `UnnecessaryCustodyColumns`: Columns are provided but not required
     /// - `MissingCustodyColumns`: Required custody columns are missing or incomplete
     pub fn new<T>(
         envelope: Arc<SignedExecutionPayloadEnvelope<E>>,
@@ -70,29 +69,54 @@ impl<E: EthSpec> AvailableEnvelope<E> {
     {
         if custody_context.data_columns_required_for_bid(bid) {
             let columns_expected = custody_context.num_of_data_columns_to_sample(bid.epoch());
-            match columns.len().cmp(&columns_expected) {
-                Ordering::Less => Err(AvailabilityCheckError::MissingCustodyColumns),
-                Ordering::Greater => Err(AvailabilityCheckError::UnnecessaryCustodyColumns),
-                Ordering::Equal => {
-                    let mut column_indices = custody_context
-                        .sampling_columns_for_epoch(bid.epoch())
-                        .iter()
-                        .collect::<HashSet<_>>();
-                    for column in &columns {
-                        column_indices.remove(column.index());
-                    }
 
-                    if !column_indices.is_empty() {
-                        return Err(AvailabilityCheckError::MissingCustodyColumns);
-                    }
+            // Get required custody column indices
+            let required_indices = custody_context
+                .sampling_columns_for_epoch(bid.epoch())
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>();
 
-                    Ok(Self { envelope, columns })
+            // Filter to only the columns we need (deduplicates if there are duplicates)
+            let mut filtered_columns = Vec::new();
+            let mut seen_indices = HashSet::new();
+            let num_provided_columns = columns.len();
+            for column in columns {
+                if required_indices.contains(column.index()) && seen_indices.insert(*column.index())
+                {
+                    filtered_columns.push(column);
                 }
             }
+
+            // Check if we have all required columns
+            if filtered_columns.len() != columns_expected {
+                return Err(AvailabilityCheckError::MissingCustodyColumns);
+            }
+
+            if num_provided_columns != filtered_columns.len() {
+                warn!(
+                    message = "More columns provided than expected",
+                    envelope = %envelope.message.payload.block_hash,
+                    num_provided_columns = %num_provided_columns,
+                    columns_expected = %columns_expected,
+                );
+            }
+
+            Ok(Self {
+                envelope,
+                columns: filtered_columns,
+            })
         } else if columns.is_empty() {
             Ok(Self { envelope, columns })
         } else {
-            Err(AvailabilityCheckError::UnnecessaryCustodyColumns)
+            warn!(
+                message = "Custody columns provided for envelope that does not require them",
+                envelope = %envelope.message.payload.block_hash,
+            );
+            Ok(Self {
+                envelope,
+                columns: vec![],
+            })
         }
     }
 

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
@@ -17,20 +17,22 @@
 //!      ExecutedEnvelope
 //!
 //! ```
-
+use crate::data_availability_checker::AvailabilityCheckError;
+use crate::{
+    BeaconChainError, BeaconChainTypes, BeaconStore, BlockError, CustodyContext,
+    ExecutionPayloadError, PayloadVerificationError, PayloadVerificationOutcome,
+};
 use state_processing::envelope_processing::EnvelopeProcessingError;
+use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::sync::Arc;
 use store::Error as DBError;
 use strum::AsRefStr;
 use tracing::instrument;
 use types::{
     BeaconState, BeaconStateError, DataColumnSidecarList, EthSpec, ExecutionBlockHash,
-    ExecutionPayloadEnvelope, Hash256, SignedExecutionPayloadEnvelope, Slot,
-};
-
-use crate::{
-    BeaconChainError, BeaconChainTypes, BeaconStore, BlockError, ExecutionPayloadError,
-    PayloadVerificationError, PayloadVerificationOutcome,
+    ExecutionPayloadEnvelope, Hash256, SignedExecutionPayloadBid, SignedExecutionPayloadEnvelope,
+    Slot,
 };
 
 pub mod execution_pending_envelope;
@@ -47,11 +49,51 @@ pub struct AvailableEnvelope<E: EthSpec> {
 }
 
 impl<E: EthSpec> AvailableEnvelope<E> {
-    pub fn new(
+    /// Constructs an `AvailableEnvelope` from an envelope and custody column data.
+    ///
+    /// This function validates that:
+    /// - Columns are not provided when not required
+    /// - Required custody columns are present in the expected quantity
+    /// - Required custody columns match the expected sampling indices for the bid's epoch
+    ///
+    /// Returns `AvailabilityCheckError` if:
+    /// - `UnnecessaryCustodyColumns`: Columns are provided but not required
+    /// - `MissingCustodyColumns`: Required custody columns are missing or incomplete
+    pub fn new<T>(
         envelope: Arc<SignedExecutionPayloadEnvelope<E>>,
         columns: DataColumnSidecarList<E>,
-    ) -> Self {
-        Self { envelope, columns }
+        bid: &SignedExecutionPayloadBid<E>,
+        custody_context: &CustodyContext<T>,
+    ) -> Result<Self, AvailabilityCheckError>
+    where
+        T: BeaconChainTypes<EthSpec = E>,
+    {
+        if custody_context.data_columns_required_for_bid(bid) {
+            let columns_expected = custody_context.num_of_data_columns_to_sample(bid.epoch());
+            match columns.len().cmp(&columns_expected) {
+                Ordering::Less => Err(AvailabilityCheckError::MissingCustodyColumns),
+                Ordering::Greater => Err(AvailabilityCheckError::UnnecessaryCustodyColumns),
+                Ordering::Equal => {
+                    let mut column_indices = custody_context
+                        .sampling_columns_for_epoch(bid.epoch())
+                        .iter()
+                        .collect::<HashSet<_>>();
+                    for column in &columns {
+                        column_indices.remove(column.index());
+                    }
+
+                    if !column_indices.is_empty() {
+                        return Err(AvailabilityCheckError::MissingCustodyColumns);
+                    }
+
+                    Ok(Self { envelope, columns })
+                }
+            }
+        } else if columns.is_empty() {
+            Ok(Self { envelope, columns })
+        } else {
+            Err(AvailabilityCheckError::UnnecessaryCustodyColumns)
+        }
     }
 
     pub fn envelope(&self) -> &Arc<SignedExecutionPayloadEnvelope<E>> {

--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -174,7 +174,6 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         &self,
         executed_envelope: AvailabilityPendingExecutedEnvelope<T::EthSpec>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
-        let epoch = executed_envelope.envelope.epoch();
         let beacon_block_root = executed_envelope.envelope.beacon_block_root();
         let bid = self
             .get_bid(&beacon_block_root)
@@ -185,17 +184,15 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
                 pending_components.insert_executed_payload_envelope(executed_envelope);
             })?;
 
-        let num_expected_columns = self.custody_context.num_of_data_columns_to_sample(epoch);
-
         pending_components.span.in_scope(|| {
             debug!(
                 component = "executed envelope",
-                status = pending_components.status_str(num_expected_columns),
+                status = pending_components.status_str(&self.custody_context),
                 "Component added to data availability checker"
             );
         });
 
-        self.check_availability(beacon_block_root, pending_components, num_expected_columns)
+        self.check_availability(beacon_block_root, pending_components)
     }
 
     /// Inserts a bid into the pending payload cache.
@@ -274,19 +271,15 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
                 pending_components.merge_data_columns(kzg_verified_data_columns)
             })?;
 
-        let epoch = bid.message.slot.epoch(T::EthSpec::slots_per_epoch());
-
-        let num_expected_columns = self.custody_context.num_of_data_columns_to_sample(epoch);
-
         pending_components.span.in_scope(|| {
             debug!(
                 component = "data_columns",
-                status = pending_components.status_str(num_expected_columns),
+                status = pending_components.status_str(&self.custody_context),
                 "Component added to data availability checker"
             );
         });
 
-        self.check_availability(block_root, pending_components, num_expected_columns)
+        self.check_availability(block_root, pending_components)
     }
 
     #[instrument(skip_all, level = "debug")]
@@ -380,9 +373,10 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         &self,
         block_root: Hash256,
         pending_components: MappedRwLockReadGuard<'_, PendingComponents<T::EthSpec>>,
-        num_expected_columns: usize,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
-        if let Some(available_envelope) = pending_components.make_available(num_expected_columns)? {
+        if let Some(available_envelope) =
+            pending_components.make_available(&self.custody_context)?
+        {
             // Explicitly drop read lock before acquiring write lock
             drop(pending_components);
             if let Some(components) = self.availability_cache.write().get_mut(&block_root) {

--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -555,7 +555,7 @@ mod data_availability_checker_tests {
             generate_data_column_indices_rand_order::<E>(),
             slot_clock,
             complete_blob_backfill,
-            &spec,
+            spec.clone(),
         ));
         let cache = Arc::new(
             PendingPayloadCache::<T>::new(kzg, custody_context, spec.clone())
@@ -580,7 +580,7 @@ mod data_availability_checker_tests {
         let epoch = bid.message.slot.epoch(E::slots_per_epoch());
         let sampling = cache
             .custody_context()
-            .sampling_columns_for_epoch(epoch, &cache.spec);
+            .sampling_columns_for_epoch(epoch, &spec);
         let custody = columns
             .into_iter()
             .filter(|c| sampling.contains(c.index()))

--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -527,7 +527,6 @@ mod data_availability_checker_tests {
         create_test_tracing_subscriber();
         let spec = Arc::new(ForkName::Gloas.make_genesis_spec(E::default_spec()));
         let kzg = get_kzg(&spec);
-        // TODO: check this with the new payload cache
         let slot_clock = TestingSlotClock::new(
             Slot::new(0),
             Duration::from_secs(0),

--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -541,9 +541,12 @@ mod data_availability_checker_tests {
         create_test_tracing_subscriber();
         let spec = Arc::new(ForkName::Gloas.make_genesis_spec(E::default_spec()));
         let kzg = get_kzg(&spec);
+        // TODO: check this with the new payload cache
+        let complete_blob_backfill = false;
         let custody_context = Arc::new(CustodyContext::<E>::new(
             node_custody,
             generate_data_column_indices_rand_order::<E>(),
+            complete_blob_backfill,
             &spec,
         ));
         let cache = Arc::new(

--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -92,14 +92,14 @@ pub struct PendingPayloadCache<T: BeaconChainTypes> {
     /// Contains all the data we keep in memory, protected by an RwLock
     availability_cache: RwLock<LruCache<Hash256, PendingComponents<T::EthSpec>>>,
     kzg: Arc<Kzg>,
-    custody_context: Arc<CustodyContext<T::EthSpec>>,
+    custody_context: Arc<CustodyContext<T>>,
     spec: Arc<ChainSpec>,
 }
 
 impl<T: BeaconChainTypes> PendingPayloadCache<T> {
     pub fn new(
         kzg: Arc<Kzg>,
-        custody_context: Arc<CustodyContext<T::EthSpec>>,
+        custody_context: Arc<CustodyContext<T>>,
         spec: Arc<ChainSpec>,
     ) -> Result<Self, AvailabilityCheckError> {
         Ok(Self {
@@ -110,7 +110,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         })
     }
 
-    pub fn custody_context(&self) -> &Arc<CustodyContext<T::EthSpec>> {
+    pub fn custody_context(&self) -> &Arc<CustodyContext<T>> {
         &self.custody_context
     }
 
@@ -516,10 +516,12 @@ mod data_availability_checker_tests {
     };
     use fork_choice::PayloadVerificationStatus;
     use logging::create_test_tracing_subscriber;
+    use slot_clock::{SlotClock, TestingSlotClock};
+    use std::time::Duration;
     use types::test_utils::test_unstructured;
     use types::{
         ExecutionPayloadEnvelope, ExecutionPayloadGloas, ExecutionRequests, ForkName,
-        MinimalEthSpec, SignedExecutionPayloadEnvelope,
+        MinimalEthSpec, SignedExecutionPayloadEnvelope, Slot,
     };
 
     type E = MinimalEthSpec;
@@ -542,10 +544,16 @@ mod data_availability_checker_tests {
         let spec = Arc::new(ForkName::Gloas.make_genesis_spec(E::default_spec()));
         let kzg = get_kzg(&spec);
         // TODO: check this with the new payload cache
+        let slot_clock = TestingSlotClock::new(
+            Slot::new(0),
+            Duration::from_secs(0),
+            spec.get_slot_duration(),
+        );
         let complete_blob_backfill = false;
-        let custody_context = Arc::new(CustodyContext::<E>::new(
+        let custody_context = Arc::new(CustodyContext::<T>::new(
             node_custody,
             generate_data_column_indices_rand_order::<E>(),
+            slot_clock,
             complete_blob_backfill,
             &spec,
         ));

--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -185,9 +185,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
                 pending_components.insert_executed_payload_envelope(executed_envelope);
             })?;
 
-        let num_expected_columns = self
-            .custody_context
-            .num_of_data_columns_to_sample(epoch, &self.spec);
+        let num_expected_columns = self.custody_context.num_of_data_columns_to_sample(epoch);
 
         pending_components.span.in_scope(|| {
             debug!(
@@ -228,9 +226,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         .map_err(AvailabilityCheckError::InvalidColumn)?;
 
         let epoch = bid.message.slot.epoch(T::EthSpec::slots_per_epoch());
-        let sampling_columns = self
-            .custody_context
-            .sampling_columns_for_epoch(epoch, &self.spec);
+        let sampling_columns = self.custody_context.sampling_columns_for_epoch(epoch);
         let verified_custody_columns = kzg_verified_columns
             .into_iter()
             .filter(|col| sampling_columns.contains(&col.index()))
@@ -252,9 +248,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
             .get_bid(&block_root)
             .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
         let epoch = bid.message.slot.epoch(T::EthSpec::slots_per_epoch());
-        let sampling_columns = self
-            .custody_context
-            .sampling_columns_for_epoch(epoch, &self.spec);
+        let sampling_columns = self.custody_context.sampling_columns_for_epoch(epoch);
         let custody_columns = data_columns
             .into_iter()
             .filter(|col| sampling_columns.contains(&col.index()))
@@ -282,9 +276,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
 
         let epoch = bid.message.slot.epoch(T::EthSpec::slots_per_epoch());
 
-        let num_expected_columns = self
-            .custody_context
-            .num_of_data_columns_to_sample(epoch, &self.spec);
+        let num_expected_columns = self.custody_context.num_of_data_columns_to_sample(epoch);
 
         pending_components.span.in_scope(|| {
             debug!(
@@ -340,7 +332,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         let slot = bid.message.slot;
         let columns_to_sample = self
             .custody_context()
-            .sampling_columns_for_epoch(slot.epoch(T::EthSpec::slots_per_epoch()), &self.spec);
+            .sampling_columns_for_epoch(slot.epoch(T::EthSpec::slots_per_epoch()));
 
         let data_columns_to_import_and_publish = all_data_columns
             .into_iter()
@@ -458,9 +450,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         let epoch = pending_components.bid.epoch();
 
         let total_column_count = T::EthSpec::number_of_columns();
-        let sampling_column_count = self
-            .custody_context
-            .num_of_data_columns_to_sample(epoch, &self.spec);
+        let sampling_column_count = self.custody_context.num_of_data_columns_to_sample(epoch);
 
         if pending_components.reconstruction_started {
             return ReconstructColumnsDecision::No("already started");
@@ -578,9 +568,7 @@ mod data_availability_checker_tests {
         cache.insert_bid(block_root, bid.clone());
 
         let epoch = bid.message.slot.epoch(E::slots_per_epoch());
-        let sampling = cache
-            .custody_context()
-            .sampling_columns_for_epoch(epoch, &spec);
+        let sampling = cache.custody_context().sampling_columns_for_epoch(epoch);
         let custody = columns
             .into_iter()
             .filter(|c| sampling.contains(c.index()))

--- a/beacon_node/beacon_chain/src/pending_payload_cache/pending_components.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/pending_components.rs
@@ -1,3 +1,5 @@
+use crate::beacon_chain::BeaconChainTypes;
+use crate::custody_context::CustodyContext;
 use crate::data_availability_checker::AvailabilityCheckError;
 use crate::data_column_verification::KzgVerifiedCustodyDataColumn;
 use crate::payload_envelope_verification::AvailabilityPendingExecutedEnvelope;
@@ -27,8 +29,15 @@ pub struct PendingComponents<E: EthSpec> {
 }
 
 impl<E: EthSpec> PendingComponents<E> {
-    pub fn num_blobs_expected(&self) -> usize {
-        self.bid.message.blob_kzg_commitments.len()
+    pub fn num_columns_required<T>(&self, custody_context: &CustodyContext<T>) -> usize
+    where
+        T: BeaconChainTypes<EthSpec = E>,
+    {
+        if custody_context.data_columns_required_for_bid(&self.bid) {
+            custody_context.num_of_data_columns_to_sample(self.bid.epoch())
+        } else {
+            0
+        }
     }
 
     /// Returns columns that have all cells present.
@@ -59,7 +68,7 @@ impl<E: EthSpec> PendingComponents<E> {
         &mut self,
         kzg_verified_data_columns: &[KzgVerifiedCustodyDataColumn<E>],
     ) {
-        let num_blobs_expected = self.num_blobs_expected();
+        let num_blobs_expected = self.bid.num_blobs_expected();
         for data_column in kzg_verified_data_columns {
             let data_column = data_column.as_data_column();
             // The Vec-backed `PendingColumn` keys cells by index, so we have to allocate up to
@@ -95,10 +104,13 @@ impl<E: EthSpec> PendingComponents<E> {
     }
 
     /// Returns `Some` if the envelope and all required data columns have been received.
-    pub fn make_available(
+    pub fn make_available<T>(
         &self,
-        num_expected_columns: usize,
-    ) -> Result<Option<AvailableExecutedEnvelope<E>>, AvailabilityCheckError> {
+        custody_context: &CustodyContext<T>,
+    ) -> Result<Option<AvailableExecutedEnvelope<E>>, AvailabilityCheckError>
+    where
+        T: BeaconChainTypes<EthSpec = E>,
+    {
         // Check if the payload has been received and executed
         let Some(envelope) = &self.envelope else {
             return Ok(None);
@@ -110,17 +122,24 @@ impl<E: EthSpec> PendingComponents<E> {
             payload_verification_outcome,
         } = envelope;
 
-        let columns = if self.num_blobs_expected() == 0 {
-            self.span.in_scope(|| {
-                debug!("Bid has no blobs, data is available");
-            });
+        let num_columns_required = self.num_columns_required(custody_context);
+        let columns = if num_columns_required == 0 {
+            if self.bid.num_blobs_expected() == 0 {
+                self.span.in_scope(|| {
+                    debug!("Bid has no blobs, data is available");
+                });
+            } else {
+                self.span.in_scope(|| {
+                    debug!("No data columns required for this epoch");
+                });
+            }
             vec![]
         } else {
             let columns = self.get_cached_data_columns();
-            match columns.len().cmp(&num_expected_columns) {
+            match columns.len().cmp(&num_columns_required) {
                 Ordering::Greater => {
                     return Err(AvailabilityCheckError::Unexpected(format!(
-                        "too many columns: got {} expected {num_expected_columns}",
+                        "too many columns: got {} expected {num_columns_required}",
                         columns.len()
                     )));
                 }
@@ -137,7 +156,8 @@ impl<E: EthSpec> PendingComponents<E> {
             }
         };
 
-        let available_envelope = AvailableEnvelope::new(envelope.clone(), columns);
+        let available_envelope =
+            AvailableEnvelope::new(envelope.clone(), columns, &self.bid, custody_context)?;
 
         Ok(Some(AvailableExecutedEnvelope {
             envelope: available_envelope,
@@ -160,12 +180,16 @@ impl<E: EthSpec> PendingComponents<E> {
         }
     }
 
-    pub fn status_str(&self, num_expected_columns: usize) -> String {
+    pub fn status_str<T>(&self, custody_context: &CustodyContext<T>) -> String
+    where
+        T: BeaconChainTypes<EthSpec = E>,
+    {
+        let num_columns_required = self.num_columns_required(custody_context);
         format!(
             "envelope {}, data_columns {}/{}",
             self.envelope.is_some(),
             self.num_completed_columns(),
-            num_expected_columns
+            num_columns_required
         )
     }
 }

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -3164,19 +3164,22 @@ where
         block: Arc<SignedBeaconBlock<E>>,
     ) -> RangeSyncBlock<E> {
         let block_root = block_root.unwrap_or_else(|| get_block_root(&block));
-        let is_gloas = block.fork_name_unchecked().gloas_enabled();
         // For Gloas, kzg commitments live in the bid (`signed_execution_payload_bid`), so the
         // body's `blob_kzg_commitments()` accessor returns Err. `num_expected_blobs` already
         // handles both shapes.
         let has_blobs = block.num_expected_blobs() > 0;
         if !has_blobs {
-            return if is_gloas {
+            return if let Ok(bid) = block.message().body().signed_execution_payload_bid() {
                 let envelope = self
                     .chain
                     .get_payload_envelope(&block_root)
                     .unwrap()
                     .map(Arc::new)
-                    .map(|envelope| AvailableEnvelope::new(envelope, vec![]));
+                    .map(|envelope| {
+                        AvailableEnvelope::new(envelope, vec![], bid, &self.chain.custody_context)
+                    })
+                    .transpose()
+                    .unwrap();
                 RangeSyncBlock::new_gloas(block, envelope).unwrap()
             } else {
                 RangeSyncBlock::new(
@@ -3197,13 +3200,22 @@ where
                 .unwrap()
                 .unwrap();
             let custody_columns = columns.into_iter().collect::<Vec<_>>();
-            if is_gloas {
+            if let Ok(bid) = block.message().body().signed_execution_payload_bid() {
                 let envelope = self
                     .chain
                     .get_payload_envelope(&block_root)
                     .unwrap()
                     .map(Arc::new)
-                    .map(|envelope| AvailableEnvelope::new(envelope, custody_columns));
+                    .map(|envelope| {
+                        AvailableEnvelope::new(
+                            envelope,
+                            custody_columns,
+                            bid,
+                            &self.chain.custody_context,
+                        )
+                    })
+                    .transpose()
+                    .unwrap();
                 RangeSyncBlock::new_gloas(block, envelope).unwrap()
             } else {
                 let block_data = AvailableBlockData::new_with_data_columns(custody_columns);
@@ -3227,7 +3239,7 @@ where
         block: Arc<SignedBeaconBlock<E, FullPayload<E>>>,
         blob_items: Option<(KzgProofs<E>, BlobsList<E>)>,
     ) -> Result<RangeSyncBlock<E>, BlockError> {
-        if block.fork_name_unchecked().gloas_enabled() {
+        if let Ok(bid) = block.message().body().signed_execution_payload_bid() {
             let columns = blob_items
                 .map(|_| generate_data_column_sidecars_from_block(&block, &self.spec))
                 .unwrap_or_default();
@@ -3236,7 +3248,11 @@ where
                 .get_payload_envelope(&block.canonical_root())
                 .map_err(|e| BlockError::BeaconChainError(Box::new(e)))?
                 .map(Arc::new)
-                .map(|envelope| AvailableEnvelope::new(envelope, columns));
+                .map(|envelope| {
+                    AvailableEnvelope::new(envelope, columns, bid, &self.chain.custody_context)
+                })
+                .transpose()
+                .unwrap();
             return RangeSyncBlock::new_gloas(block, envelope).map_err(BlockError::InternalError);
         }
 

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -3258,7 +3258,7 @@ where
 
         Ok(if self.spec.is_peer_das_enabled_for_epoch(block.epoch()) {
             let epoch = block.slot().epoch(E::slots_per_epoch());
-            let sampling_columns = self.chain.sampling_columns_for_epoch(epoch);
+            let sampling_columns = self.chain.custody_context.sampling_columns_for_epoch(epoch);
 
             if blob_items.is_some_and(|(kzg_proofs, _)| !kzg_proofs.is_empty()) {
                 // Note: this method ignores the actual custody columns and just take the first
@@ -4000,6 +4000,7 @@ where
         let custody_columns = custody_columns_opt.unwrap_or_else(|| {
             let epoch = block.slot().epoch(E::slots_per_epoch());
             self.chain
+                .custody_context
                 .sampling_columns_for_epoch(epoch)
                 .iter()
                 .copied()

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -233,12 +233,13 @@ pub fn test_da_checker<E: EthSpec>(
     );
     let kzg = get_kzg(&spec);
     let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
+    let complete_blob_backfill = false;
     let custody_context = Arc::new(CustodyContext::new(
         node_custody_type,
         ordered_custody_column_indices,
+        complete_blob_backfill,
         &spec,
     ));
-    let complete_blob_backfill = false;
     DataAvailabilityChecker::new(
         complete_blob_backfill,
         slot_clock,

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -237,6 +237,7 @@ pub fn test_da_checker<E: EthSpec>(
     let custody_context = Arc::new(CustodyContext::new(
         node_custody_type,
         ordered_custody_column_indices,
+        slot_clock.clone(),
         complete_blob_backfill,
         &spec,
     ));

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -226,23 +226,30 @@ pub fn test_da_checker<E: EthSpec>(
     spec: Arc<ChainSpec>,
     node_custody_type: NodeCustodyType,
 ) -> DataAvailabilityChecker<EphemeralHarnessType<E>> {
+    let kzg = get_kzg(&spec);
+    let custody_context = test_custody_context(node_custody_type, spec.clone());
+    DataAvailabilityChecker::new(kzg, custody_context, spec, true, false)
+        .expect("should initialise data availability checker")
+}
+
+pub fn test_custody_context<E: EthSpec>(
+    node_custody_type: NodeCustodyType,
+    spec: Arc<ChainSpec>,
+) -> Arc<CustodyContext<EphemeralHarnessType<E>>> {
+    let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
+    let complete_blob_backfill = false;
     let slot_clock = TestingSlotClock::new(
         Slot::new(0),
         Duration::from_secs(0),
         spec.get_slot_duration(),
     );
-    let kzg = get_kzg(&spec);
-    let ordered_custody_column_indices = generate_data_column_indices_rand_order::<E>();
-    let complete_blob_backfill = false;
-    let custody_context = Arc::new(CustodyContext::new(
+    Arc::new(CustodyContext::new(
         node_custody_type,
         ordered_custody_column_indices,
-        slot_clock.clone(),
+        slot_clock,
         complete_blob_backfill,
-        spec.clone(),
-    ));
-    DataAvailabilityChecker::new(kzg, custody_context, spec, true, false)
-        .expect("should initialise data availability checker")
+        spec,
+    ))
 }
 
 pub struct Builder<T: BeaconChainTypes> {
@@ -3175,8 +3182,7 @@ where
                 RangeSyncBlock::new(
                     block,
                     AvailableBlockData::NoData,
-                    &self.chain.data_availability_checker,
-                    self.chain.spec.clone(),
+                    &self.chain.custody_context,
                 )
                 .unwrap()
             };
@@ -3201,13 +3207,7 @@ where
                 RangeSyncBlock::new_gloas(block, envelope).unwrap()
             } else {
                 let block_data = AvailableBlockData::new_with_data_columns(custody_columns);
-                RangeSyncBlock::new(
-                    block,
-                    block_data,
-                    &self.chain.data_availability_checker,
-                    self.chain.spec.clone(),
-                )
-                .unwrap()
+                RangeSyncBlock::new(block, block_data, &self.chain.custody_context).unwrap()
             }
         } else {
             let blobs = self.chain.get_blobs(&block_root).unwrap().blobs();
@@ -3217,13 +3217,7 @@ where
                 AvailableBlockData::NoData
             };
 
-            RangeSyncBlock::new(
-                block,
-                block_data,
-                &self.chain.data_availability_checker,
-                self.chain.spec.clone(),
-            )
-            .unwrap()
+            RangeSyncBlock::new(block, block_data, &self.chain.custody_context).unwrap()
         }
     }
 
@@ -3259,18 +3253,12 @@ where
                     .filter(|d| sampling_columns.contains(d.index()))
                     .collect::<Vec<_>>();
                 let block_data = AvailableBlockData::new_with_data_columns(columns);
-                RangeSyncBlock::new(
-                    block,
-                    block_data,
-                    &self.chain.data_availability_checker,
-                    self.chain.spec.clone(),
-                )?
+                RangeSyncBlock::new(block, block_data, &self.chain.custody_context)?
             } else {
                 RangeSyncBlock::new(
                     block,
                     AvailableBlockData::NoData,
-                    &self.chain.data_availability_checker,
-                    self.chain.spec.clone(),
+                    &self.chain.custody_context,
                 )?
             }
         } else {
@@ -3286,12 +3274,7 @@ where
                 AvailableBlockData::NoData
             };
 
-            RangeSyncBlock::new(
-                block,
-                block_data,
-                &self.chain.data_availability_checker,
-                self.chain.spec.clone(),
-            )?
+            RangeSyncBlock::new(block, block_data, &self.chain.custody_context)?
         })
     }
 

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -241,7 +241,7 @@ pub fn test_da_checker<E: EthSpec>(
         complete_blob_backfill,
         &spec,
     ));
-    DataAvailabilityChecker::new(slot_clock, kzg, custody_context, spec, true, false)
+    DataAvailabilityChecker::new(kzg, custody_context, spec, true, false)
         .expect("should initialise data availability checker")
 }
 

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -241,16 +241,8 @@ pub fn test_da_checker<E: EthSpec>(
         complete_blob_backfill,
         &spec,
     ));
-    DataAvailabilityChecker::new(
-        complete_blob_backfill,
-        slot_clock,
-        kzg,
-        custody_context,
-        spec,
-        true,
-        false,
-    )
-    .expect("should initialise data availability checker")
+    DataAvailabilityChecker::new(slot_clock, kzg, custody_context, spec, true, false)
+        .expect("should initialise data availability checker")
 }
 
 pub struct Builder<T: BeaconChainTypes> {

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -239,7 +239,7 @@ pub fn test_da_checker<E: EthSpec>(
         ordered_custody_column_indices,
         slot_clock.clone(),
         complete_blob_backfill,
-        &spec,
+        spec.clone(),
     ));
     DataAvailabilityChecker::new(kzg, custody_context, spec, true, false)
         .expect("should initialise data availability checker")

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -1,6 +1,7 @@
 #![cfg(not(debug_assertions))]
 // TODO(gloas) we probably need similar test for payload envelope verification
 use beacon_chain::block_verification_types::{AsBlock, ExecutedBlock, LookupBlock, RangeSyncBlock};
+use beacon_chain::custody_context::CustodyContext;
 use beacon_chain::data_availability_checker::{AvailabilityCheckError, AvailableBlockData};
 use beacon_chain::data_column_verification::CustodyDataColumn;
 use beacon_chain::payload_envelope_verification::AvailableEnvelope;
@@ -178,7 +179,7 @@ fn build_range_sync_block<T>(
 where
     T: BeaconChainTypes<EthSpec = E>,
 {
-    if block.fork_name_unchecked().gloas_enabled() {
+    if let Ok(bid) = block.message().body().signed_execution_payload_bid() {
         let columns = match data_sidecars {
             Some(DataSidecars::DataColumns(columns)) => columns
                 .iter()
@@ -186,20 +187,17 @@ where
                 .collect::<Vec<_>>(),
             Some(DataSidecars::Blobs(_)) | None => vec![],
         };
-        let envelope = execution_envelope.map(|envelope| AvailableEnvelope::new(envelope, columns));
+        let envelope = execution_envelope
+            .map(|envelope| AvailableEnvelope::new(envelope, columns, bid, &chain.custody_context))
+            .transpose()
+            .unwrap();
         return RangeSyncBlock::new_gloas(block, envelope).unwrap();
     }
 
     match data_sidecars {
         Some(DataSidecars::Blobs(blobs)) => {
             let block_data = AvailableBlockData::new_with_blobs(blobs.clone());
-            RangeSyncBlock::new(
-                block,
-                block_data,
-                &chain.data_availability_checker,
-                chain.spec.clone(),
-            )
-            .unwrap()
+            RangeSyncBlock::new(block, block_data, &chain.custody_context).unwrap()
         }
         Some(DataSidecars::DataColumns(columns)) => {
             let block_data = AvailableBlockData::new_with_data_columns(
@@ -208,21 +206,11 @@ where
                     .map(|c| c.as_data_column().clone())
                     .collect::<Vec<_>>(),
             );
-            RangeSyncBlock::new(
-                block,
-                block_data,
-                &chain.data_availability_checker,
-                chain.spec.clone(),
-            )
-            .unwrap()
+            RangeSyncBlock::new(block, block_data, &chain.custody_context).unwrap()
         }
-        None => RangeSyncBlock::new(
-            block,
-            AvailableBlockData::NoData,
-            &chain.data_availability_checker,
-            chain.spec.clone(),
-        )
-        .unwrap(),
+        None => {
+            RangeSyncBlock::new(block, AvailableBlockData::NoData, &chain.custody_context).unwrap()
+        }
     }
 }
 
@@ -522,8 +510,7 @@ async fn chain_segment_non_linear_parent_roots() {
         RangeSyncBlock::new(
             mutated_block,
             blocks[3].block_data().clone(),
-            &harness.chain.data_availability_checker,
-            harness.spec.clone(),
+            &harness.chain.custody_context,
         )
         .unwrap()
     };
@@ -567,8 +554,7 @@ async fn chain_segment_non_linear_slots() {
         RangeSyncBlock::new(
             mutated_block,
             blocks[3].block_data().clone(),
-            &harness.chain.data_availability_checker,
-            harness.spec.clone(),
+            &harness.chain.custody_context,
         )
         .unwrap()
     };
@@ -602,8 +588,7 @@ async fn chain_segment_non_linear_slots() {
         RangeSyncBlock::new(
             mutated_block,
             blocks[3].block_data().clone(),
-            &harness.chain.data_availability_checker,
-            harness.chain.spec.clone(),
+            &harness.chain.custody_context,
         )
         .unwrap()
     };
@@ -1809,8 +1794,7 @@ async fn add_base_block_to_altair_chain() {
     let base_range_sync_block = RangeSyncBlock::new(
         Arc::new(base_block.clone()),
         AvailableBlockData::NoData,
-        &harness.chain.data_availability_checker,
-        harness.spec.clone(),
+        &harness.chain.custody_context,
     )
     .unwrap();
     assert!(matches!(
@@ -1840,8 +1824,7 @@ async fn add_base_block_to_altair_chain() {
                     RangeSyncBlock::new(
                         Arc::new(base_block),
                         AvailableBlockData::NoData,
-                        &harness.chain.data_availability_checker,
-                        harness.spec.clone()
+                        &harness.chain.custody_context,
                     )
                     .unwrap()
                 ],
@@ -1985,8 +1968,7 @@ async fn add_altair_block_to_base_chain() {
                     RangeSyncBlock::new(
                         Arc::new(altair_block),
                         AvailableBlockData::NoData,
-                        &harness.chain.data_availability_checker,
-                        harness.spec.clone()
+                        &harness.chain.custody_context,
                     )
                     .unwrap()
                 ],
@@ -2205,8 +2187,7 @@ async fn import_duplicate_block_unrealized_justification() {
         RangeSyncBlock::new(
             block.clone(),
             AvailableBlockData::NoData,
-            &harness.chain.data_availability_checker,
-            harness.spec.clone(),
+            &harness.chain.custody_context,
         )
         .unwrap()
     };
@@ -2284,8 +2265,11 @@ async fn import_execution_pending_block<T: BeaconChainTypes>(
     }
 }
 
-async fn make_gloas_range_sync_block_inputs()
--> Option<(Arc<SignedBeaconBlock<E>>, SignedExecutionPayloadEnvelope<E>)> {
+async fn make_gloas_range_sync_block_inputs() -> Option<(
+    Arc<SignedBeaconBlock<E>>,
+    SignedExecutionPayloadEnvelope<E>,
+    Arc<CustodyContext<EphemeralHarnessType<E>>>,
+)> {
     let spec = test_spec::<E>();
     if !spec.fork_name_at_slot::<E>(Slot::new(1)).gloas_enabled() {
         return None;
@@ -2304,16 +2288,26 @@ async fn make_gloas_range_sync_block_inputs()
     let state = harness.get_current_state();
     let slot = harness.get_current_slot();
     let ((block, _), envelope, _) = harness.make_block_with_envelope(state, slot).await;
-    Some((block, envelope.expect("gloas block should have envelope")))
+    Some((
+        block,
+        envelope.expect("gloas block should have envelope"),
+        harness.chain.custody_context.clone(),
+    ))
 }
 
 #[tokio::test]
 async fn range_sync_block_new_gloas_accepts_matching_envelope() {
-    let Some((block, envelope)) = make_gloas_range_sync_block_inputs().await else {
+    let Some((block, envelope, custody_context)) = make_gloas_range_sync_block_inputs().await
+    else {
         return;
     };
-
-    let available_envelope = AvailableEnvelope::new(Arc::new(envelope), vec![]);
+    let bid = block
+        .message()
+        .body()
+        .signed_execution_payload_bid()
+        .unwrap();
+    let available_envelope =
+        AvailableEnvelope::new(Arc::new(envelope), vec![], bid, &custody_context).unwrap();
     let result = RangeSyncBlock::new_gloas(block, Some(available_envelope));
 
     assert!(
@@ -2325,7 +2319,7 @@ async fn range_sync_block_new_gloas_accepts_matching_envelope() {
 
 #[tokio::test]
 async fn range_sync_block_new_gloas_allows_missing_envelope() {
-    let Some((block, _)) = make_gloas_range_sync_block_inputs().await else {
+    let Some((block, _, _)) = make_gloas_range_sync_block_inputs().await else {
         return;
     };
 
@@ -2340,12 +2334,19 @@ async fn range_sync_block_new_gloas_allows_missing_envelope() {
 
 #[tokio::test]
 async fn range_sync_block_new_gloas_rejects_slot_mismatch() {
-    let Some((block, mut envelope)) = make_gloas_range_sync_block_inputs().await else {
+    let Some((block, mut envelope, custody_context)) = make_gloas_range_sync_block_inputs().await
+    else {
         return;
     };
 
     envelope.message.payload.slot_number += 1;
-    let available_envelope = AvailableEnvelope::new(Arc::new(envelope), vec![]);
+    let bid = block
+        .message()
+        .body()
+        .signed_execution_payload_bid()
+        .unwrap();
+    let available_envelope =
+        AvailableEnvelope::new(Arc::new(envelope), vec![], bid, &custody_context).unwrap();
     let result = RangeSyncBlock::new_gloas(block, Some(available_envelope));
 
     assert!(
@@ -2357,12 +2358,19 @@ async fn range_sync_block_new_gloas_rejects_slot_mismatch() {
 
 #[tokio::test]
 async fn range_sync_block_new_gloas_rejects_builder_index_mismatch() {
-    let Some((block, mut envelope)) = make_gloas_range_sync_block_inputs().await else {
+    let Some((block, mut envelope, custody_context)) = make_gloas_range_sync_block_inputs().await
+    else {
         return;
     };
 
     envelope.message.builder_index += 1;
-    let available_envelope = AvailableEnvelope::new(Arc::new(envelope), vec![]);
+    let bid = block
+        .message()
+        .body()
+        .signed_execution_payload_bid()
+        .unwrap();
+    let available_envelope =
+        AvailableEnvelope::new(Arc::new(envelope), vec![], bid, &custody_context).unwrap();
     let result = RangeSyncBlock::new_gloas(block, Some(available_envelope));
 
     assert!(
@@ -2374,12 +2382,19 @@ async fn range_sync_block_new_gloas_rejects_builder_index_mismatch() {
 
 #[tokio::test]
 async fn range_sync_block_new_gloas_rejects_block_hash_mismatch() {
-    let Some((block, mut envelope)) = make_gloas_range_sync_block_inputs().await else {
+    let Some((block, mut envelope, custody_context)) = make_gloas_range_sync_block_inputs().await
+    else {
         return;
     };
 
     envelope.message.payload.block_hash = ExecutionBlockHash::repeat_byte(0x22);
-    let available_envelope = AvailableEnvelope::new(Arc::new(envelope), vec![]);
+    let bid = block
+        .message()
+        .body()
+        .signed_execution_payload_bid()
+        .unwrap();
+    let available_envelope =
+        AvailableEnvelope::new(Arc::new(envelope), vec![], bid, &custody_context).unwrap();
     let result = RangeSyncBlock::new_gloas(block, Some(available_envelope));
 
     assert!(
@@ -2442,12 +2457,8 @@ async fn range_sync_block_construction_fails_with_wrong_blob_count() {
             let block_data = AvailableBlockData::new_with_blobs(wrong_blobs);
 
             // Try to create RpcBlock with wrong blob count
-            let result = RangeSyncBlock::new(
-                Arc::new(block),
-                block_data,
-                &harness.chain.data_availability_checker,
-                harness.chain.spec.clone(),
-            );
+            let result =
+                RangeSyncBlock::new(Arc::new(block), block_data, &harness.chain.custody_context);
 
             // Should fail with MissingBlobs
             assert!(
@@ -2523,8 +2534,7 @@ async fn range_sync_block_rejects_missing_custody_columns() {
                 let result = RangeSyncBlock::new(
                     Arc::new(block),
                     block_data,
-                    &harness.chain.data_availability_checker,
-                    harness.chain.spec.clone(),
+                    &harness.chain.custody_context,
                 );
 
                 // Should fail with MissingCustodyColumns
@@ -2614,8 +2624,7 @@ async fn rpc_block_allows_construction_past_da_boundary() {
             let result = RangeSyncBlock::new(
                 Arc::new(block),
                 AvailableBlockData::NoData,
-                &harness.chain.data_availability_checker,
-                harness.chain.spec.clone(),
+                &harness.chain.custody_context,
             );
 
             assert!(

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -2308,7 +2308,8 @@ async fn make_gloas_range_sync_block_inputs() -> Option<(
 
 #[tokio::test]
 async fn range_sync_block_new_gloas_accepts_matching_envelope() {
-    let Some((block, envelope, custody_context, columns)) = make_gloas_range_sync_block_inputs().await
+    let Some((block, envelope, custody_context, columns)) =
+        make_gloas_range_sync_block_inputs().await
     else {
         return;
     };

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -2599,6 +2599,7 @@ async fn rpc_block_allows_construction_past_da_boundary() {
             // Now verify the block is past the DA boundary
             let da_boundary = harness
                 .chain
+                .custody_context
                 .data_availability_boundary()
                 .expect("DA boundary should be set");
             assert!(

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -11,7 +11,7 @@ use beacon_chain::{
     custody_context::NodeCustodyType,
     test_utils::{
         AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
-        MakeAttestationOptions, test_spec,
+        MakeAttestationOptions, generate_data_column_sidecars_from_block, test_spec,
     },
 };
 use beacon_chain::{
@@ -2269,6 +2269,7 @@ async fn make_gloas_range_sync_block_inputs() -> Option<(
     Arc<SignedBeaconBlock<E>>,
     SignedExecutionPayloadEnvelope<E>,
     Arc<CustodyContext<EphemeralHarnessType<E>>>,
+    DataColumnSidecarList<E>,
 )> {
     let spec = test_spec::<E>();
     if !spec.fork_name_at_slot::<E>(Slot::new(1)).gloas_enabled() {
@@ -2288,16 +2289,26 @@ async fn make_gloas_range_sync_block_inputs() -> Option<(
     let state = harness.get_current_state();
     let slot = harness.get_current_slot();
     let ((block, _), envelope, _) = harness.make_block_with_envelope(state, slot).await;
+    let custody_context = harness.chain.custody_context.clone();
+    let columns = generate_data_column_sidecars_from_block(&block, &harness.chain.spec)
+        .into_iter()
+        .filter(|column| {
+            custody_context
+                .sampling_columns_for_epoch(block.epoch())
+                .contains(column.index())
+        })
+        .collect();
     Some((
         block,
         envelope.expect("gloas block should have envelope"),
-        harness.chain.custody_context.clone(),
+        custody_context,
+        columns,
     ))
 }
 
 #[tokio::test]
 async fn range_sync_block_new_gloas_accepts_matching_envelope() {
-    let Some((block, envelope, custody_context)) = make_gloas_range_sync_block_inputs().await
+    let Some((block, envelope, custody_context, columns)) = make_gloas_range_sync_block_inputs().await
     else {
         return;
     };
@@ -2307,7 +2318,7 @@ async fn range_sync_block_new_gloas_accepts_matching_envelope() {
         .signed_execution_payload_bid()
         .unwrap();
     let available_envelope =
-        AvailableEnvelope::new(Arc::new(envelope), vec![], bid, &custody_context).unwrap();
+        AvailableEnvelope::new(Arc::new(envelope), columns, bid, &custody_context).unwrap();
     let result = RangeSyncBlock::new_gloas(block, Some(available_envelope));
 
     assert!(
@@ -2319,7 +2330,7 @@ async fn range_sync_block_new_gloas_accepts_matching_envelope() {
 
 #[tokio::test]
 async fn range_sync_block_new_gloas_allows_missing_envelope() {
-    let Some((block, _, _)) = make_gloas_range_sync_block_inputs().await else {
+    let Some((block, _, _, _)) = make_gloas_range_sync_block_inputs().await else {
         return;
     };
 
@@ -2334,7 +2345,8 @@ async fn range_sync_block_new_gloas_allows_missing_envelope() {
 
 #[tokio::test]
 async fn range_sync_block_new_gloas_rejects_slot_mismatch() {
-    let Some((block, mut envelope, custody_context)) = make_gloas_range_sync_block_inputs().await
+    let Some((block, mut envelope, custody_context, columns)) =
+        make_gloas_range_sync_block_inputs().await
     else {
         return;
     };
@@ -2346,7 +2358,7 @@ async fn range_sync_block_new_gloas_rejects_slot_mismatch() {
         .signed_execution_payload_bid()
         .unwrap();
     let available_envelope =
-        AvailableEnvelope::new(Arc::new(envelope), vec![], bid, &custody_context).unwrap();
+        AvailableEnvelope::new(Arc::new(envelope), columns, bid, &custody_context).unwrap();
     let result = RangeSyncBlock::new_gloas(block, Some(available_envelope));
 
     assert!(
@@ -2358,7 +2370,8 @@ async fn range_sync_block_new_gloas_rejects_slot_mismatch() {
 
 #[tokio::test]
 async fn range_sync_block_new_gloas_rejects_builder_index_mismatch() {
-    let Some((block, mut envelope, custody_context)) = make_gloas_range_sync_block_inputs().await
+    let Some((block, mut envelope, custody_context, columns)) =
+        make_gloas_range_sync_block_inputs().await
     else {
         return;
     };
@@ -2370,7 +2383,7 @@ async fn range_sync_block_new_gloas_rejects_builder_index_mismatch() {
         .signed_execution_payload_bid()
         .unwrap();
     let available_envelope =
-        AvailableEnvelope::new(Arc::new(envelope), vec![], bid, &custody_context).unwrap();
+        AvailableEnvelope::new(Arc::new(envelope), columns, bid, &custody_context).unwrap();
     let result = RangeSyncBlock::new_gloas(block, Some(available_envelope));
 
     assert!(
@@ -2382,7 +2395,8 @@ async fn range_sync_block_new_gloas_rejects_builder_index_mismatch() {
 
 #[tokio::test]
 async fn range_sync_block_new_gloas_rejects_block_hash_mismatch() {
-    let Some((block, mut envelope, custody_context)) = make_gloas_range_sync_block_inputs().await
+    let Some((block, mut envelope, custody_context, columns)) =
+        make_gloas_range_sync_block_inputs().await
     else {
         return;
     };
@@ -2394,7 +2408,7 @@ async fn range_sync_block_new_gloas_rejects_block_hash_mismatch() {
         .signed_execution_payload_bid()
         .unwrap();
     let available_envelope =
-        AvailableEnvelope::new(Arc::new(envelope), vec![], bid, &custody_context).unwrap();
+        AvailableEnvelope::new(Arc::new(envelope), columns, bid, &custody_context).unwrap();
     let result = RangeSyncBlock::new_gloas(block, Some(available_envelope));
 
     assert!(

--- a/beacon_node/beacon_chain/tests/events.rs
+++ b/beacon_node/beacon_chain/tests/events.rs
@@ -43,7 +43,10 @@ async fn data_column_sidecar_event_on_process_gossip_data_column() {
             let mut random_sidecar = DataColumnSidecarGloas::arbitrary(&mut u).unwrap();
             let epoch = slot.epoch(E::slots_per_epoch());
             random_sidecar.slot = slot;
-            random_sidecar.index = harness.chain.sampling_columns_for_epoch(epoch)[0];
+            random_sidecar.index = harness
+                .chain
+                .custody_context
+                .sampling_columns_for_epoch(epoch)[0];
 
             // For gloas, the bid must be known, e.g. in the pending payload cache
             let mut bid = SignedExecutionPayloadBid::<E>::empty();
@@ -58,7 +61,10 @@ async fn data_column_sidecar_event_on_process_gossip_data_column() {
             let mut random_sidecar = DataColumnSidecarFulu::arbitrary(&mut u).unwrap();
             let epoch = slot.epoch(E::slots_per_epoch());
             random_sidecar.signed_block_header.message.slot = slot;
-            random_sidecar.index = harness.chain.sampling_columns_for_epoch(epoch)[0];
+            random_sidecar.index = harness
+                .chain
+                .custody_context
+                .sampling_columns_for_epoch(epoch)[0];
             DataColumnSidecar::Fulu(random_sidecar)
         }
     };

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -4878,7 +4878,10 @@ async fn test_column_da_boundary() {
 
     // The column da boundary should be the fulu fork epoch
     assert_eq!(
-        harness.chain.column_data_availability_boundary(),
+        harness
+            .chain
+            .custody_context
+            .column_data_availability_boundary(),
         Some(fulu_fork_epoch)
     );
 }
@@ -5374,8 +5377,6 @@ async fn test_missing_columns_after_cgc_change() {
         return;
     }
 
-    let custody_context = harness.chain.data_availability_checker.custody_context();
-
     harness.advance_slot();
     harness
         .extend_chain(
@@ -5397,7 +5398,11 @@ async fn test_missing_columns_after_cgc_change() {
     let epoch_after_increase = Epoch::new(num_epochs_before_increase + 2);
 
     let cgc_change_slot = epoch_before_increase.end_slot(E::slots_per_epoch());
-    custody_context.register_validators(vec![(1, 32_000_000_000 * 9)], cgc_change_slot, &spec);
+    harness.chain.custody_context.register_validators(
+        vec![(1, 32_000_000_000 * 9)],
+        cgc_change_slot,
+        &spec,
+    );
 
     harness.advance_slot();
     harness
@@ -5444,8 +5449,6 @@ async fn test_safely_backfill_data_column_custody_info() {
         return;
     }
 
-    let custody_context = harness.chain.data_availability_checker.custody_context();
-
     harness.advance_slot();
     harness
         .extend_chain(
@@ -5461,7 +5464,11 @@ async fn test_safely_backfill_data_column_custody_info() {
 
     let cgc_change_slot = epoch_before_increase.end_slot(E::slots_per_epoch());
 
-    custody_context.register_validators(vec![(1, 32_000_000_000 * 16)], cgc_change_slot, &spec);
+    harness.chain.custody_context.register_validators(
+        vec![(1, 32_000_000_000 * 16)],
+        cgc_change_slot,
+        &spec,
+    );
 
     let epoch_after_increase =
         (cgc_change_slot + effective_delay_slots).epoch(E::slots_per_epoch());

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -3322,13 +3322,8 @@ async fn weak_subjectivity_sync_test(
             let (_, block, data) = clone_block(&available_blocks[0]).deconstruct();
             let mut corrupt_block = (*block).clone();
             *corrupt_block.signature_mut() = Signature::empty();
-            AvailableBlock::new(
-                Arc::new(corrupt_block),
-                data,
-                &beacon_chain.data_availability_checker,
-                Arc::new(spec),
-            )
-            .expect("available block")
+            AvailableBlock::new(Arc::new(corrupt_block), data, &beacon_chain.custody_context)
+                .expect("available block")
         };
 
         // Importing the invalid batch should error.

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -5291,6 +5291,7 @@ async fn test_custody_column_filtering_regular_node() {
     // Get custody columns for this epoch - regular nodes only store a subset
     let expected_custody_columns: HashSet<_> = harness
         .chain
+        .custody_context
         .custody_columns_for_epoch(Some(current_slot.epoch(E::slots_per_epoch())))
         .iter()
         .copied()

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -5398,11 +5398,10 @@ async fn test_missing_columns_after_cgc_change() {
     let epoch_after_increase = Epoch::new(num_epochs_before_increase + 2);
 
     let cgc_change_slot = epoch_before_increase.end_slot(E::slots_per_epoch());
-    harness.chain.custody_context.register_validators(
-        vec![(1, 32_000_000_000 * 9)],
-        cgc_change_slot,
-        &spec,
-    );
+    harness
+        .chain
+        .custody_context
+        .register_validators(vec![(1, 32_000_000_000 * 9)], cgc_change_slot);
 
     harness.advance_slot();
     harness
@@ -5464,11 +5463,10 @@ async fn test_safely_backfill_data_column_custody_info() {
 
     let cgc_change_slot = epoch_before_increase.end_slot(E::slots_per_epoch());
 
-    harness.chain.custody_context.register_validators(
-        vec![(1, 32_000_000_000 * 16)],
-        cgc_change_slot,
-        &spec,
-    );
+    harness
+        .chain
+        .custody_context
+        .register_validators(vec![(1, 32_000_000_000 * 16)], cgc_change_slot);
 
     let epoch_after_increase =
         (cgc_change_slot + effective_delay_slots).epoch(E::slots_per_epoch());

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -171,7 +171,9 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                         Ok(data_column_custody_info) => {
                             if let Some(earliest_data_column_slot) = data_column_custody_info
                                 .and_then(|info| info.earliest_data_column_slot)
-                                && let Some(da_boundary) = beacon_chain.get_column_da_boundary()
+                                && let Some(da_boundary) = beacon_chain
+                                    .custody_context
+                                    .column_data_availability_boundary()
                             {
                                 sync_distance = earliest_data_column_slot.saturating_sub(
                                     da_boundary.start_slot(T::EthSpec::slots_per_epoch()),
@@ -295,7 +297,9 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                 let speed = speedo.slots_per_second();
                 let display_speed = speed.is_some_and(|speed| speed != 0.0);
                 let est_time_in_secs = if let (Some(da_boundary_epoch), Some(original_slot)) = (
-                    beacon_chain.get_column_da_boundary(),
+                    beacon_chain
+                        .custody_context
+                        .column_data_availability_boundary(),
                     original_earliest_data_column_slot,
                 ) {
                     let target = original_slot.saturating_sub(

--- a/beacon_node/http_api/src/beacon/execution_payload_envelopes.rs
+++ b/beacon_node/http_api/src/beacon/execution_payload_envelopes.rs
@@ -200,7 +200,7 @@ pub async fn publish_execution_payload_envelope<T: BeaconChainTypes>(
             }
 
             let epoch = slot.epoch(T::EthSpec::slots_per_epoch());
-            let sampling_column_indices = chain.sampling_columns_for_epoch(epoch);
+            let sampling_column_indices = chain.custody_context.sampling_columns_for_epoch(epoch);
             let sampling_columns = gossip_verified_columns
                 .into_iter()
                 .filter(|col| sampling_column_indices.contains(&col.index()))

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -615,8 +615,7 @@ mod tests {
         let available_block = AvailableBlock::new(
             block.clone(),
             AvailableBlockData::new_with_data_columns(data_columns),
-            &chain.data_availability_checker,
-            chain.spec.clone(),
+            &chain.custody_context,
         )
         .unwrap();
 

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -602,7 +602,9 @@ mod tests {
             "precondition: test block must not be imported into fork choice yet"
         );
 
-        let sampling_columns = chain.sampling_columns_for_epoch(block.epoch());
+        let sampling_columns = chain
+            .custody_context
+            .sampling_columns_for_epoch(block.epoch());
         let data_columns = generate_data_column_sidecars_from_block(&block, &chain.spec)
             .into_iter()
             .filter(|column| sampling_columns.contains(column.index()))

--- a/beacon_node/http_api/src/custody.rs
+++ b/beacon_node/http_api/src/custody.rs
@@ -41,11 +41,11 @@ pub fn info<T: BeaconChainTypes>(
     // node is custodying.
     let custody_columns = chain
         .custody_context
-        .custody_columns_for_epoch(Some(earliest_custodied_data_column_epoch), &chain.spec)
+        .custody_columns_for_epoch(Some(earliest_custodied_data_column_epoch))
         .to_vec();
     let custody_group_count = chain
         .custody_context
-        .custody_group_count_at_epoch(earliest_custodied_data_column_epoch, &chain.spec);
+        .custody_group_count_at_epoch(earliest_custodied_data_column_epoch);
 
     Ok(CustodyInfo {
         earliest_custodied_data_column_slot,

--- a/beacon_node/http_api/src/custody.rs
+++ b/beacon_node/http_api/src/custody.rs
@@ -17,6 +17,7 @@ pub fn info<T: BeaconChainTypes>(
         .map_err(|e| custom_server_error(format!("error reading DataColumnCustodyInfo: {e:?}")))?;
 
     let column_data_availability_boundary = chain
+        .custody_context
         .column_data_availability_boundary()
         .ok_or_else(|| custom_server_error("unreachable: Fulu should be enabled".to_string()))?;
 
@@ -38,11 +39,12 @@ pub fn info<T: BeaconChainTypes>(
     // Compute the custody columns and the CGC *at the earliest custodied slot*. The node might
     // have some columns prior to this, but this value is the most up-to-date view of the data the
     // node is custodying.
-    let custody_context = chain.data_availability_checker.custody_context();
-    let custody_columns = custody_context
+    let custody_columns = chain
+        .custody_context
         .custody_columns_for_epoch(Some(earliest_custodied_data_column_epoch), &chain.spec)
         .to_vec();
-    let custody_group_count = custody_context
+    let custody_group_count = chain
+        .custody_context
         .custody_group_count_at_epoch(earliest_custodied_data_column_epoch, &chain.spec);
 
     Ok(CustodyInfo {

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -3179,10 +3179,11 @@ pub fn serve<T: BeaconChainTypes>(
                         .head_slot()
                         .epoch(T::EthSpec::slots_per_epoch())
                         + 1;
-                    let custody_context = chain.data_availability_checker.custody_context();
                     // Reset validator custody requirements to `effective_epoch` with the latest
                     // cgc requiremnets.
-                    custody_context.reset_validator_custody_requirements(effective_epoch);
+                    chain
+                        .custody_context
+                        .reset_validator_custody_requirements(effective_epoch);
                     // Update `DataColumnCustodyInfo` to reflect the custody change.
                     chain.update_data_column_custody_info(Some(
                         effective_epoch.start_slot(T::EthSpec::slots_per_epoch()),

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -217,7 +217,7 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlock<T>>(
             warp_utils::reject::custom_server_error("unable to publish data column sidecars".into())
         })?;
         let epoch = block.slot().epoch(T::EthSpec::slots_per_epoch());
-        let sampling_columns_indices = chain.sampling_columns_for_epoch(epoch);
+        let sampling_columns_indices = chain.custody_context.sampling_columns_for_epoch(epoch);
         let sampling_columns = gossip_verified_columns
             .into_iter()
             .filter(|data_column| sampling_columns_indices.contains(&data_column.index()))

--- a/beacon_node/http_api/src/validator/mod.rs
+++ b/beacon_node/http_api/src/validator/mod.rs
@@ -854,11 +854,10 @@ pub fn post_validator_prepare_beacon_proposer<T: BeaconChainTypes>(
 
                         let current_slot =
                             chain.slot().map_err(warp_utils::reject::unhandled_error)?;
-                        if let Some(cgc_change) = chain.custody_context.register_validators(
-                            validators_and_balances,
-                            current_slot,
-                            &chain.spec,
-                        ) {
+                        if let Some(cgc_change) = chain
+                            .custody_context
+                            .register_validators(validators_and_balances, current_slot)
+                        {
                             chain.update_data_column_custody_info(Some(
                                 cgc_change
                                     .effective_epoch

--- a/beacon_node/http_api/src/validator/mod.rs
+++ b/beacon_node/http_api/src/validator/mod.rs
@@ -854,11 +854,11 @@ pub fn post_validator_prepare_beacon_proposer<T: BeaconChainTypes>(
 
                         let current_slot =
                             chain.slot().map_err(warp_utils::reject::unhandled_error)?;
-                        if let Some(cgc_change) = chain
-                            .data_availability_checker
-                            .custody_context()
-                            .register_validators(validators_and_balances, current_slot, &chain.spec)
-                        {
+                        if let Some(cgc_change) = chain.custody_context.register_validators(
+                            validators_and_balances,
+                            current_slot,
+                            &chain.spec,
+                        ) {
                             chain.update_data_column_custody_info(Some(
                                 cgc_change
                                     .effective_epoch

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -2036,6 +2036,7 @@ fn get_custody_columns(tester: &InteractiveTester<E>, slot: Slot) -> HashSet<Col
         .chain
         .as_ref()
         .unwrap()
+        .custody_context
         .sampling_columns_for_epoch(epoch)
         .iter()
         .copied()

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -1276,7 +1276,7 @@ async fn lighthouse_restart_custody_backfill() {
         )
         .await;
 
-    let cgc_at_head = custody_context.custody_group_count_at_head(spec);
+    let cgc_at_head = custody_context.custody_group_count_at_head();
     let earliest_data_column_epoch = harness.chain.earliest_custodied_data_column_epoch();
 
     assert_eq!(cgc_at_head, max_cgc);
@@ -1286,9 +1286,9 @@ async fn lighthouse_restart_custody_backfill() {
         .update_and_backfill_custody_count_at_epoch(harness.chain.epoch().unwrap(), cgc_at_head);
     client.post_lighthouse_custody_backfill().await.unwrap();
 
-    let cgc_at_head = custody_context.custody_group_count_at_head(spec);
+    let cgc_at_head = custody_context.custody_group_count_at_head();
     let cgc_at_previous_epoch =
-        custody_context.custody_group_count_at_epoch(harness.chain.epoch().unwrap() - 1, spec);
+        custody_context.custody_group_count_at_epoch(harness.chain.epoch().unwrap() - 1);
     let earliest_data_column_epoch = harness.chain.earliest_custodied_data_column_epoch();
 
     // `DataColumnCustodyInfo` should have been updated to the head epoch

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -1262,8 +1262,7 @@ async fn lighthouse_restart_custody_backfill() {
     let max_cgc = spec.number_of_custody_groups;
 
     let num_blocks = 2 * E::slots_per_epoch();
-
-    let custody_context = harness.chain.data_availability_checker.custody_context();
+    let custody_context = &harness.chain.custody_context;
 
     harness.advance_slot();
     harness

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1407,10 +1407,11 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     }
 
     async fn check_reconstruction_trigger(self: &Arc<Self>, slot: Slot, block_root: &Hash256) {
-        if self.chain.custody_context.should_attempt_reconstruction(
-            slot.epoch(T::EthSpec::slots_per_epoch()),
-            &self.chain.spec,
-        ) {
+        if self
+            .chain
+            .custody_context
+            .should_attempt_reconstruction(slot.epoch(T::EthSpec::slots_per_epoch()))
+        {
             // Instead of triggering reconstruction immediately, schedule it to be run. If
             // another column arrives, it either completes availability or pushes
             // reconstruction back a bit.

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1407,15 +1407,10 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     }
 
     async fn check_reconstruction_trigger(self: &Arc<Self>, slot: Slot, block_root: &Hash256) {
-        if self
-            .chain
-            .data_availability_checker
-            .custody_context()
-            .should_attempt_reconstruction(
-                slot.epoch(T::EthSpec::slots_per_epoch()),
-                &self.chain.spec,
-            )
-        {
+        if self.chain.custody_context.should_attempt_reconstruction(
+            slot.epoch(T::EthSpec::slots_per_epoch()),
+            &self.chain.spec,
+        ) {
             // Instead of triggering reconstruction immediately, schedule it to be run. If
             // another column arrives, it either completes availability or pushes
             // reconstruction back a bit.

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -921,7 +921,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             return;
         }
         let epoch = header.slot().epoch(T::EthSpec::slots_per_epoch());
-        let custody_columns = self.chain.sampling_columns_for_epoch(epoch);
+        let custody_columns = self.chain.custody_context.sampling_columns_for_epoch(epoch);
         let self_cloned = self.clone();
         let publish_fn = move |columns: Vec<KzgVerifiedCustodyDataColumn<T::EthSpec>>| {
             if publish_blobs {
@@ -996,7 +996,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             return;
         };
         let epoch = header.slot().epoch(T::EthSpec::slots_per_epoch());
-        let custody_columns = self.chain.sampling_columns_for_epoch(epoch);
+        let custody_columns = self.chain.custody_context.sampling_columns_for_epoch(epoch);
         let columns = assembler.get_columns_and_mark_as_local_fetched(block_root, &header);
 
         let mut present_indices: HashSet<ColumnIndex> = HashSet::with_capacity(columns.len());

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -791,7 +791,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     ) -> Result<(), (RpcErrorResponse, &'static str)> {
         let mut send_data_column_count = 0;
         // Only attempt lookups for columns the node has advertised and is responsible for maintaining custody of.
-        let available_columns = self.chain.custody_columns_for_epoch(None);
+        let available_columns = self.chain.custody_context.custody_columns_for_epoch(None);
 
         for data_column_ids_by_root in request.data_column_ids.as_slice() {
             let indices_to_retrieve = data_column_ids_by_root
@@ -1802,6 +1802,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let request_start_epoch = request_start_slot.epoch(T::EthSpec::slots_per_epoch());
         let available_columns = self
             .chain
+            .custody_context
             .custody_columns_for_epoch(Some(request_start_epoch));
 
         let indices_to_retrieve = req

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -1921,7 +1921,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             let custody_columns = self
                 .chain
                 .custody_context
-                .custody_columns_for_epoch(epoch_opt, &self.chain.spec);
+                .custody_columns_for_epoch(epoch_opt);
             requested_indices
                 .iter()
                 .filter(|subnet_id| !custody_columns.contains(subnet_id))

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -1595,13 +1595,14 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             req.count
         };
 
-        let data_availability_boundary_slot = match self.chain.data_availability_boundary() {
-            Some(boundary) => boundary.start_slot(T::EthSpec::slots_per_epoch()),
-            None => {
-                debug!("Deneb fork is disabled");
-                return Err((RpcErrorResponse::InvalidRequest, "Deneb fork is disabled"));
-            }
-        };
+        let data_availability_boundary_slot =
+            match self.chain.custody_context.data_availability_boundary() {
+                Some(boundary) => boundary.start_slot(T::EthSpec::slots_per_epoch()),
+                None => {
+                    debug!("Deneb fork is disabled");
+                    return Err((RpcErrorResponse::InvalidRequest, "Deneb fork is disabled"));
+                }
+            };
 
         let oldest_blob_slot = self
             .chain
@@ -1745,14 +1746,17 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
         let request_start_slot = Slot::from(req.start_slot);
 
-        let column_data_availability_boundary_slot =
-            match self.chain.column_data_availability_boundary() {
-                Some(boundary) => boundary.start_slot(T::EthSpec::slots_per_epoch()),
-                None => {
-                    debug!("Fulu fork is disabled");
-                    return Err((RpcErrorResponse::InvalidRequest, "Fulu fork is disabled"));
-                }
-            };
+        let column_data_availability_boundary_slot = match self
+            .chain
+            .custody_context
+            .column_data_availability_boundary()
+        {
+            Some(boundary) => boundary.start_slot(T::EthSpec::slots_per_epoch()),
+            None => {
+                debug!("Fulu fork is disabled");
+                return Err((RpcErrorResponse::InvalidRequest, "Fulu fork is disabled"));
+            }
+        };
 
         let earliest_custodied_data_column_slot =
             match self.chain.earliest_custodied_data_column_epoch() {
@@ -1916,8 +1920,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let non_custody_indices = {
             let custody_columns = self
                 .chain
-                .data_availability_checker
-                .custody_context()
+                .custody_context
                 .custody_columns_for_epoch(epoch_opt, &self.chain.spec);
             requested_indices
                 .iter()

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -340,7 +340,7 @@ impl TestRig {
             if chain.spec.is_peer_das_enabled_for_epoch(block.epoch()) {
                 let kzg = get_kzg(&chain.spec);
                 let epoch = block.slot().epoch(E::slots_per_epoch());
-                let sampling_indices = chain.sampling_columns_for_epoch(epoch);
+                let sampling_indices = chain.custody_context.sampling_columns_for_epoch(epoch);
                 let custody_columns: DataColumnSidecarList<E> = blobs_to_data_column_sidecars(
                     &blobs.iter().collect_vec(),
                     kzg_proofs.clone().into_iter().collect_vec(),
@@ -1839,6 +1839,7 @@ async fn test_data_columns_by_range_request_only_returns_requested_columns() {
 
     let all_custody_columns = rig
         .chain
+        .custody_context
         .sampling_columns_for_epoch(rig.chain.epoch().unwrap());
     let available_columns: Vec<u64> = all_custody_columns.to_vec();
 
@@ -1900,7 +1901,10 @@ async fn test_data_columns_by_range_no_duplicates_with_skip_slots() {
     let skip_slots: HashSet<u64> = [5, 6].into_iter().collect();
     let mut rig = TestRig::new_with_skip_slots(128, &skip_slots).await;
 
-    let all_custody_columns = rig.chain.custody_columns_for_epoch(Some(Epoch::new(0)));
+    let all_custody_columns = rig
+        .chain
+        .custody_context
+        .custody_columns_for_epoch(Some(Epoch::new(0)));
     let requested_column = vec![all_custody_columns[0]];
 
     // Request a range that spans the skip slots (slots 0 through 9).

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -295,8 +295,7 @@ impl<T: BeaconChainTypes> NetworkService<T> {
             executor.clone(),
             service_context,
             beacon_chain
-                .data_availability_checker
-                .custody_context()
+                .custody_context
                 .custody_group_count_at_head(&beacon_chain.spec),
             local_keypair,
         )

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -294,9 +294,7 @@ impl<T: BeaconChainTypes> NetworkService<T> {
         let (mut libp2p, network_globals) = Network::new(
             executor.clone(),
             service_context,
-            beacon_chain
-                .custody_context
-                .custody_group_count_at_head(&beacon_chain.spec),
+            beacon_chain.custody_context.custody_group_count_at_head(),
             local_keypair,
         )
         .await?;

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -352,10 +352,13 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                         debug!(?batch_id, msg, "Blob peer failure");
                     }
                     CouplingError::EnvelopePeerFailure(msg) => {
-                        debug!(?batch_id, msg, "Envelope peer failure");
+                        debug!(?batch_id, ?msg, "Envelope peer failure");
                     }
                     CouplingError::InternalError(msg) => {
                         error!(?batch_id, msg, "Block components coupling internal error");
+                    }
+                    CouplingError::AvailabilityCheckError(err) => {
+                        error!(?batch_id, ?err, "Availability check error");
                     }
                 }
             }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -390,12 +390,11 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
             match &mut self.data_request {
                 DataRequest::WaitingForBlock => {
                     if let Some(block) = self.block_request.state.peek_downloaded_data() {
-                        let block_epoch = block
-                            .slot()
-                            .epoch(<T as BeaconChainTypes>::EthSpec::slots_per_epoch());
-                        self.data_request = if block.num_expected_blobs() == 0 {
-                            DataRequest::NoData
-                        } else if cx.chain.should_fetch_custody_columns(block_epoch) {
+                        self.data_request = if cx
+                            .chain
+                            .custody_context
+                            .data_columns_required_for_block(block)
+                        {
                             DataRequest::Request {
                                 slot: block.slot(),
                                 peers: self.get_data_peers(block.payload_bid_block_hash().ok()),

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -746,7 +746,7 @@ mod tests {
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
         let expected_custody_columns = da_checker
             .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         let blocks = make_gloas_blocks_and_columns(count, &spec);
 
@@ -885,7 +885,7 @@ mod tests {
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
         let expects_custody_columns = da_checker
             .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         let mut u = types::test_utils::test_unstructured();
         let blocks = (0..4)
@@ -967,7 +967,7 @@ mod tests {
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
         let expected_sampling_columns = da_checker
             .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         // Split sampling columns into two batches
         let mid = expected_sampling_columns.len() / 2;
@@ -1172,7 +1172,7 @@ mod tests {
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
         let expected_sampling_columns = da_checker
             .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         let mut u = types::test_utils::test_unstructured();
         let blocks = (0..2)
@@ -1274,7 +1274,7 @@ mod tests {
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
         let expected_sampling_columns = da_checker
             .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         let mut u = types::test_utils::test_unstructured();
         let blocks = (0..2)
@@ -1394,7 +1394,7 @@ mod tests {
         let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
         let expected_sampling_columns = da_checker
             .custody_context()
-            .sampling_columns_for_epoch(Epoch::new(0), &spec)
+            .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         let mut u = types::test_utils::test_unstructured();
         let blocks = (0..1)

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -1,3 +1,4 @@
+use beacon_chain::data_availability_checker::AvailabilityCheckError;
 use beacon_chain::payload_envelope_verification::AvailableEnvelope;
 use beacon_chain::{
     BeaconChainTypes,
@@ -81,6 +82,13 @@ pub enum CouplingError {
     },
     BlobPeerFailure(String),
     EnvelopePeerFailure(String),
+    AvailabilityCheckError(AvailabilityCheckError),
+}
+
+impl From<AvailabilityCheckError> for CouplingError {
+    fn from(e: AvailabilityCheckError) -> Self {
+        CouplingError::AvailabilityCheckError(e)
+    }
 }
 
 impl<E: EthSpec> RangeBlockComponentsRequest<E> {
@@ -493,22 +501,30 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             } else {
                 vec![]
             };
-            let range_sync_block =
-                if let Some(envelopes_by_block_root) = envelopes_by_block_root.as_mut() {
-                    let envelope = envelopes_by_block_root.remove(&block_root);
-                    let available_envelope =
-                        envelope.map(|env| AvailableEnvelope::new(env, custody_columns));
+            let range_sync_block = if let Some(envelopes_by_block_root) =
+                envelopes_by_block_root.as_mut()
+            {
+                let envelope = envelopes_by_block_root.remove(&block_root);
+                let bid = block
+                    .message()
+                    .body()
+                    .signed_execution_payload_bid()
+                    // this really should never fail
+                    .map_err(|_| AvailabilityCheckError::MissingBid(block_root))?;
+                let available_envelope = envelope
+                    .map(|env| AvailableEnvelope::new(env, custody_columns, bid, custody_context))
+                    .transpose()?;
 
-                    RangeSyncBlock::new_gloas(block, available_envelope)
-                        .map_err(CouplingError::EnvelopePeerFailure)?
-                } else if custody_columns.is_empty() {
-                    RangeSyncBlock::new(block, AvailableBlockData::NoData, custody_context)
-                        .map_err(|e| CouplingError::InternalError(format!("{:?}", e)))?
-                } else {
-                    let block_data = AvailableBlockData::new_with_data_columns(custody_columns);
-                    RangeSyncBlock::new(block, block_data, custody_context)
-                        .map_err(|e| CouplingError::InternalError(format!("{:?}", e)))?
-                };
+                RangeSyncBlock::new_gloas(block, available_envelope)
+                    .map_err(CouplingError::EnvelopePeerFailure)?
+            } else if custody_columns.is_empty() {
+                RangeSyncBlock::new(block, AvailableBlockData::NoData, custody_context)
+                    .map_err(|e| CouplingError::InternalError(format!("{:?}", e)))?
+            } else {
+                let block_data = AvailableBlockData::new_with_data_columns(custody_columns);
+                RangeSyncBlock::new(block, block_data, custody_context)
+                    .map_err(|e| CouplingError::InternalError(format!("{:?}", e)))?
+            };
             range_sync_blocks.push(range_sync_block);
         }
 

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -2,7 +2,7 @@ use beacon_chain::payload_envelope_verification::AvailableEnvelope;
 use beacon_chain::{
     BeaconChainTypes,
     block_verification_types::{AvailableBlockData, RangeSyncBlock},
-    data_availability_checker::DataAvailabilityChecker,
+    custody_context::CustodyContext,
     data_column_verification::CustodyDataColumn,
     get_block_root,
 };
@@ -221,7 +221,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
     /// Returns `Some(Err(_))` if there are issues coupling blocks with their data.
     pub fn responses<T>(
         &mut self,
-        da_checker: Arc<DataAvailabilityChecker<T>>,
+        custody_context: &CustodyContext<T>,
         spec: Arc<ChainSpec>,
     ) -> Option<Result<Vec<RangeSyncBlock<E>>, CouplingError>>
     where
@@ -241,7 +241,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             RangeBlockDataRequest::NoData => Some(Self::responses_with_blobs(
                 blocks.to_vec(),
                 vec![],
-                da_checker,
+                custody_context,
                 spec,
             )),
             RangeBlockDataRequest::Blobs(request) => {
@@ -251,7 +251,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                 Some(Self::responses_with_blobs(
                     blocks.to_vec(),
                     blobs.to_vec(),
-                    da_checker,
+                    custody_context,
                     spec,
                 ))
             }
@@ -294,8 +294,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                     column_to_peer_id,
                     expected_custody_columns,
                     *attempt,
-                    da_checker,
-                    spec,
+                    custody_context,
                     payload_envelopes,
                 );
 
@@ -321,7 +320,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
     fn responses_with_blobs<T>(
         blocks: Vec<Arc<SignedBeaconBlock<E>>>,
         blobs: Vec<Arc<BlobSidecar<E>>>,
-        da_checker: Arc<DataAvailabilityChecker<T>>,
+        custody_context: &CustodyContext<T>,
         spec: Arc<ChainSpec>,
     ) -> Result<Vec<RangeSyncBlock<E>>, CouplingError>
     where
@@ -370,7 +369,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             })?;
             let block_data = AvailableBlockData::new_with_blobs(blobs);
             responses.push(
-                RangeSyncBlock::new(block, block_data, &da_checker, spec.clone())
+                RangeSyncBlock::new(block, block_data, custody_context)
                     .map_err(|e| CouplingError::BlobPeerFailure(format!("{e:?}")))?,
             )
         }
@@ -394,8 +393,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
         column_to_peer: HashMap<u64, PeerId>,
         expects_custody_columns: &[ColumnIndex],
         attempt: usize,
-        da_checker: Arc<DataAvailabilityChecker<T>>,
-        spec: Arc<ChainSpec>,
+        custody_context: &CustodyContext<T>,
         payload_envelopes: Option<Vec<Arc<SignedExecutionPayloadEnvelope<E>>>>,
     ) -> Result<Vec<RangeSyncBlock<E>>, CouplingError>
     where
@@ -495,23 +493,22 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
             } else {
                 vec![]
             };
-            let range_sync_block = if let Some(envelopes_by_block_root) =
-                envelopes_by_block_root.as_mut()
-            {
-                let envelope = envelopes_by_block_root.remove(&block_root);
-                let available_envelope =
-                    envelope.map(|env| AvailableEnvelope::new(env, custody_columns));
+            let range_sync_block =
+                if let Some(envelopes_by_block_root) = envelopes_by_block_root.as_mut() {
+                    let envelope = envelopes_by_block_root.remove(&block_root);
+                    let available_envelope =
+                        envelope.map(|env| AvailableEnvelope::new(env, custody_columns));
 
-                RangeSyncBlock::new_gloas(block, available_envelope)
-                    .map_err(CouplingError::EnvelopePeerFailure)?
-            } else if custody_columns.is_empty() {
-                RangeSyncBlock::new(block, AvailableBlockData::NoData, &da_checker, spec.clone())
-                    .map_err(|e| CouplingError::InternalError(format!("{:?}", e)))?
-            } else {
-                let block_data = AvailableBlockData::new_with_data_columns(custody_columns);
-                RangeSyncBlock::new(block, block_data, &da_checker, spec.clone())
-                    .map_err(|e| CouplingError::InternalError(format!("{:?}", e)))?
-            };
+                    RangeSyncBlock::new_gloas(block, available_envelope)
+                        .map_err(CouplingError::EnvelopePeerFailure)?
+                } else if custody_columns.is_empty() {
+                    RangeSyncBlock::new(block, AvailableBlockData::NoData, custody_context)
+                        .map_err(|e| CouplingError::InternalError(format!("{:?}", e)))?
+                } else {
+                    let block_data = AvailableBlockData::new_with_data_columns(custody_columns);
+                    RangeSyncBlock::new(block, block_data, custody_context)
+                        .map_err(|e| CouplingError::InternalError(format!("{:?}", e)))?
+                };
             range_sync_blocks.push(range_sync_block);
         }
 
@@ -562,11 +559,10 @@ mod tests {
 
     use super::RangeBlockComponentsRequest;
     use beacon_chain::block_verification_types::RangeSyncBlock;
-    use beacon_chain::custody_context::NodeCustodyType;
-    use beacon_chain::data_availability_checker::DataAvailabilityChecker;
+    use beacon_chain::custody_context::{CustodyContext, NodeCustodyType};
     use beacon_chain::test_utils::{
         EphemeralHarnessType, NumBlobs, generate_rand_block_and_blobs,
-        generate_rand_block_and_data_columns, test_da_checker, test_spec,
+        generate_rand_block_and_data_columns, test_custody_context, test_spec,
     };
     use bls::Signature;
     use lighthouse_network::{
@@ -639,8 +635,8 @@ mod tests {
 
     fn is_finished(info: &mut RangeBlockComponentsRequest<E>) -> bool {
         let spec = Arc::new(test_spec::<E>());
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        info.responses(da_checker, spec).is_some()
+        let custody_context = test_custody_context(NodeCustodyType::Fullnode, spec.clone());
+        info.responses(&custody_context, spec).is_some()
     }
 
     fn gloas_spec() -> ChainSpec {
@@ -728,7 +724,7 @@ mod tests {
     #[allow(clippy::type_complexity)]
     struct GloasSetup {
         info: RangeBlockComponentsRequest<E>,
-        da_checker: Arc<DataAvailabilityChecker<EphemeralHarnessType<E>>>,
+        custody_context: Arc<CustodyContext<EphemeralHarnessType<E>>>,
         spec: Arc<ChainSpec>,
         blocks: Vec<(
             Arc<SignedBeaconBlock<E>>,
@@ -743,9 +739,8 @@ mod tests {
     /// ready for the per-test payload-envelope step.
     fn setup_gloas_coupling(count: usize) -> GloasSetup {
         let spec = Arc::new(gloas_spec());
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expected_custody_columns = da_checker
-            .custody_context()
+        let custody_context = test_custody_context(NodeCustodyType::Fullnode, spec.clone());
+        let expected_custody_columns = custody_context
             .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         let blocks = make_gloas_blocks_and_columns(count, &spec);
@@ -788,7 +783,7 @@ mod tests {
 
         GloasSetup {
             info,
-            da_checker,
+            custody_context,
             spec,
             blocks,
             payloads_req_id,
@@ -826,10 +821,10 @@ mod tests {
         // Send blocks and complete terminate response
         info.add_blocks(blocks_req_id, blocks).unwrap();
 
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
+        let custody_context = test_custody_context(NodeCustodyType::Fullnode, spec.clone());
 
         // Assert response is finished and RpcBlocks can be constructed
-        info.responses(da_checker, spec).unwrap().unwrap();
+        info.responses(&custody_context, spec).unwrap().unwrap();
     }
 
     #[test]
@@ -867,9 +862,9 @@ mod tests {
         // FORK_NAME.
         spec.fulu_fork_epoch = None;
         let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
+        let custody_context = test_custody_context(NodeCustodyType::Fullnode, spec.clone());
         // Blobs are no longer required for availability, so the response succeeds without them.
-        let result = info.responses(da_checker, spec).unwrap();
+        let result = info.responses(&custody_context, spec).unwrap();
         assert!(result.is_ok())
     }
 
@@ -882,9 +877,8 @@ mod tests {
         spec.deneb_fork_epoch = Some(Epoch::new(0));
         spec.fulu_fork_epoch = Some(Epoch::new(0));
         let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expects_custody_columns = da_checker
-            .custody_context()
+        let custody_context = test_custody_context(NodeCustodyType::Fullnode, spec.clone());
+        let expects_custody_columns = custody_context
             .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         let mut u = types::test_utils::test_unstructured();
@@ -952,7 +946,7 @@ mod tests {
         }
 
         // All completed construct response
-        info.responses(da_checker, spec).unwrap().unwrap();
+        info.responses(&custody_context, spec).unwrap().unwrap();
     }
 
     #[test]
@@ -964,9 +958,8 @@ mod tests {
         spec.deneb_fork_epoch = Some(Epoch::new(0));
         spec.fulu_fork_epoch = Some(Epoch::new(0));
         let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expected_sampling_columns = da_checker
-            .custody_context()
+        let custody_context = test_custody_context(NodeCustodyType::Fullnode, spec.clone());
+        let expected_sampling_columns = custody_context
             .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         // Split sampling columns into two batches
@@ -1050,27 +1043,27 @@ mod tests {
         }
 
         // All completed construct response
-        info.responses(da_checker, spec).unwrap().unwrap();
+        info.responses(&custody_context, spec).unwrap().unwrap();
     }
 
     #[test]
     fn gloas_payload_envelopes_must_complete_before_responses() {
         let GloasSetup {
             mut info,
-            da_checker,
+            custody_context,
             spec,
             ..
         } = setup_gloas_coupling(2);
 
         // No payload envelopes added yet, so the request must not be complete.
-        assert!(info.responses(da_checker, spec).is_none());
+        assert!(info.responses(&custody_context, spec).is_none());
     }
 
     #[test]
     fn gloas_payload_envelopes_are_coupled_by_block_root() {
         let GloasSetup {
             mut info,
-            da_checker,
+            custody_context,
             spec,
             blocks,
             payloads_req_id,
@@ -1088,7 +1081,7 @@ mod tests {
         )
         .unwrap();
 
-        let responses = info.responses(da_checker, spec).unwrap().unwrap();
+        let responses = info.responses(&custody_context, spec).unwrap().unwrap();
         assert_eq!(responses.len(), blocks.len());
         for response in responses {
             match response {
@@ -1111,7 +1104,7 @@ mod tests {
     fn gloas_payload_envelopes_allow_missing_envelopes() {
         let GloasSetup {
             mut info,
-            da_checker,
+            custody_context,
             spec,
             blocks,
             payloads_req_id,
@@ -1122,7 +1115,7 @@ mod tests {
         info.add_payload_envelopes(payloads_req_id, vec![blocks[0].2.clone()])
             .unwrap();
 
-        let responses = info.responses(da_checker, spec).unwrap().unwrap();
+        let responses = info.responses(&custody_context, spec).unwrap().unwrap();
         let count_with = |with_envelope: bool| {
             responses
                 .iter()
@@ -1139,7 +1132,7 @@ mod tests {
     fn gloas_payload_envelope_mismatch_fails_coupling() {
         let GloasSetup {
             mut info,
-            da_checker,
+            custody_context,
             spec,
             blocks,
             payloads_req_id,
@@ -1151,7 +1144,7 @@ mod tests {
         info.add_payload_envelopes(payloads_req_id, vec![Arc::new(bad_envelope)])
             .unwrap();
 
-        let result = info.responses(da_checker, spec).unwrap();
+        let result = info.responses(&custody_context, spec).unwrap();
         assert!(
             matches!(
                 result,
@@ -1169,9 +1162,8 @@ mod tests {
         }
         // GIVEN: A request expecting sampling columns from multiple peers
         let spec = Arc::new(test_spec::<E>());
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expected_sampling_columns = da_checker
-            .custody_context()
+        let custody_context = test_custody_context(NodeCustodyType::Fullnode, spec.clone());
+        let expected_sampling_columns = custody_context
             .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         let mut u = types::test_utils::test_unstructured();
@@ -1237,7 +1229,7 @@ mod tests {
         }
 
         // WHEN: Attempting to construct RPC blocks
-        let result = info.responses(da_checker, spec).unwrap();
+        let result = info.responses(&custody_context, spec).unwrap();
 
         // THEN: Should fail with PeerFailure identifying the faulty peers
         assert!(result.is_err());
@@ -1271,9 +1263,8 @@ mod tests {
         spec.deneb_fork_epoch = Some(Epoch::new(0));
         spec.fulu_fork_epoch = Some(Epoch::new(0));
         let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expected_sampling_columns = da_checker
-            .custody_context()
+        let custody_context = test_custody_context(NodeCustodyType::Fullnode, spec.clone());
+        let expected_sampling_columns = custody_context
             .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         let mut u = types::test_utils::test_unstructured();
@@ -1343,7 +1334,7 @@ mod tests {
         let result: Result<
             Vec<beacon_chain::block_verification_types::RangeSyncBlock<E>>,
             crate::sync::block_sidecar_coupling::CouplingError,
-        > = info.responses(da_checker.clone(), spec.clone()).unwrap();
+        > = info.responses(&custody_context, spec.clone()).unwrap();
         assert!(result.is_err());
 
         // AND: We retry with a new peer for the failed columns
@@ -1373,7 +1364,7 @@ mod tests {
         .unwrap();
 
         // WHEN: Attempting to get responses again
-        let result = info.responses(da_checker, spec).unwrap();
+        let result = info.responses(&custody_context, spec).unwrap();
 
         // THEN: Should succeed with complete RangeSync blocks
         assert!(result.is_ok());
@@ -1391,9 +1382,8 @@ mod tests {
         spec.deneb_fork_epoch = Some(Epoch::new(0));
         spec.fulu_fork_epoch = Some(Epoch::new(0));
         let spec = Arc::new(spec);
-        let da_checker = Arc::new(test_da_checker(spec.clone(), NodeCustodyType::Fullnode));
-        let expected_sampling_columns = da_checker
-            .custody_context()
+        let custody_context = test_custody_context(NodeCustodyType::Fullnode, spec.clone());
+        let expected_sampling_columns = custody_context
             .sampling_columns_for_epoch(Epoch::new(0))
             .to_vec();
         let mut u = types::test_utils::test_unstructured();
@@ -1462,7 +1452,7 @@ mod tests {
 
         // WHEN: Multiple retry attempts are made (up to max retries)
         for _ in 0..MAX_COLUMN_RETRIES {
-            let result = info.responses(da_checker.clone(), spec.clone()).unwrap();
+            let result = info.responses(&custody_context, spec.clone()).unwrap();
             assert!(result.is_err());
 
             if let Err(super::CouplingError::DataColumnPeerFailure {
@@ -1475,7 +1465,7 @@ mod tests {
         }
 
         // AND: One final attempt after exceeding max retries
-        let result = info.responses(da_checker, spec).unwrap();
+        let result = info.responses(&custody_context, spec).unwrap();
 
         // THEN: Should fail with exceeded_retries = true
         assert!(result.is_err());

--- a/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
@@ -162,7 +162,11 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
     /// - The earliest data column epoch's custodied columns != previous epoch's custodied columns
     /// - The earliest data column epoch is a finalied epoch
     pub fn should_start_custody_backfill_sync(&mut self) -> bool {
-        let Some(da_boundary_epoch) = self.beacon_chain.get_column_da_boundary() else {
+        let Some(da_boundary_epoch) = self
+            .beacon_chain
+            .custody_context
+            .column_data_availability_boundary()
+        else {
             return false;
         };
 
@@ -220,8 +224,7 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
     fn restart_if_required(&mut self) -> bool {
         let cgc_at_head = self
             .beacon_chain
-            .data_availability_checker
-            .custody_context()
+            .custody_context
             .custody_group_count_at_head(&self.beacon_chain.spec);
 
         if cgc_at_head != self.cgc {
@@ -290,7 +293,11 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
             }
         }
 
-        let Some(column_da_boundary) = self.beacon_chain.get_column_da_boundary() else {
+        let Some(column_da_boundary) = self
+            .beacon_chain
+            .custody_context
+            .column_data_availability_boundary()
+        else {
             return Ok(SyncStart::NotSyncing);
         };
 
@@ -309,8 +316,7 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
     fn set_cgc(&mut self) {
         self.cgc = self
             .beacon_chain
-            .data_availability_checker
-            .custody_context()
+            .custody_context
             .custody_group_count_at_head(&self.beacon_chain.spec);
     }
 
@@ -379,9 +385,10 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
     /// Creates the next required batch from the chain. If there are no more batches required,
     /// `None` is returned.
     fn include_next_batch(&mut self) -> Option<BatchId> {
-        let Some(column_da_boundary) = self.beacon_chain.get_column_da_boundary() else {
-            return None;
-        };
+        let column_da_boundary = self
+            .beacon_chain
+            .custody_context
+            .column_data_availability_boundary()?;
 
         // Skip all batches (Epochs) that don't have missing columns.
         for epoch in Epoch::range_inclusive_rev(self.to_be_downloaded, column_da_boundary) {
@@ -715,7 +722,11 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
 
                 self.advance_custody_backfill_sync(batch_id);
 
-                let Some(column_da_boundary) = self.beacon_chain.get_column_da_boundary() else {
+                let Some(column_da_boundary) = self
+                    .beacon_chain
+                    .custody_context
+                    .column_data_availability_boundary()
+                else {
                     return Err(CustodyBackfillError::InvalidSyncState(
                         "Can't calculate column data availability boundary".to_string(),
                     ));
@@ -889,7 +900,11 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
     ///
     /// The `validating_epoch` must align with batch boundaries.
     fn advance_custody_backfill_sync(&mut self, validating_epoch: Epoch) {
-        let Some(column_da_boundary) = self.beacon_chain.get_column_da_boundary() else {
+        let Some(column_da_boundary) = self
+            .beacon_chain
+            .custody_context
+            .column_data_availability_boundary()
+        else {
             return;
         };
         // make sure this epoch produces an advancement, unless its at the column DA boundary
@@ -986,7 +1001,11 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
                 return false;
             };
 
-            let Some(column_da_boundary) = self.beacon_chain.get_column_da_boundary() else {
+            let Some(column_da_boundary) = self
+                .beacon_chain
+                .custody_context
+                .column_data_availability_boundary()
+            else {
                 return false;
             };
 
@@ -997,7 +1016,11 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
 
     /// Checks if custody backfill would complete by syncing to `start_epoch`.
     fn would_complete(&self, start_epoch: Epoch) -> bool {
-        let Some(column_da_boundary) = self.beacon_chain.get_column_da_boundary() else {
+        let Some(column_da_boundary) = self
+            .beacon_chain
+            .custody_context
+            .column_data_availability_boundary()
+        else {
             return false;
         };
         start_epoch <= column_da_boundary

--- a/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
@@ -225,7 +225,7 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
         let cgc_at_head = self
             .beacon_chain
             .custody_context
-            .custody_group_count_at_head(&self.beacon_chain.spec);
+            .custody_group_count_at_head();
 
         if cgc_at_head != self.cgc {
             self.restart_sync();
@@ -317,7 +317,7 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
         self.cgc = self
             .beacon_chain
             .custody_context
-            .custody_group_count_at_head(&self.beacon_chain.spec);
+            .custody_group_count_at_head();
     }
 
     fn set_start_epoch(&mut self) {

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -1429,12 +1429,14 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         } else if self
             .chain
             .data_availability_checker
+            .custody_context()
             .data_columns_required_for_epoch(epoch)
         {
             ByRangeRequestType::BlocksAndColumns
         } else if self
             .chain
             .data_availability_checker
+            .custody_context()
             .blobs_required_for_epoch(epoch)
         {
             ByRangeRequestType::BlocksAndBlobs

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -591,6 +591,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             let epoch = Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch());
             let column_indexes = self
                 .chain
+                .custody_context
                 .sampling_columns_for_epoch(epoch)
                 .iter()
                 .cloned()
@@ -696,7 +697,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             data_column_requests.map(|data_column_requests| {
                 (
                     data_column_requests,
-                    self.chain.sampling_columns_for_epoch(epoch).to_vec(),
+                    self.chain
+                        .custody_context
+                        .sampling_columns_for_epoch(epoch)
+                        .to_vec(),
                 )
             }),
             payloads_req_id,
@@ -1111,6 +1115,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         // Include only the blob indexes not yet imported (received through gossip)
         let mut custody_indexes_to_fetch = self
             .chain
+            .custody_context
             .sampling_columns_for_epoch(block_slot.epoch(T::EthSpec::slots_per_epoch()))
             .iter()
             .copied()
@@ -1737,6 +1742,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         let columns_by_range_peers_to_request = {
             let column_indexes = self
                 .chain
+                .custody_context
                 .sampling_columns_for_epoch(batch_id.epoch)
                 .iter()
                 .cloned()

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -1428,17 +1428,11 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             ByRangeRequestType::BlocksAndEnvelopesAndColumns
         } else if self
             .chain
-            .data_availability_checker
-            .custody_context()
+            .custody_context
             .data_columns_required_for_epoch(epoch)
         {
             ByRangeRequestType::BlocksAndColumns
-        } else if self
-            .chain
-            .data_availability_checker
-            .custody_context()
-            .blobs_required_for_epoch(epoch)
-        {
+        } else if self.chain.custody_context.blobs_required_for_epoch(epoch) {
             ByRangeRequestType::BlocksAndBlobs
         } else {
             ByRangeRequestType::Blocks

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -819,10 +819,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         }
 
         let range_req = entry.get_mut();
-        if let Some(blocks_result) = range_req.responses(
-            self.chain.data_availability_checker.clone(),
-            self.chain.spec.clone(),
-        ) {
+        if let Some(blocks_result) =
+            range_req.responses(&self.chain.custody_context, self.chain.spec.clone())
+        {
             if let Err(CouplingError::DataColumnPeerFailure {
                 error,
                 faulty_peers: _,

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -958,6 +958,9 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                     CouplingError::InternalError(msg) => {
                         error!(?batch_id, msg, "Block components coupling internal error");
                     }
+                    CouplingError::AvailabilityCheckError(err) => {
+                        error!(?batch_id, ?err, "Availability check error");
+                    }
                 }
             }
             // A batch could be retried without the peer failing the request (disconnecting/

--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -1613,7 +1613,7 @@ impl TestRig {
         self.harness
             .chain
             .custody_context
-            .custody_columns_for_epoch(None, &self.harness.spec)
+            .custody_columns_for_epoch(None)
     }
 
     // Test setup

--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -1612,8 +1612,7 @@ impl TestRig {
     fn custody_columns(&self) -> &[ColumnIndex] {
         self.harness
             .chain
-            .data_availability_checker
-            .custody_context()
+            .custody_context
             .custody_columns_for_epoch(None, &self.harness.spec)
     }
 

--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -1282,34 +1282,34 @@ impl TestRig {
     ) {
         let block_root = block.canonical_root();
         let block_slot = block.slot();
-        let range_sync_block = if let Ok(bid) = block.message().body().signed_execution_payload_bid()
-        {
-            // Gloas carries data columns in the payload envelope, not in `block_data`.
-            let envelope = self
-                .network_blocks_by_root
-                .get(&block_root)
-                .and_then(envelope_of)
-                .map(|envelope| {
-                    AvailableEnvelope::new(
-                        envelope,
-                        columns.unwrap_or_default(),
-                        bid,
-                        &self.harness.chain.custody_context,
-                    )
-                })
-                .transpose()
-                .unwrap();
-            RangeSyncBlock::new_gloas(block, envelope).unwrap()
-        } else {
-            let block_data = if let Some(columns) = columns {
-                AvailableBlockData::new_with_data_columns(columns)
-            } else if let Some(blobs) = blobs {
-                AvailableBlockData::new_with_blobs(blobs)
+        let range_sync_block =
+            if let Ok(bid) = block.message().body().signed_execution_payload_bid() {
+                // Gloas carries data columns in the payload envelope, not in `block_data`.
+                let envelope = self
+                    .network_blocks_by_root
+                    .get(&block_root)
+                    .and_then(envelope_of)
+                    .map(|envelope| {
+                        AvailableEnvelope::new(
+                            envelope,
+                            columns.unwrap_or_default(),
+                            bid,
+                            &self.harness.chain.custody_context,
+                        )
+                    })
+                    .transpose()
+                    .unwrap();
+                RangeSyncBlock::new_gloas(block, envelope).unwrap()
             } else {
-                AvailableBlockData::NoData
+                let block_data = if let Some(columns) = columns {
+                    AvailableBlockData::new_with_data_columns(columns)
+                } else if let Some(blobs) = blobs {
+                    AvailableBlockData::new_with_blobs(blobs)
+                } else {
+                    AvailableBlockData::NoData
+                };
+                RangeSyncBlock::new(block, block_data, &self.harness.chain.custody_context).unwrap()
             };
-            RangeSyncBlock::new(block, block_data, &self.harness.chain.custody_context).unwrap()
-        };
         self.network_blocks_by_slot
             .insert(block_slot, range_sync_block.clone());
         self.network_blocks_by_root

--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -1297,24 +1297,34 @@ impl TestRig {
     ) {
         let block_root = block.canonical_root();
         let block_slot = block.slot();
-        let range_sync_block = if block.fork_name_unchecked().gloas_enabled() {
-            // Gloas carries data columns in the payload envelope, not in `block_data`.
-            let envelope = self
-                .network_envelopes_by_root
-                .get(&block_root)
-                .cloned()
-                .map(|envelope| AvailableEnvelope::new(envelope, columns.unwrap_or_default()));
-            RangeSyncBlock::new_gloas(block, envelope).unwrap()
-        } else {
-            let block_data = if let Some(columns) = columns {
-                AvailableBlockData::new_with_data_columns(columns)
-            } else if let Some(blobs) = blobs {
-                AvailableBlockData::new_with_blobs(blobs)
+        let range_sync_block =
+            if let Ok(bid) = block.message().body().signed_execution_payload_bid() {
+                // Gloas carries data columns in the payload envelope, not in `block_data`.
+                let envelope = self
+                    .network_envelopes_by_root
+                    .get(&block_root)
+                    .cloned()
+                    .map(|envelope| {
+                        AvailableEnvelope::new(
+                            envelope,
+                            columns.unwrap_or_default(),
+                            bid,
+                            &self.harness.chain.custody_context,
+                        )
+                    })
+                    .transpose()
+                    .unwrap();
+                RangeSyncBlock::new_gloas(block, envelope).unwrap()
             } else {
-                AvailableBlockData::NoData
+                let block_data = if let Some(columns) = columns {
+                    AvailableBlockData::new_with_data_columns(columns)
+                } else if let Some(blobs) = blobs {
+                    AvailableBlockData::new_with_blobs(blobs)
+                } else {
+                    AvailableBlockData::NoData
+                };
+                RangeSyncBlock::new(block, block_data, &self.harness.chain.custody_context).unwrap()
             };
-            RangeSyncBlock::new(block, block_data, &self.harness.chain.custody_context).unwrap()
-        };
         self.network_blocks_by_slot
             .insert(block_slot, range_sync_block.clone());
         self.network_blocks_by_root

--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -1313,13 +1313,7 @@ impl TestRig {
             } else {
                 AvailableBlockData::NoData
             };
-            RangeSyncBlock::new(
-                block,
-                block_data,
-                &self.harness.chain.data_availability_checker,
-                self.harness.chain.spec.clone(),
-            )
-            .unwrap()
+            RangeSyncBlock::new(block, block_data, &self.harness.chain.custody_context).unwrap()
         };
         self.network_blocks_by_slot
             .insert(block_slot, range_sync_block.clone());

--- a/consensus/types/src/execution/signed_execution_payload_bid.rs
+++ b/consensus/types/src/execution/signed_execution_payload_bid.rs
@@ -37,6 +37,10 @@ impl<E: EthSpec> SignedExecutionPayloadBid<E> {
             signature: Signature::empty(),
         }
     }
+
+    pub fn num_blobs_expected(&self) -> usize {
+        self.message.blob_kzg_commitments.len()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR refactors custody/data-availability logic to make `CustodyContext` the single source of truth for DA boundary and custody requirements, and threads that model through range sync, payload-envelope handling, and the pending payload cache.

The main structural change is moving `CustodyContext` onto the `BeaconChain` directly instead of reaching it indirectly through the `DataAvailabilityChecker`. Alongside that, DA boundary helpers and custody requirement checks are consolidated onto `CustodyContext`, including bid-aware checks for Gloas payloads. This removes a fair amount of duplicated wrapper logic from `BeaconChain` and simplifies call sites across beacon chain, network sync, HTTP API, notifier, and tests.

On the sync/availability side, the PR updates `AvailableBlock`/`RangeSyncBlock` construction and range-sync coupling to depend on `CustodyContext` directly rather than passing around a full DA checker and extra `ChainSpec`. For Gloas, `AvailableEnvelope` now validates custody columns against the signed execution payload bid and the node’s sampling requirements. This mirrors the [existing checks on `AvailableBlock`](https://github.com/sigp/lighthouse/blob/v8.2.0/beacon_node/beacon_chain/src/data_availability_checker.rs#L895).

The pending payload cache is also tightened up so availability decisions are derived from the bid plus `CustodyContext`, instead of externally-computed expected column counts. That keeps the “are columns required, and how many?” logic in one place and aligns cache availability checks with the same rules used during range sync.

Tests and helpers were updated throughout to reflect the new ownership model and validation flow, especially Gloas/range-sync test construction.