### PR TITLE
Handle attestation finalization races during shuffling lookup

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -294,7 +294,13 @@ pub enum Error {
 
 impl From<BeaconChainError> for Error {
     fn from(e: BeaconChainError) -> Self {
-        Self::BeaconChainError(Box::new(e))
+        match e {
+            // Finalization can prune fork choice after an earlier attestation check.
+            BeaconChainError::AttestationHeadNotInForkChoice(beacon_block_root) => {
+                Self::HeadBlockFinalized { beacon_block_root }
+            }
+            e => Self::BeaconChainError(Box::new(e)),
+        }
     }
 }
 

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -311,7 +311,9 @@ where
     let head_block = canonical_head
         .fork_choice_read_lock()
         .get_block(&head_block_root)
-        .ok_or(BeaconChainError::MissingBeaconBlock(head_block_root))?;
+        .ok_or(BeaconChainError::AttestationHeadNotInForkChoice(
+            head_block_root,
+        ))?;
 
     let shuffling_id = BlockShufflingIds {
         current: head_block.current_epoch_shuffling_id.clone(),

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -1356,6 +1356,20 @@ async fn attestation_validator_receive_proposer_reward_and_withdrawals() {
         .expect("should gossip verify attestation without checking withdrawals root");
 }
 
+#[test]
+fn missing_beacon_block_from_store_remains_internal() {
+    let block_root = Hash256::repeat_byte(42);
+    let error = AttnError::from(BeaconChainError::MissingBeaconBlock(block_root));
+
+    let AttnError::BeaconChainError(error) = error else {
+        panic!("store block miss should remain an internal beacon chain error");
+    };
+    assert!(matches!(
+        *error,
+        BeaconChainError::MissingBeaconBlock(error_root) if error_root == block_root
+    ));
+}
+
 #[tokio::test]
 async fn attestation_to_finalized_block() {
     let harness = get_harness(VALIDATOR_COUNT);
@@ -1424,6 +1438,32 @@ async fn attestation_to_finalized_block() {
         .cloned()
         .expect("should have at least one attestation in committee");
     assert_eq!(attestation.data.beacon_block_root, earlier_block_root);
+
+    // The pre-finalization block is retained in the archive store but pruned from fork choice.
+    assert!(
+        !harness
+            .chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .contains_block(&earlier_block_root)
+    );
+
+    let shuffling_error = harness
+        .chain
+        .with_committee_cache(earlier_block_root, attestation.data.target.epoch, |_, _| {
+            Ok::<_, BeaconChainError>(())
+        })
+        .expect_err("pruned block should be missing from fork choice");
+    assert!(matches!(
+        &shuffling_error,
+        BeaconChainError::AttestationHeadNotInForkChoice(block_root)
+            if *block_root == earlier_block_root
+    ));
+    assert!(matches!(
+        AttnError::from(shuffling_error),
+        AttnError::HeadBlockFinalized { beacon_block_root }
+            if beacon_block_root == earlier_block_root
+    ));
 
     // Attestation should be rejected for attesting to a pre-finalization block.
     let res = harness


### PR DESCRIPTION
## Issue Addressed

Closes #7839.

## Proposed Changes

Treat a shuffling lookup miss caused by finalization as `HeadBlockFinalized` instead of an internal `MissingBeaconBlock` error.

Tests cover the race and ensure genuine store misses remain internal errors.

## Additional Info

This keeps the existing lock scope. #9577 addresses the same race by avoiding the repeated fork-choice lookup.

Validation: [fork CI passed](https://github.com/1sgtpepper/lighthouse-consensus/actions/runs/30004166774). Upstream workflows await maintainer approval.