### PR TITLE
Decouple PTC blob_data_available vote from payload import

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2190,11 +2190,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 slot_start.is_some_and(|start| observed.saturating_sub(start) < payload_due)
             });
 
-        // A payload is only imported into fork choice if its data was available.
+        // Blob data availability is independent of payload import: a PTC member votes data
+        // available as soon as it holds all required custody columns for the block (spec
+        // `is_data_available`), even if the execution payload was late or has not been imported
+        // into fork choice.
         let blob_data_available = self
-            .canonical_head
-            .fork_choice_read_lock()
-            .is_payload_received(&beacon_block_root);
+            .pending_payload_cache
+            .is_data_available(&beacon_block_root);
 
         Ok(PayloadAttestationData {
             beacon_block_root,

--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -133,6 +133,19 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         })
     }
 
+    /// Returns `true` if all required custody data columns for `block_root` have been received and
+    /// kzg-verified, independent of whether the execution payload envelope has been received or
+    /// executed. Returns `false` if there is no cached entry for `block_root`.
+    ///
+    /// This backs the PTC `blob_data_available` vote (spec `is_data_available`), which must not be
+    /// coupled to payload import into fork choice.
+    #[instrument(skip_all, level = "trace")]
+    pub fn is_data_available(&self, block_root: &Hash256) -> bool {
+        self.peek_pending_components(block_root, |components| {
+            components.is_some_and(|components| components.is_data_available(&self.custody_context))
+        })
+    }
+
     /// Return the cached Gloas payload bid for `block_root`, if present.
     pub fn get_bid(
         &self,
@@ -785,5 +798,58 @@ mod data_availability_checker_tests {
 
         s.put_columns(vec![last]);
         assert_lengths_match(&s);
+    }
+
+    // --- Tier 4: `is_data_available` (PTC `blob_data_available` vote, #9679) ---
+    //
+    // The PTC data-availability vote must be true as soon as all required custody columns are
+    // held, independent of whether the execution payload envelope has been received/executed.
+
+    /// All required columns present and NO envelope: data is available. This is the exact #9679
+    /// scenario (payload_present would be false, blob_data_available must be true).
+    #[tokio::test]
+    async fn is_data_available_true_with_all_columns_and_no_envelope() {
+        let s = setup(NodeCustodyType::Fullnode);
+        s.put_columns(s.custody.clone());
+        assert!(
+            s.cache.is_data_available(&s.block_root),
+            "data must be available once all custody columns are held, even without an envelope"
+        );
+    }
+
+    /// Missing even one required column: data is not available, regardless of envelope state.
+    #[tokio::test]
+    async fn is_data_available_false_with_partial_columns() {
+        let mut s = setup(NodeCustodyType::Fullnode);
+        assert!(s.custody.len() >= 2, "needs at least 2 sampling columns");
+        let last = s.custody.pop().expect("non-empty custody");
+
+        s.put_columns(s.custody.clone());
+        assert!(
+            !s.cache.is_data_available(&s.block_root),
+            "data must not be available while a required column is missing"
+        );
+
+        // The final column flips it to available.
+        s.put_columns(vec![last]);
+        assert!(s.cache.is_data_available(&s.block_root));
+    }
+
+    /// A zero-blob block requires no columns, so data is available immediately, with no envelope
+    /// and no columns.
+    #[tokio::test]
+    async fn is_data_available_true_for_zero_blob_block() {
+        let s = setup_zero_blob(NodeCustodyType::Fullnode);
+        assert!(
+            s.cache.is_data_available(&s.block_root),
+            "a block with no blobs is trivially data-available"
+        );
+    }
+
+    /// An unknown block root (no cached entry) is not data-available.
+    #[tokio::test]
+    async fn is_data_available_false_for_unknown_block_root() {
+        let s = setup(NodeCustodyType::Fullnode);
+        assert!(!s.cache.is_data_available(&Hash256::random()));
     }
 }

