### PR TITLE
Introduce a block root invalid cache

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -174,6 +174,12 @@ pub enum Error {
     /// The attestation points to a block we have not yet imported. It's unclear if the attestation
     /// is valid or not.
     UnknownHeadBlock { beacon_block_root: Hash256 },
+    /// The `attestation.data.beacon_block_root` block was observed to fail consensus validation.
+    ///
+    /// ## Peer scoring
+    ///
+    /// The peer has sent an invalid message.
+    HeadBlockInvalid { beacon_block_root: Hash256 },
     /// An attestation indicating the presence of a payload (`index == 1`) references a block whose
     /// execution payload envelope has not been seen yet.
     ///
@@ -1251,6 +1257,13 @@ fn verify_head_block_is_known<T: BeaconChainTypes>(
         }
 
         Ok(block)
+    } else if chain
+        .observed_invalid_block_roots
+        .contains(&attestation_data.beacon_block_root)
+    {
+        Err(Error::HeadBlockInvalid {
+            beacon_block_root: attestation_data.beacon_block_root,
+        })
     } else if chain.is_pre_finalization_block(attestation_data.beacon_block_root)? {
         Err(Error::HeadBlockFinalized {
             beacon_block_root: attestation_data.beacon_block_root,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -57,6 +57,7 @@ use crate::observed_attesters::{
 };
 use crate::observed_block_producers::ObservedBlockProducers;
 use crate::observed_data_sidecars::ObservedDataSidecars;
+use crate::observed_invalid_block_roots::ObservedInvalidBlockRoots;
 use crate::observed_operations::{ObservationOutcome, ObservedOperations};
 use crate::observed_slashable::ObservedSlashable;
 use crate::partial_data_column_assembler::PartialMergeResult;
@@ -482,6 +483,9 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     pub envelope_times_cache: Arc<RwLock<EnvelopeTimesCache>>,
     /// A cache used to track pre-finalization block roots for quick rejection.
     pub pre_finalization_block_cache: PreFinalizationBlockCache,
+    /// A cache of block roots observed to be consensus-invalid, for rejecting gossip messages
+    /// that reference them.
+    pub observed_invalid_block_roots: ObservedInvalidBlockRoots,
     /// A cache used to store gossip verified payload bids.
     pub gossip_verified_payload_bid_cache: GossipVerifiedPayloadBidCache<T::EthSpec>,
     /// A cache used to store gossip verified proposer preferences.
@@ -3928,6 +3932,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             // The block failed verification.
             Err(other) => {
                 debug!(reason = other.to_string(), "Beacon block rejected");
+                if other.invalidates_block_root() {
+                    self.observed_invalid_block_roots.insert(block_root);
+                }
                 Err(other)
             }
         }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3932,7 +3932,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             // The block failed verification.
             Err(other) => {
                 debug!(reason = other.to_string(), "Beacon block rejected");
-                if other.invalidates_block_root() {
+                if other.is_deterministic_on_block_root() {
                     self.observed_invalid_block_roots.insert(block_root);
                 }
                 Err(other)

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -362,17 +362,12 @@ pub enum InvalidSignature {
 }
 
 impl BlockError {
-    /// Returns `true` if this error proves that any block with the same root is
-    /// consensus-invalid, making the root safe to record in
-    /// [`crate::observed_invalid_block_roots::ObservedInvalidBlockRoots`].
-    ///
-    /// Errors that depend on anything outside the block *message* must return `false`.
-    /// For example, a block root does not commit to a proposer signature so we cannot record
-    /// valid blocks with invalid proposer signatures in [`crate::observed_invalid_block_roots::ObservedInvalidBlockRoots`].
-    /// Internal errors (DB failures, engine offline, availability failures) must also
-    /// return `false`, as must execution payload invalidity, which is tracked separately via
-    /// fork choice's execution status.
-    pub fn invalidates_block_root(&self) -> bool {
+    /// Returns `true` if the failure is deterministic on the block message and the ancestry the
+    /// block root commits to, making any block with the same root equally invalid and the root
+    /// safe to record in [`crate::observed_invalid_block_roots::ObservedInvalidBlockRoots`].
+    /// Errors that depend on anything else (proposer signature, internal failures, our view of
+    /// time or finality) must return `false`.
+    pub fn is_deterministic_on_block_root(&self) -> bool {
         match self {
             BlockError::StateRootMismatch { .. }
             | BlockError::IncorrectBlockProposer { .. }
@@ -389,56 +384,7 @@ impl BlockError {
                 InvalidSignature::BlockBodySignatures => true,
                 InvalidSignature::ProposerSignature | InvalidSignature::Unknown => false,
             },
-            BlockError::PerBlockProcessingError(e) => match e {
-                // Failures deterministic on the block message and its ancestors.
-                BlockProcessingError::RandaoSignatureInvalid
-                | BlockProcessingError::StateRootMismatch
-                | BlockProcessingError::DepositCountInvalid { .. }
-                | BlockProcessingError::HeaderInvalid { .. }
-                | BlockProcessingError::ProposerSlashingInvalid { .. }
-                | BlockProcessingError::AttesterSlashingInvalid { .. }
-                | BlockProcessingError::IndexedAttestationInvalid { .. }
-                | BlockProcessingError::AttestationInvalid { .. }
-                | BlockProcessingError::PayloadAttestationInvalid { .. }
-                | BlockProcessingError::DepositInvalid { .. }
-                | BlockProcessingError::ExitInvalid { .. }
-                | BlockProcessingError::BlsExecutionChangeInvalid { .. }
-                | BlockProcessingError::SyncAggregateInvalid { .. }
-                | BlockProcessingError::InconsistentBlockFork(_)
-                | BlockProcessingError::ExecutionHashChainIncontiguous { .. }
-                | BlockProcessingError::ExecutionRandaoMismatch { .. }
-                | BlockProcessingError::ExecutionInvalidTimestamp { .. }
-                | BlockProcessingError::ExecutionInvalidBlobsLen { .. }
-                | BlockProcessingError::ExecutionInvalid
-                | BlockProcessingError::WithdrawalsRootMismatch { .. }
-                | BlockProcessingError::WithdrawalCredentialsInvalid
-                | BlockProcessingError::ExecutionPayloadBidInvalid { .. } => true,
-                // Internal errors, or not attributable to the block message alone.
-                // `BulkSignatureVerificationFailed` may include the proposer signature and
-                // `ExecutionRequestsRootMismatch`/`NonEmptyParentExecutionRequests` fault the
-                // envelope, which the block root does not commit to.
-                BlockProcessingError::IncorrectStateType
-                | BlockProcessingError::BulkSignatureVerificationFailed
-                | BlockProcessingError::BeaconStateError(_)
-                | BlockProcessingError::SignatureSetError(_)
-                | BlockProcessingError::SszTypesError(_)
-                | BlockProcessingError::SszDecodeError(_)
-                | BlockProcessingError::BitfieldError(_)
-                | BlockProcessingError::MerkleTreeError(_)
-                | BlockProcessingError::ArithError(_)
-                | BlockProcessingError::InconsistentStateFork(_)
-                | BlockProcessingError::ConsensusContext(_)
-                | BlockProcessingError::MilhouseError(_)
-                | BlockProcessingError::EpochCacheError(_)
-                | BlockProcessingError::WithdrawalsLimitExceeded { .. }
-                | BlockProcessingError::IncorrectExpectedWithdrawalsVariant
-                | BlockProcessingError::MissingLastWithdrawal
-                | BlockProcessingError::PendingAttestationInElectra
-                | BlockProcessingError::BuilderPaymentIndexOutOfBounds(_)
-                | BlockProcessingError::ExecutionRequestsRootMismatch { .. }
-                | BlockProcessingError::NonEmptyParentExecutionRequests => false,
-            },
-            // Unknown, duplicate, timing or finality-view statuses: not proof of invalidity.
+            BlockError::PerBlockProcessingError(e) => e.is_deterministic_on_block_root(),
             BlockError::ParentUnknown { .. }
             | BlockError::FutureSlot { .. }
             | BlockError::GenesisBlock
@@ -450,12 +396,10 @@ impl BlockError {
             | BlockError::NonLinearSlots
             | BlockError::WeakSubjectivityConflict
             | BlockError::Slashable
-            // Internal errors.
             | BlockError::BeaconChainError(_)
             | BlockError::InternalError(_)
             | BlockError::AvailabilityCheck(_)
-            // Execution payload validity is tracked via fork choice's execution status, and
-            // envelopes are not committed to by the block root.
+            // Payload validity is tracked via fork choice's execution status.
             | BlockError::ExecutionPayloadError(_)
             | BlockError::ParentExecutionPayloadInvalid { .. }
             | BlockError::KnownInvalidExecutionPayload(_)

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -377,7 +377,6 @@ impl BlockError {
             BlockError::StateRootMismatch { .. }
             | BlockError::IncorrectBlockProposer { .. }
             | BlockError::UnknownValidator(_)
-            | BlockError::InvalidSignature(InvalidSignature::BlockBodySignatures)
             | BlockError::BlockIsNotLaterThanParent { .. }
             | BlockError::InconsistentFork(_)
             | BlockError::InvalidBlobCount { .. }
@@ -385,12 +384,82 @@ impl BlockError {
             | BlockError::BlockSlotLimitReached
             | BlockError::ParentInvalid { .. }
             | BlockError::KnownInvalid { .. } => true,
-            // Exclude `BeaconStateError`, which can indicate an internal cache or state
-            // inconsistency on our side rather than an invalid block.
-            BlockError::PerBlockProcessingError(e) => {
-                !matches!(e, BlockProcessingError::BeaconStateError(_))
-            }
-            _ => false,
+            // The block root commits to the block message but not its proposer signature.
+            BlockError::InvalidSignature(sig) => match sig {
+                InvalidSignature::BlockBodySignatures => true,
+                InvalidSignature::ProposerSignature | InvalidSignature::Unknown => false,
+            },
+            BlockError::PerBlockProcessingError(e) => match e {
+                // Failures deterministic on the block message and its ancestors.
+                BlockProcessingError::RandaoSignatureInvalid
+                | BlockProcessingError::StateRootMismatch
+                | BlockProcessingError::DepositCountInvalid { .. }
+                | BlockProcessingError::HeaderInvalid { .. }
+                | BlockProcessingError::ProposerSlashingInvalid { .. }
+                | BlockProcessingError::AttesterSlashingInvalid { .. }
+                | BlockProcessingError::IndexedAttestationInvalid { .. }
+                | BlockProcessingError::AttestationInvalid { .. }
+                | BlockProcessingError::PayloadAttestationInvalid { .. }
+                | BlockProcessingError::DepositInvalid { .. }
+                | BlockProcessingError::ExitInvalid { .. }
+                | BlockProcessingError::BlsExecutionChangeInvalid { .. }
+                | BlockProcessingError::SyncAggregateInvalid { .. }
+                | BlockProcessingError::InconsistentBlockFork(_)
+                | BlockProcessingError::ExecutionHashChainIncontiguous { .. }
+                | BlockProcessingError::ExecutionRandaoMismatch { .. }
+                | BlockProcessingError::ExecutionInvalidTimestamp { .. }
+                | BlockProcessingError::ExecutionInvalidBlobsLen { .. }
+                | BlockProcessingError::ExecutionInvalid
+                | BlockProcessingError::WithdrawalsRootMismatch { .. }
+                | BlockProcessingError::WithdrawalCredentialsInvalid
+                | BlockProcessingError::ExecutionPayloadBidInvalid { .. } => true,
+                // Internal errors, or not attributable to the block message alone.
+                // `BulkSignatureVerificationFailed` may include the proposer signature and
+                // `ExecutionRequestsRootMismatch`/`NonEmptyParentExecutionRequests` fault the
+                // envelope, which the block root does not commit to.
+                BlockProcessingError::IncorrectStateType
+                | BlockProcessingError::BulkSignatureVerificationFailed
+                | BlockProcessingError::BeaconStateError(_)
+                | BlockProcessingError::SignatureSetError(_)
+                | BlockProcessingError::SszTypesError(_)
+                | BlockProcessingError::SszDecodeError(_)
+                | BlockProcessingError::BitfieldError(_)
+                | BlockProcessingError::MerkleTreeError(_)
+                | BlockProcessingError::ArithError(_)
+                | BlockProcessingError::InconsistentStateFork(_)
+                | BlockProcessingError::ConsensusContext(_)
+                | BlockProcessingError::MilhouseError(_)
+                | BlockProcessingError::EpochCacheError(_)
+                | BlockProcessingError::WithdrawalsLimitExceeded { .. }
+                | BlockProcessingError::IncorrectExpectedWithdrawalsVariant
+                | BlockProcessingError::MissingLastWithdrawal
+                | BlockProcessingError::PendingAttestationInElectra
+                | BlockProcessingError::BuilderPaymentIndexOutOfBounds(_)
+                | BlockProcessingError::ExecutionRequestsRootMismatch { .. }
+                | BlockProcessingError::NonEmptyParentExecutionRequests => false,
+            },
+            // Unknown, duplicate, timing or finality-view statuses: not proof of invalidity.
+            BlockError::ParentUnknown { .. }
+            | BlockError::FutureSlot { .. }
+            | BlockError::GenesisBlock
+            | BlockError::WouldRevertFinalizedSlot { .. }
+            | BlockError::NotFinalizedDescendant { .. }
+            | BlockError::DuplicateFullyImported(_)
+            | BlockError::DuplicateImportStatusUnknown(_)
+            | BlockError::NonLinearParentRoots
+            | BlockError::NonLinearSlots
+            | BlockError::WeakSubjectivityConflict
+            | BlockError::Slashable
+            // Internal errors.
+            | BlockError::BeaconChainError(_)
+            | BlockError::InternalError(_)
+            | BlockError::AvailabilityCheck(_)
+            // Execution payload validity is tracked via fork choice's execution status, and
+            // envelopes are not committed to by the block root.
+            | BlockError::ExecutionPayloadError(_)
+            | BlockError::ParentExecutionPayloadInvalid { .. }
+            | BlockError::KnownInvalidExecutionPayload(_)
+            | BlockError::EnvelopeError(_) => false,
         }
     }
 }

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -959,8 +959,8 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
         chain.check_invalid_block_roots(block_root)?;
 
         // Reject blocks that build on a parent observed to be consensus-invalid, and record them
-        // as invalid by descent. This must precede the finalized-descendant check, which would
-        // otherwise classify the unknown parent as `ParentUnknown` (an IGNORE, not a REJECT).
+        // as invalid. This must precede the finalized-descendant check, which would instead classify 
+        // the unknown parent as `ParentUnknown` and trigger a lookup sync.
         let parent_root = block.parent_root();
         if chain.observed_invalid_block_roots.contains(&parent_root) {
             chain.observed_invalid_block_roots.insert(block_root);

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -276,6 +276,15 @@ pub enum BlockError {
     ParentExecutionPayloadInvalid {
         parent_root: Hash256,
     },
+    /// The block references a parent block which was observed to fail consensus validation.
+    ///
+    /// ## Peer scoring
+    ///
+    /// The peer sent us a block descending from a known-invalid block. The block is invalid and
+    /// the peer is faulty.
+    ParentInvalid {
+        parent_root: Hash256,
+    },
     /// This is a known invalid block that was listed in Lighthouses configuration.
     /// At the moment this error is only relevant as part of the Holesky network recovery efforts.
     KnownInvalidExecutionPayload(Hash256),
@@ -341,6 +350,39 @@ pub enum InvalidSignature {
     BlockBodySignatures,
     // One or more signatures in SignedBeaconBlock
     Unknown,
+}
+
+impl BlockError {
+    /// Returns `true` if this error proves that any block with the same root is
+    /// consensus-invalid, making the root safe to record in
+    /// [`crate::observed_invalid_block_roots::ObservedInvalidBlockRoots`].
+    ///
+    /// Errors that depend on anything outside the block *message* must return `false`.
+    /// For example, a block root does not commit to a proposer signature so we cannot record
+    /// valid blocks with invalid proposer signatures in [`crate::observed_invalid_block_roots::ObservedInvalidBlockRoots`].
+    /// Internal errors (DB failures, engine offline, availability failures) must also
+    /// return `false`, as must execution payload invalidity, which is tracked separately via
+    /// fork choice's execution status.
+    pub fn invalidates_block_root(&self) -> bool {
+        match self {
+            BlockError::StateRootMismatch { .. }
+            | BlockError::IncorrectBlockProposer { .. }
+            | BlockError::UnknownValidator(_)
+            | BlockError::InvalidSignature(InvalidSignature::BlockBodySignatures)
+            | BlockError::BlockIsNotLaterThanParent { .. }
+            | BlockError::InconsistentFork(_)
+            | BlockError::InvalidBlobCount { .. }
+            | BlockError::BidParentRootMismatch { .. }
+            | BlockError::BlockSlotLimitReached
+            | BlockError::ParentInvalid { .. } => true,
+            // Exclude `BeaconStateError`, which can indicate an internal cache or state
+            // inconsistency on our side rather than an invalid block.
+            BlockError::PerBlockProcessingError(e) => {
+                !matches!(e, BlockProcessingError::BeaconStateError(_))
+            }
+            _ => false,
+        }
+    }
 }
 
 impl From<AvailabilityCheckError> for BlockError {
@@ -916,6 +958,15 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
         // Do not process a block that is known to be invalid.
         chain.check_invalid_block_roots(block_root)?;
 
+        // Reject blocks that build on a parent observed to be consensus-invalid, and record them
+        // as invalid by descent. This must precede the finalized-descendant check, which would
+        // otherwise classify the unknown parent as `ParentUnknown` (an IGNORE, not a REJECT).
+        let parent_root = block.parent_root();
+        if chain.observed_invalid_block_roots.contains(&parent_root) {
+            chain.observed_invalid_block_roots.insert(block_root);
+            return Err(BlockError::ParentInvalid { parent_root });
+        }
+
         // Do not process a block that doesn't descend from the finalized root.
         //
         // We check this *before* we load the parent so that we can return a more detailed error.
@@ -1446,8 +1497,15 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
                 }
             }
             ParentImportStatus::UnknownBlock | ParentImportStatus::UnknownPayload => {
+                let parent_root = block.parent_root();
+                if chain.observed_invalid_block_roots.contains(&parent_root) {
+                    // The block builds on a known consensus-invalid block, making it invalid by
+                    // descent. Record its root so its own descendants are also rejected.
+                    chain.observed_invalid_block_roots.insert(block_root);
+                    return Err(BlockError::ParentInvalid { parent_root });
+                }
                 return Err(BlockError::ParentUnknown {
-                    parent_root: block.parent_root(),
+                    parent_root,
                     parent_block_hash: block.as_block().payload_bid_parent_block_hash().ok(),
                 });
             }

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -285,6 +285,15 @@ pub enum BlockError {
     ParentInvalid {
         parent_root: Hash256,
     },
+    /// The block's own root was observed to fail consensus validation.
+    ///
+    /// ## Peer scoring
+    ///
+    /// The peer sent us a block that was previously observed to be invalid. The block is invalid
+    /// and the peer is faulty.
+    KnownInvalid {
+        block_root: Hash256,
+    },
     /// This is a known invalid block that was listed in Lighthouses configuration.
     /// At the moment this error is only relevant as part of the Holesky network recovery efforts.
     KnownInvalidExecutionPayload(Hash256),
@@ -374,7 +383,8 @@ impl BlockError {
             | BlockError::InvalidBlobCount { .. }
             | BlockError::BidParentRootMismatch { .. }
             | BlockError::BlockSlotLimitReached
-            | BlockError::ParentInvalid { .. } => true,
+            | BlockError::ParentInvalid { .. }
+            | BlockError::KnownInvalid { .. } => true,
             // Exclude `BeaconStateError`, which can indicate an internal cache or state
             // inconsistency on our side rather than an invalid block.
             BlockError::PerBlockProcessingError(e) => {
@@ -958,8 +968,13 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
         // Do not process a block that is known to be invalid.
         chain.check_invalid_block_roots(block_root)?;
 
+        // Reject blocks whose root was observed to be consensus-invalid.
+        if chain.observed_invalid_block_roots.contains(&block_root) {
+            return Err(BlockError::KnownInvalid { block_root });
+        }
+
         // Reject blocks that build on a parent observed to be consensus-invalid, and record them
-        // as invalid. This must precede the finalized-descendant check, which would instead classify 
+        // as invalid. This must precede the finalized-descendant check, which would instead classify
         // the unknown parent as `ParentUnknown` and trigger a lookup sync.
         let parent_root = block.parent_root();
         if chain.observed_invalid_block_roots.contains(&parent_root) {
@@ -1183,6 +1198,11 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
 
         // Check whether the block is a banned block prior to loading the parent.
         chain.check_invalid_block_roots(block_root)?;
+
+        // Reject blocks whose root was observed to be consensus-invalid.
+        if chain.observed_invalid_block_roots.contains(&block_root) {
+            return Err(BlockError::KnownInvalid { block_root });
+        }
 
         let (mut parent, block) = load_parent(block, chain)?;
 

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1499,8 +1499,8 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
             ParentImportStatus::UnknownBlock | ParentImportStatus::UnknownPayload => {
                 let parent_root = block.parent_root();
                 if chain.observed_invalid_block_roots.contains(&parent_root) {
-                    // The block builds on a known consensus-invalid block, making it invalid by
-                    // descent. Record its root so its own descendants are also rejected.
+                    // The block builds on a known consensus-invalid block, making it invalid.
+                    // Record its root so its descendants are also rejected.
                     chain.observed_invalid_block_roots.insert(block_root);
                     return Err(BlockError::ParentInvalid { parent_root });
                 }

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1032,6 +1032,7 @@ where
             block_times_cache: <_>::default(),
             envelope_times_cache: <_>::default(),
             pre_finalization_block_cache: <_>::default(),
+            observed_invalid_block_roots: <_>::default(),
             validator_pubkey_cache: RwLock::new(validator_pubkey_cache),
             early_attester_cache: <_>::default(),
             light_client_server_cache: LightClientServerCache::new(),

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -41,6 +41,7 @@ pub mod observed_aggregates;
 mod observed_attesters;
 pub mod observed_block_producers;
 pub mod observed_data_sidecars;
+pub mod observed_invalid_block_roots;
 pub mod observed_operations;
 mod observed_slashable;
 pub mod partial_data_column_assembler;

--- a/beacon_node/beacon_chain/src/observed_invalid_block_roots.rs
+++ b/beacon_node/beacon_chain/src/observed_invalid_block_roots.rs
@@ -1,18 +1,13 @@
-//! A bounded cache of block roots observed to be consensus-invalid.
+//! Cache of block roots observed to fail consensus validation.
 //!
-//! When a block fails consensus validation during import (e.g. `per_block_processing` failure,
-//! state root mismatch), fork choice retains no trace of it, making a later sighting of the same
-//! root indistinguishable from a block we have never seen. The gossip specification distinguishes
-//! these cases: messages referencing an *unseen* block are IGNOREd, while messages referencing a
-//! block that was seen and *failed validation* are REJECTed ("... passes validation" conditions),
-//! penalizing peers that propagate descendants of known-invalid blocks.
+//! When a block fails consensus validation during import, we store it in this cache. 
+//! This allows us to quickly reject messages that build on top of invalid blocks.
 //!
-//! Only failures attributable to the block's canonical root may be recorded here. The canonical
-//! root commits to the block *message* but not its signature, so a proposer-signature failure must
-//! never mark the root: an attacker could take an honest block, corrupt the signature bytes, and
-//! poison the honest root. See [`crate::block_verification::BlockError::invalidates_block_root`].
+//! Only failures attributable to the block root may be recorded here. The block root
+//! root to the block *message* but not its signature, so a proposer-signature failure must
+//! never mark the root as invalid. See [`crate::block_verification::BlockError::invalidates_block_root`].
 //!
-//! Payload-invalid blocks are deliberately excluded; they are tracked via fork choice's execution
+//! Pre-gloas payload-invalid blocks are deliberately excluded; they are tracked via fork choice's execution
 //! status and have separate gossip conditions (e.g. `ParentExecutionPayloadInvalid`).
 
 use hashlink::lru_cache::LruCache;

--- a/beacon_node/beacon_chain/src/observed_invalid_block_roots.rs
+++ b/beacon_node/beacon_chain/src/observed_invalid_block_roots.rs
@@ -1,6 +1,6 @@
 //! Cache of block roots observed to fail consensus validation.
 //!
-//! When a block fails consensus validation during import, we store it in this cache. 
+//! When a block fails consensus validation during import, we store it in this cache.
 //! This allows us to quickly reject messages that build on top of invalid blocks.
 //!
 //! Only failures attributable to the block root may be recorded here. The block root

--- a/beacon_node/beacon_chain/src/observed_invalid_block_roots.rs
+++ b/beacon_node/beacon_chain/src/observed_invalid_block_roots.rs
@@ -4,7 +4,7 @@
 //! This allows us to quickly reject messages that build on top of invalid blocks.
 //!
 //! Only failures attributable to the block root may be recorded here. The block root
-//! root to the block *message* but not its signature, so a proposer-signature failure must
+//! commits to the block *message* but not its proposer signature. A proposer signature failure must
 //! never mark the root as invalid. See [`crate::block_verification::BlockError::invalidates_block_root`].
 //!
 //! Pre-gloas payload-invalid blocks are deliberately excluded; they are tracked via fork choice's execution

--- a/beacon_node/beacon_chain/src/observed_invalid_block_roots.rs
+++ b/beacon_node/beacon_chain/src/observed_invalid_block_roots.rs
@@ -5,7 +5,7 @@
 //!
 //! Only failures attributable to the block root may be recorded here. The block root
 //! commits to the block *message* but not its proposer signature. A proposer signature failure must
-//! never mark the root as invalid. See [`crate::block_verification::BlockError::invalidates_block_root`].
+//! never mark the root as invalid. See [`crate::block_verification::BlockError::is_deterministic_on_block_root`].
 //!
 //! Pre-gloas payload-invalid blocks are deliberately excluded; they are tracked via fork choice's execution
 //! status and have separate gossip conditions (e.g. `ParentExecutionPayloadInvalid`).

--- a/beacon_node/beacon_chain/src/observed_invalid_block_roots.rs
+++ b/beacon_node/beacon_chain/src/observed_invalid_block_roots.rs
@@ -1,0 +1,46 @@
+//! A bounded cache of block roots observed to be consensus-invalid.
+//!
+//! When a block fails consensus validation during import (e.g. `per_block_processing` failure,
+//! state root mismatch), fork choice retains no trace of it, making a later sighting of the same
+//! root indistinguishable from a block we have never seen. The gossip specification distinguishes
+//! these cases: messages referencing an *unseen* block are IGNOREd, while messages referencing a
+//! block that was seen and *failed validation* are REJECTed ("... passes validation" conditions),
+//! penalizing peers that propagate descendants of known-invalid blocks.
+//!
+//! Only failures attributable to the block's canonical root may be recorded here. The canonical
+//! root commits to the block *message* but not its signature, so a proposer-signature failure must
+//! never mark the root: an attacker could take an honest block, corrupt the signature bytes, and
+//! poison the honest root. See [`crate::block_verification::BlockError::invalidates_block_root`].
+//!
+//! Payload-invalid blocks are deliberately excluded; they are tracked via fork choice's execution
+//! status and have separate gossip conditions (e.g. `ParentExecutionPayloadInvalid`).
+
+use hashlink::lru_cache::LruCache;
+use parking_lot::Mutex;
+use types::Hash256;
+
+/// Bounds memory at ~32 KiB while comfortably outlasting the gossip propagation window of any
+/// invalid block and its descendants.
+const CACHE_SIZE: usize = 1024;
+
+pub struct ObservedInvalidBlockRoots {
+    roots: Mutex<LruCache<Hash256, ()>>,
+}
+
+impl Default for ObservedInvalidBlockRoots {
+    fn default() -> Self {
+        Self {
+            roots: Mutex::new(LruCache::new(CACHE_SIZE)),
+        }
+    }
+}
+
+impl ObservedInvalidBlockRoots {
+    pub fn insert(&self, block_root: Hash256) {
+        self.roots.lock().insert(block_root, ());
+    }
+
+    pub fn contains(&self, block_root: &Hash256) -> bool {
+        self.roots.lock().contains_key(block_root)
+    }
+}

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/gossip_verified_envelope.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/gossip_verified_envelope.rs
@@ -14,6 +14,7 @@ use crate::{
     BeaconChain, BeaconChainError, BeaconChainTypes, BeaconStore, ServerSentEventHandler,
     beacon_proposer_cache::{self, BeaconProposerCache},
     canonical_head::CanonicalHead,
+    observed_invalid_block_roots::ObservedInvalidBlockRoots,
     payload_envelope_verification::{
         EnvelopeError, EnvelopeProcessingSnapshot, load_snapshot_from_state_root,
     },
@@ -30,6 +31,7 @@ pub struct GossipVerificationContext<'a, T: BeaconChainTypes> {
     pub validator_pubkey_cache: &'a RwLock<ValidatorPubkeyCache<T>>,
     pub genesis_validators_root: Hash256,
     pub event_handler: &'a Option<ServerSentEventHandler<T::EthSpec>>,
+    pub observed_invalid_block_roots: &'a ObservedInvalidBlockRoots,
 }
 
 /// Verify that an execution payload envelope is consistent with its beacon block
@@ -95,17 +97,18 @@ impl<T: BeaconChainTypes> GossipVerifiedEnvelope<T> {
         let beacon_block_root = envelope.beacon_block_root;
 
         // Check that we've seen the beacon block for this envelope and that it passes validation.
-        // TODO(EIP-7732): We might need some type of status table in order to differentiate between:
-        // If we have a block_processing_table, we could have a Processed(Bid, bool) state that is only
-        // entered post adding to fork choice. That way, we could potentially need only a single call to make
-        // sure the block is valid and to do all consequent checks with the bid
-        //
-        // 1. Blocks we haven't seen (IGNORE), and
-        // 2. Blocks we've seen that are invalid (REJECT).
-        //
-        // Presently these two cases are conflated.
+        // Envelopes whose block have observed to fail consensus validation are rejected; envelopes whose blocks
+        // haven't been seen yet are sent to the reprocess queue.
         let fork_choice_read_lock = ctx.canonical_head.fork_choice_read_lock();
         let Some(proto_block) = fork_choice_read_lock.get_block(&beacon_block_root) else {
+            if ctx
+                .observed_invalid_block_roots
+                .contains(&beacon_block_root)
+            {
+                return Err(EnvelopeError::BlockFailedValidation {
+                    block_root: beacon_block_root,
+                });
+            }
             return Err(EnvelopeError::BlockRootUnknown {
                 block_root: beacon_block_root,
             });
@@ -251,6 +254,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             validator_pubkey_cache: &self.validator_pubkey_cache,
             genesis_validators_root: self.genesis_validators_root,
             event_handler: &self.event_handler,
+            observed_invalid_block_roots: &self.observed_invalid_block_roots,
         }
     }
 

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/mod.rs
@@ -37,7 +37,10 @@ use types::{
 pub mod execution_pending_envelope;
 pub mod gossip_verified_envelope;
 pub mod import;
+
 mod payload_notifier;
+#[cfg(test)]
+mod tests;
 
 pub use execution_pending_envelope::ExecutionPendingEnvelope;
 
@@ -200,6 +203,8 @@ impl<E: EthSpec> AvailableExecutedEnvelope<E> {
 pub enum EnvelopeError {
     /// The envelope's block root is unknown.
     BlockRootUnknown { block_root: Hash256 },
+    /// The envelope's block was observed to fail consensus validation.
+    BlockFailedValidation { block_root: Hash256 },
     /// The signature is invalid.
     BadSignature,
     /// The builder index doesn't match the committed bid
@@ -259,7 +264,8 @@ impl EnvelopeError {
             | EnvelopeError::BlockHashMismatch { .. }
             | EnvelopeError::UnknownValidator { .. }
             | EnvelopeError::IncorrectBlockProposer { .. }
-            | EnvelopeError::EnvelopeProcessingError(_) => true,
+            | EnvelopeError::EnvelopeProcessingError(_)
+            | EnvelopeError::BlockFailedValidation { .. } => true,
             EnvelopeError::ExecutionPayloadError(e) => e.penalize_peer(),
             EnvelopeError::BlockRootUnknown { .. }
             | EnvelopeError::PriorToFinalization { .. }

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/tests.rs
@@ -1,0 +1,388 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use bls::{PublicKeyBytes, Signature};
+use ethereum_hashing::hash;
+use fork_choice::ForkChoice;
+use genesis::{generate_deterministic_keypairs, interop_genesis_state};
+use proto_array::{Block as ProtoBlock, ExecutionStatus, PayloadStatus};
+use ssz::Encode;
+use state_processing::genesis::genesis_block;
+use store::{HotColdDB, KeyValueStore, StoreConfig};
+use types::{
+    AttestationShufflingId, ChainSpec, Checkpoint, Epoch, ExecutionBlockHash,
+    ExecutionPayloadEnvelope, ExecutionPayloadGloas, ExecutionRequestsGloas, Hash256,
+    MinimalEthSpec, SignedBeaconBlock, SignedExecutionPayloadEnvelope, Slot,
+    consts::gloas::PAYLOAD_BUILDER_VERSION,
+};
+
+use crate::{
+    BeaconChainError, BeaconStore, ServerSentEventHandler,
+    beacon_fork_choice_store::BeaconForkChoiceStore,
+    beacon_proposer_cache::BeaconProposerCache,
+    beacon_snapshot::BeaconSnapshot,
+    canonical_head::CanonicalHead,
+    chain_config::FastConfirmationMode,
+    observed_invalid_block_roots::ObservedInvalidBlockRoots,
+    payload_envelope_verification::{
+        EnvelopeError,
+        gossip_verified_envelope::{GossipVerificationContext, GossipVerifiedEnvelope},
+    },
+    test_utils::{EphemeralHarnessType, fork_name_from_env, test_spec},
+    validator_pubkey_cache::ValidatorPubkeyCache,
+};
+use parking_lot::{Mutex, RwLock};
+
+type E = MinimalEthSpec;
+type T = EphemeralHarnessType<E>;
+
+const NUM_VALIDATORS: usize = 64;
+/// Balance given to the registered builder (min_deposit_amount + extra).
+const BUILDER_BALANCE: u64 = 2_000_000_000;
+
+fn gloas_fork_enabled() -> bool {
+    fork_name_from_env().is_some_and(|f| f.gloas_enabled())
+}
+
+fn builder_withdrawal_credentials(pubkey: &bls::PublicKey, spec: &ChainSpec) -> Hash256 {
+    let fake_execution_address = &hash(&pubkey.as_ssz_bytes())[0..20];
+    let mut credentials = [0u8; 32];
+    credentials[0] = spec.builder_withdrawal_prefix_byte;
+    credentials[12..].copy_from_slice(fake_execution_address);
+    Hash256::from_slice(&credentials)
+}
+
+struct TestContext {
+    canonical_head: CanonicalHead<T>,
+    store: BeaconStore<T>,
+    spec: ChainSpec,
+    beacon_proposer_cache: Mutex<BeaconProposerCache>,
+    validator_pubkey_cache: RwLock<ValidatorPubkeyCache<T>>,
+    genesis_validators_root: Hash256,
+    event_handler: Option<ServerSentEventHandler<E>>,
+    observed_invalid_block_roots: ObservedInvalidBlockRoots,
+    genesis_block_root: Hash256,
+}
+
+impl TestContext {
+    fn new() -> Self {
+        let spec = test_spec::<E>();
+        let store = Arc::new(
+            HotColdDB::open_ephemeral(StoreConfig::default(), Arc::new(spec.clone()))
+                .expect("should open ephemeral store"),
+        );
+
+        let keypairs = generate_deterministic_keypairs(NUM_VALIDATORS);
+        let mut state =
+            interop_genesis_state::<E>(&keypairs, 0, Hash256::repeat_byte(0x42), None, &spec)
+                .expect("should build genesis state");
+
+        // Register a builder at index 0, matching the genesis bid's builder index, so envelope
+        // signature verification can look up its pubkey.
+        if state.fork_name_unchecked().gloas_enabled() {
+            let keypair = &keypairs[0];
+            let creds = builder_withdrawal_credentials(&keypair.pk, &spec);
+            state
+                .add_builder_to_registry(
+                    PublicKeyBytes::from(keypair.pk.clone()),
+                    PAYLOAD_BUILDER_VERSION,
+                    creds,
+                    BUILDER_BALANCE,
+                    Slot::new(0),
+                    &spec,
+                )
+                .expect("should register builder");
+        }
+
+        let mut block = genesis_block(&state, &spec).expect("should build genesis block");
+        let state_root = state
+            .update_tree_hash_cache()
+            .expect("should hash genesis state");
+        *block.state_root_mut() = state_root;
+        let signed_block = SignedBeaconBlock::from_block(block, Signature::empty());
+        let block_root = signed_block.canonical_root();
+
+        // Initialize the store's anchor so the anchor block and state can be written (envelope
+        // verification loads them from the store).
+        let anchor_op = store
+            .init_anchor_info(
+                signed_block.message().parent_root(),
+                Slot::new(0),
+                Slot::new(0),
+                true,
+            )
+            .expect("should init anchor info");
+        store
+            .hot_db
+            .do_atomically(vec![anchor_op])
+            .expect("should commit anchor info");
+        store
+            .put_block(&block_root, signed_block.clone())
+            .expect("should store anchor block");
+        store
+            .put_state(&state_root, &state)
+            .expect("should store anchor state");
+
+        let snapshot = BeaconSnapshot::new(
+            Arc::new(signed_block.clone()),
+            None,
+            block_root,
+            state.clone(),
+        );
+
+        let fc_store = BeaconForkChoiceStore::get_forkchoice_store(store.clone(), snapshot.clone())
+            .expect("should create fork choice store");
+        let fork_choice =
+            ForkChoice::from_anchor(fc_store, block_root, &signed_block, &state, None, &spec)
+                .expect("should create fork choice");
+
+        let canonical_head = CanonicalHead::new(
+            fork_choice,
+            Arc::new(snapshot),
+            PayloadStatus::Pending,
+            FastConfirmationMode::Disabled,
+            &store,
+            &spec,
+        )
+        .unwrap();
+
+        let validator_pubkey_cache =
+            ValidatorPubkeyCache::new(&state, store.clone()).expect("should build pubkey cache");
+
+        Self {
+            canonical_head,
+            store,
+            genesis_validators_root: state.genesis_validators_root(),
+            spec,
+            beacon_proposer_cache: <_>::default(),
+            validator_pubkey_cache: RwLock::new(validator_pubkey_cache),
+            event_handler: None,
+            observed_invalid_block_roots: <_>::default(),
+            genesis_block_root: block_root,
+        }
+    }
+
+    fn gossip_ctx(&self) -> GossipVerificationContext<'_, T> {
+        GossipVerificationContext {
+            canonical_head: &self.canonical_head,
+            store: &self.store,
+            spec: &self.spec,
+            beacon_proposer_cache: &self.beacon_proposer_cache,
+            validator_pubkey_cache: &self.validator_pubkey_cache,
+            genesis_validators_root: self.genesis_validators_root,
+            event_handler: &self.event_handler,
+            observed_invalid_block_roots: &self.observed_invalid_block_roots,
+        }
+    }
+
+    /// Insert a proto block into fork choice whose block is (deliberately) not in the store.
+    fn insert_block_without_store_entry(&self) -> Hash256 {
+        let shuffling_id = AttestationShufflingId {
+            shuffling_epoch: Epoch::new(0),
+            shuffling_decision_block: self.genesis_block_root,
+        };
+        let fork_block_root = Hash256::repeat_byte(0xab);
+        let mut fc = self.canonical_head.fork_choice_write_lock();
+        fc.proto_array_mut()
+            .process_block::<E>(
+                ProtoBlock {
+                    slot: Slot::new(1),
+                    root: fork_block_root,
+                    parent_root: Some(self.genesis_block_root),
+                    target_root: fork_block_root,
+                    current_epoch_shuffling_id: shuffling_id.clone(),
+                    next_epoch_shuffling_id: shuffling_id,
+                    state_root: Hash256::ZERO,
+                    justified_checkpoint: Checkpoint {
+                        epoch: Epoch::new(0),
+                        root: self.genesis_block_root,
+                    },
+                    finalized_checkpoint: Checkpoint {
+                        epoch: Epoch::new(0),
+                        root: self.genesis_block_root,
+                    },
+                    execution_status: ExecutionStatus::irrelevant(),
+                    unrealized_justified_checkpoint: None,
+                    unrealized_finalized_checkpoint: None,
+                    execution_payload_parent_hash: Some(ExecutionBlockHash::zero()),
+                    execution_payload_block_hash: Some(ExecutionBlockHash::repeat_byte(0xab)),
+                    proposer_index: Some(0),
+                    payload_received: false,
+                },
+                Slot::new(1),
+                &self.spec,
+                Duration::from_secs(0),
+            )
+            .expect("should insert fork block");
+        fork_block_root
+    }
+}
+
+fn make_signed_envelope(
+    slot: Slot,
+    builder_index: u64,
+    block_hash: ExecutionBlockHash,
+    beacon_block_root: Hash256,
+) -> Arc<SignedExecutionPayloadEnvelope<E>> {
+    Arc::new(SignedExecutionPayloadEnvelope {
+        message: ExecutionPayloadEnvelope {
+            payload: ExecutionPayloadGloas {
+                block_hash,
+                slot_number: slot,
+                ..ExecutionPayloadGloas::default()
+            },
+            execution_requests: ExecutionRequestsGloas::default(),
+            builder_index,
+            beacon_block_root,
+            parent_beacon_block_root: Hash256::ZERO,
+        },
+        signature: Signature::empty(),
+    })
+}
+
+fn unwrap_err<T2>(result: Result<T2, EnvelopeError>) -> EnvelopeError {
+    match result {
+        Ok(_) => panic!("expected verification to fail"),
+        Err(e) => e,
+    }
+}
+
+#[test]
+fn block_root_unknown_is_ignored() {
+    let ctx = TestContext::new();
+    let unknown_root = Hash256::repeat_byte(0xcd);
+    let envelope = make_signed_envelope(Slot::new(0), 0, ExecutionBlockHash::zero(), unknown_root);
+
+    let err = unwrap_err(GossipVerifiedEnvelope::new(envelope, &ctx.gossip_ctx()));
+    assert!(
+        matches!(err, EnvelopeError::BlockRootUnknown { block_root } if block_root == unknown_root),
+        "expected BlockRootUnknown, got: {err:?}"
+    );
+}
+
+#[test]
+fn block_observed_invalid_is_rejected() {
+    let ctx = TestContext::new();
+    let invalid_root = Hash256::repeat_byte(0xcd);
+    let envelope = make_signed_envelope(Slot::new(0), 0, ExecutionBlockHash::zero(), invalid_root);
+
+    ctx.observed_invalid_block_roots.insert(invalid_root);
+    let err = unwrap_err(GossipVerifiedEnvelope::new(envelope, &ctx.gossip_ctx()));
+    assert!(
+        matches!(
+            err,
+            EnvelopeError::BlockFailedValidation { block_root } if block_root == invalid_root
+        ),
+        "expected BlockFailedValidation, got: {err:?}"
+    );
+}
+
+#[test]
+fn block_in_fork_choice_but_missing_from_store() {
+    let ctx = TestContext::new();
+    let fork_block_root = ctx.insert_block_without_store_entry();
+    let envelope =
+        make_signed_envelope(Slot::new(1), 0, ExecutionBlockHash::zero(), fork_block_root);
+
+    let err = unwrap_err(GossipVerifiedEnvelope::new(envelope, &ctx.gossip_ctx()));
+    assert!(
+        matches!(
+            &err,
+            EnvelopeError::BeaconChainError(e)
+                if matches!(**e, BeaconChainError::MissingBeaconBlock(root) if root == fork_block_root)
+        ),
+        "expected MissingBeaconBlock, got: {err:?}"
+    );
+}
+
+#[test]
+fn slot_mismatch_is_rejected() {
+    if !gloas_fork_enabled() {
+        return;
+    }
+    let ctx = TestContext::new();
+    // The anchor block is at slot 0; the envelope claims slot 1.
+    let envelope = make_signed_envelope(
+        Slot::new(1),
+        0,
+        ExecutionBlockHash::zero(),
+        ctx.genesis_block_root,
+    );
+
+    let err = unwrap_err(GossipVerifiedEnvelope::new(envelope, &ctx.gossip_ctx()));
+    assert!(
+        matches!(err, EnvelopeError::SlotMismatch { block, envelope }
+            if block == Slot::new(0) && envelope == Slot::new(1)),
+        "expected SlotMismatch, got: {err:?}"
+    );
+}
+
+#[test]
+fn builder_index_mismatch_is_rejected() {
+    if !gloas_fork_enabled() {
+        return;
+    }
+    let ctx = TestContext::new();
+    // The anchor block's bid commits to builder index 0; the envelope claims builder 5.
+    let envelope = make_signed_envelope(
+        Slot::new(0),
+        5,
+        ExecutionBlockHash::zero(),
+        ctx.genesis_block_root,
+    );
+
+    let err = unwrap_err(GossipVerifiedEnvelope::new(envelope, &ctx.gossip_ctx()));
+    assert!(
+        matches!(
+            err,
+            EnvelopeError::BuilderIndexMismatch {
+                committed_bid: 0,
+                envelope: 5
+            }
+        ),
+        "expected BuilderIndexMismatch, got: {err:?}"
+    );
+}
+
+#[test]
+fn block_hash_mismatch_is_rejected() {
+    if !gloas_fork_enabled() {
+        return;
+    }
+    let ctx = TestContext::new();
+    // The anchor block's bid commits to a zero block hash; the envelope reveals a different one.
+    let envelope = make_signed_envelope(
+        Slot::new(0),
+        0,
+        ExecutionBlockHash::repeat_byte(0xee),
+        ctx.genesis_block_root,
+    );
+
+    let err = unwrap_err(GossipVerifiedEnvelope::new(envelope, &ctx.gossip_ctx()));
+    assert!(
+        matches!(err, EnvelopeError::BlockHashMismatch { .. }),
+        "expected BlockHashMismatch, got: {err:?}"
+    );
+}
+
+#[test]
+fn bad_signature_is_rejected() {
+    if !gloas_fork_enabled() {
+        return;
+    }
+    let ctx = TestContext::new();
+    // Consistent with the anchor bid (builder 0, zero block hash, slot 0) so verification
+    // reaches the external-builder signature check, which fails on the empty signature.
+    let envelope = make_signed_envelope(
+        Slot::new(0),
+        0,
+        ExecutionBlockHash::zero(),
+        ctx.genesis_block_root,
+    );
+
+    let err = unwrap_err(GossipVerifiedEnvelope::new(envelope, &ctx.gossip_ctx()));
+    assert!(
+        matches!(err, EnvelopeError::BadSignature),
+        "expected BadSignature, got: {err:?}"
+    );
+}

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -1,5 +1,6 @@
 #![cfg(not(debug_assertions))]
 // TODO(gloas) we probably need similar test for payload envelope verification
+use beacon_chain::attestation_verification::Error as AttnError;
 use beacon_chain::block_verification_types::{AsBlock, ExecutedBlock, LookupBlock, RangeSyncBlock};
 use beacon_chain::custody_context::CustodyContext;
 use beacon_chain::data_availability_checker::{AvailabilityCheckError, AvailableBlockData};
@@ -2904,4 +2905,117 @@ async fn rpc_block_allows_construction_past_da_boundary() {
     }
 
     panic!("No block with blob commitments found");
+}
+
+#[tokio::test]
+async fn observed_invalid_block_roots_reject_descendants_and_attestations() {
+    let harness = get_harness(VALIDATOR_COUNT, NodeCustodyType::Fullnode);
+    harness
+        .extend_chain(
+            2,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    let head_state = harness.get_current_state();
+    let slot = head_state.slot() + 1;
+    harness.advance_slot();
+    let fork = harness.chain.canonical_head.cached_head().head_fork();
+
+    // A block with a valid proposer signature but an incorrect state root: consensus-invalid,
+    // with the failure attributable to the block root.
+    let ((block, _sidecars), _post_state) = harness.make_block(head_state.clone(), slot).await;
+    let (mut bare_block, _signature) = block.as_ref().clone().deconstruct();
+    *bare_block.state_root_mut() = Hash256::repeat_byte(0xff);
+    let proposer_index = bare_block.proposer_index() as usize;
+    let invalid_block = Arc::new(bare_block.sign(
+        &generate_deterministic_keypair(proposer_index).sk,
+        &fork,
+        harness.chain.genesis_validators_root,
+        &harness.chain.spec,
+    ));
+    let invalid_root = invalid_block.canonical_root();
+
+    let err = harness
+        .chain
+        .process_block(
+            invalid_root,
+            LookupBlock::new(invalid_block),
+            NotifyExecutionLayer::Yes,
+            BlockImportSource::Lookup,
+            || Ok(()),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        err.invalidates_block_root(),
+        "import should fail with an error attributable to the block root: {err:?}"
+    );
+    assert!(
+        harness
+            .chain
+            .observed_invalid_block_roots
+            .contains(&invalid_root),
+        "the invalid block root should be recorded"
+    );
+
+    // A gossip block building on the invalid block is rejected and recorded as invalid by
+    // descent.
+    harness.advance_slot();
+    let ((child, _sidecars), _post_state) = harness.make_block(head_state.clone(), slot + 1).await;
+    let (mut bare_child, _signature) = child.as_ref().clone().deconstruct();
+    *bare_child.parent_root_mut() = invalid_root;
+    let proposer_index = bare_child.proposer_index() as usize;
+    let child = Arc::new(bare_child.sign(
+        &generate_deterministic_keypair(proposer_index).sk,
+        &fork,
+        harness.chain.genesis_validators_root,
+        &harness.chain.spec,
+    ));
+    let child_root = child.canonical_root();
+
+    let err = unwrap_err(harness.chain.verify_block_for_gossip(child).await);
+    assert!(
+        matches!(err, BlockError::ParentInvalid { parent_root } if parent_root == invalid_root),
+        "expected ParentInvalid, got: {err:?}"
+    );
+    assert!(
+        harness
+            .chain
+            .observed_invalid_block_roots
+            .contains(&child_root),
+        "the descendant's root should be recorded as invalid by descent"
+    );
+
+    // A gossip attestation voting for the invalid block is rejected.
+    let (head_state, head_state_root) = harness.get_current_state_and_root();
+    let head_block_root = harness.chain.canonical_head.cached_head().head_block_root();
+    let mut single_attestation = harness
+        .make_single_attestations(
+            &(0..VALIDATOR_COUNT).collect::<Vec<_>>(),
+            &head_state,
+            head_state_root,
+            head_block_root.into(),
+            slot,
+        )
+        .into_iter()
+        .flatten()
+        .map(|(attestation, _subnet_id)| attestation)
+        .next()
+        .expect("should produce at least one attestation");
+    single_attestation.data.beacon_block_root = invalid_root;
+
+    let err = unwrap_err(
+        harness
+            .chain
+            .verify_unaggregated_attestation_for_gossip(&single_attestation, None),
+    );
+    assert!(
+        matches!(
+            err,
+            AttnError::HeadBlockInvalid { beacon_block_root } if beacon_block_root == invalid_root
+        ),
+        "expected HeadBlockInvalid, got: {err:?}"
+    );
 }

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -2941,7 +2941,7 @@ async fn observed_invalid_block_roots_reject_descendants_and_attestations() {
         .chain
         .process_block(
             invalid_root,
-            LookupBlock::new(invalid_block),
+            LookupBlock::new(invalid_block.clone()),
             NotifyExecutionLayer::Yes,
             BlockImportSource::Lookup,
             || Ok(()),
@@ -2958,6 +2958,13 @@ async fn observed_invalid_block_roots_reject_descendants_and_attestations() {
             .observed_invalid_block_roots
             .contains(&invalid_root),
         "the invalid block root should be recorded"
+    );
+
+    // A gossip copy of the invalid block itself is rejected without reprocessing.
+    let err = unwrap_err(harness.chain.verify_block_for_gossip(invalid_block).await);
+    assert!(
+        matches!(err, BlockError::KnownInvalid { block_root } if block_root == invalid_root),
+        "expected KnownInvalid, got: {err:?}"
     );
 
     // A gossip block building on the invalid block is rejected and recorded as invalid by

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -2949,7 +2949,7 @@ async fn observed_invalid_block_roots_reject_descendants_and_attestations() {
         .await
         .unwrap_err();
     assert!(
-        err.invalidates_block_root(),
+        err.is_deterministic_on_block_root(),
         "import should fail with an error attributable to the block root: {err:?}"
     );
     assert!(

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1673,7 +1673,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
                 return None;
             }
-            Err(e @ BlockError::StateRootMismatch { .. })
+            Err(e @ BlockError::ParentInvalid { .. })
+            | Err(e @ BlockError::StateRootMismatch { .. })
             | Err(e @ BlockError::IncorrectBlockProposer { .. })
             | Err(e @ BlockError::BlockSlotLimitReached)
             | Err(e @ BlockError::NonLinearSlots)
@@ -3100,6 +3101,20 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "attn_too_many_skipped_slots",
                 );
             }
+            AttnError::HeadBlockInvalid { beacon_block_root } => {
+                debug!(
+                    block_root = ?beacon_block_root,
+                    attestation_slot = %failed_att.attestation_data().slot,
+                    "Rejected attestation to invalid block"
+                );
+
+                self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Reject);
+                self.gossip_penalize_peer(
+                    peer_id,
+                    PeerAction::LowToleranceError,
+                    "attn_to_invalid_block",
+                );
+            }
             AttnError::HeadBlockFinalized { beacon_block_root } => {
                 debug!(
                     block_root = ?beacon_block_root,
@@ -3773,6 +3788,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     }
 
                     EnvelopeError::BadSignature
+                    | EnvelopeError::BlockFailedValidation { .. }
                     | EnvelopeError::BuilderIndexMismatch { .. }
                     | EnvelopeError::SlotMismatch { .. }
                     | EnvelopeError::BlockHashMismatch { .. }

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1674,6 +1674,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 return None;
             }
             Err(e @ BlockError::ParentInvalid { .. })
+            | Err(e @ BlockError::KnownInvalid { .. })
             | Err(e @ BlockError::StateRootMismatch { .. })
             | Err(e @ BlockError::IncorrectBlockProposer { .. })
             | Err(e @ BlockError::BlockSlotLimitReached)

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -1058,6 +1058,7 @@ impl From<Result<AvailabilityProcessingStatus, BlockError>> for BlockProcessingR
                     | BlockError::InconsistentFork(_)
                     | BlockError::ParentExecutionPayloadInvalid { .. }
                     | BlockError::ParentInvalid { .. }
+                    | BlockError::KnownInvalid { .. }
                     | BlockError::KnownInvalidExecutionPayload(_)
                     | BlockError::Slashable
                     | BlockError::InvalidBlobCount { .. }

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -1057,6 +1057,7 @@ impl From<Result<AvailabilityProcessingStatus, BlockError>> for BlockProcessingR
                     | BlockError::WeakSubjectivityConflict
                     | BlockError::InconsistentFork(_)
                     | BlockError::ParentExecutionPayloadInvalid { .. }
+                    | BlockError::ParentInvalid { .. }
                     | BlockError::KnownInvalidExecutionPayload(_)
                     | BlockError::Slashable
                     | BlockError::InvalidBlobCount { .. }

--- a/consensus/state_processing/src/per_block_processing/errors.rs
+++ b/consensus/state_processing/src/per_block_processing/errors.rs
@@ -117,6 +117,59 @@ pub enum BlockProcessingError {
     NonEmptyParentExecutionRequests,
 }
 
+impl BlockProcessingError {
+    /// Returns `true` if the failure is deterministic on the block message and the ancestry it
+    /// commits to, making any block with the same root equally invalid. Internal errors and
+    /// failures of data the root does not commit to (proposer signature, payload envelope)
+    /// must return `false`.
+    pub fn is_deterministic_on_block_root(&self) -> bool {
+        match self {
+            BlockProcessingError::RandaoSignatureInvalid
+            | BlockProcessingError::StateRootMismatch
+            | BlockProcessingError::DepositCountInvalid { .. }
+            | BlockProcessingError::HeaderInvalid { .. }
+            | BlockProcessingError::ProposerSlashingInvalid { .. }
+            | BlockProcessingError::AttesterSlashingInvalid { .. }
+            | BlockProcessingError::IndexedAttestationInvalid { .. }
+            | BlockProcessingError::AttestationInvalid { .. }
+            | BlockProcessingError::PayloadAttestationInvalid { .. }
+            | BlockProcessingError::DepositInvalid { .. }
+            | BlockProcessingError::ExitInvalid { .. }
+            | BlockProcessingError::BlsExecutionChangeInvalid { .. }
+            | BlockProcessingError::SyncAggregateInvalid { .. }
+            | BlockProcessingError::InconsistentBlockFork(_)
+            | BlockProcessingError::ExecutionHashChainIncontiguous { .. }
+            | BlockProcessingError::ExecutionRandaoMismatch { .. }
+            | BlockProcessingError::ExecutionInvalidTimestamp { .. }
+            | BlockProcessingError::ExecutionInvalidBlobsLen { .. }
+            | BlockProcessingError::ExecutionInvalid
+            | BlockProcessingError::WithdrawalsRootMismatch { .. }
+            | BlockProcessingError::WithdrawalCredentialsInvalid
+            | BlockProcessingError::ExecutionPayloadBidInvalid { .. } => true,
+            BlockProcessingError::IncorrectStateType
+            | BlockProcessingError::BulkSignatureVerificationFailed
+            | BlockProcessingError::BeaconStateError(_)
+            | BlockProcessingError::SignatureSetError(_)
+            | BlockProcessingError::SszTypesError(_)
+            | BlockProcessingError::SszDecodeError(_)
+            | BlockProcessingError::BitfieldError(_)
+            | BlockProcessingError::MerkleTreeError(_)
+            | BlockProcessingError::ArithError(_)
+            | BlockProcessingError::InconsistentStateFork(_)
+            | BlockProcessingError::ConsensusContext(_)
+            | BlockProcessingError::MilhouseError(_)
+            | BlockProcessingError::EpochCacheError(_)
+            | BlockProcessingError::WithdrawalsLimitExceeded { .. }
+            | BlockProcessingError::IncorrectExpectedWithdrawalsVariant
+            | BlockProcessingError::MissingLastWithdrawal
+            | BlockProcessingError::PendingAttestationInElectra
+            | BlockProcessingError::BuilderPaymentIndexOutOfBounds(_)
+            | BlockProcessingError::ExecutionRequestsRootMismatch { .. }
+            | BlockProcessingError::NonEmptyParentExecutionRequests => false,
+        }
+    }
+}
+
 impl From<BeaconStateError> for BlockProcessingError {
     fn from(e: BeaconStateError) -> Self {
         BlockProcessingError::BeaconStateError(e)


### PR DESCRIPTION
## Issue Addressed

Introduce a block root invalid cache. This allows us to quickly reject messages that build on top of invalid block roots. 

Theres also a subset of ef gossip verification tests that we cannot execute without introducing this cache (see #9713 for more details)

Additionally I added some missing test coverage for the gossip verified envelope path.
