### PR TITLE
Align gloas proposer reorg weight logic w/ spec

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5282,8 +5282,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Err(Box::new(DoNotReOrg::HeadDistance.into()));
         }
 
-        // TODO(gloas): reorg weight logic needs updating for Gloas. For now use
-        // total weight which is correct for pre-Gloas and conservative for post-Gloas.
         let head_weight = info.head_node.weight();
         let parent_weight = info.parent_node.weight();
 

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -11,7 +11,7 @@ use fork_choice::ForkChoiceStore;
 use proto_array::JustifiedBalances;
 use safe_arith::ArithError;
 use ssz_derive::{Decode, Encode};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use store::{Error as StoreError, HotColdDB, ItemStore};
@@ -132,6 +132,7 @@ pub struct BeaconForkChoiceStore<E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     unrealized_finalized_checkpoint: Checkpoint,
     proposer_boost_root: Hash256,
     equivocating_indices: BTreeSet<u64>,
+    equivocating_committee_weights: BTreeMap<Slot, u64>,
     _phantom: PhantomData<E>,
 }
 
@@ -199,8 +200,14 @@ where
             unrealized_finalized_checkpoint: finalized_checkpoint,
             proposer_boost_root: Hash256::zero(),
             equivocating_indices: BTreeSet::new(),
+            equivocating_committee_weights: BTreeMap::new(),
             _phantom: PhantomData,
         })
+    }
+
+    /// Returns the state root of the justified state.
+    pub fn justified_state_root(&self) -> Hash256 {
+        self.justified_state_root
     }
 
     /// Save the current state of `Self` to a `PersistedForkChoiceStore` which can be stored to the
@@ -247,6 +254,7 @@ where
             unrealized_finalized_checkpoint: persisted.unrealized_finalized_checkpoint,
             proposer_boost_root: persisted.proposer_boost_root,
             equivocating_indices: persisted.equivocating_indices,
+            equivocating_committee_weights: BTreeMap::new(),
             _phantom: PhantomData,
         })
     }
@@ -363,6 +371,14 @@ where
 
     fn extend_equivocating_indices(&mut self, indices: impl IntoIterator<Item = u64>) {
         self.equivocating_indices.extend(indices);
+    }
+
+    fn equivocating_committee_weights(&self) -> &BTreeMap<Slot, u64> {
+        &self.equivocating_committee_weights
+    }
+
+    fn set_equivocating_committee_weights(&mut self, weights: BTreeMap<Slot, u64>) {
+        self.equivocating_committee_weights = weights;
     }
 }
 

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -205,11 +205,6 @@ where
         })
     }
 
-    /// Returns the state root of the justified state.
-    pub fn justified_state_root(&self) -> Hash256 {
-        self.justified_state_root
-    }
-
     /// Save the current state of `Self` to a `PersistedForkChoiceStore` which can be stored to the
     /// on-disk database.
     pub fn to_persisted(&self) -> PersistedForkChoiceStore {

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -63,6 +63,7 @@ use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwL
 use slot_clock::SlotClock;
 use state_processing::AllCaches;
 use state_processing::state_advance::complete_state_advance;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 use store::{
@@ -692,7 +693,20 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let old_payload_status = old_cached_head.head_payload_status();
         let old_forkchoice_update_parameters = old_cached_head.forkchoice_update_parameters();
 
+        let equivocating_committee_weights = self.compute_equivocating_committee_weights(
+            old_cached_head.head_block_root(),
+            current_slot,
+        );
+
         let mut fork_choice_write_lock = self.canonical_head.fork_choice_write_lock();
+
+        match equivocating_committee_weights {
+            Ok(weights) => fork_choice_write_lock.set_equivocating_committee_weights(weights),
+            Err(e) => error!(
+                error = ?e,
+                "Failed to update equivocating committee weights"
+            ),
+        }
 
         // Recompute the current head via the fork choice algorithm.
         let (_, new_payload_status) = fork_choice_write_lock.get_head(current_slot, &self.spec)?;
@@ -1417,6 +1431,103 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             fork_choice_store: fork_choice.fc_store().to_persisted(),
         };
         persisted_fork_choice.as_kv_store_op(FORK_CHOICE_DB_KEY, store_config)
+    }
+
+    /// Compute the justified effective balances of equivocating validators, summed
+    /// per attestation duty slot. Used by the post-Gloas `is_head_weak` check.
+    fn compute_equivocating_committee_weights(
+        &self,
+        head_block_root: Hash256,
+        current_slot: Slot,
+    ) -> Result<BTreeMap<Slot, u64>, Error> {
+        // Don't keep track of pre-gloas equivocating committee weight. This ensures
+        // that pre-gloas `is_head_weak` is correctly calculated.
+        if !self
+            .spec
+            .fork_name_at_slot::<T::EthSpec>(current_slot)
+            .gloas_enabled()
+        {
+            return Ok(BTreeMap::new());
+        }
+
+        // TODO(gloas): once any slashing has been observed the state lookup and `equivocating_validator_balances` calculation
+        // run on every head recompute forever. We could prevent this by introducing some type of cache key like:
+        // (epoch, justified_state_root, equivocating_indices.len()).
+        let (equivocating_indices, justified_state_root) = {
+            let fork_choice_read_lock = self.canonical_head.fork_choice_read_lock();
+            let fc_store = fork_choice_read_lock.fc_store();
+            (
+                fc_store
+                    .equivocating_indices()
+                    .iter()
+                    .copied()
+                    .collect::<Vec<_>>(),
+                fc_store.justified_state_root(),
+            )
+        };
+
+        if equivocating_indices.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+
+        // The spec reads raw effective balances from the justified state, without
+        // filtering by slashed or active status.
+        let justified_state = self
+            .store
+            .get_hot_state(&justified_state_root, true)
+            .map_err(Error::DBError)?
+            .ok_or(Error::MissingBeaconState(justified_state_root))?;
+
+        let equivocating_validator_balances: Vec<(u64, u64)> = equivocating_indices
+            .iter()
+            .map(|&index| {
+                let balance = justified_state
+                    .validators()
+                    .get(index as usize)
+                    .map(|validator| validator.effective_balance)
+                    .unwrap_or(0);
+                (index, balance)
+            })
+            .collect();
+
+        let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
+        let previous_slot_epoch = current_slot
+            .saturating_sub(1u64)
+            .epoch(T::EthSpec::slots_per_epoch());
+
+        // Re-org checks evaluate at `current_slot - 1` which can fall to the
+        // previous epoch when `current_slot` is at an epoch boundary.
+        let epochs = if previous_slot_epoch == current_epoch {
+            vec![current_epoch]
+        } else {
+            vec![previous_slot_epoch, current_epoch]
+        };
+
+        let mut equivocating_committee_weights = BTreeMap::new();
+
+        for epoch in epochs {
+            let duty_weights: Vec<(Slot, u64)> =
+                self.with_committee_cache(head_block_root, epoch, |shuffling, _| {
+                    let mut duty_weights =
+                        Vec::with_capacity(equivocating_validator_balances.len());
+                    for &(index, balance) in &equivocating_validator_balances {
+                        if let Some(duty) = shuffling
+                            .committee_cache
+                            .get_attestation_duties(index as usize)?
+                        {
+                            duty_weights.push((duty.slot, balance));
+                        }
+                    }
+                    Ok(duty_weights)
+                })?;
+
+            for (slot, balance) in duty_weights {
+                let entry = equivocating_committee_weights.entry(slot).or_insert(0u64);
+                *entry = entry.saturating_add(balance);
+            }
+        }
+
+        Ok(equivocating_committee_weights)
     }
 }
 

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1450,45 +1450,29 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Ok(BTreeMap::new());
         }
 
