### PR TITLE
Backport of #9514 to `release-v8.2.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,7 +2475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/testing/execution_engine_integration/src/geth.rs
+++ b/testing/execution_engine_integration/src/geth.rs
@@ -108,7 +108,6 @@ impl GenericExecutionEngine for GethEngine {
             .arg(http_auth_port.to_string())
             .arg("--port")
             .arg(network_port.to_string())
-            .arg("--allow-insecure-unlock")
             .arg("--authrpc.jwtsecret")
             .arg(jwt_secret_path.as_path().to_str().unwrap())
             // This flag is required to help Geth perform reliably when feeding it blocks


### PR DESCRIPTION
- Remove deprecated geth flag
- Remove duplicate entries for crate `syn`
