### PR TITLE
Fix light client updates stream

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -919,6 +919,9 @@ impl<E: EthSpec> RequestType<E> {
             RequestType::BlobsByRoot(_) => ResponseTermination::BlobsByRoot,
             RequestType::DataColumnsByRoot(_) => ResponseTermination::DataColumnsByRoot,
             RequestType::DataColumnsByRange(_) => ResponseTermination::DataColumnsByRange,
+            RequestType::LightClientUpdatesByRange(_) => {
+                ResponseTermination::LightClientUpdatesByRange
+            }
             RequestType::Status(_) => unreachable!(),
             RequestType::Goodbye(_) => unreachable!(),
             RequestType::Ping(_) => unreachable!(),
@@ -926,7 +929,6 @@ impl<E: EthSpec> RequestType<E> {
             RequestType::LightClientBootstrap(_) => unreachable!(),
             RequestType::LightClientFinalityUpdate => unreachable!(),
             RequestType::LightClientOptimisticUpdate => unreachable!(),
-            RequestType::LightClientUpdatesByRange(_) => unreachable!(),
         }
     }
 
@@ -1023,7 +1025,7 @@ impl<E: EthSpec> RequestType<E> {
             RequestType::LightClientBootstrap(_) => true,
             RequestType::LightClientOptimisticUpdate => true,
             RequestType::LightClientFinalityUpdate => true,
-            RequestType::LightClientUpdatesByRange(_) => true,
+            RequestType::LightClientUpdatesByRange(_) => false,
         }
     }
 }
@@ -1264,13 +1266,5 @@ mod tests {
                 );
             }
         }
-    }
-
-    #[test]
-    fn light_client_updates_by_range_is_streaming_protocol() {
-        assert!(matches!(
-            Protocol::LightClientUpdatesByRange.terminator(),
-            Some(ResponseTermination::LightClientUpdatesByRange)
-        ));
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -321,7 +321,9 @@ impl Protocol {
             Protocol::LightClientBootstrap => None,
             Protocol::LightClientOptimisticUpdate => None,
             Protocol::LightClientFinalityUpdate => None,
-            Protocol::LightClientUpdatesByRange => None,
+            Protocol::LightClientUpdatesByRange => {
+                Some(ResponseTermination::LightClientUpdatesByRange)
+            }
         }
     }
 }
@@ -1262,5 +1264,13 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn light_client_updates_by_range_is_streaming_protocol() {
+        assert!(matches!(
+            Protocol::LightClientUpdatesByRange.terminator(),
+            Some(ResponseTermination::LightClientUpdatesByRange)
+        ));
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -919,9 +919,6 @@ impl<E: EthSpec> RequestType<E> {
             RequestType::BlobsByRoot(_) => ResponseTermination::BlobsByRoot,
             RequestType::DataColumnsByRoot(_) => ResponseTermination::DataColumnsByRoot,
             RequestType::DataColumnsByRange(_) => ResponseTermination::DataColumnsByRange,
-            RequestType::LightClientUpdatesByRange(_) => {
-                ResponseTermination::LightClientUpdatesByRange
-            }
             RequestType::Status(_) => unreachable!(),
             RequestType::Goodbye(_) => unreachable!(),
             RequestType::Ping(_) => unreachable!(),
@@ -929,6 +926,9 @@ impl<E: EthSpec> RequestType<E> {
             RequestType::LightClientBootstrap(_) => unreachable!(),
             RequestType::LightClientFinalityUpdate => unreachable!(),
             RequestType::LightClientOptimisticUpdate => unreachable!(),
+            RequestType::LightClientUpdatesByRange(_) => {
+                ResponseTermination::LightClientUpdatesByRange
+            }
         }
     }
 

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -308,15 +308,22 @@ fn test_tcp_blocks_by_range_chunked_rpc() {
     })
 }
 
