### PR TITLE
Add a bunch of semicolons to satisfy Nightly rustc

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -1148,10 +1148,12 @@ impl<E: EthSpec> BeaconProcessor<E> {
                             }
                             // Attestation batches are formed internally within the
                             // `BeaconProcessor`, they are not sent from external services.
-                            Work::GossipAttestationBatch { .. } => crit!(
-                                work_type = "GossipAttestationBatch",
-                                "Unsupported inbound event"
-                            ),
+                            Work::GossipAttestationBatch { .. } => {
+                                crit!(
+                                    work_type = "GossipAttestationBatch",
+                                    "Unsupported inbound event"
+                                );
+                            }
                             Work::GossipAggregate { .. } => work_queues.aggregate_queue.push(work),
                             // Aggregate batches are formed internally within the `BeaconProcessor`,
                             // they are not sent from external services.
@@ -1159,7 +1161,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
                                 crit!(
                                     work_type = "GossipAggregateBatch",
                                     "Unsupported inbound event"
-                                )
+                                );
                             }
                             Work::GossipBlock { .. } => {
                                 work_queues.gossip_block_queue.push(work, work_id)

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -1209,7 +1209,9 @@ impl<S: SlotClock> ReprocessQueue<S> {
                     }
                     // The message was not sent and we didn't get the correct
                     // return result. This is a logic error.
-                    _ => crit!("Unexpected return from try_send error"),
+                    _ => {
+                        crit!("Unexpected return from try_send error");
+                    }
                 }
             }
             InboundEvent::ReadyColumnReconstruction(column_reconstruction) => {

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1122,7 +1122,7 @@ impl<E: EthSpec> ExecutionLayer<E> {
                     "Chain is optimistic; can't build payload"
                 ),
                 ChainHealth::Healthy => {
-                    crit!("got healthy but also not healthy.. this shouldn't happen!")
+                    crit!("got healthy but also not healthy.. this shouldn't happen!");
                 }
             }
             return self

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -422,7 +422,9 @@ pub(crate) fn publish_column_sidecars<T: BeaconChainTypes>(
                     }
                     partial_columns.push(Arc::new(partial));
                 }
-                Err(err) => crit!(?err, "Could not convert from full to partial"),
+                Err(err) => {
+                    crit!(?err, "Could not convert from full to partial");
+                }
             }
         }
 
@@ -463,7 +465,7 @@ pub(crate) fn publish_column_sidecars<T: BeaconChainTypes>(
                 BlockError::BeaconChainError(Box::new(BeaconChainError::UnableToPublish))
             })?;
         } else {
-            crit!("Unable to extract header from full columns")
+            crit!("Unable to extract header from full columns");
         }
     }
 

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -2156,10 +2156,10 @@ impl<E: EthSpec> Network<E> {
             } => {
                 match reason {
                     Ok(_) => {
-                        debug!(?addresses, "Listener gracefully closed")
+                        debug!(?addresses, "Listener gracefully closed");
                     }
                     Err(reason) => {
-                        crit!(?addresses, ?reason, "Listener abruptly closed")
+                        crit!(?addresses, ?reason, "Listener abruptly closed");
                     }
                 };
                 if Swarm::listeners(&self.swarm).count() == 0 {

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -332,7 +332,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 results = results.len(),
                 packages = packages.len(),
                 "Batch attestation result mismatch"
-            )
+            );
         }
 
         // Map the results into a new `Vec` so that `results` no longer holds a reference to
@@ -543,7 +543,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 results = results.len(),
                 packages = packages.len(),
                 "Batch agg. attestation result mismatch"
-            )
+            );
         }
 
         // Map the results into a new `Vec` so that `results` no longer holds a reference to
@@ -823,7 +823,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         crit!(
                             error = ?err,
                             "Internal error when verifying column sidecar"
-                        )
+                        );
                     }
                     GossipDataColumnError::ProposalSignatureInvalid
                     | GossipDataColumnError::UnknownValidator(_)
@@ -948,10 +948,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             }],
                         });
                     } else {
-                        crit!("Converting from full to partial yielded headerless partial")
+                        crit!("Converting from full to partial yielded headerless partial");
                     };
                 }
-                Err(err) => crit!(?err, "Could not convert from full to partial"),
+                Err(err) => {
+                    crit!(?err, "Could not convert from full to partial");
+                }
             }
         }
 
@@ -1144,7 +1146,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     crit!(
                         error = ?err,
                         "Internal error when verifying partial column sidecar"
-                    )
+                    );
                 }
                 GossipDataColumnError::InvalidVariant
                 | GossipDataColumnError::ProposalSignatureInvalid

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -805,7 +805,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                 BatchState::Downloading(..) => {}
                 BatchState::AwaitingDownload => return,
                 BatchState::Failed | BatchState::Poisoned => {
-                    crit!("batch indicates inconsistent chain state while advancing chain")
+                    crit!("batch indicates inconsistent chain state while advancing chain");
                 }
                 BatchState::AwaitingProcessing(..) => {}
                 BatchState::Processing(_) => {

--- a/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/custody_backfill_sync/mod.rs
@@ -909,7 +909,7 @@ impl<T: BeaconChainTypes> CustodyBackFillSync<T> {
             match batch.state() {
                 BatchState::Downloading(..) | BatchState::AwaitingValidation(..) => {}
                 BatchState::Failed | BatchState::Poisoned | BatchState::AwaitingDownload => {
-                    crit!("Batch indicates inconsistent data columns while advancing custody sync")
+                    crit!("Batch indicates inconsistent data columns while advancing custody sync");
                 }
                 BatchState::AwaitingProcessing(..) => {}
                 BatchState::Processing(_) => {

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -738,7 +738,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 }
                 BatchState::Downloading(..) => {}
                 BatchState::Failed | BatchState::Poisoned | BatchState::AwaitingDownload => {
-                    crit!("batch indicates inconsistent chain state while advancing chain")
+                    crit!("batch indicates inconsistent chain state while advancing chain");
                 }
                 BatchState::AwaitingProcessing(..) => {}
                 BatchState::Processing(_) => {

--- a/validator_client/validator_services/src/attestation_service.rs
+++ b/validator_client/validator_services/src/attestation_service.rs
@@ -211,7 +211,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
                         *last_slot = current_slot;
                     }
                     Err(e) => {
-                        crit!(error = e, "Failed to spawn attestation tasks")
+                        crit!(error = e, "Failed to spawn attestation tasks");
                     }
                 }
             }
@@ -480,7 +480,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
                     committee_index,
                     slot = slot.as_u64(),
                     "Error during aggregate attestation routine"
-                )
+                );
             })?;
 
         Ok(())

--- a/validator_client/validator_services/src/sync_committee_service.rs
+++ b/validator_client/validator_services/src/sync_committee_service.rs
@@ -123,9 +123,9 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
                         crit!(
                             error = ?e,
                             "Failed to spawn sync contribution tasks"
-                        )
+                        );
                     } else {
-                        trace!("Spawned sync contribution tasks")
+                        trace!("Spawned sync contribution tasks");
                     }
 
                     // Do subscriptions for future slots/epochs.
@@ -361,7 +361,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
                     ?beacon_block_root,
                     error = %e,
                     "Failed to produce sync contribution"
-                )
+                );
             })?
             .ok_or_else(|| {
                 crit!(%slot, ?beacon_block_root, "No aggregate contribution found");


### PR DESCRIPTION
## Issue Addressed

`cargo udeps` conveniently decided to start failing:

https://github.com/sigp/lighthouse/actions/runs/29464999769/job/87516194670

## Proposed Changes

Add a bunch of semicolons after macro invocations.

