### PR TITLE
Remove attestation to convert work event

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -469,7 +469,6 @@ impl<E: EthSpec> fmt::Debug for Work<E> {
 #[strum(serialize_all = "snake_case")]
 pub enum WorkType {
     GossipAttestation,
-    GossipAttestationToConvert,
     UnknownBlockAttestation,
     UnknownBlockDataColumn,
     GossipAttestationBatch,
@@ -973,9 +972,6 @@ impl<E: EthSpec> BeaconProcessor<E> {
                                     None
                                 }
                             }
-                        // Convert any gossip attestations that need to be converted.
-                        } else if let Some(item) = work_queues.attestation_to_convert_queue.pop() {
-                            Some(item)
                         // Check payload attestation messages after attestations. They dont give rewards
                         // but they influence fork choice.
                         } else if let Some(item) =
@@ -1297,9 +1293,6 @@ impl<E: EthSpec> BeaconProcessor<E> {
                 if let Some(modified_queue_id) = modified_queue_id {
                     let queue_len = match modified_queue_id {
                         WorkType::GossipAttestation => work_queues.attestation_queue.len(),
-                        WorkType::GossipAttestationToConvert => {
-                            work_queues.attestation_to_convert_queue.len()
-                        }
                         WorkType::UnknownBlockAttestation => {
                             work_queues.unknown_block_attestation_queue.len()
                         }

--- a/beacon_node/beacon_processor/src/scheduler/work_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_queue.rs
@@ -244,7 +244,6 @@ pub struct WorkQueues<E: EthSpec> {
     pub aggregate_queue: LifoQueue<Work<E>>,
     pub aggregate_debounce: TimeLatch,
     pub attestation_queue: LifoQueue<Work<E>>,
-    pub attestation_to_convert_queue: LifoQueue<Work<E>>,
     pub attestation_debounce: TimeLatch,
     pub unknown_block_aggregate_queue: LifoQueue<Work<E>>,
     pub unknown_block_attestation_queue: LifoQueue<Work<E>>,
@@ -300,7 +299,6 @@ impl<E: EthSpec> WorkQueues<E> {
         let aggregate_queue = LifoQueue::new(queue_lengths.aggregate_queue);
         let aggregate_debounce = TimeLatch::default();
         let attestation_queue = LifoQueue::new(queue_lengths.attestation_queue);
-        let attestation_to_convert_queue = LifoQueue::new(queue_lengths.attestation_queue);
         let attestation_debounce = TimeLatch::default();
         let unknown_block_aggregate_queue =
             LifoQueue::new(queue_lengths.unknown_block_aggregate_queue);
@@ -385,7 +383,6 @@ impl<E: EthSpec> WorkQueues<E> {
             aggregate_queue,
             aggregate_debounce,
             attestation_queue,
-            attestation_to_convert_queue,
             attestation_debounce,
             unknown_block_aggregate_queue,
             unknown_block_attestation_queue,


### PR DESCRIPTION
Converting attestations from pre-electra to post-electra variants was removed in #7444 but I missed out on deleting the now unused work event. This PR just deletes that work event and work queue from the beacon processor