-// Tests a streamed LightClientUpdatesByRange RPC message.
+// Tests a streamed LightClientUpdatesByRange RPC Message
 #[test]
 fn test_tcp_light_client_updates_by_range_chunked_rpc() {
-    let _subscriber = build_tracing_subscriber("debug", false);
+    // Set up the logging.
+    let log_level = "debug";
+    let enable_logging = false;
+    let _subscriber = build_tracing_subscriber(log_level, enable_logging);
+
     let messages_to_send = 3;
+
     let rt = Arc::new(Runtime::new().unwrap());
+
     let spec = Arc::new(spec_with_all_forks_enabled());
 
     rt.block_on(async {
+        // get sender/receiver
         let response_slot = spec
             .capella_fork_epoch
             .expect("Capella fork is configured")
@@ -331,11 +338,14 @@ fn test_tcp_light_client_updates_by_range_chunked_rpc() {
         )
         .await;
 
+        // LightClientUpdatesByRange Request
         let rpc_request =
             RequestType::LightClientUpdatesByRange(LightClientUpdatesByRangeRequest {
                 start_period: 0,
                 count: messages_to_send,
             });
+
+        // LightClientUpdatesByRange Response
         let mut attested_header = types::LightClientHeaderCapella::default();
         attested_header.beacon.slot = response_slot;
         let light_client_update = LightClientUpdate::Capella(LightClientUpdateCapella {
@@ -349,32 +359,44 @@ fn test_tcp_light_client_updates_by_range_chunked_rpc() {
         });
         let rpc_response = Response::LightClientUpdatesByRange(Some(Arc::new(light_client_update)));
 
+        // keep count of the number of messages received
+        let mut messages_received = 0;
+        // build the sender future
         let sender_future = async {
-            let mut messages_received = 0;
             loop {
                 match sender.next_event().await {
                     NetworkEvent::PeerConnectedOutgoing(peer_id) => {
+                        debug!("Sending RPC");
                         sender
                             .send_request(peer_id, AppRequestId::Router, rpc_request.clone())
                             .unwrap();
                     }
-                    NetworkEvent::ResponseReceived { response, .. } => match response {
+                    NetworkEvent::ResponseReceived {
+                        peer_id: _,
+                        app_request_id: AppRequestId::Router,
+                        response,
+                    } => match response {
                         Response::LightClientUpdatesByRange(Some(_)) => {
                             assert_eq!(response, rpc_response);
                             messages_received += 1;
+                            warn!("Chunk received");
                         }
                         Response::LightClientUpdatesByRange(None) => {
+                            // should be exactly `messages_to_send` messages before terminating
                             assert_eq!(messages_received, messages_to_send);
+                            // end the test
                             return;
                         }
-                        _ => panic!("Invalid RPC response"),
+                        _ => panic!("Invalid RPC received"),
                     },
                     NetworkEvent::RPCFailed { error, .. } => panic!("RPC failed: {error:?}"),
-                    _ => {}
+                    _ => {} // Ignore other behaviour events
                 }
             }
-        };
+        }
+        .instrument(info_span!("Sender"));
 
+        // build the receiver future
         let receiver_future = async {
             loop {
                 if let NetworkEvent::RequestReceived {
@@ -384,9 +406,12 @@ fn test_tcp_light_client_updates_by_range_chunked_rpc() {
                 } = receiver.next_event().await
                     && request_type == rpc_request
                 {
+                    // send the response
+                    warn!("Receiver got request");
                     for _ in 0..messages_to_send {
                         receiver.send_response(peer_id, inbound_request_id, rpc_response.clone());
                     }
+                    // send the stream termination
                     receiver.send_response(
                         peer_id,
                         inbound_request_id,
@@ -394,12 +419,15 @@ fn test_tcp_light_client_updates_by_range_chunked_rpc() {
                     );
                 }
             }
-        };
+        }
+        .instrument(info_span!("Receiver"));
 
         tokio::select! {
             _ = sender_future => {}
             _ = receiver_future => {}
-            _ = sleep(Duration::from_secs(30)) => panic!("Future timed out"),
+            _ = sleep(Duration::from_secs(30)) => {
+                    panic!("Future timed out");
+            }
         }
     })
 }

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -24,7 +24,8 @@ use types::{
     BeaconBlock, BeaconBlockAltair, BeaconBlockBase, BeaconBlockBellatrix, BeaconBlockHeader,
     BlobSidecar, ChainSpec, DataColumnSidecar, DataColumnSidecarFulu, DataColumnSidecarGloas,
     DataColumnsByRootIdentifier, EmptyBlock, Epoch, EthSpec, ForkName, Hash256, KzgCommitment,
-    KzgProof, MinimalEthSpec, SignedBeaconBlock, SignedBeaconBlockHeader, Slot,
+    KzgProof, LightClientUpdate, LightClientUpdateCapella, MinimalEthSpec, SignedBeaconBlock,
+    SignedBeaconBlockHeader, Slot, SyncAggregate, SyncCommittee,
 };
 
 type E = MinimalEthSpec;
@@ -303,6 +304,102 @@ fn test_tcp_blocks_by_range_chunked_rpc() {
             _ = sleep(Duration::from_secs(30)) => {
                     panic!("Future timed out");
             }
+        }
+    })
+}
+
+// Tests a streamed LightClientUpdatesByRange RPC message.
+#[test]
+fn test_tcp_light_client_updates_by_range_chunked_rpc() {
+    let _subscriber = build_tracing_subscriber("debug", false);
+    let messages_to_send = 3;
+    let rt = Arc::new(Runtime::new().unwrap());
+    let spec = Arc::new(spec_with_all_forks_enabled());
+
+    rt.block_on(async {
+        let response_slot = spec
+            .capella_fork_epoch
+            .expect("Capella fork is configured")
+            .start_slot(E::slots_per_epoch());
+        let (mut sender, mut receiver) = common::build_node_pair(
+            Arc::downgrade(&rt),
+            ForkName::Capella,
+            spec.clone(),
+            Protocol::Tcp,
+            false,
+            None,
+        )
+        .await;
+
+        let rpc_request =
+            RequestType::LightClientUpdatesByRange(LightClientUpdatesByRangeRequest {
+                start_period: 0,
+                count: messages_to_send,
+            });
+        let mut attested_header = types::LightClientHeaderCapella::default();
+        attested_header.beacon.slot = response_slot;
+        let light_client_update = LightClientUpdate::Capella(LightClientUpdateCapella {
+            attested_header,
+            next_sync_committee: Arc::new(SyncCommittee::temporary()),
+            next_sync_committee_branch: Default::default(),
+            finalized_header: Default::default(),
+            finality_branch: Default::default(),
+            sync_aggregate: SyncAggregate::empty(),
+            signature_slot: response_slot,
+        });
+        let rpc_response = Response::LightClientUpdatesByRange(Some(Arc::new(light_client_update)));
+
+        let sender_future = async {
+            let mut messages_received = 0;
+            loop {
+                match sender.next_event().await {
+                    NetworkEvent::PeerConnectedOutgoing(peer_id) => {
+                        sender
+                            .send_request(peer_id, AppRequestId::Router, rpc_request.clone())
+                            .unwrap();
+                    }
+                    NetworkEvent::ResponseReceived { response, .. } => match response {
+                        Response::LightClientUpdatesByRange(Some(_)) => {
+                            assert_eq!(response, rpc_response);
+                            messages_received += 1;
+                        }
+                        Response::LightClientUpdatesByRange(None) => {
+                            assert_eq!(messages_received, messages_to_send);
+                            return;
+                        }
+                        _ => panic!("Invalid RPC response"),
+                    },
+                    NetworkEvent::RPCFailed { error, .. } => panic!("RPC failed: {error:?}"),
+                    _ => {}
+                }
+            }
+        };
+
+        let receiver_future = async {
+            loop {
+                if let NetworkEvent::RequestReceived {
+                    peer_id,
+                    inbound_request_id,
+                    request_type,
+                } = receiver.next_event().await
+                    && request_type == rpc_request
+                {
+                    for _ in 0..messages_to_send {
+                        receiver.send_response(peer_id, inbound_request_id, rpc_response.clone());
+                    }
+                    receiver.send_response(
+                        peer_id,
+                        inbound_request_id,
+                        Response::LightClientUpdatesByRange(None),
+                    );
+                }
+            }
+        };
+
+        tokio::select! {
+            _ = sender_future => {}
+            _ = receiver_future => {}
+            _ = sleep(Duration::from_secs(30)) => panic!("Future timed out"),
         }
     })
 }

