### PR TITLE
Prevent long state advance during stalled sync

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_proposer_cache.rs
+++ b/beacon_node/beacon_chain/src/beacon_proposer_cache.rs
@@ -29,6 +29,11 @@ const CACHE_SIZE: usize = 16;
 /// performance perspective).
 pub const TYPICAL_SLOTS_PER_EPOCH: usize = 32;
 
+/// The maximum number of epochs that a state may be advanced to determine proposers for a target
+/// epoch. This bounds the work done for a single request and prevents an unhealthy node (e.g. one
+/// whose head is hundreds of epochs behind) from replaying thousands of slots.
+const MAX_PROPOSER_STATE_ADVANCE_EPOCHS: u64 = 8;
+
 /// For some given slot, this contains the proposer index (`index`) and the `fork` that should be
 /// used to verify their signature.
 pub struct Proposer {
@@ -334,6 +339,13 @@ pub fn ensure_state_can_determine_proposers_for_epoch<E: EthSpec>(
         Err(BeaconStateError::SlotOutOfBounds.into())
     } else if state.current_epoch() >= minimum_epoch {
         Ok(())
+    } else if target_epoch > state.current_epoch() + MAX_PROPOSER_STATE_ADVANCE_EPOCHS {
+        // The state is so far behind the target epoch that advancing it would require replaying
+        // many empty epochs. Error rather than burden an unhealthy node.
+        Err(BeaconChainError::InvalidStateForProposers {
+            state_epoch: state.current_epoch(),
+            target_epoch,
+        })
     } else {
         // State's current epoch is less than the minimum epoch.
         // Advance the state up to the minimum epoch.

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -135,6 +135,10 @@ pub enum BeaconChainError {
         state_epoch: Epoch,
         shuffling_epoch: Epoch,
     },
+    InvalidStateForProposers {
+        state_epoch: Epoch,
+        target_epoch: Epoch,
+    },
     SyncDutiesError(BeaconStateError),
     InconsistentForwardsIter {
         request_slot: Slot,

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -34,6 +34,12 @@ pub const DEFAULT_CACHE_SIZE: usize = 16;
 /// better than low-resource nodes going OOM.
 const MAX_CONCURRENT_PROMISES: usize = 2;
 
+/// The maximum number of epochs that the head block's state may be advanced on the on-demand miss
+/// path to compute a shuffling. This bounds the work done for a single request and prevents an
+/// unhealthy node (e.g. one whose head is hundreds of epochs behind) from replaying thousands of
+/// slots.
+const MAX_SHUFFLING_STATE_ADVANCE_EPOCHS: u64 = 8;
+
 #[derive(Clone)]
 pub struct CachedShuffling<E: EthSpec> {
     pub committee_cache: Arc<CommitteeCache>,
@@ -358,6 +364,17 @@ where
         // requesting such old shufflings for this `head_block_root`.
         let head_block_epoch = head_block.slot.epoch(T::EthSpec::slots_per_epoch());
         if head_block_epoch > shuffling_epoch + 1 {
+            return Err(BeaconChainError::InvalidStateForShuffling {
+                state_epoch: head_block_epoch,
+                shuffling_epoch,
+            }
+            .into());
+        }
+
+        // Conversely, if `shuffling_epoch` is so far ahead of the block's state that computing the
+        // shuffling would require advancing the state through many empty epochs, then error rather
+        // than replay all those slots.
+        if shuffling_epoch > head_block_epoch + MAX_SHUFFLING_STATE_ADVANCE_EPOCHS {
             return Err(BeaconChainError::InvalidStateForShuffling {
                 state_epoch: head_block_epoch,
                 shuffling_epoch,

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -474,7 +474,18 @@ pub fn serve<T: BeaconChainTypes>(
                 move |network_globals: Arc<NetworkGlobals<T::EthSpec>>,
                       chain: Arc<BeaconChain<T>>| async move {
                     match *network_globals.sync_state.read() {
-                        SyncState::SyncingFinalized { .. } | SyncState::SyncingHead { .. } => {
+                        // A synced node may always serve requests.
+                        SyncState::Synced => Ok(()),
+                        // In any non-synced state, only serve requests if the head is recent
+                        // enough. This prevents a node that is far behind (e.g. stalled with a
+                        // head that is hundreds of epochs old) from serving duties based on a
+                        // stale head.
+                        SyncState::SyncingFinalized { .. }
+                        | SyncState::SyncingHead { .. }
+                        | SyncState::SyncTransition
+                        | SyncState::BackFillSyncing { .. }
+                        | SyncState::CustodyBackFillSyncing { .. }
+                        | SyncState::Stalled => {
                             let head_slot = chain.canonical_head.cached_head().head_slot();
 
                             let current_slot =
@@ -496,11 +507,6 @@ pub fn serve<T: BeaconChainTypes>(
                                 )))
                             }
                         }
-                        SyncState::SyncTransition
-                        | SyncState::BackFillSyncing { .. }
-                        | SyncState::CustodyBackFillSyncing { .. } => Ok(()),
-                        SyncState::Synced => Ok(()),
-                        SyncState::Stalled => Ok(()),
                     }
                 },
             )


### PR DESCRIPTION
## Issue Addressed

We had a range sync bug in devnet 5 that could stall sync. I noticed that if we left a node stalled for long enough, it will still try to fetch proposer duties and eventually overwhelm the beacon processor with

```
Jun 25 08:06:12.141 ERROR Work queue is full                            queue: "api_request_p0", queue_len: 1024, msg: "the system has insufficient resources for load"
```

We have some logic to prevent calculating proposer duties while syncing, but not while stalled. This vibe coded PR also ensures we dont perform proposer duties while stalled

Wondering what other people think about this as a general idea. If it seems like something useful I'll clean this up a bit and make this less vibey