### PR TITLE
Implement super batch signature verification (PoC)

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification/batch.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification/batch.rs
@@ -20,6 +20,7 @@ use state_processing::signature_sets::{
     signed_aggregate_signature_set,
 };
 use std::borrow::Cow;
+use std::collections::HashSet;
 use types::*;
 
 /// Verify aggregated attestations using batch BLS signature verification.
@@ -188,6 +189,23 @@ where
         }
 
         metrics::stop_timer(signature_setup_timer);
+
+        // Record how foldable this batch is: total signature sets vs. distinct messages. After
+        // folding the batch costs one pairing per distinct message, so `sets / distinct` is the fold
+        // ratio. The `signature_sets` spread also shows whether bigger batches would help.
+        let num_distinct_messages = signature_sets
+            .iter()
+            .map(|set| set.message())
+            .collect::<HashSet<_>>()
+            .len();
+        metrics::observe(
+            &metrics::ATTESTATION_PROCESSING_BATCH_UNAGG_SIGNATURE_SETS,
+            signature_sets.len() as f64,
+        );
+        metrics::observe(
+            &metrics::ATTESTATION_PROCESSING_BATCH_UNAGG_DISTINCT_MESSAGES,
+            num_distinct_messages as f64,
+        );
 
         let _signature_verification_timer =
             metrics::start_timer(&metrics::ATTESTATION_PROCESSING_BATCH_UNAGG_SIGNATURE_TIMES);

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -447,6 +447,28 @@ pub static ATTESTATION_PROCESSING_BATCH_UNAGG_SIGNATURE_TIMES: LazyLock<Result<H
             "Time spent on the signature verification of batch unaggregate attestation processing",
         )
     });
