### PR TITLE
Ensure we emit SSE attestation events when batch processing

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2218,7 +2218,25 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     where
         I: Iterator<Item = (&'a SingleAttestation, Option<SubnetId>)> + ExactSizeIterator,
     {
-        batch_verify_unaggregated_attestations(attestations, self)
+        let results = batch_verify_unaggregated_attestations(attestations, self)?;
+        for verified_attestation in results.iter().flatten() {
+            self.register_unaggregated_attestation_events(verified_attestation);
+        }
+        Ok(results)
+    }
+
+    /// Register SSE events for a successfully verified unaggregated attestation.
+    fn register_unaggregated_attestation_events(
+        &self,
+        verified_attestation: &VerifiedUnaggregatedAttestation<'_, T>,
+    ) {
+        if let Some(event_handler) = self.event_handler.as_ref()
+            && event_handler.has_single_attestation_subscribers()
+        {
+            event_handler.register(EventKind::SingleAttestation(Box::new(
+                verified_attestation.single_attestation(),
+            )));
+        }
     }
 
     /// Accepts some `Attestation` from the network and attempts to verify it, returning `Ok(_)` if
@@ -2237,30 +2255,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         VerifiedUnaggregatedAttestation::verify(unaggregated_attestation, subnet_id, self).inspect(
             |v| {
-                // This method is called for API and gossip attestations, so this covers all unaggregated attestation events
-                if let Some(event_handler) = self.event_handler.as_ref() {
-                    if event_handler.has_single_attestation_subscribers() {
-                        let current_fork = self
-                            .spec
-                            .fork_name_at_slot::<T::EthSpec>(v.attestation().data().slot);
-                        if current_fork.electra_enabled() {
-                            event_handler.register(EventKind::SingleAttestation(Box::new(
-                                v.single_attestation(),
-                            )));
-                        }
-                    }
-
-                    if event_handler.has_attestation_subscribers() {
-                        let current_fork = self
-                            .spec
-                            .fork_name_at_slot::<T::EthSpec>(v.attestation().data().slot);
-                        if !current_fork.electra_enabled() {
-                            event_handler.register(EventKind::Attestation(Box::new(
-                                v.attestation().clone_as_attestation(),
-                            )));
-                        }
-                    }
-                }
+                self.register_unaggregated_attestation_events(v);
                 metrics::inc_counter(&metrics::UNAGGREGATED_ATTESTATION_PROCESSING_SUCCESSES);
             },
         )
@@ -2276,7 +2271,25 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     where
         I: Iterator<Item = &'a SignedAggregateAndProof<T::EthSpec>> + ExactSizeIterator,
     {
-        batch_verify_aggregated_attestations(aggregates, self)
+        let results = batch_verify_aggregated_attestations(aggregates, self)?;
+        for verified_aggregate in results.iter().flatten() {
+            self.register_aggregated_attestation_event(verified_aggregate);
+        }
+        Ok(results)
+    }
+
+    /// Register an SSE event for a successfully verified aggregated attestation.
+    fn register_aggregated_attestation_event(
+        &self,
+        verified_aggregate: &VerifiedAggregatedAttestation<'_, T>,
+    ) {
+        if let Some(event_handler) = self.event_handler.as_ref()
+            && event_handler.has_attestation_subscribers()
+        {
+            event_handler.register(EventKind::Attestation(Box::new(
+                verified_aggregate.attestation().clone_as_attestation(),
+            )));
+        }
     }
 
     /// Accepts some `SignedAggregateAndProof` from the network and attempts to verify it,
@@ -2290,14 +2303,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             metrics::start_timer(&metrics::AGGREGATED_ATTESTATION_GOSSIP_VERIFICATION_TIMES);
 
         VerifiedAggregatedAttestation::verify(signed_aggregate, self).inspect(|v| {
-            // This method is called for API and gossip attestations, so this covers all aggregated attestation events
-            if let Some(event_handler) = self.event_handler.as_ref()
-                && event_handler.has_attestation_subscribers()
-            {
-                event_handler.register(EventKind::Attestation(Box::new(
-                    v.attestation().clone_as_attestation(),
-                )));
-            }
+            self.register_aggregated_attestation_event(v);
             metrics::inc_counter(&metrics::AGGREGATED_ATTESTATION_PROCESSING_SUCCESSES);
         })
     }

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -15,6 +15,7 @@ use beacon_chain::{
     },
 };
 use bls::{AggregateSignature, Keypair, SecretKey};
