### PR TITLE
Downgrade log on data column <-> finalization race condition

### DIFF
--- a/beacon_node/beacon_chain/src/data_column_verification.rs
+++ b/beacon_node/beacon_chain/src/data_column_verification.rs
@@ -6,6 +6,7 @@ use crate::kzg_utils::{
     reconstruct_data_columns, validate_data_columns_with_commitments, validate_full_data_columns,
     validate_partial_data_columns,
 };
+use crate::observed_block_producers::Error as ObservedBlockProducersError;
 use crate::observed_data_sidecars::{
     Error as ObservedDataSidecarsError, ObservationKey, ObservationStrategy, Observe,
 };
@@ -223,6 +224,25 @@ impl From<BeaconChainError> for GossipDataColumnError {
 impl From<BeaconStateError> for GossipDataColumnError {
     fn from(e: BeaconStateError) -> Self {
         GossipDataColumnError::BeaconChainError(BeaconChainError::BeaconStateError(e).into())
+    }
+}
+
+impl From<ObservedBlockProducersError> for GossipDataColumnError {
+    fn from(e: ObservedBlockProducersError) -> Self {
+        // This error can occur in certain race conditions, where an epoch is finalized after the
+        // finalization check but before the observation.
+        if let ObservedBlockProducersError::FinalizedBlock {
+            slot,
+            finalized_slot,
+        } = e
+        {
+            GossipDataColumnError::PastFinalizedSlot {
+                column_slot: slot,
+                finalized_slot,
+            }
+        } else {
+            GossipDataColumnError::BeaconChainError(Box::new(e.into()))
+        }
     }
 }
 
@@ -605,7 +625,7 @@ impl<E: EthSpec> GossipVerifiedPartialDataColumnHeader<E> {
                 header.signed_block_header.message.proposer_index,
                 header_hash,
             )
-            .map_err(BeaconChainError::from)?;
+            .map_err(GossipDataColumnError::from)?;
 
         Ok(Self {
             header,
@@ -1045,7 +1065,7 @@ pub fn validate_data_column_sidecar_for_gossip_fulu<T: BeaconChainTypes, O: Obse
             data_column_fulu.block_proposer_index(),
             data_column.block_root(),
         )
-        .map_err(|e| GossipDataColumnError::BeaconChainError(Box::new(e.into())))?;
+        .map_err(GossipDataColumnError::from)?;
 
     if O::observe() {
         observe_gossip_data_column(&data_column, chain)?;


### PR DESCRIPTION
## Issue Addressed
For both partials and non-partials, if an epoch is finalized during verification between `verify_parent_block_and_finalized_descendant` and `observe_slashable`, the latter will emit `Error::FinalizedBlock` which will be wrapped into a `BeaconChainError` which will end up as a `crit!` log: `Jul 14 14:24:23.533 CRIT  Internal error when verifying partial column sidecar  error: BeaconChainError(ObservedBlockProducersError(FinalizedBlock { slot: Slot(3485405), finalized_slot: Slot(3485408) }))`

## Proposed Changes

Catch the `FinalizedBlock` variant and translate it into `GossipDataColumnError::PastFinalizedSlot`, which will be handled much more gracefully.
