### PR TITLE
Add metrics for fork choice lock hold times

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -15,6 +15,7 @@ use crate::block_verification_types::{
     AsBlock, AvailableExecutedBlock, BlockImportData, ExecutedBlock, RangeSyncBlock,
 };
 pub use crate::canonical_head::CanonicalHead;
+use crate::canonical_head::ForkChoiceWriteGuard;
 use crate::chain_config::ChainConfig;
 use crate::custody_context::{CustodyContext, CustodyContextSsz};
 use crate::data_availability_checker::{
@@ -111,7 +112,7 @@ use logging::crit;
 use operation_pool::{
     CompactAttestationRef, OperationPool, PersistedOperationPool, ReceivedPreCapella,
 };
-use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
+use parking_lot::{Mutex, RwLock};
 use proto_array::{DoNotReOrg, ProposerHeadError, ReOrgThreshold};
 use rand::RngCore;
 use safe_arith::SafeArith;
@@ -4318,7 +4319,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Take an exclusive write-lock on fork choice. It's very important to prevent deadlocks by
         // avoiding taking other locks whilst holding this lock.
-        let mut fork_choice = parking_lot::RwLockUpgradableReadGuard::upgrade(fork_choice_reader);
+        let mut fork_choice = fork_choice_reader.upgrade();
 
         // Do not import a block that doesn't descend from the finalized root.
         let signed_block =
@@ -4550,7 +4551,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // We don't actually need this value, however it's always present when we call this function
         // and it needs to be dropped to prevent a dead-lock. Requiring it to be passed here is
         // defensive programming.
-        fork_choice_write_lock: RwLockWriteGuard<BeaconForkChoice<T>>,
+        fork_choice_write_lock: ForkChoiceWriteGuard<T>,
     ) -> Result<(), BlockError> {
         // Clear the early attester cache to prevent attestations which we would later be unable
         // to verify due to the failure.

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1911,7 +1911,7 @@ pub fn get_block_header_root(block_header: &SignedBeaconBlockHeader) -> Hash256 
 /// fork choice; both missing cases return `ParentUnknown`.
 #[allow(clippy::type_complexity)]
 fn verify_parent_block_and_envelope_are_known<T: BeaconChainTypes>(
-    fork_choice_read_lock: &RwLockReadGuard<BeaconForkChoice<T>>,
+    fork_choice_read_lock: &BeaconForkChoice<T>,
     block: Arc<SignedBeaconBlock<T::EthSpec>>,
 ) -> Result<(ProtoBlock, Arc<SignedBeaconBlock<T::EthSpec>>), BlockError> {
     match fork_choice_read_lock.get_parent_import_status(&block) {

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -52,8 +52,10 @@ use logging::crit;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use slot_clock::SlotClock;
 use state_processing::AllCaches;
-use std::sync::Arc;
-use std::time::Duration;
+use std::ops::{Deref, DerefMut};
+use std::panic::Location;
+use std::sync::{Arc, LazyLock};
+use std::time::{Duration, Instant};
 use store::{
     Error as StoreError, KeyValueStore, KeyValueStoreOp, StoreConfig, iter::StateRootsIterator,
 };
@@ -86,6 +88,165 @@ impl<T> CanonicalHeadRwLock<T> {
 
     fn write(&self) -> RwLockWriteGuard<'_, T> {
         self.0.write()
+    }
+}
+
+/// Log when a fork choice lock is held longer than this.
+/// One long write hold can stall every other fork choice caller, which can freeze attestation
+/// verification for the duration.
+const FORK_CHOICE_LOCK_HOLD_LOG_THRESHOLD: Duration = Duration::from_secs(1);
+
+/// Records a fork choice lock hold duration into `metric` when dropped.
+struct ForkChoiceHoldTimer {
+    acquired_at: Instant,
+    acquired_from: &'static Location<'static>,
+    metric: &'static LazyLock<metrics::Result<metrics::Histogram>>,
+    lock_kind: &'static str,
+}
+
+impl ForkChoiceHoldTimer {
+    #[track_caller]
+    fn read() -> Self {
+        Self::new(&metrics::FORK_CHOICE_READ_LOCK_HOLD_TIMES, "read")
+    }
+
+    #[track_caller]
+    fn downgraded_read() -> Self {
+        Self::new(
+            &metrics::FORK_CHOICE_READ_LOCK_HOLD_TIMES,
+            "downgraded_read",
+        )
+    }
+
+    #[track_caller]
+    fn write() -> Self {
+        Self::new(&metrics::FORK_CHOICE_WRITE_LOCK_HOLD_TIMES, "write")
+    }
+
+    #[track_caller]
+    fn upgradable_read() -> Self {
+        Self::new(
+            &metrics::FORK_CHOICE_UPGRADABLE_READ_LOCK_HOLD_TIMES,
+            "upgradable_read",
+        )
+    }
+
+    #[track_caller]
+    fn new(
+        metric: &'static LazyLock<metrics::Result<metrics::Histogram>>,
+        lock_kind: &'static str,
+    ) -> Self {
+        Self {
+            acquired_at: Instant::now(),
+            acquired_from: Location::caller(),
+            metric,
+            lock_kind,
+        }
+    }
+}
+
+impl Drop for ForkChoiceHoldTimer {
+    fn drop(&mut self) {
+        let held = self.acquired_at.elapsed();
+        metrics::observe_duration(self.metric, held);
+        if held > FORK_CHOICE_LOCK_HOLD_LOG_THRESHOLD {
+            debug!(
+                held = ?held,
+                lock = self.lock_kind,
+                acquired_from = %self.acquired_from,
+                "Fork choice lock held for a long time"
+            );
+        }
+    }
+}
+
+/// A fork choice read guard that records how long the lock was held when it is dropped.
+pub struct ForkChoiceReadGuard<'a, T: BeaconChainTypes> {
+    guard: RwLockReadGuard<'a, BeaconForkChoice<T>>,
+    _hold_timer: ForkChoiceHoldTimer,
+}
+
+impl<T: BeaconChainTypes> Deref for ForkChoiceReadGuard<'_, T> {
+    type Target = BeaconForkChoice<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+/// A fork choice write guard that records how long the lock was held when it is dropped.
+pub struct ForkChoiceWriteGuard<'a, T: BeaconChainTypes> {
+    guard: RwLockWriteGuard<'a, BeaconForkChoice<T>>,
+    _hold_timer: ForkChoiceHoldTimer,
+}
+
+impl<'a, T: BeaconChainTypes> ForkChoiceWriteGuard<'a, T> {
+    /// Downgrade to a read lock, without allowing access to any other writers. The write hold
+    /// ends when the downgrade completes and the read hold begins.
+    #[track_caller]
+    pub fn downgrade(self) -> ForkChoiceReadGuard<'a, T> {
+        let Self {
+            guard,
+            _hold_timer: write_hold_timer,
+        } = self;
+        let read_guard = RwLockWriteGuard::downgrade(guard);
+        let hold_timer = ForkChoiceHoldTimer::downgraded_read();
+        drop(write_hold_timer);
+        ForkChoiceReadGuard {
+            guard: read_guard,
+            _hold_timer: hold_timer,
+        }
+    }
+}
+
+impl<T: BeaconChainTypes> Deref for ForkChoiceWriteGuard<'_, T> {
+    type Target = BeaconForkChoice<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<T: BeaconChainTypes> DerefMut for ForkChoiceWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
+    }
+}
+
+/// A fork choice upgradable read guard that records how long the lock was held when it is
+/// dropped or upgraded.
+pub struct ForkChoiceUpgradableReadGuard<'a, T: BeaconChainTypes> {
+    // Declared before `_hold_timer` so the lock is released before the hold is observed.
+    guard: RwLockUpgradableReadGuard<'a, BeaconForkChoice<T>>,
+    _hold_timer: ForkChoiceHoldTimer,
+}
+
+impl<'a, T: BeaconChainTypes> ForkChoiceUpgradableReadGuard<'a, T> {
+    /// Upgrade to an exclusive write lock. The upgradable hold ends when the upgrade begins:
+    /// the wait for readers to finish is recorded separately (`FORK_CHOICE_UPGRADE_TIMES`) and
+    /// the write hold starts when the upgrade completes.
+    #[track_caller]
+    pub fn upgrade(self) -> ForkChoiceWriteGuard<'a, T> {
+        let Self {
+            guard,
+            _hold_timer: upgradable_hold_timer,
+        } = self;
+        drop(upgradable_hold_timer);
+        let upgrade_timer = metrics::start_timer(&metrics::FORK_CHOICE_UPGRADE_TIMES);
+        let write_guard = RwLockUpgradableReadGuard::upgrade(guard);
+        metrics::stop_timer(upgrade_timer);
+        ForkChoiceWriteGuard {
+            guard: write_guard,
+            _hold_timer: ForkChoiceHoldTimer::write(),
+        }
+    }
+}
+
+impl<T: BeaconChainTypes> Deref for ForkChoiceUpgradableReadGuard<'_, T> {
+    type Target = BeaconForkChoice<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
     }
 }
 