-        // TODO(gloas): once any slashing has been observed the state lookup and `equivocating_validator_balances` calculation
-        // run on every head recompute forever. We could prevent this by introducing some type of cache key like:
-        // (epoch, justified_state_root, equivocating_indices.len()).
-        let (equivocating_indices, justified_state_root) = {
+        let equivocating_validator_balances: Vec<(u64, u64)> = {
             let fork_choice_read_lock = self.canonical_head.fork_choice_read_lock();
             let fc_store = fork_choice_read_lock.fc_store();
-            (
-                fc_store
-                    .equivocating_indices()
-                    .iter()
-                    .copied()
-                    .collect::<Vec<_>>(),
-                fc_store.justified_state_root(),
-            )
+            let justified_balances = fc_store.justified_balances();
+            fc_store
+                .equivocating_indices()
+                .iter()
+                .map(|&index| {
+                    let balance = justified_balances
+                        .effective_balances
+                        .get(index as usize)
+                        .copied()
+                        .filter(|balance| *balance != 0)
+                        .or_else(|| justified_balances.slashed_balances.get(&index).copied())
+                        .unwrap_or(0);
+                    (index, balance)
+                })
+                .collect()
         };
 
-        if equivocating_indices.is_empty() {
+        if equivocating_validator_balances.is_empty() {
             return Ok(BTreeMap::new());
         }
-
-        // The spec reads raw effective balances from the justified state, without
-        // filtering by slashed or active status.
-        let justified_state = self
-            .store
-            .get_hot_state(&justified_state_root, true)
-            .map_err(Error::DBError)?
-            .ok_or(Error::MissingBeaconState(justified_state_root))?;
-
-        let equivocating_validator_balances: Vec<(u64, u64)> = equivocating_indices
-            .iter()
-            .map(|&index| {
-                let balance = justified_state
-                    .validators()
-                    .get(index as usize)
-                    .map(|validator| validator.effective_balance)
-                    .unwrap_or(0);
-                (index, balance)
-            })
-            .collect();
 
         let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
         let previous_slot_epoch = current_slot

--- a/beacon_node/beacon_chain/tests/op_verification.rs
+++ b/beacon_node/beacon_chain/tests/op_verification.rs
@@ -10,9 +10,11 @@ use beacon_chain::{
     },
 };
 use bls::Keypair;
+use fork_choice::ForkChoiceStore;
 use state_processing::per_block_processing::errors::{
     AttesterSlashingInvalid, BlockOperationError, ExitInvalid, ProposerSlashingInvalid,
 };
+use state_processing::state_advance::complete_state_advance;
 use std::sync::{Arc, LazyLock};
 use store::StoreConfig;
 use store::database::interface::BeaconNodeBackend;
@@ -486,4 +488,180 @@ async fn attester_slashing_duplicate_in_state() {
             AttesterSlashingInvalid::NoSlashableIndices
         ))
     ));