+// How foldable the unaggregated attestation batches are: signature sets vs. distinct messages
+// (signing roots). After folding, the batch costs one pairing per distinct message, so
+// `signature_sets / distinct_messages` is the fold ratio and `signature_sets_sum -
+// distinct_messages_sum` is the pairings saved.
+pub static ATTESTATION_PROCESSING_BATCH_UNAGG_SIGNATURE_SETS: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram_with_buckets(
+            "beacon_attestation_processing_batch_unagg_signature_sets",
+            "Number of signature sets (one per attestation) submitted to each unaggregated batch \
+             signature verification",
+            exponential_buckets(1.0, 2.0, 11),
+        )
+    });
+pub static ATTESTATION_PROCESSING_BATCH_UNAGG_DISTINCT_MESSAGES: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram_with_buckets(
+            "beacon_attestation_processing_batch_unagg_distinct_messages",
+            "Number of distinct messages (signing roots) in each unaggregated batch; equals the \
+             number of pairings after super-batch grouping",
+            exponential_buckets(1.0, 2.0, 11),
+        )
+    });
 
 /*
  * Shuffling cache

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -8,7 +8,7 @@ edition = { workspace = true }
 arbitrary = ["dep:arbitrary"]
 default = ["supranational"]
 fake_crypto = []
-supranational = ["blst"]
+supranational = ["blst", "blst/no-threads"]
 supranational-portable = ["supranational", "blst/portable"]
 supranational-force-adx = ["supranational", "blst/force-adx"]
 

--- a/crypto/bls/src/generic_signature_set.rs
+++ b/crypto/bls/src/generic_signature_set.rs
@@ -78,6 +78,12 @@ where
     Sig: TSignature<Pub> + Clone,
     AggSig: TAggregateSignature<Pub, AggPub, Sig> + Clone,
 {
+    /// The message (signing root) this set's signature is checked against. Exposed so callers can
+    /// count how many sets in a batch share a message.
+    pub fn message(&self) -> Hash256 {
+        self.message
+    }
+
     /// Instantiate self where `signature` is only signed by a single public key.
     pub fn single_pubkey(
         signature: impl Into<WrappedSignature<'a, Pub, AggPub, Sig, AggSig>>,

--- a/crypto/bls/src/impls/blst.rs
+++ b/crypto/bls/src/impls/blst.rs
@@ -9,10 +9,13 @@ use crate::{
     generic_signature::{SIGNATURE_BYTES_LEN, SIGNATURE_UNCOMPRESSED_BYTES_LEN, TSignature},
 };
 pub use blst::min_pk as blst_core;
-use blst::{BLST_ERROR, blst_scalar};
+use blst::{BLST_ERROR, MultiPoint, blst_scalar};
 use rand::Rng;
+use std::collections::HashMap;
 pub const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 pub const RAND_BITS: usize = 64;
+/// Bytes per scalar in the flat buffer that `blst`'s multi-scalar multiplication expects.
+const RAND_BYTES: usize = RAND_BITS / 8;
 
 /// Provides the externally-facing, core BLS types.
 pub mod types {
@@ -33,6 +36,16 @@ pub type SignatureSet<'a> = crate::generic_signature_set::GenericSignatureSet<
     BlstAggregateSignature,
 >;
 
+/// Batch-verify a collection of signature sets. Returns `true` only if every set is valid; one bad
+/// set fails the whole batch (callers then re-check sets one by one to find it).
+///
+/// Optimization: Sets that sign the same `message` are folded into a single pairing
+/// instead of one each. This helps most on the attestation subnets, where many unaggregated
+/// attestations vote for the same `AttestationData`.
+///
+/// To stay sound, each signature and its public key are scaled by a fresh, secret, non-zero random
+/// scalar before being summed. This is the same operation the standard batch verification already uses across
+/// messages. Without it an attacker could craft bad signatures that cancel out.
 pub fn verify_signature_sets<'a>(
     signature_sets: impl ExactSizeIterator<Item = &'a SignatureSet<'a>>,
 ) -> bool {
@@ -44,18 +57,71 @@ pub fn verify_signature_sets<'a>(
 
     let rng = &mut rand::rng();
 
-    let mut rands: Vec<blst_scalar> = Vec::with_capacity(sets.len());
-    let mut msgs_refs = Vec::with_capacity(sets.len());
-    let mut sigs = Vec::with_capacity(sets.len());
-    let mut pks = Vec::with_capacity(sets.len());
+    // Reduce each set to one `(public_key, signature)` pair and bucket the pairs by message.
+    let mut group_index: HashMap<Hash256, usize> = HashMap::with_capacity(sets.len());
+    let mut groups: Vec<(
+        Hash256,
+        Vec<blst_core::PublicKey>,
+        Vec<blst_core::Signature>,
+    )> = Vec::with_capacity(sets.len());
 
     for set in &sets {
-        // Generate random scalars.
-        let mut vals = [0u64; 4];
-        while vals[0] == 0 {
-            // Do not use zero
-            vals[0] = rng.random();
+        let Some((public_key, signature)) = reduce_signature_set(set) else {
+            // A malformed set (bad/empty signature, no signing keys) fails the whole batch.
+            return false;
+        };
+
+        match group_index.get(&set.message) {
+            Some(&i) => {
+                groups[i].1.push(public_key);
+                groups[i].2.push(signature);
+            }
+            None => {
+                group_index.insert(set.message, groups.len());
+                groups.push((set.message, vec![public_key], vec![signature]));
+            }
         }
+    }
+
+    // Collapse each group into one `(message, public_key, signature)` entry, then hand them to
+    // `blst`'s batch verifier. One entry per distinct message means one pairing per distinct message.
+    let mut msgs: Vec<Hash256> = Vec::with_capacity(groups.len());
+    let mut pks: Vec<blst_core::PublicKey> = Vec::with_capacity(groups.len());
+    let mut sigs: Vec<blst_core::Signature> = Vec::with_capacity(groups.len());
+
+    for (message, mut group_pks, mut group_sigs) in groups {
+        msgs.push(message);
+
+        if group_pks.len() == 1 {
+            // Nothing to fold. Forward the set as-is, so batches where every message is distinct
+            // (e.g. block verification) behave exactly as before.
+            pks.append(&mut group_pks);
+            sigs.append(&mut group_sigs);
+        } else {
+            // Fold the group: scale each `(public_key, signature)` by a fresh secret scalar and sum. Since
+            // the message is shared, the per-signature pairings combine into one.
+            let scalars = random_scalar_bytes(rng, group_pks.len());
+
+            pks.push(
+                group_pks
+                    .as_slice()
+                    .mult(&scalars, RAND_BITS)
+                    .to_public_key(),
+            );
+            sigs.push(
+                group_sigs
+                    .as_slice()
+                    .mult(&scalars, RAND_BITS)
+                    .to_signature(),
+            );
+        }
+    }
+
+    // One random coefficient per collapsed entry for the final batch verification.
+    let mut rands: Vec<blst_scalar> = Vec::with_capacity(msgs.len());
+    for _ in 0..msgs.len() {
+        // Only the low 64 bits (`RAND_BITS`) are used.
+        let vals = [nonzero_u64(rng), 0, 0, 0];
         let mut rand_i = std::mem::MaybeUninit::<blst_scalar>::uninit();
 
         // TODO: remove this `unsafe` code-block once we get a safe option from `blst`.
@@ -65,56 +131,68 @@ pub fn verify_signature_sets<'a>(
             blst::blst_scalar_from_uint64(rand_i.as_mut_ptr(), vals.as_ptr());
             rands.push(rand_i.assume_init());
         }
-
-        // Grab a slice of the message, to satisfy the blst API.
-        msgs_refs.push(set.message.as_slice());
-
-        if let Some(point) = set.signature.point() {
-            // Subgroup check the signature
-            if !point.0.subgroup_check() {
-                return false;
-            }
-            // Convert the aggregate signature into a signature.
-            sigs.push(point.0.to_signature())
-        } else {
-            // Any "empty" signature should cause a signature failure.
-            return false;
-        }
-
-        // Sanity check.
-        if set.signing_keys.is_empty() {
-            // A signature that has no signing keys is invalid.
-            return false;
-        }
-
-        // Collect all the public keys into a point, to satisfy the blst API.
-        //
-        // Note: we could potentially have the `SignatureSet` take a pubkey point instead of a
-        // `GenericPublicKey` and avoid this allocation.
-        let signing_keys = set
-            .signing_keys
-            .iter()
-            .map(|pk| pk.point())
-            .collect::<Vec<_>>();
-
-        // Aggregate all the public keys.
-        // Public keys have already been checked for subgroup and infinity
-        let Ok(agg_pk) = blst_core::AggregatePublicKey::aggregate(&signing_keys, false) else {
-            return false;
-        };
-        pks.push(agg_pk.to_public_key());
     }
 
-    let (sig_refs, pks_refs): (Vec<_>, Vec<_>) = sigs.iter().zip(pks.iter()).unzip();
+    let msgs_refs = msgs.iter().map(|msg| msg.as_slice()).collect::<Vec<_>>();
+    let pks_refs = pks.iter().collect::<Vec<_>>();
+    let sigs_refs = sigs.iter().collect::<Vec<_>>();
 
-    // Public keys have already been checked for subgroup and infinity
-    // Signatures have already been checked for subgroup
-    // Signature checks above could be done here for convienence as well
+    // Public keys have already been checked for subgroup and infinity.
+    // Signatures have already been checked for subgroup.
     let err = blst_core::Signature::verify_multiple_aggregate_signatures(
-        &msgs_refs, DST, &pks_refs, false, &sig_refs, false, &rands, RAND_BITS,
+        &msgs_refs, DST, &pks_refs, false, &sigs_refs, false, &rands, RAND_BITS,
     );
 
     err == blst::BLST_ERROR::BLST_SUCCESS
+}
+
+/// Reduce a `SignatureSet` to one `(public_key, signature)` pair, with the same checks as the
+/// non-folded path. Returns `None` (failing the batch) if the set is malformed: an empty or
+/// non-subgroup signature, no signing keys, or public keys that won't aggregate.
+fn reduce_signature_set(
+    set: &SignatureSet<'_>,
+) -> Option<(blst_core::PublicKey, blst_core::Signature)> {
+    // Subgroup-check the signature; an empty (`None`) signature fails.
+    let point = set.signature.point()?;
+    if !point.0.subgroup_check() {
+        return None;
+    }
+    let signature = point.0.to_signature();
+
+    // No signing keys means the set is invalid.
+    if set.signing_keys.is_empty() {
+        return None;
+    }
+
+    // Aggregate the signing keys into one public key (keys were validated at deserialization).
+    let signing_keys = set
+        .signing_keys
+        .iter()
+        .map(|pk| pk.point())
+        .collect::<Vec<_>>();
+    let agg_pk = blst_core::AggregatePublicKey::aggregate(&signing_keys, false).ok()?;
+
+    Some((agg_pk.to_public_key(), signature))
+}
+
+/// Pack `n` fresh non-zero random scalars into the flat little-endian buffer `blst`'s multi-scalar
+/// multiplication expects (`RAND_BYTES` bytes each).
+fn random_scalar_bytes(rng: &mut impl Rng, n: usize) -> Vec<u8> {
+    let mut scalars = Vec::with_capacity(n * RAND_BYTES);
+    for _ in 0..n {
+        scalars.extend_from_slice(&nonzero_u64(rng).to_le_bytes());
+    }
+    scalars
+}
+
+/// A fresh, non-zero random `u64` coefficient. Zero must never be used: it would drop a
+/// `(public_key, signature)` pair from the sum and could let an invalid signature through.
+fn nonzero_u64(rng: &mut impl Rng) -> u64 {
+    let mut r: u64 = 0;
+    while r == 0 {
+        r = rng.random();
+    }
+    r
 }
 
 impl TPublicKey for blst_core::PublicKey {

--- a/crypto/bls/tests/tests.rs
+++ b/crypto/bls/tests/tests.rs
@@ -534,6 +534,132 @@ macro_rules! test_suite {
                 .push_valid_set(2)
                 .run_checks()
         }
+
+        /// Many valid sets sharing a single message exercise the "super batch" fold (a randomized
+        /// multi-scalar multiplication over the whole group) at scale.
+        #[test]
+        fn signature_set_many_valid_sets_same_message() {
+            let mut tester = SignatureSetTester::default();
+            for _ in 0..16 {
+                tester = tester.push_valid_set(1);
+            }
+            tester.run_checks()
+        }
+
+        /// A batch that mixes several messages, with multiple sets per message, must verify when
+        /// every set is valid.
+        #[test]
+        fn signature_set_mixed_messages_all_valid() {
+            // Three sets over message `1`, two over message `2`, one over message `3`.
+            let message_layout = [1u64, 1, 1, 2, 2, 3];
+
+            let mut signatures = Vec::new();
+            let mut pubkeys = Vec::new();
+            for (i, msg) in message_layout.iter().enumerate() {
+                let secret = secret_from_u64(i as u64);
+                let message = Hash256::from_low_u64_be(*msg);
+                let mut signature = AggregateSignature::infinity();
+                signature.add_assign(&secret.sign(message));
+                signatures.push((signature, message));
+                pubkeys.push(secret.public_key());
+            }
+
+            let sets = signatures
+                .iter()
+                .zip(pubkeys.iter())
+                .map(|((signature, message), pubkey)| {
+                    SignatureSet::single_pubkey(signature, Cow::Borrowed(pubkey), *message)
+                })
+                .collect::<Vec<_>>();
+
+            assert!(verify_signature_sets(sets.iter()));
+        }
+
+        /// As above, but one set in a multi-set message group carries the wrong signature. The
+        /// whole batch must fail.
+        #[test]
+        fn signature_set_mixed_messages_one_invalid() {
+            let message_layout = [1u64, 1, 1, 2, 2, 3];
+
+            let mut signatures = Vec::new();
+            let mut pubkeys = Vec::new();
+            for (i, msg) in message_layout.iter().enumerate() {
+                let secret = secret_from_u64(i as u64);
+                let message = Hash256::from_low_u64_be(*msg);
+                let mut signature = AggregateSignature::infinity();
+                // Corrupt the second set (one of the three sharing message `1`) by signing with the
+                // wrong secret key.
+                let signing_secret = if i == 1 {
+                    secret_from_u64(999)
+                } else {
+                    secret_from_u64(i as u64)
+                };
+                signature.add_assign(&signing_secret.sign(message));
+                signatures.push((signature, message));
+                pubkeys.push(secret.public_key());
+            }
+
+            let sets = signatures
+                .iter()
+                .zip(pubkeys.iter())
+                .map(|((signature, message), pubkey)| {
+                    SignatureSet::single_pubkey(signature, Cow::Borrowed(pubkey), *message)
+                })
+                .collect::<Vec<_>>();
+
+            assert!(!verify_signature_sets(sets.iter()));
+        }
+
+        /// The core soundness property of the super-batch optimization: two attestations that are
+        /// individually invalid but whose signatures cancel out when *naively* summed must be rejected.
+        ///
+        /// Here set A carries signer 2's signature but claims signer 1's public key, and set B does
+        /// the reverse. Neither verifies alone, yet `sig_a + sig_b` is a valid aggregate signature
+        /// under `pk1 + pk2`. The per-signature randomization in the fold is what defeats this.
+        #[test]
+        fn signature_set_rejects_cancellation_attack() {
+            let message = Hash256::from_low_u64_be(42);
+
+            let sk1 = secret_from_u64(1);
+            let sk2 = secret_from_u64(2);
+            let pk1 = sk1.public_key();
+            let pk2 = sk2.public_key();
+
+            // Each set carries the *other* signer's signature, so neither is valid on its own.
+            let mut sig_a = AggregateSignature::infinity();
+            sig_a.add_assign(&sk2.sign(message));
+            let mut sig_b = AggregateSignature::infinity();
+            sig_b.add_assign(&sk1.sign(message));
+
+            let set_a = SignatureSet::single_pubkey(&sig_a, Cow::Borrowed(&pk1), message);
+            let set_b = SignatureSet::single_pubkey(&sig_b, Cow::Borrowed(&pk2), message);
+            assert!(
+                !set_a.clone().verify(),
+                "set A must be individually invalid"
+            );
+            assert!(
+                !set_b.clone().verify(),
+                "set B must be individually invalid"
+            );
+
+            // Sanity-check that the attack is real: the naive aggregate (sum of signatures under
+            // the sum of public keys) *does* verify, because the swapped signatures cancel.
+            let mut naive_aggregate = AggregateSignature::infinity();
+            naive_aggregate.add_assign(&sk2.sign(message));
+            naive_aggregate.add_assign(&sk1.sign(message));
+            assert!(
+                naive_aggregate.fast_aggregate_verify(message, &[&pk1, &pk2]),
+                "the naive aggregate must verify, otherwise the test is not exercising the attack"
+            );
+
+            // The randomized super-batch verification must reject the crafted sets.
+            let sets = [set_a, set_b];
+            assert!(
+                !verify_signature_sets(sets.iter()),
+                "super-batch verification must reject individually-invalid signatures that only \
+                 cancel out when naively summed"
+            );
+        }
     };
 }
 


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/5148

## Proposed Changes

This PR makes `verify_signature_sets` group the signature sets by their message (signing root) and verify each same-message group with a single pairing instead of one per signature. Note that since Electra, `AttestationData` messages are identical across subnets so this optimization extends beyond just "same-subnet attestations". 

This includes protection for the two different types of cancellation attacks discussed in the original issue.
See https://ethresear.ch/t/attestation-verification-optimization/20516 
A regression test for this exact attack is also included.

Note that we do not perform any additional buffering (no extra latency gets added) so batch sizes tend to be small.

## Metrics

Profiled with [spyglass](https://github.com/macladson/spyglass) on mainnet, with `--subscribe-all-subnets` and `--import-all-attestations`, comparing against `unstable`:
- BLS/Crypto CPU dropped on average **~16%** across the epoch window (ranges ~13–23% across several runs, depending on specific epoch load).
- Metrics shows that batch sizes average ~10 and collapse to on average ~1.2 distinct messages.

## Disclaimer

This is a PoC and:
1. was heavily assisted by Opus 4.8.
2.  I am not a cryptographer.