### PR TITLE
Add `--builder-tls-certs` flag for the beacon node builder client

### DIFF
--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -890,6 +890,7 @@ where
                 SensitiveUrl::parse(format!("http://127.0.0.1:{port}").as_str()).unwrap(),
                 None,
                 None,
+                None,
                 false,
             )
             .unwrap();

--- a/beacon_node/builder_client/src/lib.rs
+++ b/beacon_node/builder_client/src/lib.rs
@@ -13,7 +13,7 @@ use eth2::{
     SSZ_CONTENT_TYPE_HEADER, ok_or_error, success_or_error,
 };
 use reqwest::header::{ACCEPT, HeaderMap, HeaderValue};
-use reqwest::{IntoUrl, Response, StatusCode};
+use reqwest::{Certificate, IntoUrl, Response, StatusCode};
 use sensitive_url::SensitiveUrl;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -77,10 +77,20 @@ impl BuilderHttpClient {
         server: SensitiveUrl,
         user_agent: Option<String>,
         builder_header_timeout: Option<Duration>,
+        builder_tls_certs: Option<Vec<Certificate>>,
         disable_ssz: bool,
     ) -> Result<Self, Error> {
         let user_agent = user_agent.unwrap_or(DEFAULT_USER_AGENT.to_string());
-        let client = reqwest::Client::builder().user_agent(&user_agent).build()?;
+        let mut client_builder = reqwest::Client::builder().user_agent(&user_agent);
+        // Add any custom root certificates so the builder endpoint can be fronted
+        // by a private/internal CA. These are trusted in addition to the roots
+        // reqwest already bundles (rustls webpki roots).
+        if let Some(certs) = builder_tls_certs {
+            for cert in certs {
+                client_builder = client_builder.add_root_certificate(cert);
+            }
+        }
+        let client = client_builder.build()?;
         Ok(Self {
             client,
             server,
@@ -574,6 +584,7 @@ mod tests {
             SensitiveUrl::from_str(&server.url()).unwrap(),
             None,
             None,
+            None,
             false,
         )
         .unwrap();
@@ -607,6 +618,7 @@ mod tests {
             SensitiveUrl::from_str(&server.url()).unwrap(),
             None,
             None,
+            None,
             false,
         )
         .unwrap();
@@ -638,6 +650,7 @@ mod tests {
 
         let builder_client = BuilderHttpClient::new(
             SensitiveUrl::from_str(&server.url()).unwrap(),
+            None,
             None,
             None,
             false,

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -30,7 +30,7 @@ use slot_clock::SlotClock;
 use std::collections::{HashMap, hash_map::Entry};
 use std::fmt;
 use std::future::Future;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -479,6 +479,9 @@ pub struct Config {
     pub builder_header_timeout: Option<Duration>,
     /// User agent to send with requests to the builder API.
     pub builder_user_agent: Option<String>,
+    /// A list of custom TLS certificates (PEM) to trust when connecting to the
+    /// builder API, in addition to the certificates reqwest already bundles.
+    pub builder_tls_certs: Option<Vec<PathBuf>>,
     /// Disable ssz requests on builder. Only use json.
     pub disable_builder_ssz_requests: bool,
     /// JWT secret for the above endpoint running the engine api.
@@ -495,6 +498,51 @@ pub struct Config {
     pub execution_timeout_multiplier: Option<u32>,
 }
 
+/// Load custom TLS root certificates for the builder client from the given PEM paths.
+///
+/// Each file may contain one or more PEM-encoded certificates; every certificate found is
+/// returned. Returns `Ok(None)` when no paths are configured. File-read and parse failures
+/// are surfaced as `Error::Unexpected` at startup (no runtime panic).
+fn load_builder_tls_certificates(
+    paths: Option<Vec<PathBuf>>,
+) -> Result<Option<Vec<reqwest::Certificate>>, Error> {
+    let Some(paths) = paths else {
+        return Ok(None);
+    };
+    let mut certificates = Vec::new();
+    for path in paths {
+        let mut buf = Vec::new();
+        std::fs::File::open(&path)
+            .and_then(|mut file| file.read_to_end(&mut buf))
+            .map_err(|e| {
+                Error::Unexpected(format!(
+                    "Unable to read builder TLS certificate {:?}: {}",
+                    path, e
+                ))
+            })?;
+        let file_certs = reqwest::Certificate::from_pem_bundle(&buf).map_err(|e| {
+            Error::Unexpected(format!(
+                "Unable to parse builder TLS certificate {:?}: {}",
+                path, e
+            ))
+        })?;
+        // `from_pem_bundle` returns `Ok(empty)` for input containing no PEM
+        // certificate blocks (e.g. a DER-encoded `.cer` file, or the wrong file
+        // entirely). Treat that as an error so the flag never silently no-ops and
+        // leaves the builder connection untrusted.
+        if file_certs.is_empty() {
+            return Err(Error::Unexpected(format!(
+                "No PEM certificates found in builder TLS certificate {:?}. \
+                 The file must contain one or more PEM-encoded certificates \
+                 (is it DER-encoded?).",
+                path
+            )));
+        }
+        certificates.extend(file_certs);
+    }
+    Ok(Some(certificates))
+}
+
 /// Provides access to one execution engine and provides a neat interface for consumption by the
 /// `BeaconChain`.
 #[derive(Clone)]
@@ -509,6 +557,7 @@ impl<E: EthSpec> ExecutionLayer<E> {
             execution_endpoint: url,
             builder_url,
             builder_user_agent,
+            builder_tls_certs,
             builder_header_timeout,
             disable_builder_ssz_requests,
             secret_file,
@@ -582,6 +631,7 @@ impl<E: EthSpec> ExecutionLayer<E> {
                 builder_url,
                 builder_user_agent,
                 builder_header_timeout,
+                builder_tls_certs,
                 disable_builder_ssz_requests,
             )?;
         }
@@ -606,12 +656,15 @@ impl<E: EthSpec> ExecutionLayer<E> {
         builder_url: SensitiveUrl,
         builder_user_agent: Option<String>,
         builder_header_timeout: Option<Duration>,
+        builder_tls_certs: Option<Vec<PathBuf>>,
         disable_ssz: bool,
     ) -> Result<(), Error> {
+        let builder_tls_certs = load_builder_tls_certificates(builder_tls_certs)?;
         let builder_client = BuilderHttpClient::new(
             builder_url.clone(),
             builder_user_agent,
             builder_header_timeout,
+            builder_tls_certs,
             disable_ssz,
         )
         .map_err(Error::Builder)?;
@@ -2180,5 +2233,35 @@ mod test {
             expected_gas_limit(30_058_619, 30_000_000, &spec),
             Some(30_029_266)
         );
+    }
+
+    #[test]
+    fn builder_tls_certs_none_is_ok_none() {
+        assert!(
+            load_builder_tls_certificates(None)
+                .expect("None should be Ok")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn builder_tls_certs_missing_file_errors() {
+        let missing = std::env::temp_dir().join("lighthouse_no_such_builder_cert.pem");
+        let err = load_builder_tls_certificates(Some(vec![missing]))
+            .expect_err("a missing certificate path should error");
+        assert!(matches!(err, Error::Unexpected(_)));
+    }
+
+    #[test]
+    fn builder_tls_certs_invalid_pem_errors() {
+        let path = std::env::temp_dir().join(format!(
+            "lighthouse_bad_builder_cert_{}.pem",
+            std::process::id()
+        ));
+        std::fs::write(&path, b"this is not a valid PEM certificate").unwrap();
+        let err = load_builder_tls_certificates(Some(vec![path.clone()]))
+            .expect_err("an invalid PEM should error");
+        assert!(matches!(err, Error::Unexpected(_)));
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1496,6 +1496,19 @@ pub fn cli_app() -> Command {
                 .display_order(0)
         )
         .arg(
+            Arg::new("builder-tls-certs")
+                .long("builder-tls-certs")
+                .value_name("CERTIFICATE-FILES")
+                .help("Comma-separated paths to custom TLS certificates (PEM format) to \
+                       trust when connecting to the builder (--builder) endpoint. These \
+                       are used in addition to the certificates Lighthouse already trusts. \
+                       Commas must only be used as a delimiter, and must not be part of the \
+                       certificate path.")
+                .requires("builder")
+                .action(ArgAction::Set)
+                .display_order(0)
+        )
+        .arg(
             Arg::new("builder-disable-ssz")
                 .long("builder-disable-ssz")
                 .value_name("BOOLEAN")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -344,6 +344,10 @@ pub fn get_config<E: EthSpec>(
             clap_utils::parse_optional(cli_args, "builder-header-timeout")?
                 .map(Duration::from_millis);
 
+        el_config.builder_tls_certs = cli_args
+            .get_one::<String>("builder-tls-certs")
+            .map(|paths| paths.split(',').map(PathBuf::from).collect());
+
         el_config.disable_builder_ssz_requests = cli_args.get_flag("builder-disable-ssz");
     }
 

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -51,6 +51,12 @@ Options:
       --builder-header-timeout <MILLISECONDS>
           Defines a timeout value (in milliseconds) to use when fetching a block
           header from the builder API. [default: 1000]
+      --builder-tls-certs <CERTIFICATE-FILES>
+          Comma-separated paths to custom TLS certificates (PEM format) to trust
+          when connecting to the builder (--builder) endpoint. These are used in
+          addition to the certificates Lighthouse already trusts. Commas must
+          only be used as a delimiter, and must not be part of the certificate
+          path.
       --builder-user-agent <STRING>
           The HTTP user agent to send alongside requests to the builder URL. The
           default is Lighthouse's version string.

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -723,6 +723,39 @@ fn builder_user_agent() {
 }
 
 #[test]
+fn builder_tls_certs_flag() {
+    // No flag → no certs.
+    run_payload_builder_flag_test_with_config(
+        "builder",
+        "http://meow.cats",
+        None,
+        None,
+        |config| {
+            assert_eq!(
+                config.execution_layer.as_ref().unwrap().builder_tls_certs,
+                None
+            );
+        },
+    );
+    // Comma-separated paths → each becomes its own PathBuf (not one joined path).
+    run_payload_builder_flag_test_with_config(
+        "builder",
+        "http://meow.cats",
+        Some("builder-tls-certs"),
+        Some("/tmp/cert1.pem,/tmp/cert2.pem"),
+        |config| {
+            assert_eq!(
+                config.execution_layer.as_ref().unwrap().builder_tls_certs,
+                Some(vec![
+                    PathBuf::from("/tmp/cert1.pem"),
+                    PathBuf::from("/tmp/cert2.pem"),
+                ])
+            );
+        },
+    );
+}
+
+#[test]
 fn test_builder_disable_ssz_flag() {
     run_payload_builder_flag_test_with_config(
         "builder",


### PR DESCRIPTION
## Issue Addressed

Closes #9678

## Proposed Changes

The beacon node builder (MEV-boost) HTTP client is built with reqwest's default `rustls-tls` trust anchors (bundled webpki roots) and does not consult the OS trust store or `SSL_CERT_FILE` / `SSL_CERT_DIR`. As a result, a `--builder` endpoint fronted by a private or internal CA fails the TLS handshake during validator registration (`POST /eth/v1/builder/validators`).

This adds a `--builder-tls-certs <PATH1,PATH2,...>` flag to the beacon node, mirroring the validator client's existing `--beacon-nodes-tls-certs`. Every PEM certificate in each supplied file is added as an additional trusted root on the builder client, in addition to the bundled roots.

- The CLI flag sits next to the other `--builder-*` flags and `requires("builder")`.
- Certificate loading happens in `execution_layer` (`set_builder_url`), mapping file-read, parse, and empty-file errors to `execution_layer::Error`, so the shared `eth2::Error` type is left untouched.
- A file that yields zero PEM certificates (for example a DER-encoded file) is rejected at startup, so the flag never silently no-ops and leaves the builder connection untrusted.
- Help text avoids the validator client's "OS trust store" wording, which is inaccurate under `rustls-tls`.

## Additional Info

- Regenerated `book/src/help_bn.md` via `make cli-local`.
- Tests: a CLI parse test (`builder_tls_certs_flag`) plus unit tests for the certificate loader (`None` -> `Ok(None)`, missing file -> error, invalid/DER PEM -> error).
