### PR TITLE
Reject RPC requests with trailing bytes

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/codec.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec.rs
@@ -196,6 +196,19 @@ impl<E: EthSpec> Decoder for SSZSnappyInboundCodec<E> {
                 let n = reader.get_ref().get_ref().position();
                 self.len = None;
                 let _read_bytes = src.split_to(n as usize);
+                // Per the consensus-spec, bytes remaining after the declared SSZ payload are
+                // invalid input and must be rejected.
+                //
+                // Best-effort: only catches trailing bytes already buffered in `src` here (i.e.
+                // delivered in the same read). Bytes split into a later read go undetected, as
+                // the request stream decodes a single frame and is not polled again. This gap is
+                // accepted to avoid an extra read just to probe for EOF.
+                if !src.is_empty() {
+                    return Err(RPCError::InvalidData(format!(
+                        "Trailing bytes detected after request payload for protocol {:?}",
+                        self.protocol.versioned_protocol,
+                    )));
+                }
                 handle_rpc_request(
                     self.protocol.versioned_protocol,
                     &decoded_buffer,

--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -892,9 +892,7 @@ where
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
                 error: (proto, error, stream),
                 ..
-            }) => {
-                self.on_listen_upgrade_error(proto, error, stream)
-            }
+            }) => self.on_listen_upgrade_error(proto, error, stream),
             _ => {
                 // NOTE: ConnectionEvent is a non exhaustive enum so updates should be based on
                 // release notes more than compiler feedback
@@ -1138,9 +1136,16 @@ where
             }));
     }
 
-    fn on_listen_upgrade_error(&mut self, protocol: Protocol, error: RPCError, substream: Option<InboundFramed<Stream, E>>) {
+    fn on_listen_upgrade_error(
+        &mut self,
+        protocol: Protocol,
+        error: RPCError,
+        substream: Option<InboundFramed<Stream, E>>,
+    ) {
         // Respond with `InvalidRequest` error.
-        if let Some(stream) = substream && let RPCError::InvalidData(err) = &error {
+        if let Some(stream) = substream
+            && let RPCError::InvalidData(err) = &error
+        {
             if self.inbound_substreams.len() < MAX_INBOUND_SUBSTREAMS {
                 let delay_key = self
                     .inbound_substreams_delay

--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::cognitive_complexity)]
 
-use super::methods::{GoodbyeReason, RpcErrorResponse, RpcResponse};
+use super::methods::{ErrorType, GoodbyeReason, RpcErrorResponse, RpcResponse};
 use super::outbound::OutboundRequestContainer;
 use super::protocol::{InboundOutput, Protocol, RPCError, RPCProtocol, RequestType};
 use super::{RPCReceived, RPCSend, ReqId};
@@ -890,14 +890,10 @@ where
                 self.on_dial_upgrade_error(info, error)
             }
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                error: (proto, error),
+                error: (proto, error, stream),
                 ..
             }) => {
-                self.events_out.push(HandlerEvent::Err(HandlerErr::Inbound {
-                    id: self.current_inbound_substream_id,
-                    proto,
-                    error,
-                }));
+                self.on_listen_upgrade_error(proto, error, stream)
             }
             _ => {
                 // NOTE: ConnectionEvent is a non exhaustive enum so updates should be based on
@@ -1140,6 +1136,48 @@ where
                 proto: req.versioned_protocol().protocol(),
                 id,
             }));
