### PR TITLE
Cache slashed justified balances

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -47,29 +47,17 @@ impl From<ArithError> for Error {
 /// The number of validator balance sets that are cached within `BalancesCache`.
 const MAX_BALANCE_CACHE_SIZE: usize = 4;
 
-#[superstruct(
-    variants(V8),
-    variant_attributes(derive(PartialEq, Clone, Debug, Encode, Decode)),
-    no_enum
-)]
+#[derive(PartialEq, Clone, Debug)]
 pub(crate) struct CacheItem {
     pub(crate) block_root: Hash256,
     pub(crate) epoch: Epoch,
-    pub(crate) balances: Vec<u64>,
+    pub(crate) justified_balances: JustifiedBalances,
 }
 
-pub(crate) type CacheItem = CacheItemV8;
-
-#[superstruct(
-    variants(V8),
-    variant_attributes(derive(PartialEq, Clone, Default, Debug, Encode, Decode)),
-    no_enum
-)]
+#[derive(PartialEq, Clone, Default, Debug)]
 pub struct BalancesCache {
-    pub(crate) items: Vec<CacheItemV8>,
+    pub(crate) items: Vec<CacheItem>,
 }
-
-pub type BalancesCache = BalancesCacheV8;
 
 impl BalancesCache {
     /// Inspect the given `state` and determine the root of the block at the first slot of
@@ -98,7 +86,7 @@ impl BalancesCache {
             let item = CacheItem {
                 block_root: epoch_boundary_root,
                 epoch,
-                balances: JustifiedBalances::from_justified_state(state)?.effective_balances,
+                justified_balances: JustifiedBalances::from_justified_state(state)?,
             };
 
             if self.items.len() == MAX_BALANCE_CACHE_SIZE {
@@ -120,9 +108,9 @@ impl BalancesCache {
     /// Get the balances for the given `block_root`, if any.
     ///
     /// If some balances are found, they are cloned from the cache.
-    pub fn get(&mut self, block_root: Hash256, epoch: Epoch) -> Option<Vec<u64>> {
+    pub fn get(&mut self, block_root: Hash256, epoch: Epoch) -> Option<JustifiedBalances> {
         let i = self.position(block_root, epoch)?;
-        Some(self.items[i].balances.clone())
+        Some(self.items[i].justified_balances.clone())
     }
 }
 
@@ -333,13 +321,12 @@ where
         self.justified_checkpoint = checkpoint;
         self.justified_state_root = justified_state_root;
 
-        if let Some(balances) = self.balances_cache.get(
+        if let Some(justified_balances) = self.balances_cache.get(
             self.justified_checkpoint.root,
             self.justified_checkpoint.epoch,
         ) {
-            // NOTE: could avoid this re-calculation by introducing a `PersistedCacheItem`.
             metrics::inc_counter(&metrics::BALANCES_CACHE_HITS);
-            self.justified_balances = JustifiedBalances::from_effective_balances(balances)?;
+            self.justified_balances = justified_balances;
         } else {
             metrics::inc_counter(&metrics::BALANCES_CACHE_MISSES);
 
@@ -393,4 +380,41 @@ pub struct PersistedForkChoiceStore {
     pub unrealized_finalized_checkpoint: Checkpoint,
     pub proposer_boost_root: Hash256,
     pub equivocating_indices: BTreeSet<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use types::{MinimalEthSpec, Validator};
+
+    type E = MinimalEthSpec;
+
+    #[test]
+    fn balances_cache_hit_matches_justified_state() {
+        let spec = E::default_spec();
+        let mut state: BeaconState<E> = BeaconState::new(0, <_>::default(), &spec);
+        for i in 0..4u64 {
+            state
+                .validators_mut()
+                .push(Validator {
+                    effective_balance: 32_000_000_000,
+                    slashed: i == 1,
+                    activation_epoch: Epoch::new(0),
+                    exit_epoch: spec.far_future_epoch,
+                    withdrawable_epoch: spec.far_future_epoch,
+                    ..Default::default()
+                })
+                .unwrap();
+        }
+
+        let block_root = Hash256::repeat_byte(1);
+        let mut cache = BalancesCache::default();
+        cache.process_state(block_root, &state).unwrap();
+
+        let cached = cache.get(block_root, state.current_epoch()).unwrap();
+        let expected = JustifiedBalances::from_justified_state(&state).unwrap();
+        assert_eq!(cached, expected);
+        assert!(!cached.slashed_balances.is_empty());
+        assert!(cache.get(block_root, state.current_epoch() + 1).is_none());
+    }
 }

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -642,7 +642,7 @@ async fn justified_balances() {
 /// Check that the balances are obtained correctly when the justified state contains a slashed
 /// validator.
 ///
-/// The slashing must be included well before the justified epoch's boundary: the balances cache
+/// TODO(9691) The slashing must be included well before the justified epoch's boundary: the balances cache
 /// builds its entry from the first state processed in an epoch, so a slashing included intra-epoch
 /// (e.g. just after a skipped boundary slot) produces cached balances that differ from the
 /// checkpoint state itself.

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -14,6 +14,7 @@ use fork_choice::{
     InvalidPayloadAttestation, PayloadVerificationStatus, QueuedAttestation,
 };
 use state_processing::state_advance::complete_state_advance;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -390,27 +391,41 @@ impl ForkChoiceTest {
             .get_state(&state_root, None, CACHE_STATE_IN_TESTS)
             .unwrap()
             .unwrap();
+        let current_epoch = state.current_epoch();
+        let mut num_active_validators = 0u64;
+        let mut slashed_balances = BTreeMap::new();
         let balances = state
             .validators()
             .into_iter()
-            .map(|v| {
-                if v.is_active_at(state.current_epoch()) {
+            .enumerate()
+            .map(|(i, v)| {
+                if !v.slashed && v.is_active_at(current_epoch) {
+                    num_active_validators += 1;
                     v.effective_balance
                 } else {
+                    if v.slashed && v.is_active_at(current_epoch) {
+                        slashed_balances.insert(i as u64, v.effective_balance);
+                    }
                     0
                 }
             })
             .collect::<Vec<_>>();
 
+        let justified_balances = fc.fc_store().justified_balances();
         assert_eq!(
             &balances[..],
-            &fc.fc_store().justified_balances().effective_balances,
+            &justified_balances.effective_balances,
             "balances should match"
         );
         assert_eq!(
             balances.iter().sum::<u64>(),
-            fc.fc_store().justified_balances().total_effective_balance
+            justified_balances.total_effective_balance
         );
+        assert_eq!(
+            num_active_validators,
+            justified_balances.num_active_validators
+        );
+        assert_eq!(slashed_balances, justified_balances.slashed_balances);
     }
 
     /// Returns an attestation that is valid for some slot in the given `chain`.
@@ -622,6 +637,32 @@ async fn justified_balances() {
         .await
         .assert_justified_epoch(2)
         .check_justified_balances()
+}
+
+/// Check that the balances are obtained correctly when the justified state contains a slashed
+/// validator.
+///
+/// The slashing must be included well before the justified epoch's boundary: the balances cache
+/// builds its entry from the first state processed in an epoch, so a slashing included intra-epoch
+/// (e.g. just after a skipped boundary slot) produces cached balances that differ from the
+/// checkpoint state itself.
+#[tokio::test]
+async fn justified_balances_with_attester_slashing() {
+    let test = ForkChoiceTest::new()
+        .apply_blocks_while(|_, state| state.finalized_checkpoint().epoch == 0)
+        .await
+        .unwrap()
+        .add_previous_epoch_attester_slashing()
+        .await
+        .apply_blocks(1)
+        .await
+        .apply_blocks(2 * E::slots_per_epoch() as usize)
+        .await;
+
+    let slashed_balances =
+        test.get(|fc_store| fc_store.justified_balances().slashed_balances.clone());
+    assert_eq!(slashed_balances.len(), 1, "one attester was slashed");
+    test.check_justified_balances();
 }
 
 macro_rules! assert_invalid_block {

--- a/consensus/proto_array/src/justified_balances.rs
+++ b/consensus/proto_array/src/justified_balances.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use safe_arith::{ArithError, SafeArith};
 use types::{BeaconState, EthSpec};
 
@@ -12,6 +14,9 @@ pub struct JustifiedBalances {
     pub total_effective_balance: u64,
     /// The number of active validators included in `self.effective_balances`.
     pub num_active_validators: u64,
+    /// A mapping from a slashed validator index to its effective balance active at the current
+    /// epoch.
+    pub slashed_balances: BTreeMap<u64, u64>,
 }
 
 impl JustifiedBalances {
@@ -19,17 +24,22 @@ impl JustifiedBalances {
         let current_epoch = state.current_epoch();
         let mut total_effective_balance = 0u64;
         let mut num_active_validators = 0u64;
+        let mut slashed_balances = BTreeMap::new();
 
         let effective_balances = state
             .validators()
             .iter()
-            .map(|validator| {
+            .enumerate()
+            .map(|(i, validator)| {
                 if !validator.slashed && validator.is_active_at(current_epoch) {
                     total_effective_balance.safe_add_assign(validator.effective_balance)?;
                     num_active_validators.safe_add_assign(1)?;
 
                     Ok(validator.effective_balance)
                 } else {
+                    if validator.slashed && validator.is_active_at(current_epoch) {
+                        slashed_balances.insert(i as u64, validator.effective_balance);
+                    }
                     Ok(0)
                 }
             })
@@ -39,6 +49,7 @@ impl JustifiedBalances {
             effective_balances,
             total_effective_balance,
             num_active_validators,
+            slashed_balances,
         })
     }
 

--- a/consensus/proto_array/src/justified_balances.rs
+++ b/consensus/proto_array/src/justified_balances.rs
@@ -68,6 +68,83 @@ impl JustifiedBalances {
             effective_balances,
             total_effective_balance,
             num_active_validators,
+            slashed_balances: BTreeMap::new(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use types::{ChainSpec, Epoch, MinimalEthSpec, Validator};
+
+    type E = MinimalEthSpec;
+
+    fn push_validator(
+        state: &mut BeaconState<E>,
+        spec: &ChainSpec,
+        effective_balance: u64,
+        slashed: bool,
+        activation_epoch: Epoch,
+    ) {
+        state
+            .validators_mut()
+            .push(Validator {
+                effective_balance,
+                slashed,
+                activation_epoch,
+                exit_epoch: spec.far_future_epoch,
+                withdrawable_epoch: spec.far_future_epoch,
+                ..Default::default()
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn from_justified_state_handles_slashed_and_inactive_validators() {
+        let spec = E::default_spec();
+        let mut state: BeaconState<E> = BeaconState::new(0, <_>::default(), &spec);
+        let epoch = state.current_epoch();
+
+        push_validator(&mut state, &spec, 32_000_000_000, false, epoch);
+        push_validator(&mut state, &spec, 31_000_000_000, true, epoch);
+        push_validator(
+            &mut state,
+            &spec,
+            30_000_000_000,
+            false,
+            spec.far_future_epoch,
+        );
+        push_validator(
+            &mut state,
+            &spec,
+            29_000_000_000,
+            true,
+            spec.far_future_epoch,
+        );
+
+        let justified_balances = JustifiedBalances::from_justified_state(&state).unwrap();
+
+        assert_eq!(
+            justified_balances.effective_balances,
+            vec![32_000_000_000, 0, 0, 0]
+        );
+        assert_eq!(justified_balances.total_effective_balance, 32_000_000_000);
+        assert_eq!(justified_balances.num_active_validators, 1);
+        assert_eq!(
+            justified_balances.slashed_balances,
+            BTreeMap::from([(1, 31_000_000_000)])
+        );
+    }
+
+    #[test]
+    fn from_effective_balances_has_empty_slashed_balances() {
+        let justified_balances =
+            JustifiedBalances::from_effective_balances(vec![32_000_000_000, 0, 31_000_000_000])
+                .unwrap();
+
+        assert_eq!(justified_balances.total_effective_balance, 63_000_000_000);
+        assert_eq!(justified_balances.num_active_validators, 2);
+        assert!(justified_balances.slashed_balances.is_empty());
     }
 }


### PR DESCRIPTION
## Issue Addressed

This PR caches slashed justified balances so that we can later use these values in gloas's `is_head_weak`. Since `BalancesCache` is not persisted to disk, its superstruct variants and encode/decode implementations are no longer necessary. Instead of storing a vec of balances in the cache, we store `JustifiedBalances` directly in memory, which also contains the slashed validator balances.