@@ -305,7 +466,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         // We don't actually need this value, however it's always present when we call this function
         // and it needs to be dropped to prevent a dead-lock. Requiring it to be passed here is
         // defensive programming.
-        mut fork_choice_write_lock: RwLockWriteGuard<BeaconForkChoice<T>>,
+        mut fork_choice_write_lock: ForkChoiceWriteGuard<T>,
         reset_payload_statuses: ResetPayloadStatuses,
         store: &BeaconStore<T>,
         spec: &ChainSpec,
@@ -439,24 +600,34 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
     }
 
     /// Access a read-lock for fork choice.
-    pub fn fork_choice_read_lock(&self) -> RwLockReadGuard<'_, BeaconForkChoice<T>> {
+    #[track_caller]
+    pub fn fork_choice_read_lock(&self) -> ForkChoiceReadGuard<'_, T> {
         let _timer = metrics::start_timer(&metrics::FORK_CHOICE_READ_LOCK_AQUIRE_TIMES);
-        self.fork_choice.read()
+        ForkChoiceReadGuard {
+            guard: self.fork_choice.read(),
+            _hold_timer: ForkChoiceHoldTimer::read(),
+        }
     }
 
     /// Access an upgradable read-lock for fork choice.
-    pub fn fork_choice_upgradable_read_lock(
-        &self,
-    ) -> RwLockUpgradableReadGuard<'_, BeaconForkChoice<T>> {
+    #[track_caller]
+    pub fn fork_choice_upgradable_read_lock(&self) -> ForkChoiceUpgradableReadGuard<'_, T> {
         let _timer = metrics::start_timer(&metrics::FORK_CHOICE_UPGRADABLE_READ_LOCK_AQUIRE_TIMES);