+    }
+
+    fn on_listen_upgrade_error(&mut self, protocol: Protocol, error: RPCError, substream: Option<InboundFramed<Stream, E>>) {
+        // Respond with `InvalidRequest` error.
+        if let Some(stream) = substream && let RPCError::InvalidData(err) = &error {
+            if self.inbound_substreams.len() < MAX_INBOUND_SUBSTREAMS {
+                let delay_key = self
+                    .inbound_substreams_delay
+                    .insert(self.current_inbound_substream_id, RESP_TIMEOUT);
+                let mut pending_items = VecDeque::new();
+                pending_items.push_front(RpcResponse::Error(
+                    RpcErrorResponse::InvalidRequest,
+                    ErrorType::from(err.as_str()),
+                ));
+                self.inbound_substreams.insert(
+                    self.current_inbound_substream_id,
+                    InboundInfo {
+                        state: InboundState::Idle(stream),
+                        pending_items,
+                        delay_key: Some(delay_key),
+                        protocol,
+                        request_start_time: Instant::now(),
+                        max_remaining_chunks: 1,
+                    },
+                );
+            } else {
+                debug!(
+                    %protocol,
+                    %error,
+                    max = MAX_INBOUND_SUBSTREAMS,
+                    "Dropping InvalidRequest response; inbound substream limit reached"
+                );
+            }
+        }
+
+        // Report the error to the behaviour so it can penalise the peer.
+        self.events_out.push(HandlerEvent::Err(HandlerErr::Inbound {
+            id: self.current_inbound_substream_id,
+            proto: protocol,
+            error,
+        }));
+        self.current_inbound_substream_id.0 += 1;
     }
 }
 

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -800,10 +800,14 @@ where
                     {
                         Err(e) => Err((versioned_protocol.protocol(), RPCError::from(e), None)),
                         Ok((Some(Ok(request)), stream)) => Ok((request, stream)),
-                        Ok((Some(Err(e)), stream)) => Err((versioned_protocol.protocol(), e, Some(stream))),
-                        Ok((None, _)) => {
-                            Err((versioned_protocol.protocol(), RPCError::IncompleteStream, None))
+                        Ok((Some(Err(e)), stream)) => {
+                            Err((versioned_protocol.protocol(), e, Some(stream)))
                         }
+                        Ok((None, _)) => Err((
+                            versioned_protocol.protocol(),
+                            RPCError::IncompleteStream,
+                            None,
+                        )),
                     }
                 }
             }

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -756,7 +756,7 @@ where
     E: EthSpec,
 {
     type Output = InboundOutput<TSocket, E>;
-    type Error = (Protocol, RPCError);
+    type Error = (Protocol, RPCError, Option<InboundFramed<TSocket, E>>);
     type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
 
     fn upgrade_inbound(self, socket: TSocket, protocol: ProtocolId) -> Self::Future {
@@ -798,11 +798,11 @@ where
                     )
                     .await
                     {
-                        Err(e) => Err((versioned_protocol.protocol(), RPCError::from(e))),
+                        Err(e) => Err((versioned_protocol.protocol(), RPCError::from(e), None)),
                         Ok((Some(Ok(request)), stream)) => Ok((request, stream)),
-                        Ok((Some(Err(e)), _)) => Err((versioned_protocol.protocol(), e)),
+                        Ok((Some(Err(e)), stream)) => Err((versioned_protocol.protocol(), e, Some(stream))),
                         Ok((None, _)) => {
-                            Err((versioned_protocol.protocol(), RPCError::IncompleteStream))
+                            Err((versioned_protocol.protocol(), RPCError::IncompleteStream, None))
                         }
                     }
                 }


### PR DESCRIPTION
## Issue Addressed

#9301 

## Proposed Changes

Previously, trailing bytes after an inbound RPC request payload were silently ignored and the request was processed as normal. This violates the consensus spec, which requires such input to be rejected with an `InvalidRequest` error
response.

This PR makes the inbound codec detect trailing bytes and respond to the peer with an `InvalidRequest` error instead of just closing the stream.

I've verified the fix using the reproduction script from #9301. With this PR, Lighthouse now rejects trailing bytes as expected:

```
$ go run . --config clients.yaml
[*] Trailing Bytes Spec Violation PoC
[*] Spec: phase0/p2p-interface.md
[*] "A reader MUST consider [any remaining bytes after n SSZ bytes] as invalid input"
[*] Expected: INVALID_REQUEST.
DEBUG peerInfo: ID=16Uiu2HAmAQpT8ZAoWdTN2d2Ju36x2cSuDH6zBrmmAHDGMtiVAyJW Addrs=[/ip4/127.0.0.1/tcp/60589]
  prysm        SPEC VIOLATION — accepts trailing bytes
DEBUG peerInfo: ID=16Uiu2HAmTkd6q26Et4zKD19kebN789Zh78bsa3MLzCNEq1aaRtdS Addrs=[/ip4/127.0.0.1/tcp/60591]
  lighthouse   COMPLIANT — rejects trailing bytes
```

## Additional Info

As noted in the code comment, the trailing-bytes check is best-effort: it only catches trailing bytes that arrive in the same read as the request payload. Bytes arriving in a later read go undetected, because the request stream decodes a single frame and is not polled again. 

Detecting those would require an extra read purely to probe for EOF, which adds a network round-trip for little benefit. When trailing bytes go undetected, the behavior simply falls back to the previous one (the request is processed normally), so nothing gets worse in that case.  
