### PR TITLE
Dump local testnet logs after startup failure

### DIFF
--- a/scripts/local_testnet/stop_local_testnet.sh
+++ b/scripts/local_testnet/stop_local_testnet.sh
@@ -9,7 +9,7 @@ LOGS_SUBDIR=$LOGS_PATH/$ENCLAVE_NAME
 # Extract the service names of Lighthouse beacon nodes that start with "cl-".
 services=$(kurtosis enclave inspect "$ENCLAVE_NAME" | awk '/^=+ User Services =+$/ { in_section=1; next }
                                               /^=+/ { in_section=0 }
-                                              in_section && /^[0-9a-f]{12}/ { print $2 }' | grep '^cl-')
+                                              in_section && /^[0-9a-f]{12}/ && $2 ~ /^cl-/ { print $2 }')
 
 # Store logs (including dependency logs) to Kurtosis Files Artifacts. These are downloaded locally by `kurtosis enclave dump`.
 for service in $services; do


### PR DESCRIPTION
## Issue Addressed

This kurtosis test failed, and it didn't dump any logs - which would've helped understanding service startup failures: 
https://github.com/sigp/lighthouse/actions/runs/28983602711/job/86008500565

## Proposed Changes

Ensure genesis-sync cleanup still dumps the Kurtosis enclave when Lighthouse fails before any `cl-*` services appear. The test exit status remains unchanged.

## Additional Info

Reproduced with an invalid Lighthouse flag. The genesis-sync script exited 1 and produced a non-empty logs dump.