### PR TITLE
Resolve PENDING head under deep non-finality (GLOAS)

### DIFF
--- a/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
@@ -1325,4 +1325,71 @@ mod tests {
         }
         .run();
     }
+
+    /// Regression test for lighthouse#9544: a PENDING head under extended non-finality.
+    ///
+    /// When the chain is in deep non-finality the head reverts to the justified checkpoint,
+    /// whose entire subtree has fallen below the viability horizon
+    /// (`voting_source.epoch + 2 < current_epoch`). The justified seed is an interior node
+    /// with no viable descendant, so it is absent from the filtered block tree. `find_head`
+    /// must still resolve the seed's payload status: `get_node_children` synthesizes a
+    /// same-root virtual EMPTY child for the PENDING seed, and that virtual child must not be
+    /// filtered against the block tree (only real block children are). Before the fix the
+    /// virtual EMPTY child, which carries the seed's own non-viable index, was filtered out,
+    /// so `find_head` returned the seed still marked `PayloadStatus::Pending`. That aborts
+    /// block production, making every scheduled proposer miss its slot. The head must instead
+    /// resolve to EMPTY (the seed's payload was never received).
+    #[test]
+    fn pending_head_resolves_when_justified_subtree_non_viable() {
+        let mut ops = vec![];
+
+        // Justified seed J at slot 32 (epoch 1): the checkpoint the head reverts to.
+        ops.push(Operation::ProcessBlock {
+            slot: Slot::new(32),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(0)),
+            execution_payload_block_hash: Some(get_hash(1)),
+        });
+
+        // Descendant C of J at slot 64 (epoch 2), whose voting source is the genesis
+        // checkpoint (epoch 0). With `current_slot` in epoch 3 below, C is below the
+        // viability horizon (0 + 2 < 3), so the whole subtree under J is non-viable and
+        // J, an interior node, is excluded from the filtered block tree.
+        ops.push(Operation::ProcessBlock {
+            slot: Slot::new(64),
+            root: get_root(2),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(1)),
+            execution_payload_block_hash: Some(get_hash(2)),
+        });
+
+        // Justified at epoch 1 (the seed J = root 1), finalized still at genesis (epoch 0),
+        // current slot in epoch 3 (deep non-finality). The head is J, and its payload status
+        // must resolve to EMPTY rather than stall at PENDING.
+        ops.push(Operation::FindHead {
+            justified_checkpoint: get_checkpoint(1),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1],
+            expected_head: get_root(1),
+            current_slot: Slot::new(96),
+            expected_payload_status: Some(PayloadStatus::Empty),
+        });
+
+        ForkChoiceTestDefinition {
+            finalized_block_slot: Slot::new(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            operations: ops,
+            // Genesis anchor is a V29 (Gloas) node, so it needs execution payload hashes.
+            execution_payload_parent_hash: Some(get_hash(42)),
+            execution_payload_block_hash: Some(get_hash(0)),
+            spec: Some(gloas_spec()),
+        }
+        .run();
+    }
 }

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -1262,11 +1262,23 @@ impl ProtoArray {
             self.should_apply_proposer_boost::<E>(proposer_boost_root, justified_balances, spec)?;
 
         loop {
-            let children: Vec<_> = self
-                .get_node_children(&head)?
-                .into_iter()
-                .filter(|(fc_node, _)| viable_nodes.contains(&fc_node.proto_node_index))
-                .collect();
+            // Spec: for a PENDING node, `get_node_children` returns the same-root
+            // EMPTY (and, iff the payload was received, FULL) virtual children
+            // unconditionally. These payload-status children are not part of the
+            // filtered block tree and must not be gated on `viable_nodes`. Only real
+            // block children are filtered. Filtering the virtual children drops them
+            // when the seed justified node is itself non-viable (deep non-finality,
+            // whole subtree below the viability horizon), which strands the head at
+            // PENDING and aborts block production, making every scheduled proposer
+            // miss its slot.
+            let children: Vec<_> = if head.payload_status == PayloadStatus::Pending {
+                self.get_node_children(&head)?
+            } else {
+                self.get_node_children(&head)?
+                    .into_iter()
+                    .filter(|(fc_node, _)| viable_nodes.contains(&fc_node.proto_node_index))
+                    .collect()
+            };
 
             if children.is_empty() {
                 return Ok(head);


### PR DESCRIPTION
## Issue Addressed

Closes #9544.

## Proposed Changes

Under extended non-finality, fork choice reverts the head to the justified
checkpoint whose entire subtree has fallen below the viability horizon
(`voting_source.epoch + 2 < current_epoch`), so the justified seed is absent
from the filtered block tree.

`find_head_walk` filtered every child returned by `get_node_children` against
`viable_nodes`, including the same-root virtual EMPTY (and, when the payload
was received, FULL) payload-status children that `get_node_children`
synthesizes for a PENDING node.  Those virtual children carry the seed's own
`proto_node_index`, which is not in `viable_nodes` in this scenario, so they
were filtered out, the child set became empty, and the walk returned the seed
still marked `PayloadStatus::Pending`.

`find_head` propagates that status verbatim into the cached head status and
block production, where `should_build_on_full` returns
`Err(InvalidPayloadStatus)` for a PENDING parent.  The HTTP block-production
handler maps that to a 400 with no EMPTY fallback and no retry, so every
proposer scheduled in that window misses its slot for as long as the condition
holds.

The fix gates the `viable_nodes` filter on the head's payload status: a
PENDING node's synthesized virtual children are kept unconditionally, and the
filter is applied only to real block children.  A PENDING head therefore always
resolves to a concrete EMPTY/FULL status.  This preserves the GLOAS `get_head`
invariant that the returned head is never PENDING, and it is a no-op in the
healthy case (the justified seed is viable there, so its virtual children were
never filtered anyway).

Note on the spec description in the issue: the consensus spec `get_node_children`
does not "consult the filtered block tree" for a PENDING node.  It synthesizes
the same-root virtual EMPTY (and, iff the payload was verified, FULL) children
unconditionally, and viability is applied once, up front, over real roots only.
 Lighthouse's `get_node_children` already matches the spec (including gating the
FULL virtual child on `payload_received`);  the divergence was solely the extra
per-child `viable_nodes` filter in `find_head_walk`, which this PR removes for
PENDING nodes.

## Additional Info

Adds a `proto_array` regression test
(`pending_head_resolves_when_justified_subtree_non_viable`) that constructs a
justified seed with a non-viable descendant subtree under deep non-finality.
 Without the fix, `find_head` returns `PayloadStatus::Pending`;  with it, the
head resolves to `EMPTY`.  The full `proto_array` suite (36 tests) passes, and
`cargo fmt` / `clippy` are clean.

Portions of this contribution were drafted with AI assistance.  I have
reviewed, understood, and tested the change.
