### PR TITLE
Fix transient bug in `dequeue_attestation` and optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3600,6 +3600,7 @@ version = "0.1.0"
 dependencies = [
  "beacon_chain",
  "bls",
+ "criterion",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "fixed_bytes",

--- a/consensus/fork_choice/Cargo.toml
+++ b/consensus/fork_choice/Cargo.toml
@@ -20,5 +20,10 @@ types = { workspace = true }
 [dev-dependencies]
 beacon_chain = { workspace = true }
 bls = { workspace = true }
+criterion = { workspace = true }
 store = { workspace = true }
 tokio = { workspace = true }
+
+[[bench]]
+name = "benches"
+harness = false

--- a/consensus/fork_choice/benches/benches.rs
+++ b/consensus/fork_choice/benches/benches.rs
@@ -1,7 +1,17 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use fork_choice::{QueuedAttestation, dequeue_attestations};
 use std::collections::BTreeMap;
-use types::Slot;
+use types::{Epoch, Hash256, Slot};
+
+fn att(slot: Slot) -> QueuedAttestation {
+    QueuedAttestation {
+        slot,
+        attesting_indices: vec![],
+        block_root: Hash256::ZERO,
+        target_epoch: Epoch::new(0),
+        payload_present: false,
+    }
+}
 
 // Anticipated steady-state workload on mainnet: ~94k attestations spread over a small number of slots, then
 // many iterations of dequeue (one slot's worth) + enqueue (one slot's worth for a future slot).
@@ -15,10 +25,7 @@ fn build_queue() -> BTreeMap<Slot, Vec<QueuedAttestation>> {
     let mut queue: BTreeMap<Slot, Vec<QueuedAttestation>> = BTreeMap::new();
     for i in 0..NUM_ATTESTATIONS {
         let slot = Slot::from(i / PER_SLOT);
-        queue
-            .entry(slot)
-            .or_default()
-            .push(QueuedAttestation::inner(slot));
+        queue.entry(slot).or_default().push(att(slot));
     }
     queue
 }
@@ -38,10 +45,10 @@ fn all_benches(c: &mut Criterion) {
                     assert_eq!(dequeued_count, PER_SLOT);
 
                     let next_slot = Slot::from(UNIQUE_SLOTS + i - 1);
-                    queue.entry(next_slot).or_default().extend(
-                        std::iter::repeat_with(|| QueuedAttestation::inner(next_slot))
-                            .take(PER_SLOT),
-                    );
+                    queue
+                        .entry(next_slot)
+                        .or_default()
+                        .extend(std::iter::repeat_with(|| att(next_slot)).take(PER_SLOT));
 
                     let total: usize = queue.values().map(Vec::len).sum();
                     assert_eq!(total, NUM_ATTESTATIONS);

--- a/consensus/fork_choice/benches/benches.rs
+++ b/consensus/fork_choice/benches/benches.rs
@@ -1,0 +1,55 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use fork_choice::{QueuedAttestation, dequeue_attestations};
+use std::collections::BTreeMap;
+use types::Slot;
+
+// Anticipated steady-state workload on mainnet: ~94k attestations spread over a small number of slots, then
+// many iterations of dequeue (one slot's worth) + enqueue (one slot's worth for a future slot).
+// The queue stays at a constant size, exercising the per-slot dequeue cost.
+const NUM_ATTESTATIONS: usize = 1_500_000 / 16;
+const UNIQUE_SLOTS: usize = 2;
+const NUM_ITERATIONS: usize = 64;
+const PER_SLOT: usize = NUM_ATTESTATIONS / UNIQUE_SLOTS;
+
+fn build_queue() -> BTreeMap<Slot, Vec<QueuedAttestation>> {
+    let mut queue: BTreeMap<Slot, Vec<QueuedAttestation>> = BTreeMap::new();
+    for i in 0..NUM_ATTESTATIONS {
+        let slot = Slot::from(i / PER_SLOT);
+        queue
+            .entry(slot)
+            .or_default()
+            .push(QueuedAttestation::inner(slot));
+    }
+    queue
+}
+
+fn all_benches(c: &mut Criterion) {
+    let initial = build_queue();
+
+    c.bench_with_input(
+        BenchmarkId::new("dequeue_attestations", NUM_ATTESTATIONS),
+        &initial,
+        |b, initial| {
+            b.iter(|| {
+                let mut queue = initial.clone();
+                for i in 1..=NUM_ITERATIONS {
+                    let dequeued = dequeue_attestations(Slot::from(i), &mut queue);
+                    let dequeued_count: usize = dequeued.values().map(Vec::len).sum();
+                    assert_eq!(dequeued_count, PER_SLOT);
+
+                    let next_slot = Slot::from(UNIQUE_SLOTS + i - 1);
+                    queue.entry(next_slot).or_default().extend(
+                        std::iter::repeat_with(|| QueuedAttestation::inner(next_slot))
+                            .take(PER_SLOT),
+                    );
+
+                    let total: usize = queue.values().map(Vec::len).sum();
+                    assert_eq!(total, NUM_ATTESTATIONS);
+                }
+            })
+        },
+    );
+}
+
+criterion_group!(benches, all_benches);
+criterion_main!(benches);

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -11,7 +11,7 @@ use state_processing::{
     per_block_processing::errors::AttesterSlashingValidationError, per_epoch_processing,
 };
 use std::cmp::Ordering;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::marker::PhantomData;
 use std::time::Duration;
 use superstruct::superstruct;
@@ -313,23 +313,19 @@ impl<'a, E: EthSpec> From<IndexedAttestationRef<'a, E>> for QueuedAttestation {
     }
 }
 
-/// Returns all values in `self.queued_attestations` that have a slot that is earlier than the
-/// current slot. Also removes those values from `self.queued_attestations`.
+/// Returns all attestations in `queued_attestations` with a slot earlier than the current slot,
+/// removing them from the queue.
 fn dequeue_attestations(
     current_slot: Slot,
-    queued_attestations: &mut Vec<QueuedAttestation>,
-) -> Vec<QueuedAttestation> {
-    // The queue is not slot-sorted: `on_attestation` pushes in arrival order, so a future-slot
-    // vote can sit ahead of a due one. Partition on slot rather than splitting at a sorted prefix,
-    // otherwise a due vote stuck behind a future-slot vote would never be released.
-    let (due, remaining): (Vec<_>, Vec<_>) = std::mem::take(queued_attestations)
-        .into_iter()
-        .partition(|a| a.slot < current_slot);
-    *queued_attestations = remaining;
+    queued_attestations: &mut BTreeMap<Slot, Vec<QueuedAttestation>>,
+) -> BTreeMap<Slot, Vec<QueuedAttestation>> {
+    let remaining = queued_attestations.split_off(&current_slot);
+    let due = std::mem::replace(queued_attestations, remaining);
 
+    let dequeued_count: usize = due.values().map(Vec::len).sum();
     metrics::inc_counter_by(
         &metrics::FORK_CHOICE_DEQUEUED_ATTESTATIONS,
-        due.len() as u64,
+        dequeued_count as u64,
     );
 
     due
@@ -377,8 +373,9 @@ pub struct ForkChoice<T, E> {
     fc_store: T,
     /// The underlying representation of the block DAG.
     proto_array: ProtoArrayForkChoice,
-    /// Attestations that arrived at the current slot and must be queued for later processing.
-    queued_attestations: Vec<QueuedAttestation>,
+    /// Attestations that arrived at the current slot and must be queued for later processing,
+    /// keyed by their slot.
+    queued_attestations: BTreeMap<Slot, Vec<QueuedAttestation>>,
     /// Stores a cache of the values required to be sent to the execution layer.
     forkchoice_update_parameters: ForkchoiceUpdateParameters,
     _phantom: PhantomData<E>,
@@ -475,7 +472,7 @@ where
         let mut fork_choice = Self {
             fc_store,
             proto_array,
-            queued_attestations: vec![],
+            queued_attestations: BTreeMap::new(),
             // This will be updated during the next call to `Self::get_head`.
             forkchoice_update_parameters: ForkchoiceUpdateParameters {
                 head_hash: None,
@@ -1354,8 +1351,11 @@ where
             // Attestations can only affect the fork choice of subsequent slots.
             // Delay consideration in the fork choice until their slot is in the past.
             // ```
+            let queued_attestation = QueuedAttestation::from(attestation);
             self.queued_attestations
-                .push(QueuedAttestation::from(attestation));
+                .entry(queued_attestation.slot)
+                .or_default()
+                .push(queued_attestation);
         }
 
         Ok(())
@@ -1547,10 +1547,11 @@ where
     /// Processes and removes from the queue any queued attestations which may now be eligible for
     /// processing due to the slot clock incrementing.
     fn process_attestation_queue(&mut self) -> Result<(), Error<T::Error>> {
-        for attestation in dequeue_attestations(
+        let dequeued = dequeue_attestations(
             self.fc_store.get_current_slot(),
             &mut self.queued_attestations,
-        ) {
+        );
+        for attestation in dequeued.into_values().flatten() {
             for validator_index in attestation.attesting_indices.iter() {
                 self.proto_array.process_attestation(
                     *validator_index as usize,
@@ -1796,8 +1797,8 @@ where
         &self.fc_store
     }
 
-    /// Returns a reference to the currently queued attestations.
-    pub fn queued_attestations(&self) -> &[QueuedAttestation] {
+    /// Returns a reference to the currently queued attestations, keyed by slot.
+    pub fn queued_attestations(&self) -> &BTreeMap<Slot, Vec<QueuedAttestation>> {
         &self.queued_attestations
     }
 
@@ -1882,7 +1883,7 @@ where
         let mut fork_choice = Self {
             fc_store,
             proto_array,
-            queued_attestations: vec![],
+            queued_attestations: BTreeMap::new(),
             // Will be updated in the following call to `Self::get_head`.
             forkchoice_update_parameters: ForkchoiceUpdateParameters {
                 head_hash: None,
@@ -1995,20 +1996,33 @@ mod tests {
         }
     }
 
-    fn get_queued_attestations() -> Vec<QueuedAttestation> {
-        (1..4)
-            .map(|i| QueuedAttestation {
-                slot: Slot::new(i),
+    fn queue_from_slots(
+        slots: impl IntoIterator<Item = u64>,
+    ) -> BTreeMap<Slot, Vec<QueuedAttestation>> {
+        let mut queued: BTreeMap<Slot, Vec<QueuedAttestation>> = BTreeMap::new();
+        for i in slots {
+            let slot = Slot::new(i);
+            queued.entry(slot).or_default().push(QueuedAttestation {
+                slot,
                 attesting_indices: vec![],
                 block_root: Hash256::zero(),
                 target_epoch: Epoch::new(0),
                 payload_present: false,
-            })
-            .collect()
+            });
+        }
+        queued
     }
 
-    fn get_slots(queued_attestations: &[QueuedAttestation]) -> Vec<u64> {
-        queued_attestations.iter().map(|a| a.slot.into()).collect()
+    fn get_queued_attestations() -> BTreeMap<Slot, Vec<QueuedAttestation>> {
+        queue_from_slots(1..4)
+    }
+
+    fn get_slots(queued_attestations: &BTreeMap<Slot, Vec<QueuedAttestation>>) -> Vec<u64> {
+        queued_attestations
+            .values()
+            .flatten()
+            .map(|a| a.slot.into())
+            .collect()
     }
 
     fn test_queued_attestations(current_time: Slot) -> (Vec<u64>, Vec<u64>) {
@@ -2043,24 +2057,9 @@ mod tests {
 
     #[test]
     fn dequeue_attestations_out_of_order() {
-        // The enqueue path (`on_attestation`) pushes in arrival order and never
-        // sorts, so a future-slot vote can sit ahead of a same-slot vote.
-        let mut queued = vec![
-            QueuedAttestation {
-                slot: Slot::new(4),
-                attesting_indices: vec![],
-                block_root: Hash256::zero(),
-                target_epoch: Epoch::new(0),
-                payload_present: true,
-            },
-            QueuedAttestation {
-                slot: Slot::new(3),
-                attesting_indices: vec![],
-                block_root: Hash256::zero(),
-                target_epoch: Epoch::new(0),
-                payload_present: true,
-            },
-        ];
+        // A future-slot vote enqueued before a vote that becomes due sooner must not block the
+        // due vote from being released.
+        let mut queued = queue_from_slots([4, 3]);
 
         // At slot 4, the slot-3 vote is due (3 < 4) and must be released.
         let dequeued = dequeue_attestations(Slot::new(4), &mut queued);

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -313,9 +313,24 @@ impl<'a, E: EthSpec> From<IndexedAttestationRef<'a, E>> for QueuedAttestation {
     }
 }
 
+impl QueuedAttestation {
+    /// Construct an empty attestation for the given slot. Exposed for benchmarking.
+    #[doc(hidden)]
+    pub fn inner(slot: Slot) -> Self {
+        Self {
+            slot,
+            attesting_indices: vec![],
+            block_root: Hash256::ZERO,
+            target_epoch: Epoch::new(0),
+            payload_present: false,
+        }
+    }
+}
+
 /// Returns all attestations in `queued_attestations` with a slot earlier than the current slot,
 /// removing them from the queue.
-fn dequeue_attestations(
+#[doc(hidden)]
+pub fn dequeue_attestations(
     current_slot: Slot,
     queued_attestations: &mut BTreeMap<Slot, Vec<QueuedAttestation>>,
 ) -> BTreeMap<Slot, Vec<QueuedAttestation>> {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -284,12 +284,12 @@ fn compute_start_slot_at_epoch<E: EthSpec>(epoch: Epoch) -> Slot {
 /// information about the attestation.
 #[derive(Clone, PartialEq, Encode, Decode)]
 pub struct QueuedAttestation {
-    slot: Slot,
-    attesting_indices: Vec<u64>,
-    block_root: Hash256,
-    target_epoch: Epoch,
+    pub slot: Slot,
+    pub attesting_indices: Vec<u64>,
+    pub block_root: Hash256,
+    pub target_epoch: Epoch,
     /// Per Gloas spec: `payload_present = attestation.data.index == 1`.
-    payload_present: bool,
+    pub payload_present: bool,
 }
 
 /// Legacy queued attestation without payload_present (pre-Gloas, schema V28).
@@ -313,23 +313,8 @@ impl<'a, E: EthSpec> From<IndexedAttestationRef<'a, E>> for QueuedAttestation {
     }
 }
 
-impl QueuedAttestation {
-    /// Construct an empty attestation for the given slot. Exposed for benchmarking.
-    #[doc(hidden)]
-    pub fn inner(slot: Slot) -> Self {
-        Self {
-            slot,
-            attesting_indices: vec![],
-            block_root: Hash256::ZERO,
-            target_epoch: Epoch::new(0),
-            payload_present: false,
-        }
-    }
-}
-
 /// Returns all attestations in `queued_attestations` with a slot earlier than the current slot,
 /// removing them from the queue.
-#[doc(hidden)]
 pub fn dequeue_attestations(
     current_slot: Slot,
     queued_attestations: &mut BTreeMap<Slot, Vec<QueuedAttestation>>,

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -319,19 +319,20 @@ fn dequeue_attestations(
     current_slot: Slot,
     queued_attestations: &mut Vec<QueuedAttestation>,
 ) -> Vec<QueuedAttestation> {
-    let remaining = queued_attestations.split_off(
-        queued_attestations
-            .iter()
-            .position(|a| a.slot >= current_slot)
-            .unwrap_or(queued_attestations.len()),
-    );
+    // The queue is not slot-sorted: `on_attestation` pushes in arrival order, so a future-slot
+    // vote can sit ahead of a due one. Partition on slot rather than splitting at a sorted prefix,
+    // otherwise a due vote stuck behind a future-slot vote would never be released.
+    let (due, remaining): (Vec<_>, Vec<_>) = std::mem::take(queued_attestations)
+        .into_iter()
+        .partition(|a| a.slot < current_slot);
+    *queued_attestations = remaining;
 
     metrics::inc_counter_by(
         &metrics::FORK_CHOICE_DEQUEUED_ATTESTATIONS,
-        queued_attestations.len() as u64,
+        due.len() as u64,
     );
 
-    std::mem::replace(queued_attestations, remaining)
+    due
 }
 
 /// Denotes whether an attestation we are processing was received from a block or from gossip.

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -2039,4 +2039,40 @@ mod tests {
         assert!(queued.is_empty());
         assert_eq!(dequeued, vec![1, 2, 3]);
     }
+
+    #[test]
+    fn dequeue_attestations_out_of_order() {
+        // The enqueue path (`on_attestation`) pushes in arrival order and never
+        // sorts, so a future-slot vote can sit ahead of a same-slot vote.
+        let mut queued = vec![
+            QueuedAttestation {
+                slot: Slot::new(4),
+                attesting_indices: vec![],
+                block_root: Hash256::zero(),
+                target_epoch: Epoch::new(0),
+                payload_present: true,
+            },
+            QueuedAttestation {
+                slot: Slot::new(3),
+                attesting_indices: vec![],
+                block_root: Hash256::zero(),
+                target_epoch: Epoch::new(0),
+                payload_present: true,
+            },
+        ];
+
+        // At slot 4, the slot-3 vote is due (3 < 4) and must be released.
+        let dequeued = dequeue_attestations(Slot::new(4), &mut queued);
+
+        assert_eq!(
+            get_slots(&dequeued),
+            vec![3],
+            "slot-3 vote must be dequeued at slot 4"
+        );
+        assert_eq!(
+            get_slots(&queued),
+            vec![4],
+            "only the not-yet-due slot-4 vote should remain"
+        );
+    }
 }

--- a/consensus/fork_choice/src/lib.rs
+++ b/consensus/fork_choice/src/lib.rs
@@ -6,7 +6,7 @@ pub use crate::fork_choice::{
     AttestationFromBlock, Error, ForkChoice, ForkChoiceView, ForkchoiceUpdateParameters,
     InvalidAttestation, InvalidBlock, InvalidPayloadAttestation, ParentImportStatus,
     PayloadVerificationStatus, PersistedForkChoice, PersistedForkChoiceV28, PersistedForkChoiceV29,
-    QueuedAttestation, ResetPayloadStatuses,
+    QueuedAttestation, ResetPayloadStatuses, dequeue_attestations,
 };
 pub use fork_choice_store::ForkChoiceStore;
 pub use proto_array::{

--- a/consensus/fork_choice/src/metrics.rs
+++ b/consensus/fork_choice/src/metrics.rs
@@ -49,7 +49,11 @@ pub static FORK_CHOICE_ON_ATTESTER_SLASHING_TIMES: LazyLock<Result<Histogram>> =
 pub fn scrape_for_metrics<T: ForkChoiceStore<E>, E: EthSpec>(fork_choice: &ForkChoice<T, E>) {
     set_gauge(
         &FORK_CHOICE_QUEUED_ATTESTATIONS,
-        fork_choice.queued_attestations().len() as i64,
+        fork_choice
+            .queued_attestations()
+            .values()
+            .map(Vec::len)
+            .sum::<usize>() as i64,
     );
     set_gauge(
         &FORK_CHOICE_NODES,

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -149,13 +149,17 @@ impl ForkChoiceTest {
             .fork_choice_write_lock()
             .update_time(self.harness.chain.slot().unwrap())
             .unwrap();
-        func(
-            self.harness
-                .chain
-                .canonical_head
-                .fork_choice_read_lock()
-                .queued_attestations(),
-        );
+        let queued = self
+            .harness
+            .chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .queued_attestations()
+            .values()
+            .flatten()
+            .cloned()
+            .collect::<Vec<_>>();
+        func(&queued);
         self
     }
 

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -483,7 +483,7 @@ impl ForkChoiceTest {
         attestation
             .sign(
                 &validator_sk,
-                committee_index,
+                committee_index as usize,
                 &head.beacon_state.fork(),
                 self.harness.chain.genesis_validators_root,
                 &self.harness.chain.spec,

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -1060,19 +1060,17 @@ async fn invalid_attestation_delayed_slot() {
         .inspect_queued_attestations(|queue| assert_eq!(queue.len(), 0));
 }
 
-/// Regression test for out-of-order dequeuing of queued attestations.
+/// Regression test for dequeuing when votes for two different future slots are queued.
 ///
-/// `on_attestation` pushes queued attestations in arrival order and never sorts the queue, so a
-/// future-slot vote can sit ahead of a vote that becomes due sooner. The due vote must still be
-/// released once its slot is in the past. A dequeue that assumes the queue is slot-sorted leaves
-/// the due vote stuck behind the future-slot vote forever.
+/// With votes queued for consecutive slots, advancing the clock past the earlier one must release
+/// only that vote and leave the later one queued until its own slot is in the past.
 #[tokio::test]
 async fn dequeue_attestations_consecutive_slot_divergence() {
     ForkChoiceTest::new()
         .apply_blocks_without_new_attestations(1)
         .await
         .inspect_queued_attestations(|queue| assert_eq!(queue.len(), 0))
-        // Enqueue a future-slot vote first (slot + 2) so it sits at the front of the queue.
+        // Queue a vote for `slot + 2`.
         .apply_nth_attestation_to_chain(
             0,
             MutationDelay::NoDelay,
@@ -1083,7 +1081,7 @@ async fn dequeue_attestations_consecutive_slot_divergence() {
             |result| assert!(result.is_ok()),
         )
         .await
-        // Then enqueue a vote that becomes due sooner (slot + 1), behind the future-slot vote.
+        // Queue a vote for `slot + 1`, which becomes due sooner.
         // A different committee position avoids `PriorAttestationKnown`.
         .apply_nth_attestation_to_chain(
             1,
@@ -1102,7 +1100,7 @@ async fn dequeue_attestations_consecutive_slot_divergence() {
             assert_eq!(
                 queue.len(),
                 1,
-                "the due vote must be dequeued even though a future-slot vote is ahead of it"
+                "only the due slot+1 vote should be dequeued"
             );
             assert_eq!(
                 queue[0].slot,
@@ -1112,20 +1110,17 @@ async fn dequeue_attestations_consecutive_slot_divergence() {
         });
 }
 
-/// Companion to `dequeue_attestations_consecutive_slot_divergence`: same out-of-order enqueue, but the clock is
-/// advanced far enough that *both* votes are due at dequeue time.
+/// Companion to `dequeue_attestations_consecutive_slot_divergence`: votes for two different slots
+/// are queued, but the clock is advanced far enough that *both* are due at dequeue time.
 ///
-/// When every queued vote is in the past, `current_slot` is greater than all of them, so even a
-/// slot-sorted dequeue drains the whole queue regardless of order. This case therefore passes on
-/// the current implementation too — it pins down the boundary where the ordering bug does *not*
-/// manifest, so a future change can't quietly turn this into another stuck-vote regression.
+/// When every queued vote is in the past, the whole queue drains in a single dequeue.
 #[tokio::test]
 async fn dequeue_attestations_conciliation() {
     ForkChoiceTest::new()
         .apply_blocks_without_new_attestations(1)
         .await
         .inspect_queued_attestations(|queue| assert_eq!(queue.len(), 0))
-        // Enqueue a future-slot vote first (slot + 2) so it sits at the front of the queue.
+        // Queue a vote for `slot + 2`.
         .apply_nth_attestation_to_chain(
             0,
             MutationDelay::NoDelay,
@@ -1136,7 +1131,7 @@ async fn dequeue_attestations_conciliation() {
             |result| assert!(result.is_ok()),
         )
         .await
-        // Then enqueue a vote that becomes due sooner (slot + 1), behind the future-slot vote.
+        // Queue a vote for `slot + 1`.
         .apply_nth_attestation_to_chain(
             1,
             MutationDelay::NoDelay,
@@ -1148,13 +1143,13 @@ async fn dequeue_attestations_conciliation() {
         )
         .await
         .inspect_queued_attestations(|queue| assert_eq!(queue.len(), 2))
-        // Advance past both votes (to slot + 3) so the whole queue converges and drains.
+        // Advance past both votes (to slot + 3) so the whole queue drains.
         .skip_slots(3)
         .inspect_queued_attestations(|queue| {
             assert_eq!(
                 queue.len(),
                 0,
-                "all votes are due, so the entire queue must drain regardless of order"
+                "all votes are due, so the entire queue must drain"
             );
         });
 }

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -493,9 +493,7 @@ impl ForkChoiceTest {
 
         let single_attestation = SingleAttestation {
             attester_index: validator_index as u64,
-            committee_index: attestation
-                .committee_index()
-                .expect("should get committee index"),
+            committee_index: 0,
             data: attestation.data().clone(),
             signature: attestation.signature().clone(),
         };
@@ -1105,6 +1103,11 @@ async fn dequeue_attestations_consecutive_slot_divergence() {
                 queue.len(),
                 1,
                 "the due vote must be dequeued even though a future-slot vote is ahead of it"
+            );
+            assert_eq!(
+                queue[0].slot,
+                Slot::new(3),
+                "the surviving vote must be the not-yet-due slot+2 vote"
             );
         });
 }

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -415,6 +415,24 @@ impl ForkChoiceTest {
     async fn apply_attestation_to_chain<F, G>(
         self,
         delay: MutationDelay,
+        mutation_func: F,
+        comparison_func: G,
+    ) -> Self
+    where
+        F: FnMut(&mut IndexedAttestation<E>, &BeaconChain<EphemeralHarnessType<E>>),
+        G: FnMut(Result<(), BeaconChainError>),
+    {
+        self.apply_nth_attestation_to_chain(0, delay, mutation_func, comparison_func)
+            .await
+    }
+
+    /// Like `apply_attestation_to_chain`, but attests with the validator at
+    /// `validator_committee_index` within the committee. Lets a test enqueue multiple distinct
+    /// votes for the same slot without tripping `PriorAttestationKnown`.
+    async fn apply_nth_attestation_to_chain<F, G>(
+        self,
+        validator_committee_index: usize,
+        delay: MutationDelay,
         mut mutation_func: F,
         mut comparison_func: G,
     ) -> Self
@@ -431,7 +449,6 @@ impl ForkChoiceTest {
             .produce_unaggregated_attestation(current_slot, 0)
             .expect("should not error while producing attestation");
 
-        let validator_committee_index = 0;
         let validator_index = *head
             .beacon_state
             .get_beacon_committee(
@@ -472,7 +489,9 @@ impl ForkChoiceTest {
 
         let single_attestation = SingleAttestation {
             attester_index: validator_index as u64,
-            committee_index: validator_committee_index as u64,
+            committee_index: attestation
+                .committee_index()
+                .expect("should get committee index"),
             data: attestation.data().clone(),
             signature: attestation.signature().clone(),
         };
@@ -1037,6 +1056,100 @@ async fn invalid_attestation_delayed_slot() {
         .inspect_queued_attestations(|queue| assert_eq!(queue.len(), 1))
         .skip_slot()
         .inspect_queued_attestations(|queue| assert_eq!(queue.len(), 0));
+}
+
+/// Regression test for out-of-order dequeuing of queued attestations.
+///
+/// `on_attestation` pushes queued attestations in arrival order and never sorts the queue, so a
+/// future-slot vote can sit ahead of a vote that becomes due sooner. The due vote must still be
+/// released once its slot is in the past. A dequeue that assumes the queue is slot-sorted leaves
+/// the due vote stuck behind the future-slot vote forever.
+#[tokio::test]
+async fn dequeue_attestations_consecutive_slot_divergence() {
+    ForkChoiceTest::new()
+        .apply_blocks_without_new_attestations(1)
+        .await
+        .inspect_queued_attestations(|queue| assert_eq!(queue.len(), 0))
+        // Enqueue a future-slot vote first (slot + 2) so it sits at the front of the queue.
+        .apply_nth_attestation_to_chain(
+            0,
+            MutationDelay::NoDelay,
+            |attestation, _| {
+                let slot = attestation.data().slot;
+                attestation.data_mut().slot = slot + 2;
+            },
+            |result| assert!(result.is_ok()),
+        )
+        .await
+        // Then enqueue a vote that becomes due sooner (slot + 1), behind the future-slot vote.
+        // A different committee position avoids `PriorAttestationKnown`.
+        .apply_nth_attestation_to_chain(
+            1,
+            MutationDelay::NoDelay,
+            |attestation, _| {
+                let slot = attestation.data().slot;
+                attestation.data_mut().slot = slot + 1;
+            },
+            |result| assert!(result.is_ok()),
+        )
+        .await
+        .inspect_queued_attestations(|queue| assert_eq!(queue.len(), 2))
+        // Advance so the slot+1 vote is due (in the past) but the slot+2 vote is not yet.
+        .skip_slots(2)
+        .inspect_queued_attestations(|queue| {
+            assert_eq!(
+                queue.len(),
+                1,
+                "the due vote must be dequeued even though a future-slot vote is ahead of it"
+            );
+        });
+}
+
+/// Companion to `dequeue_attestations_consecutive_slot_divergence`: same out-of-order enqueue, but the clock is
+/// advanced far enough that *both* votes are due at dequeue time.
+///
+/// When every queued vote is in the past, `current_slot` is greater than all of them, so even a
+/// slot-sorted dequeue drains the whole queue regardless of order. This case therefore passes on
+/// the current implementation too — it pins down the boundary where the ordering bug does *not*
+/// manifest, so a future change can't quietly turn this into another stuck-vote regression.
+#[tokio::test]
+async fn dequeue_attestations_conciliation() {
+    ForkChoiceTest::new()
+        .apply_blocks_without_new_attestations(1)
+        .await
+        .inspect_queued_attestations(|queue| assert_eq!(queue.len(), 0))
+        // Enqueue a future-slot vote first (slot + 2) so it sits at the front of the queue.
+        .apply_nth_attestation_to_chain(
+            0,
+            MutationDelay::NoDelay,
+            |attestation, _| {
+                let slot = attestation.data().slot;
+                attestation.data_mut().slot = slot + 2;
+            },
+            |result| assert!(result.is_ok()),
+        )
+        .await
+        // Then enqueue a vote that becomes due sooner (slot + 1), behind the future-slot vote.
+        .apply_nth_attestation_to_chain(
+            1,
+            MutationDelay::NoDelay,
+            |attestation, _| {
+                let slot = attestation.data().slot;
+                attestation.data_mut().slot = slot + 1;
+            },
+            |result| assert!(result.is_ok()),
+        )
+        .await
+        .inspect_queued_attestations(|queue| assert_eq!(queue.len(), 2))
+        // Advance past both votes (to slot + 3) so the whole queue converges and drains.
+        .skip_slots(3)
+        .inspect_queued_attestations(|queue| {
+            assert_eq!(
+                queue.len(),
+                0,
+                "all votes are due, so the entire queue must drain regardless of order"
+            );
+        });
 }
 
 /// Tests that the correct target root is used when the attested-to block is in a prior epoch to

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -431,11 +431,11 @@ impl ForkChoiceTest {
     }
 
     /// Like `apply_attestation_to_chain`, but attests with the validator at
-    /// `validator_committee_index` within the committee. Lets a test enqueue multiple distinct
+    /// `validator_index_in_committee` within the committee. Lets a test enqueue multiple distinct
     /// votes for the same slot without tripping `PriorAttestationKnown`.
     async fn apply_nth_attestation_to_chain<F, G>(
         self,
-        validator_committee_index: usize,
+        validator_index_in_committee: usize,
         delay: MutationDelay,
         mut mutation_func: F,
         mut comparison_func: G,
@@ -453,17 +453,16 @@ impl ForkChoiceTest {
             .produce_unaggregated_attestation(current_slot, 0)
             .expect("should not error while producing attestation");
 
+        // For these tests we always use committee index 0, which also matches the "dummy" committee
+        // index used post-Electra.
+        let committee_index = 0;
+
         let validator_index = *head
             .beacon_state
-            .get_beacon_committee(
-                current_slot,
-                attestation
-                    .committee_index()
-                    .expect("should get committee index"),
-            )
+            .get_beacon_committee(current_slot, committee_index)
             .expect("should get committees")
             .committee
-            .get(validator_committee_index)
+            .get(validator_index_in_committee)
             .expect("there should be an attesting validator");
 
         let committee_count = head
@@ -473,7 +472,7 @@ impl ForkChoiceTest {
 
         let subnet_id = SubnetId::compute_subnet::<E>(
             current_slot,
-            0,
+            committee_index,
             committee_count,
             &self.harness.chain.spec,
         )
@@ -484,7 +483,7 @@ impl ForkChoiceTest {
         attestation
             .sign(
                 &validator_sk,
-                validator_committee_index,
+                committee_index,
                 &head.beacon_state.fork(),
                 self.harness.chain.genesis_validators_root,
                 &self.harness.chain.spec,
@@ -493,7 +492,7 @@ impl ForkChoiceTest {
 
         let single_attestation = SingleAttestation {
             attester_index: validator_index as u64,
-            committee_index: 0,
+            committee_index,
             data: attestation.data().clone(),
             signature: attestation.signature().clone(),
         };


### PR DESCRIPTION
## Issue Addressed

`dequeue_attestations` released votes by splitting the queue at the first entry with `slot >= current_slot`, which assumes the queue is sorted by slot. It isn't: `on_attestation` pushes attestations in arrival order and never sorts. When a future-slot vote sits ahead of a vote that is already due, the split happens at the future-slot vote and the due vote stays stuck behind it and is never applied to fork choice, even after its slot is in the past.

## Proposed Changes

The PR current uses a naive solution to solve the bug and also adds regression tests to exercise the bug. There are other competing solutions which can be used which also optimize this path at the same time.

https://github.com/sigp/lighthouse/pull/8378

https://github.com/sigp/lighthouse/pull/8378#discussion_r2543322106

## Benchmarks
used gloas adopted version of this for benchmarks 

https://github.com/michaelsproul/lighthouse/tree/dequeue-attestation-baseline-benchmark

```
naive solution
dequeue_attestations/dequeue_attestation/93750
                        time:   [61.502 ms 61.937 ms 62.398 ms]
                        (reference baseline)

michael's proposal
dequeue_attestations/dequeue_michael/93750
                        time:   [8.8218 ms 8.8547 ms 8.8878 ms]
                        change: [-85.74% -85.70% -85.65%] (p = 0.00 < 0.05)
                        Performance has improved.

dapplion's proposal
dequeue_attestations/dequeue_attestation_dapplion/93750
                        time:   [5.1626 ms 5.1739 ms 5.1856 ms]
                        change: [-91.66% -91.65% -91.63%] (p = 0.00 < 0.05)
                        Performance has improved.
```

edit: I have adopted @dapplion's proposal to use `BTreeMap` to map attestation with slot, it also performs better and doesn't have unbounded size issues as found when employing `VecDeq`. 

## AI disclosure

🤖 Claude was used for multiple iterations but the all line were manually reviewed. 
