### PR TITLE
Pin genesis generator to devnet-6

### DIFF
--- a/scripts/tests/genesis-sync-config-gloas.yaml
+++ b/scripts/tests/genesis-sync-config-gloas.yaml
@@ -14,6 +14,7 @@ network_params:
   gloas_fork_epoch: 0
   slot_duration_ms: 6000
   preset: "minimal"
+# TODO: Update this once devnet-7 changes are merged.
 ethereum_genesis_generator_params:
     image: ethpandaops/ethereum-genesis-generator:6.1.2
 additional_services:

--- a/scripts/tests/genesis-sync-config-gloas.yaml
+++ b/scripts/tests/genesis-sync-config-gloas.yaml
@@ -14,6 +14,8 @@ network_params:
   gloas_fork_epoch: 0
   slot_duration_ms: 6000
   preset: "minimal"
+ethereum_genesis_generator_params:
+    image: ethpandaops/ethereum-genesis-generator:6.1.2
 additional_services:
   - tx_fuzz
   - spamoor


### PR DESCRIPTION
Pinning the genesis generator to devnet 6. Need to update this once the devnet-7 changes are merged. 