### PR TITLE
Add experimental --disable-range-sync flag

### DIFF
--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -146,6 +146,10 @@ pub struct Config {
 
     /// Whether to enable partial data column support.
     pub enable_partial_columns: bool,
+
+    /// Disable range sync and route every peer with an unknown head straight to block (lookup)
+    /// sync, regardless of how far ahead the peer is. Experimental.
+    pub disable_range_sync: bool,
 }
 
 impl Config {
@@ -372,6 +376,7 @@ impl Default for Config {
             idontwant_message_size_threshold: DEFAULT_IDONTWANT_MESSAGE_SIZE_THRESHOLD,
             advertise_false_custody_group_count: None,
             enable_partial_columns: false,
+            disable_range_sync: false,
         }
     }
 }

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -98,6 +98,14 @@ pub struct BlockLookups<T: BeaconChainTypes> {
     // TODO: Why not index lookups by block_root?
     single_block_lookups: FnvHashMap<SingleLookupId, SingleBlockLookup<T>>,
 
+    /// Maximum depth of the parent chain searched before forcing range sync. `PARENT_DEPTH_TOLERANCE`
+    /// normally, unbounded when range sync is disabled (`--disable-range-sync`).
+    max_parent_depth: usize,
+
+    /// Maximum number of concurrent block lookups. `MAX_LOOKUPS` normally, unbounded when range sync
+    /// is disabled (`--disable-range-sync`).
+    max_lookups: usize,
+
     /// Used for testing assertions
     metrics: BlockLookupsMetrics,
 }
@@ -119,12 +127,22 @@ pub(crate) struct BlockLookupSummary {
 }
 
 impl<T: BeaconChainTypes> BlockLookups<T> {
-    pub fn new() -> Self {
+    pub fn new(disable_range_sync: bool) -> Self {
+        // Range sync is the fallback when a parent chain grows too long or too many lookups pile
+        // up. With range sync disabled there is no fallback, so the caps are removed (unbounded)
+        // and lookup sync follows the full tree of lookups without dropping chains.
+        let (max_parent_depth, max_lookups) = if disable_range_sync {
+            (usize::MAX, usize::MAX)
+        } else {
+            (PARENT_DEPTH_TOLERANCE, MAX_LOOKUPS)
+        };
         Self {
             ignored_chains: LRUTimeCache::new(Duration::from_secs(
                 IGNORED_CHAINS_CACHE_EXPIRY_SECONDS,
             )),
             single_block_lookups: Default::default(),
+            max_parent_depth,
+            max_lookups,
             metrics: <_>::default(),
         }
     }
@@ -250,7 +268,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             let trigger_is_chain_tip = parent_chain.tip == child_block_root_trigger;
 
             if (block_would_extend_chain || trigger_is_chain_tip)
-                && parent_chain.len() >= PARENT_DEPTH_TOLERANCE
+                && parent_chain.len() >= self.max_parent_depth
             {
                 debug!(block_root = ?block_root_to_search, "Parent lookup chain too long");
 
@@ -382,7 +400,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
         // Lookups contain untrusted data, bound the total count of lookups hold in memory to reduce
         // the risk of OOM in case of bugs of malicious activity.
-        if self.single_block_lookups.len() >= MAX_LOOKUPS {
+        if self.single_block_lookups.len() >= self.max_lookups {
             warn!(?block_root, "Dropping lookup reached max");
             return false;
         }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -309,6 +309,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         fork_context: Arc<ForkContext>,
     ) -> Self {
         let network_globals = beacon_processor.network_globals.clone();
+        let disable_range_sync = network_globals.config.disable_range_sync;
         Self {
             chain: beacon_chain.clone(),
             input_channel: sync_recv,
@@ -321,7 +322,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             range_sync: RangeSync::new(beacon_chain.clone()),
             backfill_sync: BackFillSync::new(beacon_chain.clone(), network_globals.clone()),
             custody_backfill_sync: CustodyBackFillSync::new(beacon_chain.clone(), network_globals),
-            block_lookups: BlockLookups::new(),
+            block_lookups: BlockLookups::new(disable_range_sync),
             notified_unknown_roots: LRUTimeCache::new(Duration::from_secs(
                 NOTIFIED_UNKNOWN_ROOT_EXPIRY_SECONDS,
             )),
@@ -410,6 +411,13 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         let is_still_connected = self.update_peer_sync_state(&peer_id, &local, &remote, &sync_type);
         if is_still_connected {
             match sync_type {
+                // Range sync disabled: direct every peer with an unknown head to block (lookup)
+                // sync regardless of how far ahead it is.
+                _ if self.network_globals().config.disable_range_sync => {
+                    if !self.chain.block_is_known_to_fork_choice(&remote.head_root) {
+                        self.handle_unknown_block_root(peer_id, remote.head_root);
+                    }
+                }
                 PeerSyncType::Behind => {} // Do nothing
                 PeerSyncType::Advanced => {
                     self.range_sync
@@ -1024,7 +1032,12 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         block_slot: Option<Slot>,
         peer_id: &PeerId,
     ) -> Result<(), &'static str> {
-        if !self.network_globals().sync_state.read().is_synced() {
+        // With range sync disabled, lookup sync is the only sync method, so search for blocks
+        // regardless of how far behind we are; the not-synced distance gate would otherwise reject
+        // every head lookup and stall.
+        if !self.network_globals().config.disable_range_sync
+            && !self.network_globals().sync_state.read().is_synced()
+        {
             let Some(block_slot) = block_slot else {
                 return Err("not synced");
             };

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -693,6 +693,16 @@ pub fn cli_app() -> Command {
                 .default_missing_value("true")
                 .display_order(0)
         )
+        .arg(
+            Arg::new("disable-range-sync")
+                .long("disable-range-sync")
+                .action(ArgAction::SetTrue)
+                .help_heading(FLAG_HEADER)
+                .help("Disable range sync and route every peer with an unknown head to block \
+                (lookup) sync regardless of how far ahead it is. Experimental.")
+                .hide(true)
+                .display_order(0)
+        )
         /*
          * Monitoring metrics
          */

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1507,6 +1507,8 @@ pub fn set_network_config(
             })?;
     }
 
+    config.disable_range_sync = cli_args.get_flag("disable-range-sync");
+
     Ok(())
 }
 

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2852,6 +2852,21 @@ fn enable_mplex_no_value() {
 }
 
 #[test]
+fn disable_range_sync() {
+    CommandLineTest::new()
+        .flag("disable-range-sync", None)
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(config.network.disable_range_sync);
+        });
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(!config.network.disable_range_sync);
+        })
+}
+
+#[test]
 fn partial_columns() {
     CommandLineTest::new()
         .flag("enable-partial-columns", Some("true"))


### PR DESCRIPTION
Adds `--disable-range-sync`, a hidden experimental flag for testing lookup ("tree") sync in isolation. With it set, every peer with an unknown head goes straight to lookup sync regardless of distance, instead of splitting between range and lookup sync.

To allow lookup sync to sync large distances it disables the DoS protections of `PARENT_DEPTH_TOLERANCE` / `MAX_LOOKUPS`. As this flag is meant to be used in experimental nodes only it does not pose a security risk.

No-op unless the flag is passed.

### AI disclosure

Original work by me in the main tree sync branch. Ported to standalone PR by agent. Reviewed by me line by line