--- a/consensus/types/src/light_client/light_client_update.rs
+++ b/consensus/types/src/light_client/light_client_update.rs
@@ -480,17 +480,32 @@ impl<E: EthSpec> LightClientUpdate<E> {
     // Spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md#lightclientupdate
     #[allow(clippy::arithmetic_side_effects)]
     pub fn ssz_max_len_for_fork(fork_name: ForkName) -> usize {
-        let fixed_len = match fork_name {
-            ForkName::Base | ForkName::Bellatrix => 0,
-            ForkName::Altair => <LightClientUpdateAltair<E> as Encode>::ssz_fixed_len(),
-            ForkName::Capella => <LightClientUpdateCapella<E> as Encode>::ssz_fixed_len(),
-            ForkName::Deneb => <LightClientUpdateDeneb<E> as Encode>::ssz_fixed_len(),
-            ForkName::Electra => <LightClientUpdateElectra<E> as Encode>::ssz_fixed_len(),
-            ForkName::Fulu => <LightClientUpdateFulu<E> as Encode>::ssz_fixed_len(),
+        let next_sync_committee = Arc::new(SyncCommittee::<E>::temporary());
+        macro_rules! min_len {
+            ($update:ident) => {
+                $update::<E> {
+                    attested_header: Default::default(),
+                    next_sync_committee: next_sync_committee.clone(),
+                    next_sync_committee_branch: Default::default(),
+                    finalized_header: Default::default(),
+                    finality_branch: Default::default(),
+                    sync_aggregate: SyncAggregate::empty(),
+                    signature_slot: Slot::new(0),
+                }
+                .ssz_bytes_len()
+            };
+        }
+        let min_len = match fork_name {
+            ForkName::Base => 0,
+            ForkName::Altair | ForkName::Bellatrix => min_len!(LightClientUpdateAltair),
+            ForkName::Capella => min_len!(LightClientUpdateCapella),
+            ForkName::Deneb => min_len!(LightClientUpdateDeneb),
+            ForkName::Electra => min_len!(LightClientUpdateElectra),
+            ForkName::Fulu => min_len!(LightClientUpdateFulu),
             // TODO(gloas): implement Gloas light client
             ForkName::Gloas => 0,
         };
-        fixed_len + 2 * LightClientHeader::<E>::ssz_max_var_len_for_fork(fork_name)
+        min_len + 2 * LightClientHeader::<E>::ssz_max_var_len_for_fork(fork_name)
     }
 
     pub fn map_with_fork_name<F, R>(&self, func: F) -> R


### PR DESCRIPTION
## Issue Addressed

`LightClientUpdatesByRange` was treated as a non-streaming RPC protocol even
though a request may produce multiple responses.

After sending the first light client update, the inbound request was removed
from the active request map. Subsequent updates for the same request were
therefore rejected.

Closes #9619.


## Proposed Changes

- Mark `LightClientUpdatesByRange` as a streaming protocol with the existing
  `ResponseTermination::LightClientUpdatesByRange` terminator.
- Add a regression test covering the protocol's streaming semantics.



## Additional Info


- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test -p lighthouse_network --lib` (93 tests passed)