+}
+
+#[tokio::test]
+async fn attester_slashing_updates_equivocating_committee_weights() {
+    let spec = Arc::new(ForkName::Gloas.make_genesis_spec(E::default_spec()));
+    let harness = BeaconChainHarness::builder(MinimalEthSpec)
+        .spec(spec)
+        .keypairs(KEYPAIRS.to_vec())
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build();
+    harness.advance_slot();
+
+    // Advance to a mid-epoch slot so the weights are computed for a single epoch.
+    harness
+        .extend_chain(
+            3,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    // No equivocations: the map is empty.
+    assert!(
+        harness
+            .chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .fc_store()
+            .equivocating_committee_weights()
+            .is_empty()
+    );
+
+    // Slash a validator and import the slashing into fork choice.
+    let slashed_validator = 0;
+    let slashing = harness.make_attester_slashing(vec![slashed_validator]);
+    let ObservationOutcome::New(verified_slashing) = harness
+        .chain
+        .verify_attester_slashing_for_gossip(slashing)
+        .unwrap()
+    else {
+        panic!("slashing should verify");
+    };
+    harness.chain.import_attester_slashing(verified_slashing);
+
+    harness.chain.recompute_head_at_current_slot().await;
+
+    // The map now contains the slashed validator's justified balance at its duty slot.
+    let mut head_state = harness.get_current_state();
+    head_state
+        .build_committee_cache(RelativeEpoch::Current, &harness.chain.spec)
+        .unwrap();
+    let duty = head_state
+        .get_attestation_duties(slashed_validator as usize, RelativeEpoch::Current)
+        .unwrap()
+        .expect("slashed validator should have an attestation duty");
+
+    let fork_choice_read_lock = harness.chain.canonical_head.fork_choice_read_lock();
+    let fc_store = fork_choice_read_lock.fc_store();
+    let expected_balance =
+        fc_store.justified_balances().effective_balances[slashed_validator as usize];
+    assert!(expected_balance > 0);
+    assert_eq!(
+        fc_store
+            .equivocating_committee_weights()
+            .get(&duty.slot)
+            .copied(),
+        Some(expected_balance)
+    );
+}
+
+#[tokio::test]
+async fn equivocating_committee_weights_use_raw_justified_balances() {
+    let spec = Arc::new(ForkName::Gloas.make_genesis_spec(E::default_spec()));
+    let harness = BeaconChainHarness::builder(MinimalEthSpec)
+        .spec(spec)
+        .keypairs(KEYPAIRS.to_vec())
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build();
+    harness.advance_slot();
+
+    harness
+        .extend_chain(
+            3,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    // Slash a validator: fork choice learns of the equivocation and the op pool
+    // includes the slashing in a subsequent block.
+    let slashed_validator = 0;
+    let slashing = harness.make_attester_slashing(vec![slashed_validator]);
+    let ObservationOutcome::New(verified_slashing) = harness
+        .chain
+        .verify_attester_slashing_for_gossip(slashing)
+        .unwrap()
+    else {
+        panic!("slashing should verify");
+    };
+    harness.chain.import_attester_slashing(verified_slashing);
+    harness.advance_slot();
+
+    // Advance until the justified state has the validator marked as slashed,
+    // skipping slots where the slashed validator is the proposer.
+    while harness.get_current_slot() < Slot::new(29) {
+        let slot = harness.get_current_slot();
+        let mut state = harness.get_current_state();
+        complete_state_advance(&mut state, None, slot, &harness.chain.spec).unwrap();
+        state
+            .build_committee_cache(RelativeEpoch::Current, &harness.chain.spec)
+            .unwrap();
+        let proposer = state
+            .get_beacon_proposer_index(slot, &harness.chain.spec)
+            .unwrap();
+        if proposer != slashed_validator as usize {
+            harness
+                .extend_chain(
+                    1,
+                    BlockStrategy::OnCanonicalHead,
+                    AttestationStrategy::AllValidators,
+                )
+                .await;
+        }
+        harness.advance_slot();
+    }
+    harness.chain.recompute_head_at_current_slot().await;
+
+    let justified_state_root = harness
+        .chain
+        .canonical_head
+        .fork_choice_read_lock()
+        .fc_store()
+        .justified_state_root();
+    let justified_state = harness
+        .chain
+        .store
+        .get_hot_state(&justified_state_root, false)
+        .unwrap()
+        .expect("justified state should exist");
+    let validator = justified_state
+        .validators()
+        .get(slashed_validator as usize)
+        .unwrap();
+    assert!(
+        validator.slashed,
+        "slashing should be reflected in the justified state"
+    );
+    let raw_balance = validator.effective_balance;
+    assert!(raw_balance > 0);
+
+    let mut head_state = harness.get_current_state();
+    head_state
+        .build_committee_cache(RelativeEpoch::Current, &harness.chain.spec)
+        .unwrap();
+    let duty = head_state
+        .get_attestation_duties(slashed_validator as usize, RelativeEpoch::Current)
+        .unwrap()
+        .expect("slashed validator should have an attestation duty");
+
+    let fork_choice_read_lock = harness.chain.canonical_head.fork_choice_read_lock();
+    let fc_store = fork_choice_read_lock.fc_store();
+    // The zeroed justified balances differ from the raw balance here; a regression
+    // to reading them would make the map entry zero.
+    assert_eq!(
+        fc_store.justified_balances().effective_balances[slashed_validator as usize],
+        0
+    );
+    assert_eq!(
+        fc_store
+            .equivocating_committee_weights()
+            .get(&duty.slot)
+            .copied(),
+        Some(raw_balance)
+    );
 }

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -8,7 +8,7 @@
 //! `get_latest_confirmed` is measured across a table of realistic (chain position, FCR run slot)
 //! scenarios — see `SCENARIOS`.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
@@ -235,6 +235,7 @@ fn build_chain_inner(
         &balances,
         Hash256::zero(), // no proposer boost
         &BTreeSet::new(),
+        &BTreeMap::new(),
         Slot::new(CHAIN_TIP_SLOT),
         &spec,
     )

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -588,6 +588,7 @@ where
             store.justified_balances(),
             store.proposer_boost_root(),
             store.equivocating_indices(),
+            store.equivocating_committee_weights(),
             current_slot,
             spec,
         )?;
@@ -674,6 +675,7 @@ where
                 self.fc_store.justified_balances(),
                 re_org_head_threshold,
                 re_org_parent_threshold,
+                self.fc_store().equivocating_committee_weights(),
                 max_epochs_since_finalization,
             )
             .map_err(ProposerHeadError::convert_inner_error)
@@ -1480,6 +1482,11 @@ where
             .extend_equivocating_indices(att1_indices.intersection(&att2_indices).copied());
     }
 
