### PR TITLE
Add blocks_by_head consumer

### DIFF
--- a/beacon_node/lighthouse_network/src/metrics.rs
+++ b/beacon_node/lighthouse_network/src/metrics.rs
@@ -11,6 +11,13 @@ pub static PEERS_CONNECTED: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
     try_create_int_gauge("libp2p_peers", "Count of libp2p peers currently connected")
 });
 
+pub static PEERS_SUPPORTING_BLOCKS_BY_HEAD: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "libp2p_peers_supporting_blocks_by_head",
+        "Count of connected peers advertising the beacon_blocks_by_head protocol",
+    )
+});
+
 pub static PEERS_CONNECTED_MULTI: LazyLock<Result<IntGaugeVec>> = LazyLock::new(|| {
     try_create_int_gauge_vec(
         "libp2p_peers_multi",

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -32,6 +32,7 @@ use peerdb::score::{PeerAction, ReportSource};
 pub use peerdb::sync_status::{SyncInfo, SyncStatus};
 use std::collections::{HashMap, HashSet, hash_map::Entry};
 use std::net::IpAddr;
+use std::str::FromStr;
 use strum::IntoEnumIterator;
 use types::data::{CustodyIndex, compute_subnets_from_custody_group, get_custody_groups};
 
@@ -504,6 +505,12 @@ impl<E: EthSpec> PeerManager<E> {
             let previous_listening_addresses =
                 peer_info.set_listening_addresses(info.listen_addrs.clone());
             peer_info.set_client(peerdb::client::Client::from_identify_info(info));
+            peer_info.set_supported_protocols(
+                info.protocols
+                    .iter()
+                    .filter_map(|protocol| rpc_protocol_from_id(protocol.as_ref()))
+                    .collect(),
+            );
 
             if previous_kind != peer_info.client().kind
                 || *peer_info.listening_addresses() != previous_listening_addresses
@@ -1565,6 +1572,7 @@ impl<E: EthSpec> PeerManager<E> {
     // Update peer count related metrics.
     fn update_peer_count_metrics(&self) {
         let mut peers_connected = 0;
+        let mut peers_supporting_blocks_by_head: i64 = 0;
         let mut clients_per_peer = HashMap::new();
         let mut inbound_ipv4_peers_connected: usize = 0;
         let mut inbound_ipv6_peers_connected: usize = 0;
@@ -1573,6 +1581,10 @@ impl<E: EthSpec> PeerManager<E> {
 
         for (_, peer_info) in self.network_globals.peers.read().connected_peers() {
             peers_connected += 1;
+
+            if peer_info.supports_protocol(Protocol::BlocksByHead) {
+                peers_supporting_blocks_by_head += 1;
+            }
 
             *clients_per_peer
                 .entry(peer_info.client().kind.to_string())
@@ -1633,6 +1645,12 @@ impl<E: EthSpec> PeerManager<E> {
 
         // PEERS_CONNECTED
         metrics::set_gauge(&metrics::PEERS_CONNECTED, peers_connected);
+
+        // PEERS_SUPPORTING_BLOCKS_BY_HEAD
+        metrics::set_gauge(
+            &metrics::PEERS_SUPPORTING_BLOCKS_BY_HEAD,
+            peers_supporting_blocks_by_head,
+        );
 
         // CUSTODY_GROUP_COUNT
         for (custody_group_count, peer_count) in peers_per_custody_group_count.into_iter() {
@@ -1723,12 +1741,32 @@ enum ConnectingType {
     },
 }
 
+/// Parses a libp2p protocol id of the form `/eth2/beacon_chain/req/<name>/<version>/<encoding>`
+/// into the corresponding ReqResp [`Protocol`], returning `None` for non-ReqResp protocols.
+fn rpc_protocol_from_id(protocol_id: &str) -> Option<Protocol> {
+    protocol_id
+        .strip_prefix("/eth2/beacon_chain/req/")
+        .and_then(|rest| rest.split('/').next())
+        .and_then(|name| Protocol::from_str(name).ok())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::NetworkConfig;
     use crate::rpc::MetaDataV3;
     use types::{ChainSpec, ForkName, MainnetEthSpec as E};
+
+    #[test]
+    fn rpc_protocol_from_id_parses_reqresp_protocols() {
+        // A known ReqResp protocol is parsed from its name segment.
+        assert_eq!(
+            rpc_protocol_from_id("/eth2/beacon_chain/req/beacon_blocks_by_head/1/ssz_snappy"),
+            Some(Protocol::BlocksByHead)
+        );
+        // Non-ReqResp protocols are ignored.
+        assert_eq!(rpc_protocol_from_id("/meshsub/1.1.0"), None);
+    }
 
     async fn build_peer_manager(target_peer_count: usize) -> PeerManager<E> {
         build_peer_manager_with_trusted_peers(vec![], target_peer_count).await

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -870,6 +870,17 @@ impl<E: EthSpec> PeerDB<E> {
             .ok_or_else(|| "Cannot set custody subnets, peer not found".to_string())
     }
 
+    pub fn __set_supported_protocols(
+        &mut self,
+        peer_id: &PeerId,
+        supported_protocols: HashSet<crate::rpc::Protocol>,
+    ) -> Result<(), String> {
+        self.peers
+            .get_mut(peer_id)
+            .map(|info| info.set_supported_protocols(supported_protocols))
+            .ok_or_else(|| "Cannot set supported protocols, peer not found".to_string())
+    }
+
     /// The connection state of the peer has been changed. Modify the peer in the db to ensure all
     /// variables are in sync with libp2p.
     /// Updating the state can lead to a `BanOperation` which needs to be processed via the peer

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -2,6 +2,7 @@ use super::client::Client;
 use super::score::{PeerAction, Score, ScoreState};
 use super::sync_status::SyncStatus;
 use crate::discovery::Eth2Enr;
+use crate::rpc::Protocol as RpcProtocol;
 use crate::{rpc::MetaData, types::Subnet};
 use PeerConnectionStatus::*;
 use discv5::Enr;
@@ -59,6 +60,8 @@ pub struct PeerInfo<E: EthSpec> {
     connection_direction: Option<ConnectionDirection>,
     /// The enr of the peer, if known.
     enr: Option<Enr>,
+    /// The set of ReqResp protocols the peer advertised via `identify`. Empty until identified.
+    supported_protocols: HashSet<RpcProtocol>,
 }
 
 impl<E: EthSpec> Default for PeerInfo<E> {
@@ -78,6 +81,7 @@ impl<E: EthSpec> Default for PeerInfo<E> {
             is_trusted: false,
             connection_direction: None,
             enr: None,
+            supported_protocols: HashSet::new(),
         }
     }
 }
@@ -170,6 +174,11 @@ impl<E: EthSpec> PeerInfo<E> {
     /// The ENR of the peer if it is known.
     pub fn enr(&self) -> Option<&Enr> {
         self.enr.as_ref()
+    }
+
+    /// Returns true if the peer advertised support for `protocol` via `identify`.
+    pub fn supports_protocol(&self, protocol: RpcProtocol) -> bool {
+        self.supported_protocols.contains(&protocol)
     }
 
     /// An iterator over all the subnets this peer is subscribed to.
@@ -398,6 +407,15 @@ impl<E: EthSpec> PeerInfo<E> {
     // VISIBILITY: The peer manager is able to set the client
     pub(in crate::peer_manager) fn set_client(&mut self, client: Client) {
         self.client = client
+    }
+
+    /// Replaces the set of ReqResp protocols the peer advertised via `identify`.
+    // VISIBILITY: The peer manager is able to set the supported protocols
+    pub(in crate::peer_manager) fn set_supported_protocols(
+        &mut self,
+        supported_protocols: HashSet<RpcProtocol>,
+    ) {
+        self.supported_protocols = supported_protocols;
     }
 
     /// Replaces the current listening addresses with those specified, returning the current

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -303,6 +303,13 @@ pub enum Protocol {
     LightClientUpdatesByRange,
 }
 
+impl serde::Serialize for Protocol {
+    /// Serialize as the canonical protocol name (matching `AsRef<str>`/`Display`).
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_ref())
+    }
+}
+
 impl Protocol {
     pub(crate) fn terminator(self) -> Option<ResponseTermination> {
         match self {

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -21,6 +21,8 @@ pub struct SingleLookupReqId {
 pub enum SyncRequestId {
     /// Request searching for a block given a hash.
     SingleBlock { id: SingleLookupReqId },
+    /// Request walking the ancestors of a block given its root, via `beacon_blocks_by_head`.
+    BlocksByHead(SingleLookupReqId),
     /// Request searching for a payload envelope given a hash.
     SinglePayloadEnvelope { id: SingleLookupReqId },
     /// Request searching for a set of data columns given a hash and list of column indices.

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -355,10 +355,8 @@ impl<T: BeaconChainTypes> Router<T> {
             Response::PayloadEnvelopesByRange(envelope) => {
                 self.on_payload_envelopes_by_range_response(peer_id, app_request_id, envelope);
             }
-            // Lighthouse currently only serves BlocksByHead and does not issue it as a client,
-            // so receiving a response is unexpected. Drop it without crashing.
-            Response::BlocksByHead(_) => {
-                debug!("BlocksByHead response received but not requested by lighthouse");
+            Response::BlocksByHead(beacon_block) => {
+                self.on_blocks_by_head_response(peer_id, app_request_id, beacon_block);
             }
             // Light client responses should not be received
             Response::LightClientBootstrap(_)
@@ -710,6 +708,29 @@ impl<T: BeaconChainTypes> Router<T> {
             %peer_id,
             "Received BlocksByRoot Response"
         );
+        self.send_to_sync(SyncMessage::RpcBlock {
+            peer_id,
+            sync_request_id,
+            beacon_block,
+        });
+    }
+
+    /// Handle a `BlocksByHead` response from the peer.
+    /// A `beacon_block` behaves as a stream which is terminated on a `None` response.
+    pub fn on_blocks_by_head_response(
+        &mut self,
+        peer_id: PeerId,
+        app_request_id: AppRequestId,
+        beacon_block: Option<Arc<SignedBeaconBlock<T::EthSpec>>>,
+    ) {
+        let sync_request_id = match app_request_id {
+            AppRequestId::Sync(id @ SyncRequestId::BlocksByHead { .. }) => id,
+            other => {
+                crit!(request = ?other, "BlocksByHead response on incorrect request");
+                return;
+            }
+        };
+
         self.send_to_sync(SyncMessage::RpcBlock {
             peer_id,
             sync_request_id,

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -503,6 +503,9 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             SyncRequestId::SingleBlock { id } => {
                 self.on_single_block_response(id, peer_id, RpcEvent::RPCError(error))
             }
+            SyncRequestId::BlocksByHead(id) => {
+                self.on_blocks_by_head_response(id, peer_id, RpcEvent::RPCError(error))
+            }
             SyncRequestId::SinglePayloadEnvelope { id } => {
                 self.on_single_payload_envelope_response(id, peer_id, RpcEvent::RPCError(error))
             }
@@ -1116,6 +1119,9 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             SyncRequestId::SingleBlock { id } => {
                 self.on_single_block_response(id, peer_id, RpcEvent::from_chunk(block))
             }
+            SyncRequestId::BlocksByHead(id) => {
+                self.on_blocks_by_head_response(id, peer_id, RpcEvent::from_chunk(block))
+            }
             SyncRequestId::BlocksByRange(id) => {
                 self.on_blocks_by_range_response(id, peer_id, RpcEvent::from_chunk(block))
             }
@@ -1139,6 +1145,16 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 &mut self.network,
             )
         }
+    }
+
+    fn on_blocks_by_head_response(
+        &mut self,
+        id: SingleLookupReqId,
+        peer_id: PeerId,
+        block: RpcEvent<Arc<SignedBeaconBlock<T::EthSpec>>>,
+    ) {
+        // The response is not consumed yet: a follow-up will inject the blocks into lookup sync.
+        self.network.on_blocks_by_head_response(id, peer_id, block);
     }
 
     fn rpc_blob_received(

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -24,10 +24,11 @@ use beacon_chain::{BeaconChain, BeaconChainTypes, BlockProcessStatus, EngineStat
 use custody::CustodyRequestResult;
 use fnv::FnvHashMap;
 use lighthouse_network::rpc::methods::{
-    BlobsByRangeRequest, DataColumnsByRangeRequest, PayloadEnvelopesByRangeRequest,
+    BlobsByRangeRequest, BlocksByHeadRequest, DataColumnsByRangeRequest,
+    PayloadEnvelopesByRangeRequest,
 };
 use lighthouse_network::rpc::{
-    BlocksByRangeRequest, GoodbyeReason, MAX_CONCURRENT_REQUESTS, RPCError, RequestType,
+    BlocksByRangeRequest, GoodbyeReason, MAX_CONCURRENT_REQUESTS, Protocol, RPCError, RequestType,
 };
 pub use lighthouse_network::service::api_types::RangeRequestId;
 use lighthouse_network::service::api_types::{
@@ -41,9 +42,10 @@ use lighthouse_network::{Client, NetworkGlobals, PeerAction, PeerId, ReportSourc
 use parking_lot::RwLock;
 pub use requests::LookupVerifyError;
 use requests::{
-    ActiveRequestItems, ActiveRequests, BlobsByRangeRequestItems, BlocksByRangeRequestItems,
-    BlocksByRootRequestItems, DataColumnsByRangeRequestItems, DataColumnsByRootRequestItems,
-    PayloadEnvelopesByRangeRequestItems, PayloadEnvelopesByRootRequestItems,
+    ActiveRequestItems, ActiveRequests, BlobsByRangeRequestItems, BlocksByHeadRequestItems,
+    BlocksByRangeRequestItems, BlocksByRootRequestItems, DataColumnsByRangeRequestItems,
+    DataColumnsByRootRequestItems, PayloadEnvelopesByRangeRequestItems,
+    PayloadEnvelopesByRootRequestItems,
 };
 #[cfg(test)]
 use slot_clock::SlotClock;
@@ -224,6 +226,9 @@ pub struct SyncNetworkContext<T: BeaconChainTypes> {
     /// A mapping of active BlocksByRoot requests, including both current slot and parent lookups.
     blocks_by_root_requests:
         ActiveRequests<SingleLookupReqId, BlocksByRootRequestItems<T::EthSpec>>,
+    /// A mapping of active BlocksByHead requests, used by block lookups to walk a block's ancestors.
+    blocks_by_head_requests:
+        ActiveRequests<SingleLookupReqId, BlocksByHeadRequestItems<T::EthSpec>>,
     /// A mapping of active PayloadEnvelopesByRoot requests
     payload_envelopes_by_root_requests:
         ActiveRequests<SingleLookupReqId, PayloadEnvelopesByRootRequestItems<T::EthSpec>>,
@@ -328,6 +333,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             execution_engine_state: EngineState::Online, // always assume `Online` at the start
             request_id: 1,
             blocks_by_root_requests: ActiveRequests::new("blocks_by_root"),
+            blocks_by_head_requests: ActiveRequests::new("blocks_by_head"),
             payload_envelopes_by_root_requests: ActiveRequests::new("payload_envelopes_by_root"),
             data_columns_by_root_requests: ActiveRequests::new("data_columns_by_root"),
             blocks_by_range_requests: ActiveRequests::new("blocks_by_range"),
@@ -361,6 +367,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             network_send: _,
             request_id: _,
             blocks_by_root_requests,
+            blocks_by_head_requests,
             payload_envelopes_by_root_requests,
             data_columns_by_root_requests,
             blocks_by_range_requests,
@@ -382,6 +389,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .active_requests_of_peer(peer_id)
             .into_iter()
             .map(|id| SyncRequestId::SingleBlock { id: *id });
+        let blocks_by_head_ids = blocks_by_head_requests
+            .active_requests_of_peer(peer_id)
+            .into_iter()
+            .map(|id| SyncRequestId::BlocksByHead(*id));
         let payload_envelopes_by_root_ids = payload_envelopes_by_root_requests
             .active_requests_of_peer(peer_id)
             .into_iter()
@@ -407,6 +418,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .into_iter()
             .map(|req_id| SyncRequestId::PayloadEnvelopesByRange(*req_id));
         blocks_by_root_ids
+            .chain(blocks_by_head_ids)
             .chain(payload_envelopes_by_root_ids)
             .chain(data_column_by_root_ids)
             .chain(blocks_by_range_ids)
@@ -423,6 +435,16 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
     pub fn network_globals(&self) -> &NetworkGlobals<T::EthSpec> {
         &self.network_beacon_processor.network_globals
+    }
+
+    /// Returns true if the peer advertised support for the `beacon_blocks_by_head` protocol.
+    pub fn peer_supports_blocks_by_head(&self, peer_id: &PeerId) -> bool {
+        self.network_globals()
+            .peers
+            .read()
+            .peer_info(peer_id)
+            .map(|info| info.supports_protocol(Protocol::BlocksByHead))
+            .unwrap_or(false)
     }
 
     /// Returns the Client type of the peer if known
@@ -813,6 +835,52 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         );
 
         Ok(LookupRequestResult::RequestSent(id.req_id))
+    }
+
+    /// Sends a `beacon_blocks_by_head` request to `peer_id`, fetching `request.beacon_root` and a
+    /// run of its ancestors in a single request.
+    pub fn send_blocks_by_head(
+        &mut self,
+        peer_id: PeerId,
+        lookup_id: SingleLookupId,
+        request: BlocksByHeadRequest,
+    ) -> Result<Id, RpcRequestSendError> {
+        let id = SingleLookupReqId {
+            lookup_id,
+            req_id: self.next_id(),
+        };
+        self.network_send
+            .send(NetworkMessage::SendRequest {
+                peer_id,
+                request: RequestType::BlocksByHead(request.clone()),
+                app_request_id: AppRequestId::Sync(SyncRequestId::BlocksByHead(id)),
+            })
+            .map_err(|_| RpcRequestSendError::InternalError("network send error".to_owned()))?;
+
+        debug!(
+            method = "BlocksByHead",
+            block_root = ?request.beacon_root,
+            peer = %peer_id,
+            %id,
+            "Sync RPC request sent"
+        );
+
+        let request_span = debug_span!(
+            parent: Span::current(),
+            "lh_outgoing_block_by_head_request",
+            block_root = %request.beacon_root,
+        );
+        self.blocks_by_head_requests.insert(
+            id,
+            peer_id,
+            // false = the peer may return fewer blocks than requested (e.g. reached genesis or
+            // finalization), so the request completes on stream termination.
+            false,
+            BlocksByHeadRequestItems::new(request.beacon_root, request.count as usize),
+            request_span,
+        );
+
+        Ok(id.req_id)
     }
 
     /// Request a payload envelope for a block root via PayloadEnvelopesByRoot RPC.
@@ -1365,6 +1433,28 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         self.on_rpc_response_result(resp, peer_id)
     }
 
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn on_blocks_by_head_response(
+        &mut self,
+        id: SingleLookupReqId,
+        peer_id: PeerId,
+        rpc_event: RpcEvent<Arc<SignedBeaconBlock<T::EthSpec>>>,
+    ) -> Option<RpcResponseResult<Vec<Arc<SignedBeaconBlock<T::EthSpec>>>>> {
+        // The response has the requested `beacon_root` first followed by its ancestors in
+        // descending slot order, and must contain at least the requested block.
+        let resp = self.blocks_by_head_requests.on_response(id, rpc_event);
+        let resp = resp.map(|res| {
+            res.and_then(|blocks| {
+                if blocks.is_empty() {
+                    Err(LookupVerifyError::NotEnoughResponsesReturned { actual: 0 }.into())
+                } else {
+                    Ok(blocks)
+                }
+            })
+        });
+        self.on_rpc_response_result(resp, peer_id)
+    }
+
     pub(crate) fn on_single_payload_envelope_response(
         &mut self,
         id: SingleLookupReqId,
@@ -1719,6 +1809,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     pub(crate) fn register_metrics(&self) {
         for (id, count) in [
             ("blocks_by_root", self.blocks_by_root_requests.len()),
+            ("blocks_by_head", self.blocks_by_head_requests.len()),
             (
                 "data_columns_by_root",
                 self.data_columns_by_root_requests.len(),

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -8,6 +8,7 @@ use tracing::{Span, debug};
 use types::{Hash256, Slot};
 
 pub use blobs_by_range::BlobsByRangeRequestItems;
+pub use blocks_by_head::BlocksByHeadRequestItems;
 pub use blocks_by_range::BlocksByRangeRequestItems;
 pub use blocks_by_root::{BlocksByRootRequestItems, BlocksByRootSingleRequest};
 pub use data_columns_by_range::DataColumnsByRangeRequestItems;
@@ -22,6 +23,7 @@ use crate::metrics;
 use super::{RpcEvent, RpcResponseError, RpcResponseResult};
 
 mod blobs_by_range;
+mod blocks_by_head;
 mod blocks_by_range;
 mod blocks_by_root;
 mod data_columns_by_range;

--- a/beacon_node/network/src/sync/network_context/requests/blocks_by_head.rs
+++ b/beacon_node/network/src/sync/network_context/requests/blocks_by_head.rs
@@ -1,0 +1,58 @@
+use super::{ActiveRequestItems, LookupVerifyError};
+use beacon_chain::get_block_root;
+use std::sync::Arc;
+use types::{EthSpec, Hash256, SignedBeaconBlock};
+
+/// Accumulates the response of a `blocks_by_head` request. The responder walks the parent chain of
+/// `beacon_root` (inclusive) and emits up to `count` blocks in descending slot order, so the first
+/// chunk MUST be `beacon_root` and the rest are its ancestors.
+pub struct BlocksByHeadRequestItems<E: EthSpec> {
+    beacon_root: Hash256,
+    count: usize,
+    items: Vec<Arc<SignedBeaconBlock<E>>>,
+}
+
+impl<E: EthSpec> BlocksByHeadRequestItems<E> {
+    pub fn new(beacon_root: Hash256, count: usize) -> Self {
+        Self {
+            beacon_root,
+            count,
+            items: vec![],
+        }
+    }
+}
+
+impl<E: EthSpec> ActiveRequestItems for BlocksByHeadRequestItems<E> {
+    type Item = Arc<SignedBeaconBlock<E>>;
+
+    /// Append a response chunk. The blocks must form a parent chain in strictly descending slot
+    /// order, with the chain tip (first chunk) equal to the requested `beacon_root`.
+    /// The active request SHOULD be dropped after `add` returns an error.
+    fn add(&mut self, block: Self::Item) -> Result<bool, LookupVerifyError> {
+        let block_root = get_block_root(&block);
+        if let Some(child) = self.items.last() {
+            // Each subsequent block must be the parent of the previous one, with a strictly lower
+            // slot, so the response forms a contiguous descending chain.
+            if child.parent_root() != block_root {
+                return Err(LookupVerifyError::UnrequestedBlockRoot(block_root));
+            }
+            if block.slot() >= child.slot() {
+                return Err(LookupVerifyError::UnrequestedSlot(block.slot()));
+            }
+        } else {
+            // The first block returned is the chain tip and must match the requested root.
+            if self.beacon_root != block_root {
+                return Err(LookupVerifyError::UnrequestedBlockRoot(block_root));
+            }
+        }
+
+        self.items.push(block);
+        // The peer may return fewer blocks than requested (e.g. reached genesis or finalization),
+        // in which case the request completes on stream termination instead.
+        Ok(self.items.len() >= self.count)
+    }
+
+    fn consume(&mut self) -> Vec<Self::Item> {
+        std::mem::take(&mut self.items)
+    }
+}


### PR DESCRIPTION
Trimmed down the original PR to just introduce the consumer for blocks_by_head. It doesn't touch any sync code.

This route can be used later by backfill sync or lookup sync.

### AI disclosure

Original design by hand, completed by Claude (Opus 4.8), reviewed line by line.
