### PR TITLE
🤖 CI: pin geth to `master-e5c5e18` in genesis-sync tests

### DIFF
--- a/scripts/tests/genesis-sync-config-fulu.yaml
+++ b/scripts/tests/genesis-sync-config-fulu.yaml
@@ -3,20 +3,20 @@ participants:
   - cl_type: lighthouse
     cl_image: lighthouse:local
     el_type: geth
-    el_image: ethpandaops/geth:master
+    el_image: ethpandaops/geth:master-e5c5e18
     supernode: true
     count: 2
   # nodes without validators, used for testing sync.
   - cl_type: lighthouse
     cl_image: lighthouse:local
     el_type: geth
-    el_image: ethpandaops/geth:master
+    el_image: ethpandaops/geth:master-e5c5e18
     supernode: true
     validator_count: 0
   - cl_type: lighthouse
     cl_image: lighthouse:local
     el_type: geth
-    el_image: ethpandaops/geth:master
+    el_image: ethpandaops/geth:master-e5c5e18
     supernode: false
     validator_count: 0
 network_params:

--- a/scripts/tests/genesis-sync-config-gloas.yaml
+++ b/scripts/tests/genesis-sync-config-gloas.yaml
@@ -2,13 +2,19 @@
 participants:
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    el_type: geth
+    el_image: ethpandaops/geth:master-e5c5e18
     count: 2
   # nodes without validators, used for testing sync.
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    el_type: geth
+    el_image: ethpandaops/geth:master-e5c5e18
     validator_count: 0
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    el_type: geth
+    el_image: ethpandaops/geth:master-e5c5e18
     validator_count: 0
 network_params:
   gloas_fork_epoch: 0


### PR DESCRIPTION
## Issue Addressed

The `genesis-sync-test-gloas-*` jobs on the `local testnet` workflow are failing on `unstable` without any related code change (e.g. seen on #9597). The `genesis-sync-test-fulu-*` jobs then get cancelled by fail-fast, so all four genesis-sync jobs show red.

## Root cause

The genesis-sync kurtosis configs use the floating `ethpandaops/geth:master` nightly tag. That tag advanced from the `2026-07-06` build (`e5c5e18`) to the `2026-07-09` build (`896a4ab`), and the newer geth build makes the Lighthouse beacon node fail at startup on a **gloas** genesis:

```
CRIT Failed to start beacon node
     reason: "Failed to build beacon chain: Head block not found in store"
```

Kurtosis then can't bring up `cl-1-lighthouse-geth` (ports never open) and the test exits 1. Fulu genesis is unaffected.

Evidence it's the geth bump and not a Lighthouse change:

| Run | Date | gloas genesis-sync | geth |
|-----|------|--------------------|------|
| last green | 07-07 | ✅ pass | `v1.17.5-unstable-e5c5e18-20260706` |
| first red  | 07-09 | ❌ fail | `v1.17.5-unstable-896a4ab-20260709` |

## Proposed Changes

Pin both genesis-sync configs (`fulu` and `gloas`) to the last known-good geth build `ethpandaops/geth:master-e5c5e18` to stabilise CI. The `gloas` config previously specified no EL image and inherited the floating default; it now pins geth explicitly like the `fulu` config.

This is a CI-stabilisation pin only. Whether the newer geth build is itself buggy or exposes a latent gloas-genesis fragility in Lighthouse is a separate investigation; this unblocks the merge queue in the meantime.