-        self.fork_choice.upgradable_read()
+        ForkChoiceUpgradableReadGuard {
+            guard: self.fork_choice.upgradable_read(),
+            _hold_timer: ForkChoiceHoldTimer::upgradable_read(),
+        }
     }
 
     /// Access a write-lock for fork choice.
     #[instrument(skip_all)]
-    pub fn fork_choice_write_lock(&self) -> RwLockWriteGuard<'_, BeaconForkChoice<T>> {
+    #[track_caller]
+    pub fn fork_choice_write_lock(&self) -> ForkChoiceWriteGuard<'_, T> {
         let _timer = metrics::start_timer(&metrics::FORK_CHOICE_WRITE_LOCK_AQUIRE_TIMES);
-        self.fork_choice.write()
+        ForkChoiceWriteGuard {
+            guard: self.fork_choice.write(),
+            _hold_timer: ForkChoiceHoldTimer::write(),
+        }
     }
 }
 
@@ -643,7 +814,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Downgrade the fork choice write-lock to a read lock, without allowing access to any
         // other writers.
-        let fork_choice_read_lock = RwLockWriteGuard::downgrade(fork_choice_write_lock);
+        let fork_choice_read_lock = fork_choice_write_lock.downgrade();
 
         // Read the current head value from the fork choice algorithm.
         let new_view = fork_choice_read_lock.cached_fork_choice_view();

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -612,6 +612,35 @@ pub static FORK_CHOICE_WRITE_LOCK_AQUIRE_TIMES: LazyLock<Result<Histogram>> = La
         exponential_buckets(1e-3, 4.0, 7),
     )
 });
+pub static FORK_CHOICE_READ_LOCK_HOLD_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram_with_buckets(
+        "beacon_fork_choice_read_lock_hold_seconds",
+        "Time the fork-choice read lock was held before being released.",
+        decimal_buckets(-4, 1),
+    )
+});
+pub static FORK_CHOICE_WRITE_LOCK_HOLD_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram_with_buckets(
+        "beacon_fork_choice_write_lock_hold_seconds",
+        "Time the fork-choice write lock was held before being released.",
+        decimal_buckets(-4, 1),
+    )
+});
+pub static FORK_CHOICE_UPGRADABLE_READ_LOCK_HOLD_TIMES: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram_with_buckets(
+            "beacon_fork_choice_upgradable_read_lock_hold_seconds",
+            "Time the fork-choice upgradable read lock was held before being released or upgraded.",
+            decimal_buckets(-4, 1),
+        )
+    });
+pub static FORK_CHOICE_UPGRADE_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram_with_buckets(
+        "beacon_fork_choice_upgrade_seconds",
+        "Time taken to upgrade the fork-choice upgradable read lock to a write lock.",
+        exponential_buckets(1e-3, 4.0, 7),
+    )
+});
 pub static FORK_CHOICE_ENCODE_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
     try_create_histogram(
         "beacon_fork_choice_encode_seconds",

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -242,7 +242,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Take an exclusive write-lock on fork choice. It's very important to prevent deadlocks by
         // avoiding taking other locks whilst holding this lock.
-        let mut fork_choice = parking_lot::RwLockUpgradableReadGuard::upgrade(fork_choice_reader);
+        let mut fork_choice = fork_choice_reader.upgrade();
 
         // Update the block's payload to received in fork choice, which creates the `Full` virtual
         // node which can be eligible for head.


### PR DESCRIPTION
## Issue Addressed

In many places we currently measure how long callers have to *wait* to acquire a fork choice lock, but we do not have any visibility into how long specific callers actually *hold* the lock for.

## Proposed Changes

- Adds a wrapper around the fork choice lock with built in timing instrumentation.
- Adds histograms for read/write lock hold times (including upgradeable).
- Also adds a log indicating when and where a long-lasting lock was held, e.g.

```
DEBUG Fork choice lock held for a long time  held=2.4s lock="write" acquired_from="beacon_node/beacon_chain/src/beacon_chain.rs:4322:47"
```

## Additional Info

There's a very small performance penalty for the lock, in the 100ns range which I believe is acceptable.
