### PR TITLE
Ensure we always use fcu v4 post gloas

### DIFF
--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -1499,6 +1499,9 @@ impl HttpJsonRpc {
                     }
                 }
             }
+        } else if engine_capabilities.forkchoice_updated_v4 {
+            self.forkchoice_updated_v4(forkchoice_state, maybe_payload_attributes)
+                .await
         } else if engine_capabilities.forkchoice_updated_v3 {
             self.forkchoice_updated_v3(forkchoice_state, maybe_payload_attributes)
                 .await


### PR DESCRIPTION
We were only using fcu v4 post gloas when we provided payload attributes (i.e. when we were the proposer). This PR ensures we use fcu v4 regardless of wether payload attributes are provided


devnet-7 evidence: 
<img width="1254" height="382" alt="image" src="https://github.com/user-attachments/assets/4ad8c475-80cf-4eaa-8507-19a295d15f9d" />