+use eth2::types::EventKind;
 use execution_layer::test_utils::generate_genesis_header;
 use fixed_bytes::FixedBytesExtended;
 use genesis::{DEFAULT_ETH1_BLOCK_HASH, interop_genesis_state};
@@ -971,6 +972,47 @@ async fn aggregated_gossip_verification() {
                 ))
             },
         );
+}
+
+/// Ensures the batch verification paths emit SSE events for each valid attestation, just like
+/// the individual verification paths.
+#[tokio::test]
+async fn batch_verification_emits_events() {
+    let tester = GossipTester::new().await;
+    let chain = &tester.harness.chain;
+
+    let event_handler = chain.event_handler.as_ref().unwrap();
+    let mut single_attestation_receiver = event_handler.subscribe_single_attestation();
+    let mut attestation_receiver = event_handler.subscribe_attestation();
+
+    let results = chain
+        .batch_verify_unaggregated_attestations_for_gossip(
+            vec![(
+                &tester.valid_attestation,
+                Some(tester.attestation_subnet_id),
+            )]
+            .into_iter(),
+        )
+        .unwrap();
+    assert!(results.iter().all(|result| result.is_ok()));
+
+    match single_attestation_receiver.try_recv() {
+        Ok(EventKind::SingleAttestation(single_attestation)) => {
+            assert_eq!(*single_attestation, tester.valid_attestation)
+        }
+        other => panic!("expected single_attestation event, got {other:?}"),
+    }
+    assert!(attestation_receiver.try_recv().is_err());
+
+    let results = chain
+        .batch_verify_aggregated_attestations_for_gossip(vec![&tester.valid_aggregate].into_iter())
+        .unwrap();
+    assert!(results.iter().all(|result| result.is_ok()));
+
+    assert!(matches!(
+        attestation_receiver.try_recv(),
+        Ok(EventKind::Attestation(_))
+    ));
 }
 
 /// Tests the verification conditions for an unaggregated attestation on the gossip network.

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -7580,7 +7580,7 @@ impl ApiTester {
     pub async fn test_get_events(self) -> Self {
         // Subscribe to all events
         let topics = vec![
-            EventTopic::Attestation,
+            EventTopic::SingleAttestation,
             EventTopic::VoluntaryExit,
             EventTopic::Block,
             EventTopic::BlockGossip,
@@ -7638,7 +7638,7 @@ impl ApiTester {
             .fork_name_at_slot::<E>(attestations.first().unwrap().data.slot);
 
         self.client
-            .post_beacon_pool_attestations_v2::<E>(attestations, fork_name)
+            .post_beacon_pool_attestations_v2::<E>(attestations.clone(), fork_name)
             .await
             .unwrap();
 
@@ -7650,10 +7650,11 @@ impl ApiTester {
         .await;
         assert_eq!(
             attestation_events.as_slice(),
-            self.attestations
-                .clone()
+            attestations
                 .into_iter()
-                .map(|attestation| EventKind::Attestation(Box::new(attestation)))
+                .map(|single_attestation| EventKind::SingleAttestation(Box::new(
+                    single_attestation
+                )))
                 .collect::<Vec<_>>()
                 .as_slice()
         );


### PR DESCRIPTION
## Issue Addressed

We were not emitting sse events when processing attestations by batch. We also werent emitting sse events for aggregate attestations during batch processing. I've also deleted any pre-electra related logic since that is no longer supported