### PR TITLE
Silence future-incompat warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,9 @@
 [env]
 # Set the number of arenas to 16 when using jemalloc.
 JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,narenas:16"
+
+# Silence the future-incompatibility warning caused by `proc-macro-error2`.
+# TODO: Remove this once alloy releases with an updated dependency and we upgrade.
+# See: https://github.com/sigp/lighthouse/issues/9618
+[future-incompat-report]
+frequency = "never"


### PR DESCRIPTION
## Issue Addressed

Temporary workaround for:

- https://github.com/sigp/lighthouse/issues/9618

## Proposed Changes

Silence the warning so it doesn't scare users compiling from source.
