### PR TITLE
Fix peerless lookup getting stuck while awaiting download

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -114,6 +114,8 @@ pub(crate) struct BlockLookupSummary {
     pub block_root: Hash256,
     /// List of peers that claim to have imported this set of block components.
     pub peers: Vec<PeerId>,
+    /// Whether the lookup expects some future event to make progress.
+    pub is_awaiting_event: bool,
 }
 
 impl<T: BeaconChainTypes> BlockLookups<T> {
@@ -150,6 +152,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 id: *id,
                 block_root: l.block_root(),
                 peers: l.all_peers(),
+                is_awaiting_event: l.is_awaiting_event(),
             })
             .collect()
     }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -355,16 +355,12 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         self.awaiting_parent.is_some()
             || self.block_request.state.is_awaiting_event()
             || match &self.data_request {
-                // Not awaiting an event itself; it's blocked on the block request, already covered
-                // by the `block_request` term above. Returning `true` kept a peerless lookup parked
-                // in `AwaitingDownload` from being pruned, so it got stuck.
-                DataRequest::WaitingForBlock => false,
+                DataRequest::WaitingForBlock => self.block_request.state.is_awaiting_event(),
                 DataRequest::Request { state, .. } => state.is_awaiting_event(),
                 DataRequest::NoData => false,
             }
             || match &self.payload_request {
-                // See `data_request` above: not awaiting an event itself, the block request covers it.
-                PayloadRequest::WaitingForBlock => false,
+                PayloadRequest::WaitingForBlock => self.block_request.state.is_awaiting_event(),
                 PayloadRequest::Request { state, .. } => state.is_awaiting_event(),
                 PayloadRequest::PreGloas => false,
             }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -355,12 +355,16 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         self.awaiting_parent.is_some()
             || self.block_request.state.is_awaiting_event()
             || match &self.data_request {
-                DataRequest::WaitingForBlock => true,
+                // Not awaiting an event itself; it's blocked on the block request, already covered
+                // by the `block_request` term above. Returning `true` kept a peerless lookup parked
+                // in `AwaitingDownload` from being pruned, so it got stuck.
+                DataRequest::WaitingForBlock => false,
                 DataRequest::Request { state, .. } => state.is_awaiting_event(),
                 DataRequest::NoData => false,
             }
             || match &self.payload_request {
-                PayloadRequest::WaitingForBlock => true,
+                // See `data_request` above: not awaiting an event itself, the block request covers it.
+                PayloadRequest::WaitingForBlock => false,
                 PayloadRequest::Request { state, .. } => state.is_awaiting_event(),
                 PayloadRequest::PreGloas => false,
             }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -355,12 +355,16 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         self.awaiting_parent.is_some()
             || self.block_request.state.is_awaiting_event()
             || match &self.data_request {
-                DataRequest::WaitingForBlock => self.block_request.state.is_awaiting_event(),
+                // Not awaiting an event itself; it's blocked on the block request, already covered
+                // by the `block_request` term above. Returning `true` kept a peerless lookup parked
+                // in `AwaitingDownload` from being pruned, so it got stuck.
+                DataRequest::WaitingForBlock => false,
                 DataRequest::Request { state, .. } => state.is_awaiting_event(),
                 DataRequest::NoData => false,
             }
             || match &self.payload_request {
-                PayloadRequest::WaitingForBlock => self.block_request.state.is_awaiting_event(),
+                // See `data_request` above: not awaiting an event itself, the block request covers it.
+                PayloadRequest::WaitingForBlock => false,
                 PayloadRequest::Request { state, .. } => state.is_awaiting_event(),
                 PayloadRequest::PreGloas => false,
             }

--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -2397,6 +2397,21 @@ async fn peer_disconnected_then_rpc_error(depth: usize) {
 }
 
 #[tokio::test]
+/// A lookup that loses its only peer while still waiting to download the block must not report
+/// itself as awaiting an event, else `drop_lookups_without_peers` skips it and it gets stuck.
+/// Regression for the "Notify the devs a sync lookup is stuck" report.
+async fn peerless_lookup_awaiting_download_is_not_awaiting_event() {
+    let mut r = TestRig::default();
+    r.build_chain_and_trigger_last_block(1).await;
+    r.disconnect_all_peers();
+    r.simulate(SimulateConfig::new().return_rpc_error(RPCError::Disconnected))
+        .await;
+    let lookup = &r.active_single_lookups()[0];
+    assert_eq!(lookup.peers.len(), 0);
+    assert!(!lookup.is_awaiting_event);
+}
+
+#[tokio::test]
 /// Assert that when creating multiple lookups their parent-child relation is discovered and we add
 /// peers recursively from child to parent.
 async fn lookups_form_chain() {


### PR DESCRIPTION
A lookup whose only peer disconnects before the block downloads parks its block request in AwaitingDownload while data_request (and, post-Gloas, payload_request) stays WaitingForBlock. is_awaiting_event() returned true for WaitingForBlock, so drop_lookups_without_peers skipped the lookup and it survived until the 16-minute stuck backstop, emitting 'Notify the devs a sync lookup is stuck'.

WaitingForBlock is not awaiting an event itself; it's blocked on the block request, which is already covered by the block_request term in is_awaiting_event. Return false so a peerless lookup parked in AwaitingDownload is correctly prunable.

### Bug effect

Warmless `warn` log. The lookup should be pruned by the peer-less prune function but instead if pruned by the stuck lookup sweep
