### PR TITLE
Update `spin`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8539,9 +8539,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
## Issue Addressed

Bump spin to 0.9.9 to get away from the yanked 0.9.8 which presumably has the same soundness issue fixed in 0.12.2 (they didn't bother updating the changelog for 0.9.9):

https://codeberg.org/zesterer/spin/src/branch/master/CHANGELOG.md#0-12-2-2026-07-13