+    /// Replaces the per-slot equivocating committee weights.
+    pub fn set_equivocating_committee_weights(&mut self, weights: BTreeMap<Slot, u64>) {
+        self.fc_store.set_equivocating_committee_weights(weights);
+    }
+
     /// Call `on_tick` for all slots between `fc_store.get_current_slot()` and the provided
     /// `current_slot`. Returns the value of `self.fc_store.get_current_slot`.
     pub fn update_time(&mut self, current_slot: Slot) -> Result<Slot, Error<T::Error>> {
@@ -1678,6 +1685,7 @@ where
                     block_root,
                     current_slot,
                     proposer_boost_root,
+                    self.fc_store().equivocating_committee_weights(),
                     spec,
                 )
                 .map_err(Error::ProtoArrayError)

--- a/consensus/fork_choice/src/fork_choice_store.rs
+++ b/consensus/fork_choice/src/fork_choice_store.rs
@@ -1,5 +1,5 @@
 use proto_array::JustifiedBalances;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use types::{AbstractExecPayload, BeaconBlockRef, BeaconState, Checkpoint, EthSpec, Hash256, Slot};
 
@@ -89,4 +89,10 @@ pub trait ForkChoiceStore<E: EthSpec>: Sized {
 
     /// Adds to the set of equivocating indices.
     fn extend_equivocating_indices(&mut self, indices: impl IntoIterator<Item = u64>);
+
+    /// Gets the per-slot committee weight of equivocating validators.
+    fn equivocating_committee_weights(&self) -> &BTreeMap<Slot, u64>;
+
+    /// Replaces the per-slot equivocating committee weights.
+    fn set_equivocating_committee_weights(&mut self, weights: BTreeMap<Slot, u64>);
 }

