### PR TITLE
Report datadir disk usage in remote monitoring

### DIFF
--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -275,6 +275,7 @@ pub fn get_config<E: EthSpec>(
             clap_utils::parse_optional(cli_args, "monitoring-endpoint-period")?;
 
         client_config.monitoring_api = Some(monitoring_api::Config {
+            data_dir: Some(client_config.get_data_dir()),
             db_path: None,
             freezer_db_path: None,
             update_period_secs,

--- a/book/src/api_metrics.md
+++ b/book/src/api_metrics.md
@@ -57,6 +57,8 @@ can be found in beaconcha.in's docs:
 - <https://kb.beaconcha.in/beaconcha.in-explorer/mobile-app-less-than-greater-than-beacon-node>
 
 The Lighthouse flag for setting the monitoring URL is `--monitoring-endpoint`.
+The reported total and free disk capacity describe the filesystem containing the configured
+beacon node or validator client data directory.
 
 When sending metrics to a remote server you should be conscious of security:
 

--- a/common/health_metrics/src/observe.rs
+++ b/common/health_metrics/src/observe.rs
@@ -1,4 +1,5 @@
 use eth2::lighthouse::{Health, ProcessHealth, SystemHealth};
+use std::path::Path;
 
 #[cfg(target_os = "linux")]
 use {
@@ -26,66 +27,75 @@ impl Observe for Health {
 }
 
 impl Observe for SystemHealth {
-    #[cfg(not(target_os = "linux"))]
     fn observe() -> Result<Self, String> {
-        Err("Health is only available on Linux".into())
+        observe_system_health(Path::new("/"))
     }
+}
 
-    #[cfg(target_os = "linux")]
-    fn observe() -> Result<Self, String> {
-        let vm = psutil::memory::virtual_memory()
-            .map_err(|e| format!("Unable to get virtual memory: {:?}", e))?;
-        let loadavg =
-            psutil::host::loadavg().map_err(|e| format!("Unable to get loadavg: {:?}", e))?;
+/// Observes system health using the filesystem containing `data_dir` for disk capacity metrics.
+#[cfg(not(target_os = "linux"))]
+pub fn observe_system_health(_data_dir: &Path) -> Result<SystemHealth, String> {
+    Err("Health is only available on Linux".into())
+}
 
-        let cpu =
-            psutil::cpu::cpu_times().map_err(|e| format!("Unable to get cpu times: {:?}", e))?;
+/// Observes system health using the filesystem containing `data_dir` for disk capacity metrics.
+#[cfg(target_os = "linux")]
+pub fn observe_system_health(data_dir: &Path) -> Result<SystemHealth, String> {
+    let vm = psutil::memory::virtual_memory()
+        .map_err(|e| format!("Unable to get virtual memory: {:?}", e))?;
+    let loadavg = psutil::host::loadavg().map_err(|e| format!("Unable to get loadavg: {:?}", e))?;
 
-        let disk_usage = psutil::disk::disk_usage("/")
-            .map_err(|e| format!("Unable to disk usage info: {:?}", e))?;
+    let cpu = psutil::cpu::cpu_times().map_err(|e| format!("Unable to get cpu times: {:?}", e))?;
 
-        let disk = psutil::disk::DiskIoCountersCollector::default()
-            .disk_io_counters()
-            .map_err(|e| format!("Unable to get disk counters: {:?}", e))?;
+    let disk_usage = psutil::disk::disk_usage(data_dir).map_err(|e| {
+        format!(
+            "Unable to get disk usage for {}: {:?}",
+            data_dir.display(),
+            e
+        )
+    })?;
 
-        let net = psutil::network::NetIoCountersCollector::default()
-            .net_io_counters()
-            .map_err(|e| format!("Unable to get network io counters: {:?}", e))?;
+    let disk = psutil::disk::DiskIoCountersCollector::default()
+        .disk_io_counters()
+        .map_err(|e| format!("Unable to get disk counters: {:?}", e))?;
 
-        let boot_time = psutil::host::boot_time()
-            .map_err(|e| format!("Unable to get system boot time: {:?}", e))?
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|e| format!("Boot time is lower than unix epoch: {}", e))?
-            .as_secs();
+    let net = psutil::network::NetIoCountersCollector::default()
+        .net_io_counters()
+        .map_err(|e| format!("Unable to get network io counters: {:?}", e))?;
 
-        Ok(Self {
-            sys_virt_mem_total: vm.total(),
-            sys_virt_mem_available: vm.available(),
-            sys_virt_mem_used: vm.used(),
-            sys_virt_mem_free: vm.free(),
-            sys_virt_mem_cached: vm.cached(),
-            sys_virt_mem_buffers: vm.buffers(),
-            sys_virt_mem_percent: vm.percent(),
-            sys_loadavg_1: loadavg.one,
-            sys_loadavg_5: loadavg.five,
-            sys_loadavg_15: loadavg.fifteen,
-            cpu_cores: psutil::cpu::cpu_count_physical(),
-            cpu_threads: psutil::cpu::cpu_count(),
-            system_seconds_total: cpu.system().as_secs(),
-            cpu_time_total: cpu.total().as_secs(),
-            user_seconds_total: cpu.user().as_secs(),
-            iowait_seconds_total: cpu.iowait().as_secs(),
-            idle_seconds_total: cpu.idle().as_secs(),
-            disk_node_bytes_total: disk_usage.total(),
-            disk_node_bytes_free: disk_usage.free(),
-            disk_node_reads_total: disk.read_count(),
-            disk_node_writes_total: disk.write_count(),
-            network_node_bytes_total_received: net.bytes_recv(),
-            network_node_bytes_total_transmit: net.bytes_sent(),
-            misc_node_boot_ts_seconds: boot_time,
-            misc_os: std::env::consts::OS.to_string(),
-        })
-    }
+    let boot_time = psutil::host::boot_time()
+        .map_err(|e| format!("Unable to get system boot time: {:?}", e))?
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("Boot time is lower than unix epoch: {}", e))?
+        .as_secs();
+
+    Ok(SystemHealth {
+        sys_virt_mem_total: vm.total(),
+        sys_virt_mem_available: vm.available(),
+        sys_virt_mem_used: vm.used(),
+        sys_virt_mem_free: vm.free(),
+        sys_virt_mem_cached: vm.cached(),
+        sys_virt_mem_buffers: vm.buffers(),
+        sys_virt_mem_percent: vm.percent(),
+        sys_loadavg_1: loadavg.one,
+        sys_loadavg_5: loadavg.five,
+        sys_loadavg_15: loadavg.fifteen,
+        cpu_cores: psutil::cpu::cpu_count_physical(),
+        cpu_threads: psutil::cpu::cpu_count(),
+        system_seconds_total: cpu.system().as_secs(),
+        cpu_time_total: cpu.total().as_secs(),
+        user_seconds_total: cpu.user().as_secs(),
+        iowait_seconds_total: cpu.iowait().as_secs(),
+        idle_seconds_total: cpu.idle().as_secs(),
+        disk_node_bytes_total: disk_usage.total(),
+        disk_node_bytes_free: disk_usage.free(),
+        disk_node_reads_total: disk.read_count(),
+        disk_node_writes_total: disk.write_count(),
+        network_node_bytes_total_received: net.bytes_recv(),
+        network_node_bytes_total_transmit: net.bytes_sent(),
+        misc_node_boot_ts_seconds: boot_time,
+        misc_os: std::env::consts::OS.to_string(),
+    })
 }
 
 impl Observe for ProcessHealth {
@@ -123,5 +133,18 @@ impl Observe for ProcessHealth {
                 + process_times.children_system().as_secs()
                 + process_times.children_user().as_secs(),
         })
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_health_reports_the_requested_disk_path() {
+        let missing_path = Path::new("/proc/lighthouse-health-metrics-missing-path");
+        let error = observe_system_health(missing_path).expect_err("path should not exist");
+
+        assert!(error.contains(&missing_path.display().to_string()));
     }
 }

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -2,9 +2,8 @@ mod gather;
 mod types;
 use std::{path::PathBuf, time::Duration};
 
-use eth2::lighthouse::SystemHealth;
 use gather::{gather_beacon_metrics, gather_validator_metrics};
-use health_metrics::observe::Observe;
+use health_metrics::observe::observe_system_health;
 use pretty_reqwest_error::PrettyReqwestError;
 use reqwest::{IntoUrl, Response};
 pub use reqwest::{StatusCode, Url};
@@ -57,6 +56,8 @@ impl From<reqwest::Error> for Error {
 pub struct Config {
     /// Endpoint
     pub monitoring_endpoint: String,
+    /// Path whose filesystem should be used for disk capacity metrics.
+    pub data_dir: Option<PathBuf>,
     /// Path for the hot database required for fetching beacon db size metrics.
     /// Note: not relevant for validator and system metrics.
     pub db_path: Option<PathBuf>,
@@ -70,6 +71,8 @@ pub struct Config {
 #[derive(Clone)]
 pub struct MonitoringHttpClient {
     client: reqwest::Client,
+    /// Path whose filesystem should be used for disk capacity metrics.
+    data_dir: PathBuf,
     /// Path to the hot database. Required for getting db size metrics
     db_path: Option<PathBuf>,
     /// Path to the freezer database.
@@ -82,6 +85,10 @@ impl MonitoringHttpClient {
     pub fn new(config: &Config) -> Result<Self, String> {
         Ok(Self {
             client: reqwest::Client::new(),
+            data_dir: config
+                .data_dir
+                .clone()
+                .unwrap_or_else(|| PathBuf::from("/")),
             db_path: config.db_path.clone(),
             freezer_db_path: config.freezer_db_path.clone(),
             update_period: Duration::from_secs(
@@ -165,7 +172,8 @@ impl MonitoringHttpClient {
 
     /// Gets system metrics by observing capturing the SystemHealth metrics.
     pub fn get_system_metrics(&self) -> Result<MonitoringMetrics, Error> {
-        let system_health = SystemHealth::observe().map_err(Error::SystemMetricsFailed)?;
+        let system_health =
+            observe_system_health(&self.data_dir).map_err(Error::SystemMetricsFailed)?;
         Ok(MonitoringMetrics {
             metadata: Metadata::new(ProcessType::System),
             process_metrics: Process::System(system_health.into()),
@@ -235,6 +243,7 @@ mod tests {
 
         let client = MonitoringHttpClient::new(&Config {
             monitoring_endpoint: "http://127.0.0.1/".to_string(),
+            data_dir: None,
             db_path: None,
             freezer_db_path: None,
             update_period_secs: None,
@@ -254,5 +263,44 @@ mod tests {
         assert!(!formatted_error.contains("apikey"));
         assert!(!formatted_error.contains(api_key));
         assert!(!formatted_error.contains(&format!("apikey={api_key}")));
+    }
+
+    #[test]
+    fn monitoring_client_uses_configured_data_dir() {
+        let data_dir = PathBuf::from("/configured-data-dir");
+        let client = MonitoringHttpClient::new(&Config {
+            monitoring_endpoint: "http://127.0.0.1/".to_string(),
+            data_dir: Some(data_dir.clone()),
+            ..Config::default()
+        })
+        .expect("monitoring endpoint should be valid");
+
+        assert_eq!(client.data_dir, data_dir);
+    }
+
+    #[test]
+    fn monitoring_client_defaults_to_root_for_older_configs() {
+        let client = MonitoringHttpClient::new(&Config {
+            monitoring_endpoint: "http://127.0.0.1/".to_string(),
+            ..Config::default()
+        })
+        .expect("monitoring endpoint should be valid");
+
+        assert_eq!(client.data_dir, PathBuf::from("/"));
+    }
+
+    #[test]
+    fn config_without_data_dir_deserializes() {
+        let config: Config = serde_json::from_str(
+            r#"{
+                "monitoring_endpoint": "http://127.0.0.1/",
+                "db_path": null,
+                "freezer_db_path": null,
+                "update_period_secs": null
+            }"#,
+        )
+        .expect("older monitoring config should deserialize");
+
+        assert_eq!(config.data_dir, None);
     }
 }

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -363,6 +363,7 @@ impl Config {
         if let Some(monitoring_endpoint) = validator_client_config.monitoring_endpoint.as_ref() {
             let update_period_secs = Some(validator_client_config.monitoring_endpoint_period);
             config.monitoring_api = Some(monitoring_api::Config {
+                data_dir: Some(config.validator_dir.clone()),
                 db_path: None,
                 freezer_db_path: None,
                 update_period_secs,


### PR DESCRIPTION
## Issue Addressed

Closes #6687.

Remote monitoring currently obtains `SystemHealth` through `SystemHealth::observe()`, which always asks `psutil` for disk capacity at `/`. Operators who place the beacon node or validator client data directory on a separate filesystem therefore receive `disk_node_bytes_total` and `disk_node_bytes_free` values for the root filesystem instead of the filesystem that can actually run out of space.

## Proposed Changes

- Add `observe_system_health(&Path)` so callers can select the path used for disk capacity collection.
- Preserve `SystemHealth::observe()` as the root-filesystem behavior used by existing HTTP health and Prometheus endpoints.
- Add an optional data-directory path to remote monitoring configuration.
- Pass the resolved beacon node data directory and validator directory into their respective remote monitoring clients.
- Retain `/` as the fallback when an older serialized monitoring configuration has no data-directory field.
- Include the selected path in disk-usage errors to make configuration failures diagnosable.
- Document that remote disk capacity metrics describe the filesystem containing the configured data directory.
- Add tests for configured path selection, root fallback, and deserialization of older monitoring configurations. A Linux-only collector test verifies that errors identify the requested path.

This keeps the behavior change limited to remote monitoring. The `/lighthouse/health` and Prometheus endpoints continue to report their existing root-filesystem values.

## Additional Info

`psutil::disk::disk_usage` resolves capacity for the filesystem containing the supplied path, so no mount-point discovery or platform-specific parsing is required.

Only the total and free capacity fields are path-specific. Existing disk I/O counters remain system-wide. Beacon node freezer or blob databases placed on other filesystems are also outside this issue's single-datadir scope.

PR #7421 addresses the same issue with a broader change to HTTP health endpoints and remains blocked by an unsafe temporary-directory lifetime. This proposal avoids that lifetime problem and focuses on the remote-monitoring behavior requested by the issue.

Validation completed:

- `cargo fmt --all -- --check`
- `cargo test --locked -p health_metrics -p monitoring_api --lib`
- `cargo check --locked -p beacon_node -p validator_client`
- `cargo clippy --locked --no-deps -p health_metrics -p monitoring_api -p beacon_node -p validator_client --all-targets -- -D warnings -A clippy::uninlined-format-args`

A workspace-wide all-target Clippy attempt also reaches existing lint failures in unrelated dependency crates on the current `unstable` head. The package-only command above keeps all warnings denied for the four affected crates.

Development note: AI assistance was used during implementation. The final patch was reviewed against every monitoring configuration call site and validated with the commands above.
