### PR TITLE
Fix Gloas sync tests by adding supernode config

### DIFF
--- a/scripts/tests/genesis-sync-config-gloas.yaml
+++ b/scripts/tests/genesis-sync-config-gloas.yaml
@@ -2,13 +2,16 @@
 participants:
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    supernode: true
     count: 2
   # nodes without validators, used for testing sync.
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    supernode: true
     validator_count: 0
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    supernode: false
     validator_count: 0
 network_params:
   gloas_fork_epoch: 0


### PR DESCRIPTION
## Issue Addressed

Fix Gloas sync tests on CI (again):

https://github.com/sigp/lighthouse/actions/runs/29260924868/job/86855361533

## Proposed Changes

Use the supernode config to work around this old issue:

- https://github.com/sigp/lighthouse/pull/8929
