### PR TITLE
Avoid redundant fork choice lookups in attestation verification

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -331,6 +331,7 @@ struct IndexedUnaggregatedAttestation<'a, T: BeaconChainTypes> {
     indexed_attestation: IndexedAttestation<T::EthSpec>,
     subnet_id: Option<SubnetId>,
     validator_index: u64,
+    head_block: ProtoBlock,
 }
 
 /// Wraps a `SignedAggregateAndProof` that has been fully verified for propagation on the gossip
@@ -374,6 +375,7 @@ impl<T: BeaconChainTypes> Clone for IndexedUnaggregatedAttestation<'_, T> {
             indexed_attestation: self.indexed_attestation.clone(),
             subnet_id: self.subnet_id,
             validator_index: self.validator_index,
+            head_block: self.head_block.clone(),
         }
     }
 }
@@ -881,10 +883,12 @@ impl<'a, T: BeaconChainTypes> VerifiedAggregatedAttestation<'a, T> {
 
 impl<'a, T: BeaconChainTypes> IndexedUnaggregatedAttestation<'a, T> {
     /// Run the checks that happen before an indexed attestation is constructed.
+    ///
+    /// Returns the `ProtoBlock` for the attestation's head block.
     pub fn verify_early_checks(
         attestation: &'a SingleAttestation,
         chain: &BeaconChain<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<ProtoBlock, Error> {
         let attestation_epoch = attestation.data.slot.epoch(T::EthSpec::slots_per_epoch());
 
         // Check the attestation's epoch matches its target.
@@ -956,7 +960,7 @@ impl<'a, T: BeaconChainTypes> IndexedUnaggregatedAttestation<'a, T> {
         // Check the attestation target root is consistent with the head root.
         verify_attestation_target_root::<T::EthSpec>(&head_block, &attestation.data)?;
 
-        Ok(())
+        Ok(head_block)
     }
 
     /// Run the checks that apply to the indexed attestation before the signature is checked.
@@ -1007,9 +1011,10 @@ impl<'a, T: BeaconChainTypes> IndexedUnaggregatedAttestation<'a, T> {
     ) -> Result<Self, AttestationSlashInfo<'a, T, Error>> {
         use AttestationSlashInfo::*;
 
-        if let Err(e) = Self::verify_early_checks(attestation, chain) {
-            return Err(SignatureNotCheckedSingle(attestation, e));
-        }
+        let head_block = match Self::verify_early_checks(attestation, chain) {
+            Ok(head_block) => head_block,
+            Err(e) => return Err(SignatureNotCheckedSingle(attestation, e)),
+        };
 
         let fork_name = chain
             .spec
@@ -1029,6 +1034,7 @@ impl<'a, T: BeaconChainTypes> IndexedUnaggregatedAttestation<'a, T> {
             indexed_attestation,
             subnet_id,
             validator_index,
+            head_block,
         })
     }
 
@@ -1045,13 +1051,19 @@ impl<'a, T: BeaconChainTypes> VerifiedUnaggregatedAttestation<'a, T> {
     /// Run the checks that apply after the signature has been checked.
     fn verify_late_checks(
         attestation: &'a SingleAttestation,
+        head_block: ProtoBlock,
         validator_index: u64,
         subnet_id: Option<SubnetId>,
         chain: &BeaconChain<T>,
     ) -> Result<(Attestation<T::EthSpec>, SubnetId), Error> {
-        // Check that the attester is a member of the committee
-        let (committee_opt, committees_per_slot) = chain.with_committee_cache(
-            attestation.data.target.root,
+        // Check that the attester is a member of the committee.
+        //
+        // The head block resolves to the same shuffling for the attestation's epoch as the
+        // target block would: `verify_early_checks` has confirmed that `target.root` is the
+        // head block's target checkpoint, so both are on the same chain and share the same
+        // shuffling decision root. Using the head block avoids another fork choice lookup.
+        let (committee_opt, committees_per_slot) = chain.with_committee_cache_for_block(
+            head_block,
             attestation.data.slot.epoch(T::EthSpec::slots_per_epoch()),
             |cached_shuffling, _| {
                 let committee_cache = cached_shuffling.committee_cache.as_ref();
@@ -1164,6 +1176,7 @@ impl<'a, T: BeaconChainTypes> VerifiedUnaggregatedAttestation<'a, T> {
             indexed_attestation,
             subnet_id,
             validator_index,
+            head_block,
         } = attestation;
 
         match check_signature {
@@ -1175,11 +1188,16 @@ impl<'a, T: BeaconChainTypes> VerifiedUnaggregatedAttestation<'a, T> {
             CheckAttestationSignature::No => (),
         };
 
-        let (unaggregated_attestation, subnet_id) =
-            match Self::verify_late_checks(attestation, validator_index, subnet_id, chain) {
-                Ok(a) => a,
-                Err(e) => return Err(SignatureValid(indexed_attestation, e)),
-            };
+        let (unaggregated_attestation, subnet_id) = match Self::verify_late_checks(
+            attestation,
+            head_block,
+            validator_index,
+            subnet_id,
+            chain,
+        ) {
+            Ok(a) => a,
+            Err(e) => return Err(SignatureValid(indexed_attestation, e)),
+        };
 
         Ok(Self {
             single_attestation: attestation,
@@ -1589,34 +1607,42 @@ where
     let attestation_epoch = attestation.data().slot.epoch(T::EthSpec::slots_per_epoch());
     let target = &attestation.data().target;
 
-    // Attestation target must be for a known block.
+    // Attestation target must be for a known block. We look the block up once here and reuse it
+    // for the committee cache below, rather than reading fork choice a second time.
     //
     // We use fork choice to find the target root, which means that we reject any attestation
     // that has a `target.root` earlier than our latest finalized root. There's no point in
     // processing an attestation that does not include our latest finalized block in its chain.
     //
     // We do not delay consideration for later, we simply drop the attestation.
-    if !chain
+    //
+    // Blocks that are still being imported are not yet in fork choice, but their `ProtoBlock`
+    // (captured from fork choice during import) is available from the early attester cache.
+    let Some(target_block) = chain
         .canonical_head
         .fork_choice_read_lock()
-        .contains_block(&target.root)
-        && !chain.early_attester_cache.contains_block(target.root)
-    {
+        .get_block(&target.root)
+        .or_else(|| chain.early_attester_cache.get_proto_block(target.root))
+    else {
         return Err(Error::UnknownTargetRoot(target.root));
-    }
+    };
 
-    chain.with_committee_cache(target.root, attestation_epoch, |cached_shuffling, _| {
-        let committee_cache = cached_shuffling.committee_cache.as_ref();
-        let committees_per_slot = committee_cache.committees_per_slot();
+    chain.with_committee_cache_for_block(
+        target_block,
+        attestation_epoch,
+        |cached_shuffling, _| {
+            let committee_cache = cached_shuffling.committee_cache.as_ref();
+            let committees_per_slot = committee_cache.committees_per_slot();
 
-        Ok(committee_cache
-            .get_beacon_committees_at_slot(attestation.data().slot)
-            .map(|committees| map_fn((committees, committees_per_slot)))
-            .unwrap_or_else(|_| {
-                Err(Error::NoCommitteeForSlotAndIndex {
-                    slot: attestation.data().slot,
-                    index: attestation.committee_index().unwrap_or(0),
-                })
-            }))
-    })?
+            Ok(committee_cache
+                .get_beacon_committees_at_slot(attestation.data().slot)
+                .map(|committees| map_fn((committees, committees_per_slot)))
+                .unwrap_or_else(|_| {
+                    Err(Error::NoCommitteeForSlotAndIndex {
+                        slot: attestation.data().slot,
+                        index: attestation.committee_index().unwrap_or(0),
+                    })
+                }))
+        },
+    )?
 }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -76,7 +76,10 @@ use crate::persisted_custody::persist_custody_context;
 use crate::persisted_fork_choice::PersistedForkChoice;
 use crate::pre_finalization_cache::PreFinalizationBlockCache;
 use crate::proposer_preferences_verification::proposer_preference_cache::GossipVerifiedProposerPreferenceCache;
-use crate::shuffling_cache::{CachedPTCs, CachedShuffling, ShufflingCache, with_cached_shuffling};
+use crate::shuffling_cache::{
+    BlockShufflingIds, CachedPTCs, CachedShuffling, ShufflingCache, with_cached_shuffling,
+    with_cached_shuffling_for_block,
+};
 use crate::sync_committee_verification::{
     Error as SyncCommitteeError, VerifiedSyncCommitteeMessage, VerifiedSyncContribution,
 };
@@ -101,7 +104,7 @@ use execution_layer::{
 use fixed_bytes::FixedBytesExtended;
 use fork_choice::{
     AttestationFromBlock, ExecutionStatus, ForkChoice, ForkchoiceUpdateParameters,
-    InvalidationOperation, PayloadVerificationStatus, ResetPayloadStatuses,
+    InvalidationOperation, PayloadVerificationStatus, ProtoBlock, ResetPayloadStatuses,
 };
 use futures::channel::mpsc::Sender;
 use itertools::Itertools;
@@ -1679,14 +1682,15 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         epoch: Epoch,
         head_block_root: Hash256,
     ) -> Result<(Vec<Option<AttestationDuty>>, Hash256, ExecutionStatus), Error> {
-        let execution_status = self
+        let head_block = self
             .canonical_head
             .fork_choice_read_lock()
-            .get_block_execution_status(&head_block_root)
+            .get_block(&head_block_root)
             .ok_or(Error::AttestationHeadNotInForkChoice(head_block_root))?;
+        let execution_status = head_block.execution_status;
 
-        let (duties, dependent_root) = self.with_committee_cache(
-            head_block_root,
+        let (duties, dependent_root) = self.with_committee_cache_for_block(
+            head_block,
             epoch,
             |cached_shuffling, dependent_root| {
                 let committee_cache = cached_shuffling.committee_cache.as_ref();
@@ -2704,17 +2708,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .ok_or(Error::AttestationHeadNotInForkChoice(*block_root))?;
         drop(fork_choice_lock);
 
-        let block_shuffling_id = if target_epoch == block.current_epoch_shuffling_id.shuffling_epoch
-        {
-            block.current_epoch_shuffling_id
-        } else if target_epoch == block.next_epoch_shuffling_id.shuffling_epoch {
-            block.next_epoch_shuffling_id
-        } else if target_epoch > block.next_epoch_shuffling_id.shuffling_epoch {
-            AttestationShufflingId {
-                shuffling_epoch: target_epoch,
-                shuffling_decision_block: *block_root,
-            }
-        } else {
+        let Some(block_shuffling_id) =
+            BlockShufflingIds::from_proto_block(&block).id_for_epoch(target_epoch)
+        else {
             debug!(
                 ?block_root,
                 %target_epoch,
@@ -7065,6 +7061,28 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             &self.store,
             &self.spec,
             head_block_root,
+            shuffling_epoch,
+            map_fn,
+        )
+    }
+
+    /// Like `with_committee_cache` but takes a `head_block` already resolved from fork
+    /// choice, allowing callers that already have the block to avoid a redundant lookup.
+    pub fn with_committee_cache_for_block<F, R>(
+        &self,
+        head_block: ProtoBlock,
+        shuffling_epoch: Epoch,
+        map_fn: F,
+    ) -> Result<R, Error>
+    where
+        F: Fn(&CachedShuffling<T::EthSpec>, Hash256) -> Result<R, Error>,
+    {
+        with_cached_shuffling_for_block(
+            &self.canonical_head,
+            &self.shuffling_cache,
+            &self.store,
+            &self.spec,
+            head_block,
             shuffling_epoch,
             map_fn,
         )

--- a/beacon_node/beacon_chain/src/payload_attestation_verification/gossip_verified_payload_attestation.rs
+++ b/beacon_node/beacon_chain/src/payload_attestation_verification/gossip_verified_payload_attestation.rs
@@ -2,7 +2,7 @@ use super::Error;
 use crate::beacon_chain::BeaconStore;
 use crate::canonical_head::CanonicalHead;
 use crate::observed_attesters::ObservedPayloadAttesters;
-use crate::shuffling_cache::{ShufflingCache, with_cached_shuffling};
+use crate::shuffling_cache::{ShufflingCache, with_cached_shuffling_for_block};
 use crate::validator_pubkey_cache::ValidatorPubkeyCache;
 use crate::{BeaconChain, BeaconChainError, BeaconChainTypes, metrics};
 use bls::AggregateSignature;
@@ -88,12 +88,12 @@ impl<T: BeaconChainTypes> VerifiedPayloadAttestationMessage<T> {
         }
 
         let message_epoch = slot.epoch(T::EthSpec::slots_per_epoch());
-        let ptc = with_cached_shuffling(
+        let ptc = with_cached_shuffling_for_block(
             ctx.canonical_head,
             ctx.shuffling_cache,
             ctx.store,
             ctx.spec,
-            beacon_block_root,
+            block,
             message_epoch,
             |cached_shuffling, _| cached_shuffling.ptc_for_slot(slot),
         )?;

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use fork_choice::ProtoBlock;
 use itertools::Itertools;
 use oneshot_broadcast::{Receiver, Sender, oneshot};
 use parking_lot::RwLock;
@@ -312,18 +313,39 @@ where
         .fork_choice_read_lock()
         .get_block(&head_block_root)
         .ok_or(BeaconChainError::MissingBeaconBlock(head_block_root))?;
-
-    let shuffling_id = BlockShufflingIds {
-        current: head_block.current_epoch_shuffling_id.clone(),
-        next: head_block.next_epoch_shuffling_id.clone(),
-        previous: None,
-        block_root: head_block.root,
-    }
-    .id_for_epoch(shuffling_epoch)
-    .ok_or_else(|| BeaconChainError::InvalidShufflingId {
+    with_cached_shuffling_for_block(
+        canonical_head,
+        shuffling_cache_lock,
+        store,
+        spec,
+        head_block,
         shuffling_epoch,
-        head_block_epoch: head_block.slot.epoch(T::EthSpec::slots_per_epoch()),
-    })?;
+        map_fn,
+    )
+}
+
+/// Like `with_cached_shuffling`, but takes a `head_block` already resolved from fork choice, so
+/// callers that have looked it up don't pay for a second fork choice read.
+pub fn with_cached_shuffling_for_block<T, F, R, Error>(
+    canonical_head: &CanonicalHead<T>,
+    shuffling_cache_lock: &RwLock<ShufflingCache<T::EthSpec>>,
+    store: &BeaconStore<T>,
+    spec: &ChainSpec,
+    head_block: ProtoBlock,
+    shuffling_epoch: Epoch,
+    map_fn: F,
+) -> Result<R, Error>
+where
+    T: BeaconChainTypes,
+    F: Fn(&CachedShuffling<T::EthSpec>, Hash256) -> Result<R, Error>,
+    Error: From<BeaconChainError>,
+{
+    let shuffling_id = BlockShufflingIds::from_proto_block(&head_block)
+        .id_for_epoch(shuffling_epoch)
+        .ok_or_else(|| BeaconChainError::InvalidShufflingId {
+            shuffling_epoch,
+            head_block_epoch: head_block.slot.epoch(T::EthSpec::slots_per_epoch()),
+        })?;
 
     let mut shuffling_cache = {
         let _ = metrics::start_timer(&metrics::ATTESTATION_PROCESSING_SHUFFLING_CACHE_WAIT_TIMES);
@@ -349,7 +371,7 @@ where
 
         debug!(
             shuffling_id = ?shuffling_epoch,
-            head_block_root = head_block_root.to_string(),
+            head_block_root = head_block.root.to_string(),
             "Committee cache miss"
         );
 
@@ -369,7 +391,7 @@ where
             metrics::start_timer(&metrics::ATTESTATION_PROCESSING_STATE_READ_TIMES);
 
         let cached_head = canonical_head.cached_head();
-        let head_state_opt = if cached_head.head_block_root() == head_block_root {
+        let head_state_opt = if cached_head.head_block_root() == head_block.root {
             Some((
                 cached_head.snapshot.beacon_state.clone(),
                 cached_head.head_state_root(),
@@ -405,7 +427,7 @@ where
             (state, state_root)
         } else {
             let (state_root, state) = store
-                .get_advanced_hot_state(head_block_root, target_slot, head_block.state_root)
+                .get_advanced_hot_state(head_block.root, target_slot, head_block.state_root)
                 .map_err(BeaconChainError::DBError)?
                 .ok_or(BeaconChainError::MissingBeaconState(head_block.state_root))?;
             (state, state_root)
@@ -471,6 +493,19 @@ pub struct BlockShufflingIds {
 }
 
 impl BlockShufflingIds {
+    /// Returns the shuffling IDs tracked by a `ProtoBlock`.
+    ///
+    /// Fork choice only tracks the current and next-epoch shufflings for each block, so
+    /// `previous` is always `None`.
+    pub fn from_proto_block(block: &ProtoBlock) -> Self {
+        Self {
+            current: block.current_epoch_shuffling_id.clone(),
+            next: block.next_epoch_shuffling_id.clone(),
+            previous: None,
+            block_root: block.root,
+        }
+    }
+
     /// Returns the shuffling ID for the given epoch.
     ///
     /// Returns `None` if `epoch` is prior to `self.previous?.shuffling_epoch` or


### PR DESCRIPTION
## Issue Addressed

`with_committee_cache` / `with_cached_shuffling` already perform a fork choice
lookup internally to resolve the shuffling ID from the head block.

There are certain callers who take the fork choice read lock and look up the *same* block
immediately before calling it, which performs the lookup again.

## Proposed Changes

Thread the pre-fetched block into the shuffling cache via new
`with_committee_cache_for_block`/`with_cached_shuffling_for_block` methods that takes the block instead of the
root, so we avoid the redundant lookup.