### PR TITLE
Narrow payload bid cache generics to EthSpec

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -484,7 +484,7 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     /// A cache used to track pre-finalization block roots for quick rejection.
     pub pre_finalization_block_cache: PreFinalizationBlockCache,
     /// A cache used to store gossip verified payload bids.
-    pub gossip_verified_payload_bid_cache: GossipVerifiedPayloadBidCache<T>,
+    pub gossip_verified_payload_bid_cache: GossipVerifiedPayloadBidCache<T::EthSpec>,
     /// A cache used to store gossip verified proposer preferences.
     pub gossip_verified_proposer_preferences_cache: GossipVerifiedProposerPreferenceCache,
     /// A cache used to produce light_client server messages

--- a/beacon_node/beacon_chain/src/payload_bid_verification/gossip_verified_bid.rs
+++ b/beacon_node/beacon_chain/src/payload_bid_verification/gossip_verified_bid.rs
@@ -84,7 +84,7 @@ pub(crate) fn verify_bid_consistency<E: EthSpec>(
 
 pub struct GossipVerificationContext<'a, T: BeaconChainTypes> {
     pub canonical_head: &'a CanonicalHead<T>,
-    pub gossip_verified_payload_bid_cache: &'a GossipVerifiedPayloadBidCache<T>,
+    pub gossip_verified_payload_bid_cache: &'a GossipVerifiedPayloadBidCache<T::EthSpec>,
     pub gossip_verified_proposer_preferences_cache: &'a GossipVerifiedProposerPreferenceCache,
     pub slot_clock: &'a T::SlotClock,
     pub spec: &'a ChainSpec,
@@ -93,19 +93,19 @@ pub struct GossipVerificationContext<'a, T: BeaconChainTypes> {
 /// A wrapper around a `SignedExecutionPayloadBid` that indicates it has been approved for re-gossiping on
 /// the p2p network.
 #[derive(Educe)]
-#[educe(
-    Debug(bound = "T: BeaconChainTypes"),
-    Clone(bound = "T: BeaconChainTypes")
-)]
-pub struct GossipVerifiedPayloadBid<T: BeaconChainTypes> {
-    pub signed_bid: Arc<SignedExecutionPayloadBid<T::EthSpec>>,
+#[educe(Debug(bound = "E: EthSpec"), Clone(bound = "E: EthSpec"))]
+pub struct GossipVerifiedPayloadBid<E: EthSpec> {
+    pub signed_bid: Arc<SignedExecutionPayloadBid<E>>,
 }
 
-impl<T: BeaconChainTypes> GossipVerifiedPayloadBid<T> {
-    pub fn new(
+impl<E: EthSpec> GossipVerifiedPayloadBid<E> {
+    pub fn new<T>(
         signed_bid: Arc<SignedExecutionPayloadBid<T::EthSpec>>,
         ctx: &GossipVerificationContext<'_, T>,
-    ) -> Result<Self, PayloadBidError> {
+    ) -> Result<Self, PayloadBidError>
+    where
+        T: BeaconChainTypes<EthSpec = E>,
+    {
         let bid_slot = signed_bid.message.slot;
         let bid_parent_block_hash = signed_bid.message.parent_block_hash;
         let bid_parent_block_root = signed_bid.message.parent_block_root;
@@ -178,7 +178,7 @@ impl<T: BeaconChainTypes> GossipVerifiedPayloadBid<T> {
         // [REJECT] `bid.prev_randao` is the correct RANDAO mix -- i.e. validate that
         // `bid.prev_randao == get_randao_mix(parent_state, get_current_epoch(parent_state))`
         if signed_bid.message.prev_randao
-            != *head_state.get_randao_mix(current_slot.epoch(T::EthSpec::slots_per_epoch()))?
+            != *head_state.get_randao_mix(current_slot.epoch(E::slots_per_epoch()))?
         {
             return Err(PayloadBidError::InvalidPrevRandao { slot: bid_slot });
         }
@@ -266,7 +266,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn verify_payload_bid_for_gossip(
         &self,
         bid: Arc<SignedExecutionPayloadBid<T::EthSpec>>,
-    ) -> Result<GossipVerifiedPayloadBid<T>, PayloadBidError> {
+    ) -> Result<GossipVerifiedPayloadBid<T::EthSpec>, PayloadBidError> {
         let slot = bid.message.slot;
         let parent_block_root = bid.message.parent_block_root;
         let parent_block_hash = bid.message.parent_block_hash;

--- a/beacon_node/beacon_chain/src/payload_bid_verification/payload_bid_cache.rs
+++ b/beacon_node/beacon_chain/src/payload_bid_verification/payload_bid_cache.rs
@@ -1,23 +1,20 @@
+use crate::payload_bid_verification::gossip_verified_bid::GossipVerifiedPayloadBid;
+use parking_lot::RwLock;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
+use types::{BuilderIndex, EthSpec, ExecutionBlockHash, Hash256, SignedExecutionPayloadBid, Slot};
 
-use crate::{
-    BeaconChainTypes, payload_bid_verification::gossip_verified_bid::GossipVerifiedPayloadBid,
-};
-use parking_lot::RwLock;
-use types::{BuilderIndex, ExecutionBlockHash, Hash256, SignedExecutionPayloadBid, Slot};
+type HighestBidMap<E> =
+    BTreeMap<Slot, HashMap<(ExecutionBlockHash, Hash256), GossipVerifiedPayloadBid<E>>>;
 
-type HighestBidMap<T> =
-    BTreeMap<Slot, HashMap<(ExecutionBlockHash, Hash256), GossipVerifiedPayloadBid<T>>>;
-
-pub struct GossipVerifiedPayloadBidCache<T: BeaconChainTypes> {
-    highest_bid: RwLock<HighestBidMap<T>>,
+pub struct GossipVerifiedPayloadBidCache<E: EthSpec> {
+    highest_bid: RwLock<HighestBidMap<E>>,
     seen_builder: RwLock<BTreeMap<Slot, HashSet<BuilderIndex>>>,
 }
 
-impl<T: BeaconChainTypes> Default for GossipVerifiedPayloadBidCache<T> {
+impl<E: EthSpec> Default for GossipVerifiedPayloadBidCache<E> {
     fn default() -> Self {
         Self {
             highest_bid: RwLock::new(BTreeMap::new()),
@@ -26,14 +23,14 @@ impl<T: BeaconChainTypes> Default for GossipVerifiedPayloadBidCache<T> {
     }
 }
 
-impl<T: BeaconChainTypes> GossipVerifiedPayloadBidCache<T> {
+impl<E: EthSpec> GossipVerifiedPayloadBidCache<E> {
     /// Get the cached bid for the tuple `(slot, parent_block_hash, parent_block_root)`.
     pub fn get_highest_bid(
         &self,
         slot: Slot,
         parent_block_hash: ExecutionBlockHash,
         parent_block_root: Hash256,
-    ) -> Option<Arc<SignedExecutionPayloadBid<T::EthSpec>>> {
+    ) -> Option<Arc<SignedExecutionPayloadBid<E>>> {
         self.highest_bid.read().get(&slot).and_then(|map| {
             map.get(&(parent_block_hash, parent_block_root))
                 .map(|b| b.signed_bid.clone())
@@ -42,7 +39,7 @@ impl<T: BeaconChainTypes> GossipVerifiedPayloadBidCache<T> {
 
     /// Insert a bid for the tuple `(slot, parent_block_hash, parent_block_root)` only if
     /// its value is higher than the currently cached bid for that tuple.
-    pub fn insert_highest_bid(&self, bid: GossipVerifiedPayloadBid<T>) {
+    pub fn insert_highest_bid(&self, bid: GossipVerifiedPayloadBid<E>) {
         let key = (
             bid.signed_bid.message.parent_block_hash,
             bid.signed_bid.message.parent_block_root,
@@ -67,7 +64,7 @@ impl<T: BeaconChainTypes> GossipVerifiedPayloadBidCache<T> {
     }
 
     /// Insert a builder into the seen cache.
-    pub fn insert_seen_builder(&self, bid: &GossipVerifiedPayloadBid<T>) {
+    pub fn insert_seen_builder(&self, bid: &GossipVerifiedPayloadBid<E>) {
         let mut seen_builder = self.seen_builder.write();
         seen_builder
             .entry(bid.signed_bid.message.slot)
@@ -98,13 +95,9 @@ mod tests {
     };
 
     use super::GossipVerifiedPayloadBidCache;
-    use crate::{
-        payload_bid_verification::gossip_verified_bid::GossipVerifiedPayloadBid,
-        test_utils::EphemeralHarnessType,
-    };
+    use crate::payload_bid_verification::gossip_verified_bid::GossipVerifiedPayloadBid;
 
     type E = MinimalEthSpec;
-    type T = EphemeralHarnessType<E>;
 
     fn make_gossip_verified(
         slot: Slot,
@@ -112,7 +105,7 @@ mod tests {
         parent_block_hash: ExecutionBlockHash,
         parent_block_root: Hash256,
         value: u64,
-    ) -> GossipVerifiedPayloadBid<T> {
+    ) -> GossipVerifiedPayloadBid<E> {
         GossipVerifiedPayloadBid {
             signed_bid: Arc::new(SignedExecutionPayloadBid {
                 message: ExecutionPayloadBid {
@@ -130,7 +123,7 @@ mod tests {
 
     #[test]
     fn prune_removes_old_retains_current() {
-        let cache = GossipVerifiedPayloadBidCache::<T>::default();
+        let cache = GossipVerifiedPayloadBidCache::<E>::default();
         let hash = ExecutionBlockHash::zero();
         let root = Hash256::ZERO;
 

--- a/beacon_node/beacon_chain/src/payload_bid_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/payload_bid_verification/tests.rs
@@ -51,7 +51,7 @@ const BUILDER_BALANCE: u64 = 2_000_000_000;
 
 struct TestContext {
     canonical_head: CanonicalHead<T>,
-    bid_cache: GossipVerifiedPayloadBidCache<T>,
+    bid_cache: GossipVerifiedPayloadBidCache<E>,
     preferences_cache: GossipVerifiedProposerPreferenceCache,
     slot_clock: TestingSlotClock,
     keypairs: Vec<Keypair>,


### PR DESCRIPTION
## Issue Addressed

N/A — code-quality refactor.

## Proposed Changes

Parameterize `GossipVerifiedPayloadBid` and `GossipVerifiedPayloadBidCache` by
`EthSpec` instead of the broader `BeaconChainTypes`.

This removes an unnecessary dependency on the beacon chain type while retaining
the full `BeaconChainTypes` bound where gossip verification requires it.

## Additional Info

No functional changes.
