### PR TITLE
Add early payload envelopes to the reprocess queue

### DIFF
--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -39,7 +39,7 @@ use crate::metrics::{
 };
 use crate::observed_data_sidecars::ObservationStrategy;
 use pending_components::{PendingComponents, ReconstructColumnsDecision};
-use types::SignedExecutionPayloadBid;
+use types::{SignedExecutionPayloadBid, SignedExecutionPayloadEnvelope};
 
 /// The LRU Cache stores `PendingComponents`, which store the block root, the execution payload bid, and its associated column data.
 /// The execution payload bid stores the kzg commitments which we use to verify against incoming column data.
@@ -140,6 +140,22 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
     ) -> Option<Arc<SignedExecutionPayloadBid<T::EthSpec>>> {
         self.peek_pending_components(block_root, |components| {
             components.map(|components| components.bid.clone())
+        })
+    }
+
+    /// Return the executed payload envelope cached for `block_root` awaiting data availability,
+    /// if present.
+    pub fn get_executed_payload_envelope(
+        &self,
+        block_root: &Hash256,
+    ) -> Option<Arc<SignedExecutionPayloadEnvelope<T::EthSpec>>> {
+        self.peek_pending_components(block_root, |components| {
+            components.and_then(|components| {
+                components
+                    .envelope
+                    .as_ref()
+                    .map(|envelope| envelope.envelope.clone())
+            })
         })
     }
 

--- a/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/scheduler/work_reprocessing_queue.rs
@@ -37,6 +37,7 @@ use types::{EthSpec, Hash256, Slot};
 const TASK_NAME: &str = "beacon_processor_reprocess_queue";
 const GOSSIP_BLOCKS: &str = "gossip_blocks";
 const GOSSIP_ENVELOPES: &str = "gossip_envelopes";
+const EARLY_ENVELOPES: &str = "early_envelopes";
 const RPC_BLOCKS: &str = "rpc_blocks";
 const ATTESTATIONS: &str = "attestations";
 const ATTESTATIONS_PER_ROOT: &str = "attestations_per_root";