--- a/consensus/proto_array/benches/find_head.rs
+++ b/consensus/proto_array/benches/find_head.rs
@@ -1,7 +1,7 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use fixed_bytes::FixedBytesExtended;
 use proto_array::{Block, ExecutionStatus, JustifiedBalances, ProtoArrayForkChoice};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 use types::{
     AttestationShufflingId, Checkpoint, Epoch, EthSpec, ExecutionBlockHash, Hash256,
@@ -82,6 +82,7 @@ fn build_chain(num_blocks: u64, gloas: bool) -> (ProtoArrayForkChoice, types::Ch
 fn bench_find_head(c: &mut Criterion) {
     let mut group = c.benchmark_group("find_head");
     let equivocating_indices = BTreeSet::new();
+    let equivocating_committee_weights = BTreeMap::new();
     let finalized_checkpoint = Checkpoint {
         epoch: Epoch::new(0),
         root: get_root(0),
@@ -103,6 +104,7 @@ fn bench_find_head(c: &mut Criterion) {
                             &balances,
                             Hash256::zero(),
                             &equivocating_indices,
+                            &equivocating_committee_weights,
                             Slot::new(num_blocks),
                             &spec,
                         )

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -10,7 +10,7 @@ use crate::{InvalidationOperation, JustifiedBalances};
 use fixed_bytes::FixedBytesExtended;
 use serde::{Deserialize, Serialize};
 use ssz::BitVector;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 use types::{
     AttestationShufflingId, ChainSpec, Checkpoint, Epoch, EthSpec, ExecutionBlockHash, Hash256,
@@ -177,6 +177,7 @@ impl ForkChoiceTestDefinition {
         )
         .expect("should create fork choice struct");
         let equivocating_indices = BTreeSet::new();
+        let equivocating_committee_weights = BTreeMap::new();
         let mut last_current_slot = Slot::new(0);
 
         for (op_index, op) in self.operations.into_iter().enumerate() {
@@ -199,6 +200,7 @@ impl ForkChoiceTestDefinition {
                             &justified_balances,
                             Hash256::zero(),
                             &equivocating_indices,
+                            &equivocating_committee_weights,
                             current_slot,
                             &spec,
                         )
@@ -223,6 +225,7 @@ impl ForkChoiceTestDefinition {
                         &head,
                         current_slot,
                         Hash256::zero(),
+                        &equivocating_committee_weights,
                         &spec,
                         payload_status,
                         op_index,
@@ -247,6 +250,7 @@ impl ForkChoiceTestDefinition {
                             &justified_balances,
                             proposer_boost_root,
                             &equivocating_indices,
+                            &equivocating_committee_weights,
                             Slot::new(0),
                             &spec,
                         )
@@ -264,6 +268,7 @@ impl ForkChoiceTestDefinition {
                         &head,
                         Slot::new(0),
                         proposer_boost_root,
+                        &equivocating_committee_weights,
                         &spec,
                         payload_status,
                         op_index,
@@ -284,6 +289,7 @@ impl ForkChoiceTestDefinition {
                         &justified_balances,
                         Hash256::zero(),
                         &equivocating_indices,
+                        &equivocating_committee_weights,
                         Slot::new(0),
                         &spec,
                     );
@@ -607,6 +613,7 @@ impl ForkChoiceTestDefinition {
                             &block_root,
                             current_slot.unwrap_or(last_current_slot),
                             proposer_boost_root.unwrap_or_else(Hash256::zero),
+                            &equivocating_committee_weights,
                             &spec,
                         )
                         .unwrap();
@@ -666,11 +673,13 @@ fn get_checkpoint(i: u64) -> Checkpoint {
 
 /// Checks that `get_canonical_payload_status` agrees with the `payload_status`
 /// returned by `find_head` for the head block.
+#[allow(clippy::too_many_arguments)]
 fn assert_canonical_payload_status_matches_find_head(
     fork_choice: &ProtoArrayForkChoice,
     head: &Hash256,
     current_slot: Slot,
     proposer_boost_root: Hash256,
+    equivocating_committee_weights: &BTreeMap<Slot, u64>,
     spec: &ChainSpec,
     expected: PayloadStatus,
     op_index: usize,
@@ -679,6 +688,7 @@ fn assert_canonical_payload_status_matches_find_head(
         head,
         current_slot,
         proposer_boost_root,
+        equivocating_committee_weights,
         spec,
     ) {
         Ok(actual) => assert_eq!(

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -8,7 +8,7 @@ use ssz::BitVector;
 use ssz::Encode;
 use ssz::four_byte_option_impl;
 use ssz_derive::{Decode, Encode};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Duration;
 use superstruct::superstruct;
 use typenum::U512;
@@ -166,11 +166,6 @@ pub struct ProtoNode {
     /// to detect equivocations at the parent's slot.
     #[superstruct(only(V29), partial_getter(copy))]
     pub proposer_index: u64,
-    /// Weight from equivocating validators that voted for this block.
-    /// Used by `is_head_weak` to match the spec's monotonicity guarantee:
-    /// more attestations can only increase head weight, never decrease it.
-    #[superstruct(only(V29), partial_getter(copy))]
-    pub equivocating_attestation_score: u64,
 }
 
 impl ProtoNode {
@@ -198,6 +193,27 @@ impl ProtoNode {
                 .unwrap_or_else(|_| self.weight()),
             PayloadStatus::Full => self.full_payload_weight().unwrap_or_else(|_| self.weight()),
         }
+    }
+
+    /// Head weight for re-org checks, including equivocating validators' weight
+    pub fn head_weight_for_reorg(&self, equivocating_committee_weight: u64) -> u64 {
+        self.attestation_score(PayloadStatus::Pending)
+            .saturating_add(equivocating_committee_weight)
+    }
+
+    /// Spec: `is_head_weak`.
+    pub fn is_head_weak(
+        &self,
+        re_org_head_weight_threshold: u64,
+        equivocating_committee_weight: u64,
+    ) -> bool {
+        self.head_weight_for_reorg(equivocating_committee_weight) < re_org_head_weight_threshold
+    }
+
+    /// Spec: `is_parent_strong`. `PayloadStatus::Pending` measures support regardless
+    /// of payload status. https://github.com/ethereum/consensus-specs/issues/5305
+    pub fn is_parent_strong(&self, re_org_parent_weight_threshold: u64) -> bool {
+        self.attestation_score(PayloadStatus::Pending) > re_org_parent_weight_threshold
     }
 
     /// Checks if `timely` matches our view of payload timeliness.
@@ -297,8 +313,6 @@ pub struct NodeDelta {
     pub empty_delta: i64,
     /// Weight change from `PayloadStatus::Full` votes.
     pub full_delta: i64,
-    /// Weight from equivocating validators that voted for this node.
-    pub equivocating_attestation_delta: u64,
 }
 
 impl NodeDelta {
@@ -355,7 +369,6 @@ impl NodeDelta {
             delta,
             empty_delta: 0,
             full_delta: 0,
-            equivocating_attestation_delta: 0,
         }
     }
 
@@ -487,9 +500,6 @@ impl ProtoArray {
                     apply_delta(node.empty_payload_weight, node_empty_delta, node_index)?;
                 node.full_payload_weight =
                     apply_delta(node.full_payload_weight, node_full_delta, node_index)?;
-                node.equivocating_attestation_score = node
-                    .equivocating_attestation_score
-                    .saturating_add(node_delta.equivocating_attestation_delta);
             }
 
             // Update the parent delta (if any).
@@ -655,7 +665,6 @@ impl ProtoArray {
                         && time_into_slot < spec.get_attestation_due::<E>(current_slot)),
                 block_timeliness_ptc_threshold: is_anchor
                     || (is_current_slot && time_into_slot < spec.get_payload_attestation_due()),
-                equivocating_attestation_score: 0,
             })
         };
 
@@ -700,35 +709,6 @@ impl ProtoArray {
         Ok(())
     }
 
-    /// Spec: `is_head_weak`.
-    // TODO(gloas): the spec adds weight from equivocating validators in the
-    // head slot's *committees*, regardless of who they voted for. We approximate
-    // with `equivocating_attestation_score` which only tracks equivocating
-    // validators whose vote pointed at this block. This under-counts when an
-    // equivocating validator is in the committee but voted for a different fork,
-    // which could allow a re-org the spec wouldn't. In practice the deviation
-    // is small — it requires equivocating validators voting for competing forks
-    // AND the head weight to be exactly at the reorg threshold boundary.
-    // Fixing this properly requires committee computation from BeaconState,
-    // which is not available in proto_array. The fix would be to pass
-    // pre-computed equivocating committee weight from the beacon_chain caller.
-    fn is_head_weak<E: EthSpec>(
-        &self,
-        head_node: &ProtoNode,
-        justified_balances: &JustifiedBalances,
-        spec: &ChainSpec,
-    ) -> bool {
-        let reorg_threshold =
-            calculate_committee_fraction::<E>(justified_balances, spec.reorg_head_weight_threshold)
-                .unwrap_or(0);
-
-        let head_weight = head_node
-            .attestation_score(PayloadStatus::Pending)
-            .saturating_add(head_node.equivocating_attestation_score().unwrap_or(0));
-
-        head_weight < reorg_threshold
-    }
-
     /// Spec's `should_apply_proposer_boost` for Gloas.
     ///
     /// Returns `true` if the proposer boost should be kept. Returns `false` if the
@@ -738,6 +718,7 @@ impl ProtoArray {
         &self,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         spec: &ChainSpec,
     ) -> Result<bool, Error> {
         if proposer_boost_root.is_zero() {
@@ -767,7 +748,16 @@ impl ProtoArray {
         }
 
         // Apply proposer boost if `parent` is not weak
-        if !self.is_head_weak::<E>(parent, justified_balances, spec) {
+        let re_org_head_weight_threshold =
+            calculate_committee_fraction::<E>(justified_balances, spec.reorg_head_weight_threshold)
+                .unwrap_or(0);
+
+        let equivocating_committee_weight = equivocating_committee_weights
+            .get(&parent.slot())
+            .copied()
+            .unwrap_or(0);
+
+        if !parent.is_head_weak(re_org_head_weight_threshold, equivocating_committee_weight) {
             return Ok(true);
         }
 
@@ -1076,6 +1066,7 @@ impl ProtoArray {
         best_finalized_checkpoint: Checkpoint,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         spec: &ChainSpec,
     ) -> Result<(Hash256, PayloadStatus), Error> {
         let justified_index = self
@@ -1107,6 +1098,7 @@ impl ProtoArray {
             best_finalized_checkpoint,
             proposer_boost_root,
             justified_balances,
+            equivocating_committee_weights,
             spec,
         )?;
 
@@ -1241,6 +1233,7 @@ impl ProtoArray {
         best_finalized_checkpoint: Checkpoint,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         spec: &ChainSpec,
     ) -> Result<IndexedForkChoiceNode, Error> {
         let mut head = IndexedForkChoiceNode {
@@ -1258,8 +1251,12 @@ impl ProtoArray {
         )?;
 
         // Compute once rather than per-child per-level.
-        let apply_proposer_boost =
-            self.should_apply_proposer_boost::<E>(proposer_boost_root, justified_balances, spec)?;
+        let apply_proposer_boost = self.should_apply_proposer_boost::<E>(
+            proposer_boost_root,
+            justified_balances,
+            equivocating_committee_weights,
+            spec,
+        )?;
 
         loop {
             let children: Vec<_> = self
@@ -1310,6 +1307,7 @@ impl ProtoArray {
         current_slot: Slot,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         spec: &ChainSpec,
     ) -> Result<PayloadStatus, Error> {
         let proto_node_index = *self.indices.get(&root).ok_or(Error::NodeUnknown(root))?;
@@ -1338,8 +1336,12 @@ impl ProtoArray {
 
         // Matches the hoisting optimization in `find_head`: `get_weight`'s spec-level
         // `should_apply_proposer_boost` check is precomputed once.
-        let apply_proposer_boost =
-            self.should_apply_proposer_boost::<E>(proposer_boost_root, justified_balances, spec)?;
+        let apply_proposer_boost = self.should_apply_proposer_boost::<E>(
+            proposer_boost_root,
+            justified_balances,
+            equivocating_committee_weights,
+            spec,
+        )?;
 
         let full_weight = self.get_weight::<E>(
             &full_fc,

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     fmt,
     time::Duration,
 };
@@ -654,6 +654,7 @@ impl ProtoArrayForkChoice {
         justified_state_balances: &JustifiedBalances,
         proposer_boost_root: Hash256,
         equivocating_indices: &BTreeSet<u64>,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         current_slot: Slot,
         spec: &ChainSpec,
     ) -> Result<(Hash256, PayloadStatus), String> {
@@ -690,6 +691,7 @@ impl ProtoArrayForkChoice {
                 finalized_checkpoint,
                 proposer_boost_root,
                 new_balances,
+                equivocating_committee_weights,
                 spec,
             )
             .map_err(|e| format!("find_head failed: {:?}", e))
@@ -706,6 +708,7 @@ impl ProtoArrayForkChoice {
         justified_balances: &JustifiedBalances,
         re_org_head_threshold: ReOrgThreshold,
         re_org_parent_threshold: ReOrgThreshold,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         max_epochs_since_finalization: Epoch,
     ) -> Result<ProposerHeadInfo, ProposerHeadError<Error>> {
         let info = self.get_proposer_head_info::<E>(
@@ -723,27 +726,32 @@ impl ProtoArrayForkChoice {
             return Err(DoNotReOrg::HeadDistance.into());
         }
 
+        let equivocating_committee_weight = equivocating_committee_weights
+            .get(&info.head_node.slot())
+            .copied()
+            .unwrap_or(0);
+
         // Only re-org if the head's weight is less than the heads configured committee fraction.
-        let head_weight = info.head_node.weight();
-        let re_org_head_weight_threshold = info.re_org_head_weight_threshold;
-        let weak_head = head_weight < re_org_head_weight_threshold;
-        if !weak_head {
+        if !info.head_node.is_head_weak(
+            info.re_org_head_weight_threshold,
+            equivocating_committee_weight,
+        ) {
             return Err(DoNotReOrg::HeadNotWeak {
-                head_weight,
-                re_org_head_weight_threshold,
+                head_weight: info
+                    .head_node
+                    .head_weight_for_reorg(equivocating_committee_weight),
+                re_org_head_weight_threshold: info.re_org_head_weight_threshold,
             }
             .into());
         }
 
-        // Spec: `is_parent_strong`. Use `PayloadStatus::Pending` to avoid weight split
-        // between payload statuses. https://github.com/ethereum/consensus-specs/issues/5305
-        let parent_pending_weight = info.parent_node.attestation_score(PayloadStatus::Pending);
-        let re_org_parent_weight_threshold = info.re_org_parent_weight_threshold;
-        let parent_strong = parent_pending_weight > re_org_parent_weight_threshold;
-        if !parent_strong {
+        if !info
+            .parent_node
+            .is_parent_strong(info.re_org_parent_weight_threshold)
+        {
             return Err(DoNotReOrg::ParentNotStrong {
-                parent_weight: parent_pending_weight,
-                re_org_parent_weight_threshold,
+                parent_weight: info.parent_node.attestation_score(PayloadStatus::Pending),
+                re_org_parent_weight_threshold: info.re_org_parent_weight_threshold,
             }
             .into());
         }
@@ -1060,6 +1068,7 @@ impl ProtoArrayForkChoice {
         block_root: &Hash256,
         current_slot: Slot,
         proposer_boost_root: Hash256,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         spec: &ChainSpec,
     ) -> Result<PayloadStatus, Error> {
         self.proto_array.get_canonical_payload_status::<E>(
@@ -1067,6 +1076,7 @@ impl ProtoArrayForkChoice {
             current_slot,
             proposer_boost_root,
             &self.balances,
+            equivocating_committee_weights,
             spec,
         )
     }
@@ -1212,7 +1222,6 @@ fn compute_deltas(
             delta: 0,
             empty_delta: 0,
             full_delta: 0,
-            equivocating_attestation_delta: 0,
         };
         indices.len()
     ];
@@ -1254,11 +1263,6 @@ fn compute_deltas(
                         block_slot(current_delta_index)?,
                     );
                     node_delta.sub_payload_delta(status, old_balance, current_delta_index)?;
-
-                    // Track equivocating weight for `is_head_weak` monotonicity.
-                    node_delta.equivocating_attestation_delta = node_delta
-                        .equivocating_attestation_delta
-                        .saturating_add(old_balance);
                 }
 
                 vote.current_root = Hash256::zero();
@@ -2286,5 +2290,249 @@ mod test_compute_deltas {
         assert_eq!(deltas[0].delta, 0);
         assert_eq!(deltas[0].empty_delta, 0);
         assert_eq!(deltas[0].full_delta, 0);
+    }
+
+    #[test]
+    fn equivocating_committee_weight_prevents_reorg() {
+        let mut spec = MainnetEthSpec::default_spec();
+        spec.gloas_fork_epoch = Some(Epoch::new(0));
+
+        let genesis_root = hash_from_index(0);
+        let parent_root = hash_from_index(1);
+        let head_root = hash_from_index(2);
+        let genesis_checkpoint = Checkpoint {
+            epoch: Epoch::new(0),
+            root: genesis_root,
+        };
+        let junk_shuffling_id =
+            AttestationShufflingId::from_components(Epoch::new(0), Hash256::zero());
+
+        let mut fork_choice = ProtoArrayForkChoice::new::<MainnetEthSpec>(
+            Slot::new(0),
+            Slot::new(0),
+            Hash256::zero(),
+            genesis_checkpoint,
+            genesis_checkpoint,
+            junk_shuffling_id.clone(),
+            junk_shuffling_id.clone(),
+            ExecutionStatus::Optimistic(ExecutionBlockHash::zero()),
+            Some(ExecutionBlockHash::zero()),
+            Some(ExecutionBlockHash::from_root(genesis_root)),
+            0,
+            &spec,
+        )
+        .unwrap();
+
+        // Chain: genesis (slot 0) <- parent (slot 1) <- head (slot 2).
+        for (slot, root, parent) in [(1, parent_root, genesis_root), (2, head_root, parent_root)] {
+            let block = Block {
+                slot: Slot::new(slot),
+                root,
+                parent_root: Some(parent),
+                state_root: Hash256::zero(),
+                target_root: genesis_root,
+                current_epoch_shuffling_id: junk_shuffling_id.clone(),
+                next_epoch_shuffling_id: junk_shuffling_id.clone(),
+                justified_checkpoint: genesis_checkpoint,
+                finalized_checkpoint: genesis_checkpoint,
+                execution_status: ExecutionStatus::Optimistic(ExecutionBlockHash::from_root(root)),
+                unrealized_justified_checkpoint: Some(genesis_checkpoint),
+                unrealized_finalized_checkpoint: Some(genesis_checkpoint),
+                // Mismatched parent payload hash keeps each block on its parent's Empty
+                // path, which the head walk follows when no payload envelopes are received.
+                execution_payload_parent_hash: Some(ExecutionBlockHash::from_root(
+                    hash_from_index(99),
+                )),
+                execution_payload_block_hash: Some(ExecutionBlockHash::from_root(root)),
+                proposer_index: Some(0),
+                payload_received: false,
+            };
+            fork_choice
+                .process_block::<MainnetEthSpec>(block, Slot::new(slot), &spec, Duration::ZERO)
+                .unwrap();
+        }
+
+        // Two validators attest to the parent; nobody attests to the head.
+        for validator in 0..2 {
+            fork_choice
+                .process_attestation(validator, parent_root, Slot::new(1), false)
+                .unwrap();
+        }
+
+        // 32 validators with balance 32: committee weight = 1024 / 32 = 32.
+        // Head threshold (20%) = 6, parent threshold (160%) = 51.
+        // Parent weight = 2 * 32 = 64 > 51 (strong); head weight = 0 < 6 (weak).
+        let justified_balances = JustifiedBalances::from_effective_balances(vec![32; 32]).unwrap();
+        let equivocating_indices = BTreeSet::new();
+        let no_equivocating_weights = BTreeMap::new();
+
+        let (head, _) = fork_choice
+            .find_head::<MainnetEthSpec>(
+                genesis_checkpoint,
+                genesis_checkpoint,
+                &justified_balances,
+                Hash256::zero(),
+                &equivocating_indices,
+                &no_equivocating_weights,
+                Slot::new(3),
+                &spec,
+            )
+            .unwrap();
+        assert_eq!(head, head_root);
+
+        let re_org_head_threshold = ReOrgThreshold(spec.reorg_head_weight_threshold);
+        let re_org_parent_threshold = ReOrgThreshold(spec.reorg_parent_weight_threshold);
+        let max_epochs_since_finalization = Epoch::new(spec.reorg_max_epochs_since_finalization);
+
+        // Control: without equivocating committee weight the head is weak and the
+        // re-org is permitted.
+        let info = fork_choice
+            .get_proposer_head::<MainnetEthSpec>(
+                Slot::new(3),
+                head_root,
+                &justified_balances,
+                re_org_head_threshold,
+                re_org_parent_threshold,
+                &no_equivocating_weights,
+                max_epochs_since_finalization,
+            )
+            .expect("head should be weak without equivocating committee weight");
+        assert_eq!(info.parent_node.root(), parent_root);
+
+        // Equivocating committee weight at the head's slot pushes it over the
+        // threshold: the head is no longer weak and the re-org is rejected.
+        let equivocating_committee_weights = BTreeMap::from_iter([(Slot::new(2), 32)]);
+        match fork_choice.get_proposer_head::<MainnetEthSpec>(
+            Slot::new(3),
+            head_root,
+            &justified_balances,
+            re_org_head_threshold,
+            re_org_parent_threshold,
+            &equivocating_committee_weights,
+            max_epochs_since_finalization,
+        ) {
+            Err(ProposerHeadError::DoNotReOrg(DoNotReOrg::HeadNotWeak { head_weight, .. })) => {
+                assert_eq!(head_weight, 32);
+            }
+            other => panic!("expected HeadNotWeak, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn equivocating_committee_weight_prevents_boost_invalidation() {
+        let mut spec = MainnetEthSpec::default_spec();
+        spec.gloas_fork_epoch = Some(Epoch::new(0));
+
+        let genesis_root = hash_from_index(0);
+        let parent_root = hash_from_index(1);
+        let equivocating_root = hash_from_index(2);
+        let boosted_root = hash_from_index(3);
+        let competing_root = hash_from_index(4);
+        let genesis_checkpoint = Checkpoint {
+            epoch: Epoch::new(0),
+            root: genesis_root,
+        };
+        let junk_shuffling_id =
+            AttestationShufflingId::from_components(Epoch::new(0), Hash256::zero());
+
+        let mut fork_choice = ProtoArrayForkChoice::new::<MainnetEthSpec>(
+            Slot::new(0),
+            Slot::new(0),
+            Hash256::zero(),
+            genesis_checkpoint,
+            genesis_checkpoint,
+            junk_shuffling_id.clone(),
+            junk_shuffling_id.clone(),
+            ExecutionStatus::Optimistic(ExecutionBlockHash::zero()),
+            Some(ExecutionBlockHash::zero()),
+            Some(ExecutionBlockHash::from_root(genesis_root)),
+            0,
+            &spec,
+        )
+        .unwrap();
+
+        // Tree: genesis <- {parent, equivocating} at slot 1 (same proposer), and
+        // {boosted, competing} at slot 2 as children of parent.
+        for (slot, root, parent, proposer_index) in [
+            (1, parent_root, genesis_root, 0),
+            (1, equivocating_root, genesis_root, 0),
+            (2, boosted_root, parent_root, 1),
+            (2, competing_root, parent_root, 2),
+        ] {
+            let block = Block {
+                slot: Slot::new(slot),
+                root,
+                parent_root: Some(parent),
+                state_root: Hash256::zero(),
+                target_root: genesis_root,
+                current_epoch_shuffling_id: junk_shuffling_id.clone(),
+                next_epoch_shuffling_id: junk_shuffling_id.clone(),
+                justified_checkpoint: genesis_checkpoint,
+                finalized_checkpoint: genesis_checkpoint,
+                execution_status: ExecutionStatus::Optimistic(ExecutionBlockHash::from_root(root)),
+                unrealized_justified_checkpoint: Some(genesis_checkpoint),
+                unrealized_finalized_checkpoint: Some(genesis_checkpoint),
+                // Mismatched parent payload hash keeps each block on its parent's Empty
+                // path, which the head walk follows when no payload envelopes are received.
+                execution_payload_parent_hash: Some(ExecutionBlockHash::from_root(
+                    hash_from_index(99),
+                )),
+                execution_payload_block_hash: Some(ExecutionBlockHash::from_root(root)),
+                proposer_index: Some(proposer_index),
+                payload_received: false,
+            };
+            fork_choice
+                .process_block::<MainnetEthSpec>(block, Slot::new(slot), &spec, Duration::ZERO)
+                .unwrap();
+        }
+
+        // Validator 0 (balance 4) attests to the competing block; this is the
+        // parent's entire subtree weight.
+        fork_choice
+            .process_attestation(0, competing_root, Slot::new(2), false)
+            .unwrap();
+
+        // Total balance = 31 * 32 + 4 = 996, committee weight = 996 / 32 = 31.
+        // Head-weak threshold (20%) = 6, proposer boost (40%) = 12.
+        // Parent weight = 4 < 6 (weak); boost 12 beats competing weight 4.
+        let mut balances = vec![32; 32];
+        balances[0] = 4;
+        let justified_balances = JustifiedBalances::from_effective_balances(balances).unwrap();
+        let equivocating_indices = BTreeSet::new();
+        let no_equivocating_weights = BTreeMap::new();
+
+        // Control: the parent is weak and the same proposer produced an equivocating
+        // block at the parent's slot, so the boost is invalidated and the competing
+        // block wins on attestation weight.
+        let (head, _) = fork_choice
+            .find_head::<MainnetEthSpec>(
+                genesis_checkpoint,
+                genesis_checkpoint,
+                &justified_balances,
+                boosted_root,
+                &equivocating_indices,
+                &no_equivocating_weights,
+                Slot::new(2),
+                &spec,
+            )
+            .unwrap();
+        assert_eq!(head, competing_root);
+
+        // Equivocating committee weight at the parent's slot makes the parent
+        // not weak, so the boost is kept and the boosted block wins.
+        let equivocating_committee_weights = BTreeMap::from_iter([(Slot::new(1), 32)]);
+        let (head, _) = fork_choice
+            .find_head::<MainnetEthSpec>(
+                genesis_checkpoint,
+                genesis_checkpoint,
+                &justified_balances,
+                boosted_root,
+                &equivocating_indices,
+                &equivocating_committee_weights,
+                Slot::new(2),
+                &spec,
+            )
+            .unwrap();
+        assert_eq!(head, boosted_root);
     }
 }


### PR DESCRIPTION
## Issue Addressed

#9593

## Proposed Changes

`is_head_weak` now takes into account justified balances of slashed validators. I've also refactored things slightly so that we dont have two implementations of `is_parent_strong` and `is_parent_weak` and added test coverage for these changes.