### PR TITLE
Clean up custody backfill requests after peer failures

### DIFF
--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -347,6 +347,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
     }
 
     #[cfg(test)]
+    pub(crate) fn network_context(&mut self) -> &mut SyncNetworkContext<T> {
+        &mut self.network
+    }
+
+    #[cfg(test)]
     pub(crate) fn get_range_sync_chains(
         &self,
     ) -> Result<Option<(RangeSyncType, Slot, Slot)>, &'static str> {

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -47,7 +47,6 @@ use requests::{
 };
 #[cfg(test)]
 use slot_clock::SlotClock;
-use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -1663,9 +1662,11 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         req_id: DataColumnsByRangeRequestId,
         data_columns: RpcResponseResult<DataColumnSidecarList<T::EthSpec>>,
     ) -> Option<Result<DataColumnSidecarList<T::EthSpec>, RpcResponseError>> {
-        let Entry::Occupied(mut entry) = self
+        // Remove before processing so every terminal result drops the request and its columns.
+        // Re-insert below only while waiting for more responses.
+        let Some(mut request) = self
             .custody_backfill_data_column_batch_requests
-            .entry(custody_sync_request_id)
+            .remove(&custody_sync_request_id)
         else {
             metrics::inc_counter_vec(
                 &metrics::SYNC_UNKNOWN_NETWORK_REQUESTS,
@@ -1674,33 +1675,44 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             return None;
         };
 
-        if let Err(e) = {
-            let request = entry.get_mut();
-            data_columns.and_then(|data_columns| {
-                request
-                    .add_custody_columns(req_id, data_columns.clone())
-                    .map_err(|e| {
-                        RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(
-                            e,
-                        ))
-                    })
-            })
-        } {
-            entry.remove();
+        if let Err(e) = data_columns.and_then(|data_columns| {
+            request
+                .add_custody_columns(req_id, data_columns)
+                .map_err(|e| {
+                    RpcResponseError::BlockComponentCouplingError(CouplingError::InternalError(e))
+                })
+        }) {
             return Some(Err(e));
         }
 
-        if let Some(data_column_result) = entry.get_mut().responses() {
-            if data_column_result.is_ok() {
-                // remove the entry only if it coupled successfully with
-                // no errors
-                entry.remove();
-            }
-            // If the request is finished, dequeue everything
+        if let Some(data_column_result) = request.responses() {
             Some(data_column_result.map_err(RpcResponseError::BlockComponentCouplingError))
         } else {
+            // Re-insert — still waiting for more data column responses.
+            self.custody_backfill_data_column_batch_requests
+                .insert(custody_sync_request_id, request);
             None
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn custody_backfill_batch_request_count(&self) -> usize {
+        self.custody_backfill_data_column_batch_requests.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert_test_custody_backfill_entry(
+        &mut self,
+        batch_req_id: CustodyBackFillBatchRequestId,
+        requests: Vec<(DataColumnsByRangeRequestId, Vec<ColumnIndex>)>,
+    ) {
+        let request = RangeDataColumnBatchRequest::new(
+            requests,
+            self.chain.clone(),
+            batch_req_id.batch_id.epoch,
+        );
+        self.custody_backfill_data_column_batch_requests
+            .insert(batch_req_id, request);
     }
 
     pub(crate) fn register_metrics(&self) {

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -1662,8 +1662,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         req_id: DataColumnsByRangeRequestId,
         data_columns: RpcResponseResult<DataColumnSidecarList<T::EthSpec>>,
     ) -> Option<Result<DataColumnSidecarList<T::EthSpec>, RpcResponseError>> {
-        // Remove before processing so every terminal result drops the request and its columns.
-        // Re-insert below only while waiting for more responses.
+        // Remove first so a failed request is not left in the map.
         let Some(mut request) = self
             .custody_backfill_data_column_batch_requests
             .remove(&custody_sync_request_id)
@@ -1685,13 +1684,15 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             return Some(Err(e));
         }
 
-        if let Some(data_column_result) = request.responses() {
-            Some(data_column_result.map_err(RpcResponseError::BlockComponentCouplingError))
-        } else {
-            // Re-insert — still waiting for more data column responses.
-            self.custody_backfill_data_column_batch_requests
-                .insert(custody_sync_request_id, request);
-            None
+        match request.responses() {
+            Some(data_column_result) => {
+                Some(data_column_result.map_err(RpcResponseError::BlockComponentCouplingError))
+            }
+            None => {
+                self.custody_backfill_data_column_batch_requests
+                    .insert(custody_sync_request_id, request);
+                None
+            }
         }
     }
 

--- a/beacon_node/network/src/sync/tests/range.rs
+++ b/beacon_node/network/src/sync/tests/range.rs
@@ -21,12 +21,18 @@
 use super::lookups::SimulateConfig;
 use super::*;
 use crate::status::ToStatusMessage;
-use crate::sync::SyncMessage;
-use crate::sync::manager::SLOT_IMPORT_TOLERANCE;
-use crate::sync::range_sync::RangeSyncType;
-use lighthouse_network::rpc::RPCError;
-use lighthouse_network::rpc::methods::StatusMessageV2;
-use lighthouse_network::{PeerId, SyncInfo};
+use crate::sync::{
+    SyncMessage, block_sidecar_coupling::CouplingError, manager::SLOT_IMPORT_TOLERANCE,
+    network_context::RpcResponseError, range_sync::RangeSyncType,
+};
+use lighthouse_network::{
+    PeerId, SyncInfo,
+    rpc::{RPCError, methods::StatusMessageV2},
+    service::api_types::{
+        CustodyBackFillBatchRequestId, CustodyBackfillBatchId, DataColumnsByRangeRequestId,
+        DataColumnsByRangeRequester,
+    },
+};
 use std::collections::HashSet;
 use types::{Epoch, EthSpec, ForkName, Hash256, MinimalEthSpec as E, Slot};
 
@@ -252,13 +258,6 @@ impl TestRig {
     }
 
     async fn assert_custody_backfill_peer_failure_cleans_up_request(&mut self) {
-        use crate::sync::block_sidecar_coupling::CouplingError;
-        use crate::sync::network_context::RpcResponseError;
-        use lighthouse_network::service::api_types::{
-            CustodyBackFillBatchRequestId, CustodyBackfillBatchId, DataColumnsByRangeRequestId,
-            DataColumnsByRangeRequester,
-        };
-
         self.build_chain(1).await;
         self.import_blocks_up_to_slot(1).await;
         let good_peer = self.new_connected_supernode_peer();
@@ -268,9 +267,16 @@ impl TestRig {
             .get(&Slot::new(1))
             .and_then(|block| block.data_columns())
             .expect("slot 1 should have data columns");
-        let good_column = columns[0].clone();
+        let mut columns = columns.iter();
+        let good_column = columns
+            .next()
+            .expect("slot 1 should have two columns")
+            .clone();
         let good_column_index = *good_column.index();
-        let missing_column_index = *columns[1].index();
+        let missing_column_index = *columns
+            .next()
+            .expect("slot 1 should have two columns")
+            .index();
 
         let batch_request_id = CustodyBackFillBatchRequestId {
             id: 999,
@@ -626,7 +632,6 @@ async fn finalized_sync_not_enough_custody_peers_resume_after_peer_cgc_update() 
     r.assert_range_sync_completed();
 }
 
-/// A completed custody-backfill request with missing columns must be removed before retrying.
 #[tokio::test]
 async fn custody_backfill_entry_cleaned_up_on_peer_failure() {
     let mut r = TestRig::default();

--- a/beacon_node/network/src/sync/tests/range.rs
+++ b/beacon_node/network/src/sync/tests/range.rs
@@ -28,7 +28,7 @@ use lighthouse_network::rpc::RPCError;
 use lighthouse_network::rpc::methods::StatusMessageV2;
 use lighthouse_network::{PeerId, SyncInfo};
 use std::collections::HashSet;
-use types::{Epoch, EthSpec, Hash256, MinimalEthSpec as E, Slot};
+use types::{Epoch, EthSpec, ForkName, Hash256, MinimalEthSpec as E, Slot};
 
 /// MinimalEthSpec has 8 slots per epoch
 const SLOTS_PER_EPOCH: usize = 8;
@@ -249,6 +249,81 @@ impl TestRig {
             _ => None,
         })
         .expect("Peer with blacklisted root should receive Goodbye");
+    }
+
+    async fn assert_custody_backfill_peer_failure_cleans_up_request(&mut self) {
+        use crate::sync::block_sidecar_coupling::CouplingError;
+        use crate::sync::network_context::RpcResponseError;
+        use lighthouse_network::service::api_types::{
+            CustodyBackFillBatchRequestId, CustodyBackfillBatchId, DataColumnsByRangeRequestId,
+            DataColumnsByRangeRequester,
+        };
+
+        self.build_chain(1).await;
+        self.import_blocks_up_to_slot(1).await;
+        let good_peer = self.new_connected_supernode_peer();
+        let bad_peer = self.new_connected_supernode_peer();
+        let columns = self
+            .network_blocks_by_slot
+            .get(&Slot::new(1))
+            .and_then(|block| block.data_columns())
+            .expect("slot 1 should have data columns");
+        let good_column = columns[0].clone();
+        let good_column_index = *good_column.index();
+        let missing_column_index = *columns[1].index();
+
+        let batch_request_id = CustodyBackFillBatchRequestId {
+            id: 999,
+            batch_id: CustodyBackfillBatchId {
+                epoch: Epoch::new(0),
+                run_id: 1,
+            },
+        };
+        let good_request_id = DataColumnsByRangeRequestId {
+            id: 1000,
+            parent_request_id: DataColumnsByRangeRequester::CustodyBackfillSync(batch_request_id),
+            peer: good_peer,
+        };
+        let bad_request_id = DataColumnsByRangeRequestId {
+            id: 1001,
+            parent_request_id: DataColumnsByRangeRequester::CustodyBackfillSync(batch_request_id),
+            peer: bad_peer,
+        };
+
+        let context = self.sync_manager.network_context();
+        context.insert_test_custody_backfill_entry(
+            batch_request_id,
+            vec![
+                (good_request_id, vec![good_column_index]),
+                (bad_request_id, vec![missing_column_index]),
+            ],
+        );
+        assert_eq!(context.custody_backfill_batch_request_count(), 1);
+
+        let pending_response = context.custody_backfill_data_columns_response(
+            batch_request_id,
+            good_request_id,
+            Ok(vec![good_column]),
+        );
+        assert!(pending_response.is_none());
+        assert_eq!(context.custody_backfill_batch_request_count(), 1);
+
+        let response = context.custody_backfill_data_columns_response(
+            batch_request_id,
+            bad_request_id,
+            Ok(vec![]),
+        );
+
+        assert!(
+            matches!(
+                response,
+                Some(Err(RpcResponseError::BlockComponentCouplingError(
+                    CouplingError::DataColumnPeerFailure { .. }
+                )))
+            ),
+            "expected DataColumnPeerFailure, got {response:?}",
+        );
+        assert_eq!(context.custody_backfill_batch_request_count(), 0);
     }
 }
 
@@ -549,4 +624,15 @@ async fn finalized_sync_not_enough_custody_peers_resume_after_peer_cgc_update() 
 
     r.simulate(SimulateConfig::happy_path()).await;
     r.assert_range_sync_completed();
+}
+
+/// A completed custody-backfill request with missing columns must be removed before retrying.
+#[tokio::test]
+async fn custody_backfill_entry_cleaned_up_on_peer_failure() {
+    let mut r = TestRig::default();
+    if r.fork_name != ForkName::Fulu {
+        return;
+    }
+    r.assert_custody_backfill_peer_failure_cleans_up_request()
+        .await;
 }


### PR DESCRIPTION
## Description

Custody backfill batch requests are only removed from `custody_backfill_data_column_batch_requests` when response coupling succeeds. If coupling ends with a `DataColumnPeerFailure`, the error is returned without removing the request. Retries use a new request ID, leaving the failed entry in the map.

https://github.com/sigp/lighthouse/blob/7d2b64341bcabaed85332fa59e7be28d3740e88a/beacon_node/network/src/sync/network_context.rs#L1693-L1700

Remove the request before processing the response and reinsert it only while more data column responses are pending.

This extracts the fix and regression test from #8890. The unrelated range sync fix in that PR has since been superseded by #9496.