@@ -112,6 +113,9 @@ pub enum ReprocessQueueMessage {
     EarlyBlock(QueuedGossipBlock),
     /// An execution payload envelope that references a block not yet in fork choice.
     UnknownBlockForEnvelope(QueuedGossipEnvelope),
+    /// A verified execution payload envelope that arrived before its slot and should be queued
+    /// until the slot arrives.
+    EarlyEnvelope(QueuedGossipEnvelope),
     /// A gossip block for hash `X` is being imported, we should queue the rpc block for the same
     /// hash until the gossip block is imported.
     RpcBlock(QueuedRpcBlock),
@@ -263,6 +267,8 @@ enum InboundEvent {
     ReadyGossipBlock(QueuedGossipBlock),
     /// An envelope whose block has been imported and is now ready for processing.
     ReadyEnvelope(Hash256),
+    /// An early envelope that was queued until its slot and is now ready for processing.
+    ReadyEarlyEnvelope(QueuedGossipEnvelope),
     /// A rpc block that was queued because the same gossip block was being imported
     /// will now be retried for import.
     ReadyRpcBlock(QueuedRpcBlock),
@@ -292,6 +298,8 @@ struct ReprocessQueue<S> {
     gossip_block_delay_queue: DelayQueue<QueuedGossipBlock>,
     /// Queue to manage envelope timeouts (keyed by block root).
     envelope_delay_queue: DelayQueue<Hash256>,
+    /// Queue to manage scheduled early envelopes.
+    early_envelope_delay_queue: DelayQueue<QueuedGossipEnvelope>,
     /// Queue to manage scheduled early blocks.
     rpc_block_delay_queue: DelayQueue<QueuedRpcBlock>,
     /// Queue to manage scheduled attestations.
@@ -308,6 +316,8 @@ struct ReprocessQueue<S> {
     queued_gossip_block_roots: HashSet<Hash256>,
     /// Queued envelopes awaiting their block, keyed by block root.
     awaiting_envelopes_per_root: HashMap<Hash256, (QueuedGossipEnvelope, DelayKey)>,
+    /// Block roots of queued early envelopes.
+    queued_early_envelope_block_roots: HashSet<Hash256>,
     /// Queued aggregated attestations.
     queued_aggregates: FnvHashMap<usize, (QueuedAggregate, DelayKey)>,
     /// Queued attestations.
@@ -338,6 +348,7 @@ struct ReprocessQueue<S> {
     next_lc_update: usize,
     early_block_debounce: TimeLatch,
     envelope_delay_debounce: TimeLatch,
+    early_envelope_debounce: TimeLatch,
     rpc_block_debounce: TimeLatch,
     attestation_delay_debounce: TimeLatch,
     lc_update_delay_debounce: TimeLatch,
@@ -414,6 +425,15 @@ impl<S: SlotClock> Stream for ReprocessQueue<S> {
         match self.envelope_delay_queue.poll_expired(cx) {
             Poll::Ready(Some(block_root)) => {
                 return Poll::Ready(Some(InboundEvent::ReadyEnvelope(block_root.into_inner())));
+            }
+            Poll::Ready(None) | Poll::Pending => (),
+        }
+
+        match self.early_envelope_delay_queue.poll_expired(cx) {
+            Poll::Ready(Some(queued_envelope)) => {
+                return Poll::Ready(Some(InboundEvent::ReadyEarlyEnvelope(
+                    queued_envelope.into_inner(),
+                )));
             }
             Poll::Ready(None) | Poll::Pending => (),
         }
@@ -529,6 +549,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
             ready_work_tx,
             gossip_block_delay_queue: DelayQueue::new(),
             envelope_delay_queue: DelayQueue::new(),
+            early_envelope_delay_queue: DelayQueue::new(),
             rpc_block_delay_queue: DelayQueue::new(),
             attestations_delay_queue: DelayQueue::new(),
             lc_updates_delay_queue: DelayQueue::new(),
@@ -536,6 +557,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
             data_columns_delay_queue: DelayQueue::new(),
             queued_gossip_block_roots: HashSet::new(),
             awaiting_envelopes_per_root: HashMap::new(),
+            queued_early_envelope_block_roots: HashSet::new(),
             queued_lc_updates: FnvHashMap::default(),
             queued_aggregates: FnvHashMap::default(),
             queued_unaggregates: FnvHashMap::default(),
@@ -551,6 +573,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
             next_lc_update: 0,
             early_block_debounce: TimeLatch::default(),
             envelope_delay_debounce: TimeLatch::default(),
+            early_envelope_debounce: TimeLatch::default(),
             rpc_block_debounce: TimeLatch::default(),
             attestation_delay_debounce: TimeLatch::default(),
             lc_update_delay_debounce: TimeLatch::default(),
@@ -681,6 +704,56 @@ impl<S: SlotClock> ReprocessQueue<S> {
                             .is_err()
                     {
                         error!("Failed to send block");
+                    }
+                }
+            }
+            // A verified envelope that has been indicated as early (envelope slot > chain slot)
+            // and should be processed when the appropriate slot arrives.
+            InboundEvent::Msg(EarlyEnvelope(early_envelope)) => {
+                let envelope_slot = early_envelope.beacon_block_slot;
+                let block_root = early_envelope.beacon_block_root;
+
+                // Don't add the same envelope to the queue twice. This prevents DoS attacks.
+                if self.queued_early_envelope_block_roots.contains(&block_root) {
+                    return;
+                }
+
+                if let Some(duration_till_slot) = self.slot_clock.duration_to_slot(envelope_slot) {
+                    // Check to ensure this won't over-fill the queue.
+                    if self.queued_early_envelope_block_roots.len() >= MAXIMUM_QUEUED_ENVELOPES {
+                        if self.early_envelope_debounce.elapsed() {
+                            warn!(
+                                queue_size = MAXIMUM_QUEUED_ENVELOPES,
+                                msg = "system resources may be saturated",
+                                "Early envelopes queue is full"
+                            );
+                        }
+                        // Drop the envelope.
+                        return;
+                    }
+
+                    self.queued_early_envelope_block_roots.insert(block_root);
+                    // Queue the envelope until the start of the appropriate slot, plus
+                    // `ADDITIONAL_QUEUED_BLOCK_DELAY`.
+                    self.early_envelope_delay_queue.insert(
+                        early_envelope,
+                        duration_till_slot + ADDITIONAL_QUEUED_BLOCK_DELAY,
+                    );
+                } else {
+                    // If there is no duration till the next slot, check to see if the slot
+                    // has already arrived. If it has already arrived, send it out for
+                    // immediate processing.
+                    //
+                    // If we can't read the slot or the slot hasn't arrived, simply drop the
+                    // envelope.
+                    if let Some(now) = self.slot_clock.now()
+                        && envelope_slot <= now
+                        && self
+                            .ready_work_tx
+                            .try_send(ReadyWork::Envelope(early_envelope))
+                            .is_err()
+                    {
+                        error!(?block_root, "Failed to send early envelope");
                     }
                 }
             }
@@ -1135,6 +1208,22 @@ impl<S: SlotClock> ReprocessQueue<S> {
                     }
                 }
             }
+            // An early envelope's slot has arrived. Send it for processing.
+            InboundEvent::ReadyEarlyEnvelope(early_envelope) => {
+                let block_root = early_envelope.beacon_block_root;
+
+                if !self.queued_early_envelope_block_roots.remove(&block_root) {
+                    error!(?block_root, "Unknown early envelope in delay queue");
+                }
+
+                if self
+                    .ready_work_tx
+                    .try_send(ReadyWork::Envelope(early_envelope))
+                    .is_err()
+                {
+                    error!(?block_root, "Failed to send early envelope for processing");
+                }
+            }
             InboundEvent::ReadyAttestation(queued_id) => {
                 metrics::inc_counter(
                     &metrics::BEACON_PROCESSOR_REPROCESSING_QUEUE_EXPIRED_ATTESTATIONS,
@@ -1322,6 +1411,11 @@ impl<S: SlotClock> ReprocessQueue<S> {
         );
         metrics::set_gauge_vec(
             &metrics::BEACON_PROCESSOR_REPROCESSING_QUEUE_TOTAL,
+            &[EARLY_ENVELOPES],
+            self.early_envelope_delay_queue.len() as i64,
+        );
+        metrics::set_gauge_vec(
+            &metrics::BEACON_PROCESSOR_REPROCESSING_QUEUE_TOTAL,
             &[RPC_BLOCKS],
             self.rpc_block_delay_queue.len() as i64,
         );
@@ -1495,6 +1589,176 @@ mod tests {
             ready_work_rx.try_recv(),
             Ok(ReadyWork::BackfillSync { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn early_envelope_released_when_slot_arrives() {
+        create_test_tracing_subscriber();
+        let runtime = TestRuntime::default();
+        let (work_reprocessing_tx, work_reprocessing_rx) = mpsc::channel(16);
+        let (ready_work_tx, mut ready_work_rx) = mpsc::channel(16);
+        let slot_duration = 12;
+        let slot_clock = Arc::new(testing_slot_clock(slot_duration));
+
+        spawn_reprocess_scheduler(
+            ready_work_tx,
+            work_reprocessing_rx,
+            &runtime.task_executor,
+            slot_clock.clone(),
+            Duration::from_millis(500),
+        )
+        .unwrap();
+
+        // Pause time so it only advances manually
+        tokio::time::pause();
+
+        // Queue an envelope that arrived one slot early.
+        let envelope_slot = slot_clock.now().unwrap() + 1;
+        let block_root = Hash256::repeat_byte(0xab);
+        work_reprocessing_tx
+            .try_send(ReprocessQueueMessage::EarlyEnvelope(QueuedGossipEnvelope {
+                beacon_block_slot: envelope_slot,
+                beacon_block_root: block_root,
+                process_fn: Box::pin(async {}),
+            }))
+            .unwrap();
+        tokio::task::yield_now().await;
+
+        // The envelope is not released before its slot arrives.
+        assert!(ready_work_rx.try_recv().is_err());
+
+        // Advance to the start of the envelope's slot, plus the additional queuing delay.
+        let duration_to_slot = slot_clock.duration_to_next_slot().unwrap();
+        advance_time(
+            &slot_clock,
+            duration_to_slot + ADDITIONAL_QUEUED_BLOCK_DELAY + Duration::from_millis(1),
+        )
+        .await;
+
+        let ready_work = tokio::time::timeout(Duration::from_secs(60), ready_work_rx.recv())
+            .await
+            .expect("the early envelope should be released when its slot arrives")
+            .expect("the reprocess scheduler should be alive");
+        match ready_work {
+            ReadyWork::Envelope(envelope) => {
+                assert_eq!(envelope.beacon_block_root, block_root)
+            }
+            _ => panic!("expected a ready envelope, got a different work type"),
+        }
+    }
+
+    #[tokio::test]
+    async fn early_envelope_deduplicated_by_block_root() {
+        create_test_tracing_subscriber();
+        let runtime = TestRuntime::default();
+        let (work_reprocessing_tx, work_reprocessing_rx) = mpsc::channel(16);
+        let (ready_work_tx, mut ready_work_rx) = mpsc::channel(16);
+        let slot_duration = 12;
+        let slot_clock = Arc::new(testing_slot_clock(slot_duration));
+
+        spawn_reprocess_scheduler(
+            ready_work_tx,
+            work_reprocessing_rx,
+            &runtime.task_executor,
+            slot_clock.clone(),
+            Duration::from_millis(500),
+        )
+        .unwrap();
+
+        // Pause time so it only advances manually
+        tokio::time::pause();
+
+        // Queue two early envelopes for the same block root.
+        let envelope_slot = slot_clock.now().unwrap() + 1;
+        let block_root = Hash256::repeat_byte(0xab);
+        for _ in 0..2 {
+            work_reprocessing_tx
+                .try_send(ReprocessQueueMessage::EarlyEnvelope(QueuedGossipEnvelope {
+                    beacon_block_slot: envelope_slot,
+                    beacon_block_root: block_root,
+                    process_fn: Box::pin(async {}),
+                }))
+                .unwrap();
+            tokio::task::yield_now().await;
+        }
+
+        let duration_to_slot = slot_clock.duration_to_next_slot().unwrap();
+        advance_time(
+            &slot_clock,
+            duration_to_slot + ADDITIONAL_QUEUED_BLOCK_DELAY + Duration::from_millis(1),
+        )
+        .await;
+
+        // Only one envelope is released for the duplicated root.
+        let ready_work = tokio::time::timeout(Duration::from_secs(60), ready_work_rx.recv())
+            .await
+            .expect("the early envelope should be released when its slot arrives")
+            .expect("the reprocess scheduler should be alive");
+        assert!(matches!(ready_work, ReadyWork::Envelope(_)));
+        assert!(ready_work_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn early_envelope_queue_is_bounded() {
+        create_test_tracing_subscriber();
+        let runtime = TestRuntime::default();
+        let (work_reprocessing_tx, work_reprocessing_rx) =
+            mpsc::channel(2 * MAXIMUM_QUEUED_ENVELOPES);
+        let (ready_work_tx, mut ready_work_rx) = mpsc::channel(2 * MAXIMUM_QUEUED_ENVELOPES);
+        let slot_duration = 12;
+        let slot_clock = Arc::new(testing_slot_clock(slot_duration));
+
+        spawn_reprocess_scheduler(
+            ready_work_tx,
+            work_reprocessing_rx,
+            &runtime.task_executor,
+            slot_clock.clone(),
+            Duration::from_millis(500),
+        )
+        .unwrap();
+
+        // Pause time so it only advances manually
+        tokio::time::pause();
+
+        // Queue one more early envelope than the queue can hold, each for a distinct block root.
+        let envelope_slot = slot_clock.now().unwrap() + 1;
+        for i in 0..=MAXIMUM_QUEUED_ENVELOPES {
+            work_reprocessing_tx
+                .try_send(ReprocessQueueMessage::EarlyEnvelope(QueuedGossipEnvelope {
+                    beacon_block_slot: envelope_slot,
+                    beacon_block_root: Hash256::repeat_byte(i as u8),
+                    process_fn: Box::pin(async {}),
+                }))
+                .unwrap();
+            tokio::task::yield_now().await;
+        }
+
+        let duration_to_slot = slot_clock.duration_to_next_slot().unwrap();
+        advance_time(
+            &slot_clock,
+            duration_to_slot + ADDITIONAL_QUEUED_BLOCK_DELAY + Duration::from_millis(1),
+        )
+        .await;
+
+        // Exactly `MAXIMUM_QUEUED_ENVELOPES` envelopes are released; the excess one was dropped.
+        let mut released_roots = HashSet::new();
+        for _ in 0..MAXIMUM_QUEUED_ENVELOPES {
+            let ready_work = tokio::time::timeout(Duration::from_secs(60), ready_work_rx.recv())
+                .await
+                .expect("queued early envelopes should be released when their slot arrives")
+                .expect("the reprocess scheduler should be alive");
+            match ready_work {
+                ReadyWork::Envelope(envelope) => {
+                    released_roots.insert(envelope.beacon_block_root);
+                }
+                _ => panic!("expected a ready envelope, got a different work type"),
+            }
+        }
+        let expected_roots: HashSet<_> = (0..MAXIMUM_QUEUED_ENVELOPES)
+            .map(|i| Hash256::repeat_byte(i as u8))
+            .collect();
+        assert_eq!(released_roots, expected_roots);
+        assert!(ready_work_rx.try_recv().is_err());
     }
 
     /// Advances slot clock and test clock time by the same duration.

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -135,6 +135,20 @@ pub static BEACON_PROCESSOR_GOSSIP_BLOCK_EARLY_SECONDS: LazyLock<Result<Histogra
         )
     },
 );
+pub static BEACON_PROCESSOR_GOSSIP_PAYLOAD_ENVELOPE_REQUEUED_TOTAL: LazyLock<Result<IntCounter>> =
+    LazyLock::new(|| {
+        try_create_int_counter(
+            "beacon_processor_gossip_payload_envelope_requeued_total",
+            "Total number of gossip payload envelopes that arrived early and were re-queued for later processing.",
+        )
+    });
+pub static BEACON_PROCESSOR_GOSSIP_PAYLOAD_ENVELOPE_EARLY_SECONDS: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram(
+            "beacon_processor_gossip_payload_envelope_early_seconds",
+            "Whenever a gossip payload envelope is received early this metric is set to how early that envelope was.",
+        )
+    });
 pub static BEACON_PROCESSOR_GOSSIP_DATA_COLUMN_SIDECAR_VERIFIED_TOTAL: LazyLock<
     Result<IntCounter>,
 > = LazyLock::new(|| {

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -3891,10 +3891,25 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "envelope arrived early"
                 );
 
-                // TODO(gloas) update metrics to note how early the envelope arrived
+                // Take note of how early this envelope arrived.
+                if let Some(duration) = self
+                    .chain
+                    .slot_clock
+                    .start_of(envelope_slot)
+                    .and_then(|start| start.checked_sub(seen_duration))
+                {
+                    metrics::observe_duration(
+                        &metrics::BEACON_PROCESSOR_GOSSIP_PAYLOAD_ENVELOPE_EARLY_SECONDS,
+                        duration,
+                    );
+                }
+
+                metrics::inc_counter(
+                    &metrics::BEACON_PROCESSOR_GOSSIP_PAYLOAD_ENVELOPE_REQUEUED_TOTAL,
+                );
 
                 let inner_self = self.clone();
-                let _process_fn = Box::pin(async move {
+                let process_fn = Box::pin(async move {
                     inner_self
                         .process_gossip_verified_execution_payload_envelope(
                             peer_id,
@@ -3902,8 +3917,27 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         )
                         .await;
                 });
-
-                // TODO(gloas) send to reprocess queue
+                if self
+                    .beacon_processor_send
+                    .try_send(WorkEvent {
+                        drop_during_sync: false,
+                        work: Work::Reprocess(ReprocessQueueMessage::EarlyEnvelope(
+                            QueuedGossipEnvelope {
+                                beacon_block_slot: envelope_slot,
+                                beacon_block_root,
+                                process_fn,
+                            },
+                        )),
+                    })
+                    .is_err()
+                {
+                    error!(
+                        %envelope_slot,
+                        ?beacon_block_root,
+                        location = "envelope gossip",
+                        "Failed to defer envelope import"
+                    )
+                }
                 None
             }
             Ok(_) => Some(verified_envelope),

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -67,6 +67,7 @@ const STANDARD_TIMEOUT: Duration = Duration::from_secs(10);
 struct TestRig {
     chain: Arc<BeaconChain<T>>,
     next_block: Arc<SignedBeaconBlock<E>>,
+    next_block_envelope: Option<Arc<SignedExecutionPayloadEnvelope<E>>>,
     next_data_columns: Option<DataColumnSidecarList<E>>,
     attestations: Vec<(SingleAttestation, SubnetId)>,
     next_block_attestations: Vec<(SingleAttestation, SubnetId)>,
@@ -206,8 +207,8 @@ impl TestRig {
             .server
             .execution_block_generator()
             .set_min_blob_count(1);
-        let (next_block_tuple, next_state) = harness
-            .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
+        let (next_block_tuple, next_block_envelope, next_state) = harness
+            .make_block_with_envelope(head.beacon_state.clone(), harness.chain.slot().unwrap())
             .await;
 
         let head_state_root = head.beacon_state_root();
@@ -365,6 +366,7 @@ impl TestRig {
         Self {
             chain,
             next_block: block,
+            next_block_envelope: next_block_envelope.map(Arc::new),
             next_data_columns: data_columns,
             attestations,
             next_block_attestations,
@@ -396,6 +398,21 @@ impl TestRig {
                 junk_peer_id(),
                 Client::default(),
                 self.next_block.clone(),
+                Duration::from_secs(0),
+            )
+            .unwrap();
+    }
+
+    pub fn enqueue_gossip_envelope(&self) {
+        let envelope = self
+            .next_block_envelope
+            .as_ref()
+            .expect("the next block should have an envelope post-Gloas");
+        self.network_beacon_processor
+            .send_gossip_execution_payload(
+                junk_message_id(),
+                junk_peer_id(),
+                Box::new(envelope.as_ref().clone()),
                 Duration::from_secs(0),
             )
             .unwrap();
@@ -1542,6 +1559,83 @@ async fn requeue_unknown_block_gossip_payload_attestation_without_import() {
         rig.chain.op_pool.num_payload_attestation_messages(),
         initial_messages,
         "Payload attestation should not have been included."
+    );
+}
+
+/// Ensure that a payload envelope arriving before its slot (e.g. due to clock drift) is re-queued
+/// and re-processed once the slot arrives.
+#[tokio::test]
+async fn requeue_early_gossip_payload_envelope() {
+    // Only test when the Gloas fork is scheduled
+    if test_spec::<E>().gloas_fork_epoch.is_none() {
+        return;
+    }
+
+    let mut rig = TestRig::new(SMALL_CHAIN).await;
+    let block_root = rig.next_block.canonical_root();
+
+    // Import the block for the next slot.
+    rig.enqueue_gossip_block();
+    rig.assert_event_journal_completes(&[WorkType::GossipBlock])
+        .await;
+
+    // Wind the clock back to just before the block's slot, so the envelope arrives "early".
+    let slot_start = rig
+        .chain
+        .slot_clock
+        .start_of(rig.next_block.slot())
+        .unwrap();
+    rig.chain
+        .slot_clock
+        .set_current_time(slot_start - rig.chain.spec.maximum_gossip_clock_disparity());
+    assert_eq!(
+        rig.chain.slot().unwrap(),
+        rig.next_block.slot() - 1,
+        "chain should be at the correct slot"
+    );
+
+    // The envelope passes gossip verification but is queued until its slot instead of imported.
+    rig.enqueue_gossip_envelope();
+    rig.assert_event_journal_completes(&[WorkType::GossipExecutionPayload])
+        .await;
+    assert!(
+        rig.chain
+            .get_payload_envelope(&block_root)
+            .unwrap()
+            .is_none(),
+        "The early envelope should not have been imported."
+    );
+    assert!(
+        rig.chain
+            .pending_payload_cache
+            .get_executed_payload_envelope(&block_root)
+            .is_none(),
+        "The early envelope should be queued, not in the data availability checker."
+    );
+
+    // Restore the clock and ensure the envelope is released and re-processed when its slot
+    // arrives.
+    rig.chain.slot_clock.set_current_time(slot_start);
+    rig.assert_event_journal_with_timeout(
+        &[
+            WorkType::DelayedImportEnvelope.into(),
+            WORKER_FREED,
+            NOTHING_TO_DO,
+        ],
+        Duration::from_secs(2),
+        false,
+        false,
+    )
+    .await;
+
+    // The released envelope has been re-processed into the data availability checker, where its
+    // import remains pending on data column availability, which is not exercised here.
+    assert!(
+        rig.chain
+            .pending_payload_cache
+            .get_executed_payload_envelope(&block_root)
+            .is_some(),
+        "The envelope should have been re-processed into the data availability checker."
     );
 }
 


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/8922

## Proposed Changes

- Early payload envelopes (arriving before their slot is current) are now queued for reprocessing and retried at the start of their slot, instead of being dropped
- Follows the same reprocess-queue pattern used by early blocks: deduplicated by block root and bounded in size. Gossip propagation is not affected
- Includes unit tests for the queue behaviour and an e2e test covering the full requeue-and-retry flow