### PR TITLE
fix(monitoring_api): redact reqwest error URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6056,6 +6056,7 @@ dependencies = [
  "health_metrics",
  "lighthouse_version",
  "metrics",
+ "pretty_reqwest_error",
  "regex",
  "reqwest",
  "sensitive_url",

--- a/common/monitoring_api/Cargo.toml
+++ b/common/monitoring_api/Cargo.toml
@@ -10,6 +10,7 @@ eth2 = { workspace = true, features = ["lighthouse"] }
 health_metrics = { workspace = true }
 lighthouse_version = { workspace = true }
 metrics = { workspace = true }
+pretty_reqwest_error = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 sensitive_url = { workspace = true }

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -227,11 +227,11 @@ mod tests {
 
     #[tokio::test]
     async fn reqwest_error_display_redacts_monitoring_endpoint_query() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let accept_thread = std::thread::spawn(move || {
-            let _ = listener.accept();
-        });
+        let port = TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
 
         let client = MonitoringHttpClient::new(&Config {
             monitoring_endpoint: "http://127.0.0.1/".to_string(),
@@ -247,7 +247,6 @@ mod tests {
             .post(url, &Vec::<MonitoringMetrics>::new())
             .await
             .unwrap_err();
-        accept_thread.join().unwrap();
 
         let formatted_error = error.to_string();
 

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -5,6 +5,7 @@ use std::{path::PathBuf, time::Duration};
 use eth2::lighthouse::SystemHealth;
 use gather::{gather_beacon_metrics, gather_validator_metrics};
 use health_metrics::observe::Observe;
+use pretty_reqwest_error::PrettyReqwestError;
 use reqwest::{IntoUrl, Response};
 pub use reqwest::{StatusCode, Url};
 use sensitive_url::SensitiveUrl;
@@ -24,7 +25,7 @@ pub const TIMEOUT_DURATION: u64 = 5;
 #[derive(Debug)]
 pub enum Error {
     /// The `reqwest` client raised an error.
-    Reqwest(reqwest::Error),
+    Reqwest(PrettyReqwestError),
     /// The supplied URL is badly formatted. It should look something like `http://127.0.0.1:5052`.
     InvalidUrl(SensitiveUrl),
     SystemMetricsFailed(String),
@@ -43,6 +44,12 @@ impl std::fmt::Display for Error {
             // Print the debug value
             e => write!(f, "{:?}", e),
         }
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(e: reqwest::Error) -> Self {
+        Error::Reqwest(e.into())
     }
 }
 
@@ -93,8 +100,7 @@ impl MonitoringHttpClient {
             .json(body)
             .timeout(Duration::from_secs(TIMEOUT_DURATION))
             .send()
-            .await
-            .map_err(Error::Reqwest)?;
+            .await?;
         ok_or_error(response).await?;
         Ok(())
     }
@@ -211,5 +217,43 @@ async fn ok_or_error(response: Response) -> Result<Response, Error> {
         Err(Error::ServerMessage(message))
     } else {
         Err(Error::StatusCode(status))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    #[tokio::test]
+    async fn reqwest_error_display_redacts_monitoring_endpoint_query() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accept_thread = std::thread::spawn(move || {
+            let _ = listener.accept();
+        });
+
+        let client = MonitoringHttpClient::new(&Config {
+            monitoring_endpoint: "http://127.0.0.1/".to_string(),
+            db_path: None,
+            freezer_db_path: None,
+            update_period_secs: None,
+        })
+        .unwrap();
+        let api_key = "test-api-key";
+        let url = format!("http://127.0.0.1:{port}/api/v1/client/metrics?apikey={api_key}");
+
+        let error = client
+            .post(url, &Vec::<MonitoringMetrics>::new())
+            .await
+            .unwrap_err();
+        accept_thread.join().unwrap();
+
+        let formatted_error = error.to_string();
+
+        assert!(formatted_error.contains(&format!("http://127.0.0.1:{port}/")));
+        assert!(!formatted_error.contains("apikey"));
+        assert!(!formatted_error.contains(api_key));
+        assert!(!formatted_error.contains(&format!("apikey={api_key}")));
     }
 }


### PR DESCRIPTION
## Summary

- wrap monitoring API `reqwest` errors with `PrettyReqwestError`
- use the existing `SensitiveUrl` redaction path for transport-error formatting
- add a focused regression test for monitoring endpoint query redaction

## Notes

429 responses still flow through the existing non-200 handling as `ServerMessage` or `StatusCode`. I left backoff or log-level changes out of this PR so the security fix stays narrow.

## Validation

- `cargo fmt --all --check`
- `cargo test -p pretty_reqwest_error`
- `cargo run --manifest-path /private/tmp/lh-redaction-smoke/Cargo.toml --locked`
- `cargo test -p monitoring_api reqwest_error_display_redacts_monitoring_endpoint_query` blocked locally before compiling `monitoring_api`: `xdelta3` bindgen cannot load libclang because the active Rust host is `x86_64-apple-darwin` while installed Xcode/Homebrew libclang is `arm64`