--- a/beacon_node/beacon_chain/src/pending_payload_cache/pending_components.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/pending_components.rs
@@ -103,6 +103,22 @@ impl<E: EthSpec> PendingComponents<E> {
         self.get_cached_data_columns().len()
     }
 
+    /// Returns `true` if all required custody data columns have been received and kzg-verified,
+    /// independent of whether the execution payload envelope has been received or executed.
+    ///
+    /// This is the data-availability half of `make_available` without the envelope gate: it is the
+    /// signal a PTC member uses to vote `blob_data_available` (spec `is_data_available`). A block
+    /// that requires no columns (no blobs, or not sampling this epoch) is trivially available.
+    pub fn is_data_available<T>(&self, custody_context: &CustodyContext<T>) -> bool
+    where
+        T: BeaconChainTypes<EthSpec = E>,
+    {
+        // `>=`, not `==`: incoming columns are pre-filtered to the node's sampling subset before
+        // being cached, so the completed count cannot exceed the requirement in practice. Using
+        // `>=` keeps this an honest "custody satisfied" check that never yields a false negative.
+        self.num_completed_columns() >= self.num_columns_required(custody_context)
+    }
+
     /// Returns `Some` if the envelope and all required data columns have been received.
     pub fn make_available<T>(
         &self,

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -4,6 +4,7 @@ use beacon_chain::attestation_simulator::produce_unaggregated_attestation;
 use beacon_chain::custody_context::NodeCustodyType;
 use beacon_chain::test_utils::{
     AttestationStrategy, BeaconChainHarness, BlockStrategy, fork_name_from_env,
+    generate_data_column_sidecars_from_block,
 };
 use beacon_chain::validator_monitor::UNAGGREGATED_ATTESTATION_LAG_SLOTS;
 use beacon_chain::{StateSkipConfig, WhenSlotSkipped, metrics};
@@ -452,11 +453,15 @@ async fn gloas_attestation_index_payload_absent() {
 }
 
 /// Verify that `produce_payload_attestation_data` reports `payload_present = true` but
-/// `blob_data_available = false` when the envelope was observed on but not imported
-/// because its data was unavailable.
+/// `blob_data_available = false` when the envelope was observed on time but the block's blob
+/// data columns have not been received (genuine data unavailability).
 ///
-/// Setup: build a chain through slot 2, then at slot 3 import only the beacon block (no
-/// envelope) and mark the envelope as observed on time.
+/// The block is forced to carry a blob so the vote is exercised against real column-custody
+/// requirements rather than the trivial zero-blob path. `blob_data_available` must NOT be coupled
+/// to envelope import: here it is false purely because the required columns are missing.
+///
+/// Setup: build a chain through slot 2, then at slot 3 import only the beacon block (no envelope,
+/// no columns) and mark the envelope as observed on time.
 #[tokio::test]
 async fn gloas_payload_attestation_seen_but_data_unavailable() {
     if fork_name_from_env().is_some_and(|f| !f.gloas_enabled()) {
@@ -471,6 +476,8 @@ async fn gloas_payload_attestation_seen_but_data_unavailable() {
         .build();
 
     let chain = &harness.chain;
+    // Force the block to carry a blob so `blob_data_available` reflects real column custody.
+    harness.execution_block_generator().set_min_blob_count(1);
 
     harness.advance_slot();
     harness
@@ -481,12 +488,24 @@ async fn gloas_payload_attestation_seen_but_data_unavailable() {
         )
         .await;
 
-    // Slot 3: import the beacon block but withhold its envelope.
+    // Slot 3: import the beacon block but withhold its envelope and its data columns.
     harness.advance_slot();
     let state = harness.get_current_state();
     let (block_contents, _envelope, _new_state) =
         harness.make_block_with_envelope(state, Slot::new(3)).await;
     let block_root = block_contents.0.canonical_root();
+    assert!(
+        !block_contents
+            .0
+            .message()
+            .body()
+            .signed_execution_payload_bid()
+            .expect("gloas block has a bid")
+            .message
+            .blob_kzg_commitments
+            .is_empty(),
+        "test requires a block with at least one blob commitment"
+    );
     harness
         .process_block(Slot::new(3), block_root, block_contents)
         .await
@@ -513,6 +532,95 @@ async fn gloas_payload_attestation_seen_but_data_unavailable() {
     );
     assert!(
         !pa_data.blob_data_available,
-        "unimported envelope data should vote blob_data_available=false"
+        "missing data columns should vote blob_data_available=false"
+    );
+}
+
+/// Regression test for https://github.com/sigp/lighthouse/issues/9679.
+///
+/// When all required blob data columns have been received but the execution payload envelope has
+/// NOT been imported into fork choice, a PTC member must still vote `blob_data_available = true`.
+/// Previously this was derived from `fork_choice.is_payload_received`, which is only true after the
+/// payload is executed and imported, so this scenario (payload not present, data available) wrongly
+/// voted `blob_data_available = false`.
+#[tokio::test]
+async fn gloas_payload_attestation_data_available_without_envelope_import() {
+    if fork_name_from_env().is_some_and(|f| !f.gloas_enabled()) {
+        return;
+    }
+
+    let harness = BeaconChainHarness::builder(MainnetEthSpec)
+        .default_spec()
+        .keypairs(KEYPAIRS[..].to_vec())
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build();
+
+    let chain = &harness.chain;
+    // Force the block to carry a blob so there are real data columns to make available.
+    harness.execution_block_generator().set_min_blob_count(1);
+
+    harness.advance_slot();
+    harness
+        .extend_chain(
+            2,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    // Slot 3: import the beacon block, withhold its envelope (never imported into fork choice).
+    harness.advance_slot();
+    let state = harness.get_current_state();
+    let (block_contents, _envelope, _new_state) =
+        harness.make_block_with_envelope(state, Slot::new(3)).await;
+    let signed_block = block_contents.0.clone();
+    assert!(
+        !signed_block
+            .message()
+            .body()
+            .signed_execution_payload_bid()
+            .expect("gloas block has a bid")
+            .message
+            .blob_kzg_commitments
+            .is_empty(),
+        "test requires a block with at least one blob commitment"
+    );
+    let block_root = signed_block.canonical_root();
+    harness
+        .process_block(Slot::new(3), block_root, block_contents)
+        .await
+        .expect("block should import without envelope");
+    assert_eq!(chain.head_snapshot().beacon_block.slot(), Slot::new(3));
+
+    // The payload envelope is deliberately never imported, so fork choice reports the payload as
+    // not received.
+    assert!(
+        !chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .is_payload_received(&block_root),
+        "envelope must not be imported for this test"
+    );
+
+    // Deliver all of the block's data columns to the availability cache.
+    let data_columns = generate_data_column_sidecars_from_block(&signed_block, &chain.spec);
+    chain
+        .process_rpc_custody_columns(data_columns)
+        .await
+        .expect("custody columns should be accepted");
+
+    let pa_data = chain
+        .produce_payload_attestation_data(Slot::new(3))
+        .expect("should produce payload attestation data");
+
+    assert!(
+        !pa_data.payload_present,
+        "no envelope was observed, so payload_present must be false"
+    );
+    assert!(
+        pa_data.blob_data_available,
+        "all custody columns are held, so blob_data_available must be true even though the \
+         envelope has not been imported"
     );
 }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -5182,12 +5182,19 @@ impl ApiTester {
         self
     }
 
-    /// When a payload hasn't been seen, the payload attestation data
-    /// must report `payload_present = false` and `blob_data_available = false`.
+    /// When a payload hasn't been seen and the block's data columns have not been received, the
+    /// payload attestation data must report `payload_present = false` and
+    /// `blob_data_available = false`. The block is forced to carry a blob so that
+    /// `blob_data_available` reflects real column custody rather than the trivial zero-blob path.
     pub async fn test_payload_attestation_unavailable_without_envelope(self) -> Self {
         if !self.chain.spec.is_gloas_scheduled() {
             return self;
         }
+
+        // Force blocks to carry a blob so data availability is not trivially satisfied.
+        self.harness
+            .execution_block_generator()
+            .set_min_blob_count(1);
 
         let fork = self.chain.canonical_head.cached_head().head_fork();
         let genesis_validators_root = self.chain.genesis_validators_root;
@@ -5238,7 +5245,8 @@ impl ApiTester {
             );
             assert!(
                 !pa_data.blob_data_available,
-                "blob_data_available should be false when the envelope is not imported (slot {slot})"
+                "blob_data_available should be false when the block's data columns are not \
+                 received (slot {slot})"
             );
 
             return self;


### PR DESCRIPTION
## Issue Addressed

Closes #9679.

PTC voting reports blob data as unavailable when the execution payload has not been imported, even though the blob data columns have all been received and verified.

## Proposed Changes

`produce_payload_attestation_data` computed the `blob_data_available` field of `PayloadAttestationData` from `fork_choice.is_payload_received(block_root)`. That flag is only set once the execution payload has been executed and imported into fork choice (`on_valid_payload_envelope_received`), so it couples data availability to payload import. A block whose custody columns were all received and kzg-verified, but whose execution payload arrived after `get_payload_due_ms()` or had not yet been imported, therefore voted `blob_data_available = false`.

Per the Gloas spec (`specs/gloas/validator.md`), the field is `is_data_available(beacon_block_root)`, a data-availability predicate that is independent of the payload.

- Add `PendingComponents::is_data_available` (the column-completeness half of `make_available`, without the envelope gate) and expose it as `PendingPayloadCache::is_data_available(block_root)`. It returns `true` once all required custody columns for the block have been received and kzg-verified (and trivially for blocks that require no columns), independent of the execution payload envelope.
- Use it for `blob_data_available` in `produce_payload_attestation_data`.
- `payload_present` already reflects a gossip-verified `SignedExecutionPayloadEnvelope` observed before the payload-due deadline (`envelope_times_cache`), which matches the spec, so it is unchanged.

The two fields are now computed from independent sources, as the fork-choice logic (`payload_timeliness_votes` vs `payload_data_availability_votes`, `should_build_on_full` / `should_extend_payload`) expects.

## Additional Info

Tests:
- Unit tests for `is_data_available` in `pending_payload_cache` (all columns + no envelope → available; partial columns → not available; zero-blob block → available; unknown block root → not available).
- End-to-end regression test `gloas_payload_attestation_data_available_without_envelope_import`: imports a block, delivers all data columns, keeps the envelope unimported, and asserts `payload_present = false` with `blob_data_available = true`. It fails on `unstable` and passes with this change.
- The two existing "unavailable" tests (`gloas_payload_attestation_seen_but_data_unavailable` and the http_api `test_payload_attestation_unavailable_without_envelope`) now force a blob (`set_min_blob_count(1)`) so they exercise real column custody instead of the trivial zero-blob path; their `blob_data_available = false` assertions remain valid because the columns are withheld.

Notes for reviewers:
- The vote now reads from `PendingPayloadCache`, a 32-entry LRU. For a current-slot head vote the entry is guaranteed present: the bid is inserted synchronously during block import, so the head block's entry is the most-recently-used at vote-production time.
- `is_data_available` uses `>=` rather than `==`: incoming columns are pre-filtered to the node's sampling subset before caching, so the completed count cannot exceed the requirement in practice, and `>=` keeps it an honest "custody satisfied" check.
- No serialized types change (`PayloadAttestationData` is untouched); only how `blob_data_available` is computed.
- The inverse case raised in the issue (payload timely, blobs unavailable) is also handled: `payload_present` and `blob_data_available` are now fully independent.

Verified locally: `beacon_chain` (unit + `attestation_production`) and `http_api` payload-attestation tests pass under `FORK_NAME=gloas`; `cargo fmt` and clippy (`-D warnings`) are clean on both crates.

Disclosure: this change was developed with AI assistance (Claude Code). I have reviewed and tested it.
