### PR TITLE
Check if cached cells are identical to received cells

### DIFF
--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -269,9 +269,18 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         if let Some(assembler) = &self.partial_assembler {
             match assembler.get_partial(&block_root, column_index) {
                 Some(AssemblyColumn::Incomplete(cached_partial)) => {
-                    return Ok(partial_data_column.sidecar.filter(|idx| {
-                        cached_partial.as_data_column().sidecar.get(idx).is_none()
-                    })?);
+                    return partial_data_column.sidecar.try_filter(|idx, cell, proof| {
+                        match cached_partial.as_data_column().sidecar.get(idx) {
+                            None => Ok(true),
+                            Some((cached_cell, cached_proof)) => {
+                                if cell == cached_cell && proof == cached_proof {
+                                    Ok(false)
+                                } else {
+                                    Err(MissingCellsError::MismatchesCachedColumn)
+                                }
+                            }
+                        }
+                    });
                 }
                 // This can happen if the column has been marked as completed already but has not
                 // reached the availability cache yet.
@@ -284,7 +293,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
             }
         }
         // No cached data, all cells are "missing" (new data we want)
-        Ok(partial_data_column.sidecar.filter(|_| true)?)
+        partial_data_column.sidecar.try_filter(|_, _, _| Ok(true))
     }
 
     /// Get a blob from the availability cache.

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -234,8 +234,12 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
                 }
                 // This can happen if the column has been marked as completed already but has not
                 // reached the availability cache yet.
-                Some(AssemblyColumn::Complete(_)) => {
-                    return Ok(None);
+                Some(AssemblyColumn::Complete(cached)) => {
+                    return if data_column == cached.as_data_column() {
+                        Ok(None)
+                    } else {
+                        Err(MissingCellsError::MismatchesCachedColumn)
+                    };
                 }
                 None => {
                     // No cached data, all cells are "missing" (new data we want)
@@ -248,6 +252,8 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
 
     /// Filter out all cells that are already cached for the given `block_root`.
     /// Returns input for kzg verification, or None if all cells are already cached.
+    /// We do not need to check individual cells when returning `Ok(None)` in here, as we do not
+    /// do anything with the received column in that case.
     pub fn missing_cells_for_partial_column_sidecar<'a>(
         &'_ self,
         partial_data_column: &'a PartialDataColumn<T::EthSpec>,

--- a/beacon_node/lighthouse_network/src/types/partial.rs
+++ b/beacon_node/lighthouse_network/src/types/partial.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::Arc;
 use tracing::{error, trace};
+use types::PartialDataColumnSidecarError;
 use types::core::{EthSpec, Hash256};
 use types::data::{
     CellBitmap, PartialDataColumn, PartialDataColumnHeader, PartialDataColumnPartsMetadata,
@@ -222,8 +223,8 @@ impl<E: EthSpec> Partial for OutgoingPartialColumn<E> {
                 let send = self
                     .partial_column
                     .sidecar
-                    .filter(|idx| want.get(idx).unwrap_or(false))
-                    .map_err(|err| {
+                    .try_filter(|idx, _, _| Ok(want.get(idx).unwrap_or(false)))
+                    .map_err(|err: PartialDataColumnSidecarError| {
                         error!(?err, "Unexpected error filtering sidecar");
                         PartialError::InvalidFormat
                     })?

--- a/consensus/types/src/data/partial_data_column_sidecar.rs
+++ b/consensus/types/src/data/partial_data_column_sidecar.rs
@@ -74,12 +74,13 @@ impl<E: EthSpec> PartialDataColumnSidecar<E> {
 
     /// Creates a reference to this sidecar containing only the blob indices for which the passed
     /// closure returns `true` and is present in `self`. Will return `None` if there is no overlap.
-    pub fn filter<F>(
+    pub fn try_filter<F, Err>(
         &self,
         filter: F,
-    ) -> Result<Option<PartialDataColumnSidecarRef<'_, E>>, PartialDataColumnSidecarError>
+    ) -> Result<Option<PartialDataColumnSidecarRef<'_, E>>, Err>
     where
-        F: Fn(usize) -> bool,
+        F: Fn(usize, &Cell<E>, &KzgProof) -> Result<bool, Err>,
+        Err: From<PartialDataColumnSidecarError>,
     {
         let len = self.verify_len()?;
 
@@ -93,7 +94,7 @@ impl<E: EthSpec> PartialDataColumnSidecar<E> {
                 let (cell, proof) = iter
                     .next()
                     .ok_or(PartialDataColumnSidecarError::UnexpectedBounds)?;
-                if filter(blob_idx) {
+                if filter(blob_idx, cell, proof)? {
                     // Keep this cell
                     new_column.push(cell);
                     new_proofs.push(proof);
@@ -317,7 +318,10 @@ mod tests {
     #[test]
     fn filter_keeps_matching_cells() {
         let sidecar = make_sidecar(6, &[0, 2, 4]);
-        let filtered = sidecar.filter(|idx| idx == 0 || idx == 4).unwrap().unwrap();
+        let filtered = sidecar
+            .try_filter::<_, PartialDataColumnSidecarError>(|idx, _, _| Ok(idx == 0 || idx == 4))
+            .unwrap()
+            .unwrap();
         assert_eq!(filtered.column.len(), 2);
         assert_eq!(filtered.kzg_proofs.len(), 2);
         assert!(filtered.cells_present_bitmap.get(0).unwrap());
@@ -330,7 +334,9 @@ mod tests {
         let sidecar = make_sidecar(6, &[0, 2, 4]);
         assert!(
             sidecar
-                .filter(|idx| idx == 1 || idx == 3)
+                .try_filter::<_, PartialDataColumnSidecarError>(
+                    |idx, _, _| Ok(idx == 1 || idx == 3)
+                )
                 .unwrap()
                 .is_none()
         );
@@ -339,7 +345,10 @@ mod tests {
     #[test]
     fn filter_preserves_all_when_all_match() {
         let sidecar = make_sidecar(6, &[0, 2, 4]);
-        let filtered = sidecar.filter(|_| true).unwrap().unwrap();
+        let filtered = sidecar
+            .try_filter::<_, PartialDataColumnSidecarError>(|_, _, _| Ok(true))
+            .unwrap()
+            .unwrap();
         assert_eq!(filtered.column.len(), 3);
         assert_eq!(filtered.kzg_proofs.len(), 3);
         assert_eq!(filtered.cells_present_bitmap, sidecar.cells_present_bitmap);


### PR DESCRIPTION
## Issue Addressed

When a partial column it is received, only unknown cells are KZG verified. This can cause issues when non-verified cells are inserted into the cache anyway if the previous cache entry becomes evicted from the cache.

## Proposed Changes

Make sure that received cells are equal to cached cells.

This is already done for incoming full columns, (`try_filter_to_partial_ref`) and now implemented for partial columns (`filter` -> `try_filter`).

