### PR TITLE
Implement Gloas light client type support

### DIFF
--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -308,6 +308,7 @@ async fn light_client_bootstrap_test() {
         LightClientBootstrap::Deneb(lc_bootstrap) => lc_bootstrap.header.beacon.slot,
         LightClientBootstrap::Electra(lc_bootstrap) => lc_bootstrap.header.beacon.slot,
         LightClientBootstrap::Fulu(lc_bootstrap) => lc_bootstrap.header.beacon.slot,
+        LightClientBootstrap::Gloas(lc_bootstrap) => lc_bootstrap.header.beacon.slot,
     };
 
     assert_eq!(

--- a/consensus/types/src/light_client/consts.rs
+++ b/consensus/types/src/light_client/consts.rs
@@ -19,3 +19,14 @@ pub const NEXT_SYNC_COMMITTEE_INDEX_ELECTRA: usize = 87;
 // Max light client updates by range request limits
 // spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#configuration
 pub const MAX_REQUEST_LIGHT_CLIENT_UPDATES: u64 = 128;
+
+pub const FINALIZED_ROOT_INDEX_GLOAS: usize = 735;
+pub const CURRENT_SYNC_COMMITTEE_INDEX_GLOAS: usize = 2_945;
+pub const NEXT_SYNC_COMMITTEE_INDEX_GLOAS: usize = 2_946;
+
+pub const FINALIZED_ROOT_PROOF_LEN_GLOAS: usize = 9;
+pub const CURRENT_SYNC_COMMITTEE_PROOF_LEN_GLOAS: usize = 11;
+pub const NEXT_SYNC_COMMITTEE_PROOF_LEN_GLOAS: usize = 11;
+
+pub const EXECUTION_BLOCK_HASH_INDEX_GLOAS: usize = 2_856;
+pub const EXECUTION_BLOCK_HASH_PROOF_LEN_GLOAS: usize = 11;

--- a/consensus/types/src/light_client/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client/light_client_bootstrap.rs
@@ -14,9 +14,10 @@ use crate::{
     core::{ChainSpec, EthSpec, Hash256, Slot},
     fork::ForkName,
     light_client::{
-        CurrentSyncCommitteeProofLen, CurrentSyncCommitteeProofLenElectra, LightClientError,
-        LightClientHeader, LightClientHeaderAltair, LightClientHeaderCapella,
-        LightClientHeaderDeneb, LightClientHeaderElectra, LightClientHeaderFulu,
+        CurrentSyncCommitteeProofLen, CurrentSyncCommitteeProofLenElectra,
+        CurrentSyncCommitteeProofLenGloas, LightClientError, LightClientHeader,
+        LightClientHeaderAltair, LightClientHeaderCapella, LightClientHeaderDeneb,
+        LightClientHeaderElectra, LightClientHeaderFulu, LightClientHeaderGloas,
     },
     state::BeaconState,
     sync_committee::SyncCommittee,
@@ -25,7 +26,7 @@ use crate::{
 /// A LightClientBootstrap is the initializer we send over to light_client nodes
 /// that are trying to generate their basic storage when booting up.
 #[superstruct(
-    variants(Altair, Capella, Deneb, Electra, Fulu),
+    variants(Altair, Capella, Deneb, Electra, Fulu, Gloas,),
     variant_attributes(
         derive(Debug, Clone, Serialize, Deserialize, Educe, Decode, Encode, TreeHash,),
         educe(PartialEq),
@@ -60,6 +61,8 @@ pub struct LightClientBootstrap<E: EthSpec> {
     pub header: LightClientHeaderElectra<E>,
     #[superstruct(only(Fulu), partial_getter(rename = "header_fulu"))]
     pub header: LightClientHeaderFulu<E>,
+    #[superstruct(only(Gloas), partial_getter(rename = "header_gloas"))]
+    pub header: LightClientHeaderGloas<E>,
     /// The `SyncCommittee` used in the requested period.
     pub current_sync_committee: Arc<SyncCommittee<E>>,
     /// Merkle proof for sync committee
@@ -73,6 +76,11 @@ pub struct LightClientBootstrap<E: EthSpec> {
         partial_getter(rename = "current_sync_committee_branch_electra")
     )]
     pub current_sync_committee_branch: FixedVector<Hash256, CurrentSyncCommitteeProofLenElectra>,
+    #[superstruct(
+        only(Gloas),
+        partial_getter(rename = "current_sync_committee_branch_gloas")
+    )]
+    pub current_sync_committee_branch: FixedVector<Hash256, CurrentSyncCommitteeProofLenGloas>,
 }
 
 impl<E: EthSpec> LightClientBootstrap<E> {
@@ -86,6 +94,7 @@ impl<E: EthSpec> LightClientBootstrap<E> {
             Self::Deneb(_) => func(ForkName::Deneb),
             Self::Electra(_) => func(ForkName::Electra),
             Self::Fulu(_) => func(ForkName::Fulu),
+            Self::Gloas(_) => func(ForkName::Gloas),
         }
     }
 
@@ -105,8 +114,9 @@ impl<E: EthSpec> LightClientBootstrap<E> {
             ForkName::Deneb => Self::Deneb(LightClientBootstrapDeneb::from_ssz_bytes(bytes)?),
             ForkName::Electra => Self::Electra(LightClientBootstrapElectra::from_ssz_bytes(bytes)?),
             ForkName::Fulu => Self::Fulu(LightClientBootstrapFulu::from_ssz_bytes(bytes)?),
-            // TODO(gloas): implement Gloas light client
-            ForkName::Base | ForkName::Gloas | ForkName::Heze => {
+            ForkName::Gloas => Self::Gloas(LightClientBootstrapGloas::from_ssz_bytes(bytes)?),
+            // TODO(gloas): implement Heze light client
+            ForkName::Base | ForkName::Heze => {
                 return Err(ssz::DecodeError::BytesInvalid(format!(
                     "LightClientBootstrap decoding for {fork_name} not implemented"
                 )));
@@ -127,10 +137,9 @@ impl<E: EthSpec> LightClientBootstrap<E> {
             ForkName::Deneb => <LightClientBootstrapDeneb<E> as Encode>::ssz_fixed_len(),
             ForkName::Electra => <LightClientBootstrapElectra<E> as Encode>::ssz_fixed_len(),
             ForkName::Fulu => <LightClientBootstrapFulu<E> as Encode>::ssz_fixed_len(),
-            // TODO(gloas): implement Gloas light client
-            ForkName::Gloas | ForkName::Heze => {
-                <LightClientBootstrapAltair<E> as Encode>::ssz_fixed_len()
-            }
+            ForkName::Gloas => <LightClientBootstrapGloas<E> as Encode>::ssz_fixed_len(),
+            // TODO(heze): implement Heze light client
+            ForkName::Heze => <LightClientBootstrapAltair<E> as Encode>::ssz_fixed_len(),
         };
         fixed_len + LightClientHeader::<E>::ssz_max_var_len_for_fork(fork_name)
     }
@@ -181,8 +190,16 @@ impl<E: EthSpec> LightClientBootstrap<E> {
                     .try_into()
                     .map_err(LightClientError::SszTypesError)?,
             }),
-            // TODO(gloas): implement Gloas light client
-            ForkName::Gloas => return Err(LightClientError::GloasNotImplemented),
+            // TODO: `LightClientHeaderGloas::block_to_light_client_header` currently returns
+            // `Err(GloasNotImplemented)`
+            ForkName::Gloas => Self::Gloas(LightClientBootstrapGloas {
+                header: LightClientHeaderGloas::block_to_light_client_header(block)?,
+                current_sync_committee,
+                current_sync_committee_branch: current_sync_committee_branch
+                    .try_into()
+                    .map_err(LightClientError::SszTypesError)?,
+            }),
+            // TODO(gloas): implement Heze light client
             ForkName::Heze => return Err(LightClientError::HezeNotImplemented),
         };
 
@@ -194,6 +211,7 @@ impl<E: EthSpec> LightClientBootstrap<E> {
         block: &SignedBlindedBeaconBlock<E>,
         chain_spec: &ChainSpec,
     ) -> Result<Self, LightClientError> {
+        // (TODO):Blocked on sigp/lighthouse#9450 as ....
         let current_sync_committee_branch = beacon_state.compute_current_sync_committee_proof()?;
         let current_sync_committee = beacon_state.current_sync_committee()?.clone();
 
@@ -237,8 +255,13 @@ impl<E: EthSpec> LightClientBootstrap<E> {
                     .try_into()
                     .map_err(LightClientError::SszTypesError)?,
             }),
-            // TODO(gloas): implement Gloas light client
-            ForkName::Gloas => return Err(LightClientError::GloasNotImplemented),
+            ForkName::Gloas => Self::Gloas(LightClientBootstrapGloas {
+                header: LightClientHeaderGloas::block_to_light_client_header(block)?,
+                current_sync_committee,
+                current_sync_committee_branch: current_sync_committee_branch
+                    .try_into()
+                    .map_err(LightClientError::SszTypesError)?,
+            }),
             ForkName::Heze => return Err(LightClientError::HezeNotImplemented),
         };
 
@@ -279,7 +302,10 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientBootstrap
             ForkName::Fulu => {
                 Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
             }
-            ForkName::Gloas | ForkName::Heze => {
+            ForkName::Gloas => {
+                Self::Gloas(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Heze => {
                 // TODO(EIP-7732): check if this is correct
                 return Err(serde::de::Error::custom(format!(
                     "LightClientBootstrap failed to deserialize: unsupported fork '{}'",
@@ -321,5 +347,11 @@ mod tests {
     mod fulu {
         use crate::{LightClientBootstrapFulu, MainnetEthSpec};
         ssz_tests!(LightClientBootstrapFulu<MainnetEthSpec>);
+    }
+
+    #[cfg(test)]
+    mod gloas {
+        use crate::{LightClientBootstrapGloas, MainnetEthSpec};
+        ssz_tests!(LightClientBootstrapGloas<MainnetEthSpec>);
     }
 }

--- a/consensus/types/src/light_client/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client/light_client_bootstrap.rs
@@ -115,7 +115,6 @@ impl<E: EthSpec> LightClientBootstrap<E> {
             ForkName::Electra => Self::Electra(LightClientBootstrapElectra::from_ssz_bytes(bytes)?),
             ForkName::Fulu => Self::Fulu(LightClientBootstrapFulu::from_ssz_bytes(bytes)?),
             ForkName::Gloas => Self::Gloas(LightClientBootstrapGloas::from_ssz_bytes(bytes)?),
-            // TODO(gloas): implement Heze light client
             ForkName::Base | ForkName::Heze => {
                 return Err(ssz::DecodeError::BytesInvalid(format!(
                     "LightClientBootstrap decoding for {fork_name} not implemented"
@@ -138,7 +137,6 @@ impl<E: EthSpec> LightClientBootstrap<E> {
             ForkName::Electra => <LightClientBootstrapElectra<E> as Encode>::ssz_fixed_len(),
             ForkName::Fulu => <LightClientBootstrapFulu<E> as Encode>::ssz_fixed_len(),
             ForkName::Gloas => <LightClientBootstrapGloas<E> as Encode>::ssz_fixed_len(),
-            // TODO(heze): implement Heze light client
             ForkName::Heze => <LightClientBootstrapAltair<E> as Encode>::ssz_fixed_len(),
         };
         fixed_len + LightClientHeader::<E>::ssz_max_var_len_for_fork(fork_name)
@@ -190,8 +188,6 @@ impl<E: EthSpec> LightClientBootstrap<E> {
                     .try_into()
                     .map_err(LightClientError::SszTypesError)?,
             }),
-            // TODO: `LightClientHeaderGloas::block_to_light_client_header` currently returns
-            // `Err(GloasNotImplemented)`
             ForkName::Gloas => Self::Gloas(LightClientBootstrapGloas {
                 header: LightClientHeaderGloas::block_to_light_client_header(block)?,
                 current_sync_committee,
@@ -199,7 +195,6 @@ impl<E: EthSpec> LightClientBootstrap<E> {
                     .try_into()
                     .map_err(LightClientError::SszTypesError)?,
             }),
-            // TODO(gloas): implement Heze light client
             ForkName::Heze => return Err(LightClientError::HezeNotImplemented),
         };
 
@@ -211,7 +206,6 @@ impl<E: EthSpec> LightClientBootstrap<E> {
         block: &SignedBlindedBeaconBlock<E>,
         chain_spec: &ChainSpec,
     ) -> Result<Self, LightClientError> {
-        // (TODO):Blocked on sigp/lighthouse#9450 as ....
         let current_sync_committee_branch = beacon_state.compute_current_sync_committee_proof()?;
         let current_sync_committee = beacon_state.current_sync_committee()?.clone();
 

--- a/consensus/types/src/light_client/light_client_finality_update.rs
+++ b/consensus/types/src/light_client/light_client_finality_update.rs
@@ -8,6 +8,8 @@ use ssz_types::FixedVector;
 use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
 
+use crate::FinalizedRootProofLenGloas;
+use crate::LightClientHeaderGloas;
 use crate::{
     block::SignedBlindedBeaconBlock,
     core::{ChainSpec, EthSpec, Hash256, Slot},
@@ -21,7 +23,7 @@ use crate::{
 };
 
 #[superstruct(
-    variants(Altair, Capella, Deneb, Electra, Fulu),
+    variants(Altair, Capella, Deneb, Electra, Fulu, Gloas),
     variant_attributes(
         derive(Debug, Clone, Serialize, Deserialize, Educe, Decode, Encode, TreeHash,),
         educe(PartialEq),
@@ -56,6 +58,8 @@ pub struct LightClientFinalityUpdate<E: EthSpec> {
     pub attested_header: LightClientHeaderElectra<E>,
     #[superstruct(only(Fulu), partial_getter(rename = "attested_header_fulu"))]
     pub attested_header: LightClientHeaderFulu<E>,
+    #[superstruct(only(Gloas), partial_getter(rename = "attested_header_gloas"))]
+    pub attested_header: LightClientHeaderGloas<E>,
     /// The last `BeaconBlockHeader` from the last attested finalized block (end of epoch).
     #[superstruct(only(Altair), partial_getter(rename = "finalized_header_altair"))]
     pub finalized_header: LightClientHeaderAltair<E>,
@@ -67,6 +71,8 @@ pub struct LightClientFinalityUpdate<E: EthSpec> {
     pub finalized_header: LightClientHeaderElectra<E>,
     #[superstruct(only(Fulu), partial_getter(rename = "finalized_header_fulu"))]
     pub finalized_header: LightClientHeaderFulu<E>,
+    #[superstruct(only(Gloas), partial_getter(rename = "finalized_header_gloas"))]
+    pub finalized_header: LightClientHeaderGloas<E>,
     /// Merkle proof attesting finalized header.
     #[superstruct(
         only(Altair, Capella, Deneb),
@@ -78,6 +84,8 @@ pub struct LightClientFinalityUpdate<E: EthSpec> {
         partial_getter(rename = "finality_branch_electra")
     )]
     pub finality_branch: FixedVector<Hash256, FinalizedRootProofLenElectra>,
+    #[superstruct(only(Gloas), partial_getter(rename = "finality_branch_gloas"))]
+    pub finality_branch: FixedVector<Hash256, FinalizedRootProofLenGloas>,
     /// current sync aggregate
     pub sync_aggregate: SyncAggregate<E>,
     /// Slot of the sync aggregated signature
@@ -165,7 +173,19 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
                 sync_aggregate,
                 signature_slot,
             }),
-            ForkName::Gloas => return Err(LightClientError::GloasNotImplemented),
+            ForkName::Gloas => Self::Gloas(LightClientFinalityUpdateGloas {
+                attested_header: LightClientHeaderGloas::block_to_light_client_header(
+                    attested_block,
+                )?,
+                finalized_header: LightClientHeaderGloas::block_to_light_client_header(
+                    finalized_block,
+                )?,
+                finality_branch: finality_branch
+                    .try_into()
+                    .map_err(LightClientError::SszTypesError)?,
+                sync_aggregate,
+                signature_slot,
+            }),
             ForkName::Heze => return Err(LightClientError::HezeNotImplemented),
             ForkName::Base => return Err(LightClientError::AltairForkNotActive),
         };
@@ -183,6 +203,7 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
             Self::Deneb(_) => func(ForkName::Deneb),
             Self::Electra(_) => func(ForkName::Electra),
             Self::Fulu(_) => func(ForkName::Fulu),
+            Self::Gloas(_) => func(ForkName::Gloas),
         }
     }
 
@@ -220,8 +241,9 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
                 Self::Electra(LightClientFinalityUpdateElectra::from_ssz_bytes(bytes)?)
             }
             ForkName::Fulu => Self::Fulu(LightClientFinalityUpdateFulu::from_ssz_bytes(bytes)?),
+            ForkName::Gloas => Self::Gloas(LightClientFinalityUpdateGloas::from_ssz_bytes(bytes)?),
             // TODO(gloas): implement Gloas light client
-            ForkName::Base | ForkName::Gloas | ForkName::Heze => {
+            ForkName::Base | ForkName::Heze => {
                 return Err(ssz::DecodeError::BytesInvalid(format!(
                     "LightClientFinalityUpdate decoding for {fork_name} not implemented"
                 )));
@@ -242,8 +264,8 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
             ForkName::Deneb => <LightClientFinalityUpdateDeneb<E> as Encode>::ssz_fixed_len(),
             ForkName::Electra => <LightClientFinalityUpdateElectra<E> as Encode>::ssz_fixed_len(),
             ForkName::Fulu => <LightClientFinalityUpdateFulu<E> as Encode>::ssz_fixed_len(),
-            // TODO(gloas): implement Gloas light client
-            ForkName::Gloas | ForkName::Heze => 0,
+            ForkName::Gloas => <LightClientFinalityUpdateGloas<E> as Encode>::ssz_fixed_len(),
+            ForkName::Heze => 0,
         };
         // `2 *` because there are two headers in the update
         fixed_size + 2 * LightClientHeader::<E>::ssz_max_var_len_for_fork(fork_name)
@@ -296,7 +318,10 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientFinalityU
             ForkName::Fulu => {
                 Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
             }
-            ForkName::Gloas | ForkName::Heze => {
+            ForkName::Gloas => {
+                Self::Gloas(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Heze => {
                 // TODO(EIP-7732): check if this is correct
                 return Err(serde::de::Error::custom(format!(
                     "LightClientBootstrap failed to deserialize: unsupported fork '{}'",
@@ -338,5 +363,11 @@ mod tests {
     mod fulu {
         use crate::{LightClientFinalityUpdateFulu, MainnetEthSpec};
         ssz_tests!(LightClientFinalityUpdateFulu<MainnetEthSpec>);
+    }
+
+    #[cfg(test)]
+    mod gloas {
+        use crate::{LightClientFinalityUpdateGloas, MainnetEthSpec};
+        ssz_tests!(LightClientFinalityUpdateGloas<MainnetEthSpec>);
     }
 }

--- a/consensus/types/src/light_client/light_client_header.rs
+++ b/consensus/types/src/light_client/light_client_header.rs
@@ -19,8 +19,8 @@ use crate::{
     },
     fork::ForkName,
     light_client::{
-        ExecutionPayloadProofLen, LightClientError, consts::EXECUTION_PAYLOAD_INDEX,
-        light_client_update::ExecutionBlockHashProofLenGloas,
+        ExecutionBlockHashProofLenGloas, ExecutionPayloadProofLen, LightClientError,
+        consts::{EXECUTION_BLOCK_HASH_INDEX_GLOAS, EXECUTION_PAYLOAD_INDEX},
     },
 };
 
@@ -134,7 +134,6 @@ impl<E: EthSpec> LightClientHeader<E> {
             ForkName::Gloas => {
                 LightClientHeader::Gloas(LightClientHeaderGloas::from_ssz_bytes(bytes)?)
             }
-            // TODO(gloas): implement Gloas light client
             ForkName::Base | ForkName::Heze => {
                 return Err(ssz::DecodeError::BytesInvalid(format!(
                     "LightClientHeader decoding for {fork_name} not implemented"
@@ -379,15 +378,12 @@ impl<E: EthSpec> LightClientHeaderGloas<E> {
         })
     }
 
-    /// Proof of inclusion for `signed_execution_payload_bid.message.parent_block_hash` at
-    /// `EXECUTION_BLOCK_HASH_INDEX_GLOAS`.
     fn execution_block_hash_merkle_proof<Payload: AbstractExecPayload<E>>(
-        _beacon_block_body: &BeaconBlockBody<E, Payload>,
+        beacon_block_body: &BeaconBlockBody<E, Payload>,
     ) -> Result<Vec<Hash256>, LightClientError> {
-        // TODO(gloas): blocked on sigp/lighthouse#9450
-        // ProgressiveContainer merkleization is required for nested gindex
-        // EXECUTION_BLOCK_HASH_INDEX_GLOAS.
-        Err(LightClientError::GloasNotImplemented)
+        Ok(beacon_block_body
+            .to_ref()
+            .block_body_merkle_proof(EXECUTION_BLOCK_HASH_INDEX_GLOAS)?)
     }
 }
 
@@ -414,7 +410,6 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientHeader<E>
             ))
         };
         Ok(match context {
-            // TODO: implement Heze light client
             ForkName::Base | ForkName::Heze => {
                 return Err(serde::de::Error::custom(format!(
                     "LightClientFinalityUpdate failed to deserialize: unsupported fork '{}'",

--- a/consensus/types/src/light_client/light_client_header.rs
+++ b/consensus/types/src/light_client/light_client_header.rs
@@ -10,6 +10,7 @@ use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
 
 use crate::{
+    AbstractExecPayload, ExecutionBlockHash,
     block::{BeaconBlockBody, BeaconBlockHeader, SignedBlindedBeaconBlock},
     core::{ChainSpec, EthSpec, Hash256},
     execution::{
@@ -17,11 +18,14 @@ use crate::{
         ExecutionPayloadHeaderElectra, ExecutionPayloadHeaderFulu,
     },
     fork::ForkName,
-    light_client::{ExecutionPayloadProofLen, LightClientError, consts::EXECUTION_PAYLOAD_INDEX},
+    light_client::{
+        ExecutionPayloadProofLen, LightClientError, consts::EXECUTION_PAYLOAD_INDEX,
+        light_client_update::ExecutionBlockHashProofLenGloas,
+    },
 };
 
 #[superstruct(
-    variants(Altair, Capella, Deneb, Electra, Fulu,),
+    variants(Altair, Capella, Deneb, Electra, Fulu, Gloas,),
     variant_attributes(
         derive(Debug, Clone, Serialize, Deserialize, Educe, Decode, Encode, TreeHash,),
         educe(PartialEq),
@@ -62,8 +66,13 @@ pub struct LightClientHeader<E: EthSpec> {
     #[superstruct(only(Fulu), partial_getter(rename = "execution_payload_header_fulu"))]
     pub execution: ExecutionPayloadHeaderFulu<E>,
 
+    #[superstruct(only(Gloas))]
+    pub execution_block_hash: ExecutionBlockHash,
+
     #[superstruct(only(Capella, Deneb, Electra, Fulu))]
     pub execution_branch: FixedVector<Hash256, ExecutionPayloadProofLen>,
+    #[superstruct(only(Gloas), partial_getter(rename = "execution_branch_gloas"))]
+    pub execution_branch: FixedVector<Hash256, ExecutionBlockHashProofLenGloas>,
 
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]
@@ -97,8 +106,9 @@ impl<E: EthSpec> LightClientHeader<E> {
             ForkName::Fulu => {
                 LightClientHeader::Fulu(LightClientHeaderFulu::block_to_light_client_header(block)?)
             }
-            // TODO(gloas): implement Gloas light client
-            ForkName::Gloas => return Err(LightClientError::GloasNotImplemented),
+            ForkName::Gloas => LightClientHeader::Gloas(
+                LightClientHeaderGloas::block_to_light_client_header(block)?,
+            ),
             ForkName::Heze => return Err(LightClientError::HezeNotImplemented),
         };
         Ok(header)
@@ -121,8 +131,11 @@ impl<E: EthSpec> LightClientHeader<E> {
             ForkName::Fulu => {
                 LightClientHeader::Fulu(LightClientHeaderFulu::from_ssz_bytes(bytes)?)
             }
+            ForkName::Gloas => {
+                LightClientHeader::Gloas(LightClientHeaderGloas::from_ssz_bytes(bytes)?)
+            }
             // TODO(gloas): implement Gloas light client
-            ForkName::Base | ForkName::Gloas | ForkName::Heze => {
+            ForkName::Base | ForkName::Heze => {
                 return Err(ssz::DecodeError::BytesInvalid(format!(
                     "LightClientHeader decoding for {fork_name} not implemented"
                 )));
@@ -142,7 +155,8 @@ impl<E: EthSpec> LightClientHeader<E> {
 
     pub fn ssz_max_var_len_for_fork(fork_name: ForkName) -> usize {
         if fork_name.gloas_enabled() {
-            // TODO(EIP7732): check this
+            // Gloas: `LightClientHeaderGloas` has no variable-length fields (`execution_block_hash`
+            // is a fixed-size hash and `execution_branch` is a `FixedVector`)
             0
         } else if fork_name.capella_enabled() {
             ExecutionPayloadHeader::<E>::ssz_max_var_len_for_fork(fork_name)
@@ -340,6 +354,54 @@ impl<E: EthSpec> Default for LightClientHeaderFulu<E> {
     }
 }
 
+impl<E: EthSpec> LightClientHeaderGloas<E> {
+    pub fn block_to_light_client_header(
+        block: &SignedBlindedBeaconBlock<E>,
+    ) -> Result<Self, LightClientError> {
+        let body_gloas = block
+            .message()
+            .body_gloas()
+            .map_err(|_| LightClientError::BeaconBlockBodyError)?;
+
+        let execution_block_hash = body_gloas
+            .signed_execution_payload_bid
+            .message
+            .parent_block_hash;
+
+        let beacon_block_body = BeaconBlockBody::from(body_gloas.to_owned());
+        let execution_branch = Self::execution_block_hash_merkle_proof(&beacon_block_body)?;
+
+        Ok(LightClientHeaderGloas {
+            beacon: block.message().block_header(),
+            execution_block_hash,
+            execution_branch: FixedVector::new(execution_branch)?,
+            _phantom_data: PhantomData,
+        })
+    }
+
+    /// Proof of inclusion for `signed_execution_payload_bid.message.parent_block_hash` at
+    /// `EXECUTION_BLOCK_HASH_INDEX_GLOAS`.
+    fn execution_block_hash_merkle_proof<Payload: AbstractExecPayload<E>>(
+        _beacon_block_body: &BeaconBlockBody<E, Payload>,
+    ) -> Result<Vec<Hash256>, LightClientError> {
+        // TODO(gloas): blocked on sigp/lighthouse#9450
+        // ProgressiveContainer merkleization is required for nested gindex
+        // EXECUTION_BLOCK_HASH_INDEX_GLOAS.
+        Err(LightClientError::GloasNotImplemented)
+    }
+}
+
+impl<E: EthSpec> Default for LightClientHeaderGloas<E> {
+    fn default() -> Self {
+        Self {
+            beacon: BeaconBlockHeader::empty(),
+            execution_block_hash: ExecutionBlockHash::zero(),
+            execution_branch: FixedVector::default(),
+            _phantom_data: PhantomData,
+        }
+    }
+}
+
 impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientHeader<E> {
     fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>
     where
@@ -352,8 +414,8 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientHeader<E>
             ))
         };
         Ok(match context {
-            // TODO(gloas): implement Gloas light client
-            ForkName::Base | ForkName::Gloas | ForkName::Heze => {
+            // TODO: implement Heze light client
+            ForkName::Base | ForkName::Heze => {
                 return Err(serde::de::Error::custom(format!(
                     "LightClientFinalityUpdate failed to deserialize: unsupported fork '{}'",
                     context
@@ -373,6 +435,9 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientHeader<E>
             }
             ForkName::Fulu => {
                 Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Gloas => {
+                Self::Gloas(Deserialize::deserialize(deserializer).map_err(convert_err)?)
             }
         })
     }
@@ -409,5 +474,11 @@ mod tests {
     mod fulu {
         use crate::{LightClientHeaderFulu, MainnetEthSpec};
         ssz_tests!(LightClientHeaderFulu<MainnetEthSpec>);
+    }
+
+    #[cfg(test)]
+    mod gloas {
+        use crate::{LightClientHeaderGloas, MainnetEthSpec};
+        ssz_tests!(LightClientHeaderGloas<MainnetEthSpec>);
     }
 }

--- a/consensus/types/src/light_client/light_client_optimistic_update.rs
+++ b/consensus/types/src/light_client/light_client_optimistic_update.rs
@@ -14,6 +14,7 @@ use crate::{
     light_client::{
         LightClientError, LightClientHeader, LightClientHeaderAltair, LightClientHeaderCapella,
         LightClientHeaderDeneb, LightClientHeaderElectra, LightClientHeaderFulu,
+        LightClientHeaderGloas,
     },
     sync_committee::SyncAggregate,
 };
@@ -21,7 +22,7 @@ use crate::{
 /// A LightClientOptimisticUpdate is the update we send on each slot,
 /// it is based off the current unfinalized epoch is verified only against BLS signature.
 #[superstruct(
-    variants(Altair, Capella, Deneb, Electra, Fulu),
+    variants(Altair, Capella, Deneb, Electra, Fulu, Gloas),
     variant_attributes(
         derive(Debug, Clone, Serialize, Deserialize, Educe, Decode, Encode, TreeHash,),
         educe(PartialEq),
@@ -56,6 +57,8 @@ pub struct LightClientOptimisticUpdate<E: EthSpec> {
     pub attested_header: LightClientHeaderElectra<E>,
     #[superstruct(only(Fulu), partial_getter(rename = "attested_header_fulu"))]
     pub attested_header: LightClientHeaderFulu<E>,
+    #[superstruct(only(Gloas), partial_getter(rename = "attested_header_gloas"))]
+    pub attested_header: LightClientHeaderGloas<E>,
     /// current sync aggregate
     pub sync_aggregate: SyncAggregate<E>,
     /// Slot of the sync aggregated signature
@@ -111,7 +114,13 @@ impl<E: EthSpec> LightClientOptimisticUpdate<E> {
                 sync_aggregate,
                 signature_slot,
             }),
-            ForkName::Gloas => return Err(LightClientError::GloasNotImplemented),
+            ForkName::Gloas => Self::Gloas(LightClientOptimisticUpdateGloas {
+                attested_header: LightClientHeaderGloas::block_to_light_client_header(
+                    attested_block,
+                )?,
+                sync_aggregate,
+                signature_slot,
+            }),
             ForkName::Heze => return Err(LightClientError::HezeNotImplemented),
             ForkName::Base => return Err(LightClientError::AltairForkNotActive),
         };
@@ -129,6 +138,7 @@ impl<E: EthSpec> LightClientOptimisticUpdate<E> {
             Self::Deneb(_) => func(ForkName::Deneb),
             Self::Electra(_) => func(ForkName::Electra),
             Self::Fulu(_) => func(ForkName::Fulu),
+            Self::Gloas(_) => func(ForkName::Gloas),
         }
     }
 
@@ -168,8 +178,10 @@ impl<E: EthSpec> LightClientOptimisticUpdate<E> {
                 Self::Electra(LightClientOptimisticUpdateElectra::from_ssz_bytes(bytes)?)
             }
             ForkName::Fulu => Self::Fulu(LightClientOptimisticUpdateFulu::from_ssz_bytes(bytes)?),
-            // TODO(gloas): implement Gloas light client
-            ForkName::Base | ForkName::Gloas | ForkName::Heze => {
+            ForkName::Gloas => {
+                Self::Gloas(LightClientOptimisticUpdateGloas::from_ssz_bytes(bytes)?)
+            }
+            ForkName::Base | ForkName::Heze => {
                 return Err(ssz::DecodeError::BytesInvalid(format!(
                     "LightClientOptimisticUpdate decoding for {fork_name} not implemented"
                 )));
@@ -190,8 +202,8 @@ impl<E: EthSpec> LightClientOptimisticUpdate<E> {
             ForkName::Deneb => <LightClientOptimisticUpdateDeneb<E> as Encode>::ssz_fixed_len(),
             ForkName::Electra => <LightClientOptimisticUpdateElectra<E> as Encode>::ssz_fixed_len(),
             ForkName::Fulu => <LightClientOptimisticUpdateFulu<E> as Encode>::ssz_fixed_len(),
-            // TODO(gloas): implement Gloas light client
-            ForkName::Gloas | ForkName::Heze => 0,
+            ForkName::Gloas => <LightClientOptimisticUpdateGloas<E> as Encode>::ssz_fixed_len(),
+            ForkName::Heze => 0,
         };
         fixed_len + LightClientHeader::<E>::ssz_max_var_len_for_fork(fork_name)
     }
@@ -243,7 +255,10 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientOptimisti
             ForkName::Fulu => {
                 Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
             }
-            ForkName::Gloas | ForkName::Heze => {
+            ForkName::Gloas => {
+                Self::Gloas(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Heze => {
                 // TODO(EIP-7732): check if this is correct
                 return Err(serde::de::Error::custom(format!(
                     "LightClientBootstrap failed to deserialize: unsupported fork '{}'",
@@ -285,5 +300,11 @@ mod tests {
     mod fulu {
         use crate::{LightClientOptimisticUpdateFulu, MainnetEthSpec};
         ssz_tests!(LightClientOptimisticUpdateFulu<MainnetEthSpec>);
+    }
+
+    #[cfg(test)]
+    mod gloas {
+        use crate::{LightClientOptimisticUpdateGloas, MainnetEthSpec};
+        ssz_tests!(LightClientOptimisticUpdateGloas<MainnetEthSpec>);
     }
 }

--- a/consensus/types/src/light_client/light_client_update.rs
+++ b/consensus/types/src/light_client/light_client_update.rs
@@ -335,8 +335,6 @@ impl<E: EthSpec> LightClientUpdate<E> {
                     signature_slot: block_slot,
                 })
             }
-            // `LightClientHeaderGloas::block_to_light_client_header` currently returns
-            // `Err(GloasNotImplemented)` (blocked on sigp/lighthouse#9450)
             fork_name @ ForkName::Gloas => {
                 let attested_header =
                     LightClientHeaderGloas::block_to_light_client_header(attested_block)?;
@@ -384,7 +382,6 @@ impl<E: EthSpec> LightClientUpdate<E> {
             ForkName::Electra => Self::Electra(LightClientUpdateElectra::from_ssz_bytes(bytes)?),
             ForkName::Fulu => Self::Fulu(LightClientUpdateFulu::from_ssz_bytes(bytes)?),
             ForkName::Gloas => Self::Gloas(LightClientUpdateGloas::from_ssz_bytes(bytes)?),
-            // TODO(heze): implement Heze light client
             ForkName::Base | ForkName::Heze => {
                 return Err(ssz::DecodeError::BytesInvalid(format!(
                     "LightClientUpdate decoding for {fork_name} not implemented"
@@ -558,8 +555,8 @@ impl<E: EthSpec> LightClientUpdate<E> {
             ForkName::Deneb => min_len!(LightClientUpdateDeneb),
             ForkName::Electra => min_len!(LightClientUpdateElectra),
             ForkName::Fulu => min_len!(LightClientUpdateFulu),
-            // TODO(gloas): implement Gloas light client
-            ForkName::Gloas | ForkName::Heze => 0,
+            ForkName::Gloas => min_len!(LightClientUpdateGloas),
+            ForkName::Heze => 0,
         };
         min_len + 2 * LightClientHeader::<E>::ssz_max_var_len_for_fork(fork_name)
     }

--- a/consensus/types/src/light_client/light_client_update.rs
+++ b/consensus/types/src/light_client/light_client_update.rs
@@ -11,8 +11,11 @@ use ssz_derive::Encode;
 use ssz_types::FixedVector;
 use superstruct::superstruct;
 use tree_hash_derive::TreeHash;
+use typenum::U9;
+use typenum::U11;
 use typenum::{U4, U5, U6, U7};
 
+use crate::LightClientHeaderGloas;
 use crate::{
     block::SignedBlindedBeaconBlock,
     core::{ChainSpec, Epoch, EthSpec, Hash256, Slot},
@@ -33,17 +36,24 @@ pub type FinalizedRootProofLenElectra = U7;
 pub type CurrentSyncCommitteeProofLenElectra = U6;
 pub type NextSyncCommitteeProofLenElectra = U6;
 
+pub type FinalizedRootProofLenGloas = U9;
+pub type CurrentSyncCommitteeProofLenGloas = U11;
+pub type NextSyncCommitteeProofLenGloas = U11;
+pub type ExecutionBlockHashProofLenGloas = U11;
+
 type FinalityBranch = FixedVector<Hash256, FinalizedRootProofLen>;
 type FinalityBranchElectra = FixedVector<Hash256, FinalizedRootProofLenElectra>;
+type FinalityBranchGloas = FixedVector<Hash256, FinalizedRootProofLenGloas>;
 type NextSyncCommitteeBranch = FixedVector<Hash256, NextSyncCommitteeProofLen>;
 
 type NextSyncCommitteeBranchElectra = FixedVector<Hash256, NextSyncCommitteeProofLenElectra>;
+type NextSyncCommitteeBranchGloas = FixedVector<Hash256, NextSyncCommitteeProofLenGloas>;
 
 /// A LightClientUpdate is the update we request solely to either complete the bootstrapping process,
 /// or to sync up to the last committee period, we need to have one ready for each ALTAIR period
 /// we go over, note: there is no need to keep all of the updates from [ALTAIR_PERIOD, CURRENT_PERIOD].
 #[superstruct(
-    variants(Altair, Capella, Deneb, Electra, Fulu),
+    variants(Altair, Capella, Deneb, Electra, Fulu, Gloas),
     variant_attributes(
         derive(Debug, Clone, Serialize, Deserialize, Educe, Decode, Encode, TreeHash,),
         educe(PartialEq),
@@ -78,6 +88,8 @@ pub struct LightClientUpdate<E: EthSpec> {
     pub attested_header: LightClientHeaderElectra<E>,
     #[superstruct(only(Fulu), partial_getter(rename = "attested_header_fulu"))]
     pub attested_header: LightClientHeaderFulu<E>,
+    #[superstruct(only(Gloas), partial_getter(rename = "attested_header_gloas"))]
+    pub attested_header: LightClientHeaderGloas<E>,
     /// The `SyncCommittee` used in the next period.
     pub next_sync_committee: Arc<SyncCommittee<E>>,
     // Merkle proof for next sync committee
@@ -91,6 +103,11 @@ pub struct LightClientUpdate<E: EthSpec> {
         partial_getter(rename = "next_sync_committee_branch_electra")
     )]
     pub next_sync_committee_branch: NextSyncCommitteeBranchElectra,
+    #[superstruct(
+        only(Gloas),
+        partial_getter(rename = "next_sync_committee_branch_gloas")
+    )]
+    pub next_sync_committee_branch: NextSyncCommitteeBranchGloas,
     /// The last `BeaconBlockHeader` from the last attested finalized block (end of epoch).
     #[superstruct(only(Altair), partial_getter(rename = "finalized_header_altair"))]
     pub finalized_header: LightClientHeaderAltair<E>,
@@ -102,6 +119,8 @@ pub struct LightClientUpdate<E: EthSpec> {
     pub finalized_header: LightClientHeaderElectra<E>,
     #[superstruct(only(Fulu), partial_getter(rename = "finalized_header_fulu"))]
     pub finalized_header: LightClientHeaderFulu<E>,
+    #[superstruct(only(Gloas), partial_getter(rename = "finalized_header_gloas"))]
+    pub finalized_header: LightClientHeaderGloas<E>,
     /// Merkle proof attesting finalized header.
     #[superstruct(
         only(Altair, Capella, Deneb),
@@ -113,6 +132,8 @@ pub struct LightClientUpdate<E: EthSpec> {
         partial_getter(rename = "finality_branch_electra")
     )]
     pub finality_branch: FinalityBranchElectra,
+    #[superstruct(only(Gloas), partial_getter(rename = "finality_branch_gloas"))]
+    pub finality_branch: FinalityBranchGloas,
     /// current sync aggreggate
     pub sync_aggregate: SyncAggregate<E>,
     /// Slot of the sync aggregated signature
@@ -129,7 +150,7 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientUpdate<E>
         };
         Ok(match context {
             // TODO(gloas): implement Gloas light client
-            ForkName::Base | ForkName::Gloas | ForkName::Heze => {
+            ForkName::Base | ForkName::Heze => {
                 return Err(serde::de::Error::custom(format!(
                     "LightClientUpdate failed to deserialize: unsupported fork '{}'",
                     context
@@ -149,6 +170,9 @@ impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientUpdate<E>
             }
             ForkName::Fulu => {
                 Self::Fulu(Deserialize::deserialize(deserializer).map_err(convert_err)?)
+            }
+            ForkName::Gloas => {
+                Self::Gloas(Deserialize::deserialize(deserializer).map_err(convert_err)?)
             }
         })
     }
@@ -311,11 +335,39 @@ impl<E: EthSpec> LightClientUpdate<E> {
                     signature_slot: block_slot,
                 })
             }
+            // `LightClientHeaderGloas::block_to_light_client_header` currently returns
+            // `Err(GloasNotImplemented)` (blocked on sigp/lighthouse#9450)
+            fork_name @ ForkName::Gloas => {
+                let attested_header =
+                    LightClientHeaderGloas::block_to_light_client_header(attested_block)?;
+
+                let finalized_header = if let Some(finalized_block) = finalized_block {
+                    if finalized_block.fork_name_unchecked() == fork_name {
+                        LightClientHeaderGloas::block_to_light_client_header(finalized_block)?
+                    } else {
+                        LightClientHeaderGloas::default()
+                    }
+                } else {
+                    LightClientHeaderGloas::default()
+                };
+
+                Self::Gloas(LightClientUpdateGloas {
+                    attested_header,
+                    next_sync_committee,
+                    next_sync_committee_branch: next_sync_committee_branch
+                        .try_into()
+                        .map_err(LightClientError::SszTypesError)?,
+                    finalized_header,
+                    finality_branch: finality_branch
+                        .try_into()
+                        .map_err(LightClientError::SszTypesError)?,
+                    sync_aggregate: sync_aggregate.clone(),
+                    signature_slot: block_slot,
+                })
+            }
             // To add a new fork, just append the new fork variant on the latest fork. Forks that
             // have a distinct execution header will need a new LightClientUpdate variant only
             // if you need to test or support lightclient usages
-            // TODO(gloas): implement Gloas light client
-            ForkName::Gloas => return Err(LightClientError::GloasNotImplemented),
             ForkName::Heze => return Err(LightClientError::HezeNotImplemented),
         };
 
@@ -331,8 +383,9 @@ impl<E: EthSpec> LightClientUpdate<E> {
             ForkName::Deneb => Self::Deneb(LightClientUpdateDeneb::from_ssz_bytes(bytes)?),
             ForkName::Electra => Self::Electra(LightClientUpdateElectra::from_ssz_bytes(bytes)?),
             ForkName::Fulu => Self::Fulu(LightClientUpdateFulu::from_ssz_bytes(bytes)?),
-            // TODO(gloas): implement Gloas light client
-            ForkName::Base | ForkName::Gloas | ForkName::Heze => {
+            ForkName::Gloas => Self::Gloas(LightClientUpdateGloas::from_ssz_bytes(bytes)?),
+            // TODO(heze): implement Heze light client
+            ForkName::Base | ForkName::Heze => {
                 return Err(ssz::DecodeError::BytesInvalid(format!(
                     "LightClientUpdate decoding for {fork_name} not implemented"
                 )));
@@ -349,6 +402,7 @@ impl<E: EthSpec> LightClientUpdate<E> {
             LightClientUpdate::Deneb(update) => update.attested_header.beacon.slot,
             LightClientUpdate::Electra(update) => update.attested_header.beacon.slot,
             LightClientUpdate::Fulu(update) => update.attested_header.beacon.slot,
+            LightClientUpdate::Gloas(update) => update.attested_header.beacon.slot,
         }
     }
 
@@ -359,6 +413,7 @@ impl<E: EthSpec> LightClientUpdate<E> {
             LightClientUpdate::Deneb(update) => update.finalized_header.beacon.slot,
             LightClientUpdate::Electra(update) => update.finalized_header.beacon.slot,
             LightClientUpdate::Fulu(update) => update.finalized_header.beacon.slot,
+            LightClientUpdate::Gloas(update) => update.finalized_header.beacon.slot,
         }
     }
 
@@ -519,6 +574,7 @@ impl<E: EthSpec> LightClientUpdate<E> {
             Self::Deneb(_) => func(ForkName::Deneb),
             Self::Electra(_) => func(ForkName::Electra),
             Self::Fulu(_) => func(ForkName::Fulu),
+            Self::Gloas(_) => func(ForkName::Gloas),
         }
     }
 }
@@ -580,6 +636,13 @@ mod tests {
         use super::*;
         use crate::MainnetEthSpec;
         ssz_tests!(LightClientUpdateFulu<MainnetEthSpec>);
+    }
+
+    #[cfg(test)]
+    mod gloas {
+        use super::*;
+        use crate::MainnetEthSpec;
+        ssz_tests!(LightClientUpdateGloas<MainnetEthSpec>);
     }
 
     #[test]

--- a/consensus/types/src/light_client/mod.rs
+++ b/consensus/types/src/light_client/mod.rs
@@ -11,6 +11,7 @@ pub use error::LightClientError;
 pub use light_client_bootstrap::{
     LightClientBootstrap, LightClientBootstrapAltair, LightClientBootstrapCapella,
     LightClientBootstrapDeneb, LightClientBootstrapElectra, LightClientBootstrapFulu,
+    LightClientBootstrapGloas,
 };
 pub use light_client_finality_update::{
     LightClientFinalityUpdate, LightClientFinalityUpdateAltair, LightClientFinalityUpdateCapella,
@@ -19,7 +20,7 @@ pub use light_client_finality_update::{
 };
 pub use light_client_header::{
     LightClientHeader, LightClientHeaderAltair, LightClientHeaderCapella, LightClientHeaderDeneb,
-    LightClientHeaderElectra, LightClientHeaderFulu,
+    LightClientHeaderElectra, LightClientHeaderFulu, LightClientHeaderGloas,
 };
 pub use light_client_optimistic_update::{
     LightClientOptimisticUpdate, LightClientOptimisticUpdateAltair,
@@ -27,9 +28,10 @@ pub use light_client_optimistic_update::{
     LightClientOptimisticUpdateElectra, LightClientOptimisticUpdateFulu,
 };
 pub use light_client_update::{
-    CurrentSyncCommitteeProofLen, CurrentSyncCommitteeProofLenElectra, ExecutionPayloadProofLen,
-    FinalizedRootProofLen, FinalizedRootProofLenElectra, LightClientUpdate,
-    LightClientUpdateAltair, LightClientUpdateCapella, LightClientUpdateDeneb,
+    CurrentSyncCommitteeProofLen, CurrentSyncCommitteeProofLenElectra,
+    CurrentSyncCommitteeProofLenGloas, ExecutionBlockHashProofLenGloas, ExecutionPayloadProofLen,
+    FinalizedRootProofLen, FinalizedRootProofLenElectra, FinalizedRootProofLenGloas,
+    LightClientUpdate, LightClientUpdateAltair, LightClientUpdateCapella, LightClientUpdateDeneb,
     LightClientUpdateElectra, LightClientUpdateFulu, NextSyncCommitteeProofLen,
-    NextSyncCommitteeProofLenElectra,
+    NextSyncCommitteeProofLenElectra, NextSyncCommitteeProofLenGloas,
 };

--- a/consensus/types/src/light_client/mod.rs
+++ b/consensus/types/src/light_client/mod.rs
@@ -16,7 +16,7 @@ pub use light_client_bootstrap::{
 pub use light_client_finality_update::{
     LightClientFinalityUpdate, LightClientFinalityUpdateAltair, LightClientFinalityUpdateCapella,
     LightClientFinalityUpdateDeneb, LightClientFinalityUpdateElectra,
-    LightClientFinalityUpdateFulu,
+    LightClientFinalityUpdateFulu, LightClientFinalityUpdateGloas,
 };
 pub use light_client_header::{
     LightClientHeader, LightClientHeaderAltair, LightClientHeaderCapella, LightClientHeaderDeneb,
@@ -26,12 +26,13 @@ pub use light_client_optimistic_update::{
     LightClientOptimisticUpdate, LightClientOptimisticUpdateAltair,
     LightClientOptimisticUpdateCapella, LightClientOptimisticUpdateDeneb,
     LightClientOptimisticUpdateElectra, LightClientOptimisticUpdateFulu,
+    LightClientOptimisticUpdateGloas,
 };
 pub use light_client_update::{
     CurrentSyncCommitteeProofLen, CurrentSyncCommitteeProofLenElectra,
     CurrentSyncCommitteeProofLenGloas, ExecutionBlockHashProofLenGloas, ExecutionPayloadProofLen,
     FinalizedRootProofLen, FinalizedRootProofLenElectra, FinalizedRootProofLenGloas,
     LightClientUpdate, LightClientUpdateAltair, LightClientUpdateCapella, LightClientUpdateDeneb,
-    LightClientUpdateElectra, LightClientUpdateFulu, NextSyncCommitteeProofLen,
-    NextSyncCommitteeProofLenElectra, NextSyncCommitteeProofLenGloas,
+    LightClientUpdateElectra, LightClientUpdateFulu, LightClientUpdateGloas,
+    NextSyncCommitteeProofLen, NextSyncCommitteeProofLenElectra, NextSyncCommitteeProofLenGloas,
 };

--- a/testing/ef_tests/src/cases/merkle_proof_validity.rs
+++ b/testing/ef_tests/src/cases/merkle_proof_validity.rs
@@ -99,15 +99,20 @@ impl<E: EthSpec> Case for BeaconStateMerkleProofValidity<E> {
 
         let proof = match self.merkle_proof.leaf_index {
             light_client::consts::CURRENT_SYNC_COMMITTEE_INDEX_ELECTRA
-            | light_client::consts::CURRENT_SYNC_COMMITTEE_INDEX => {
+            | light_client::consts::CURRENT_SYNC_COMMITTEE_INDEX
+            | light_client::consts::CURRENT_SYNC_COMMITTEE_INDEX_GLOAS => {
                 state.compute_current_sync_committee_proof()
             }
             light_client::consts::NEXT_SYNC_COMMITTEE_INDEX_ELECTRA
-            | light_client::consts::NEXT_SYNC_COMMITTEE_INDEX => {
+            | light_client::consts::NEXT_SYNC_COMMITTEE_INDEX
+            | light_client::consts::NEXT_SYNC_COMMITTEE_INDEX_GLOAS => {
                 state.compute_next_sync_committee_proof()
             }
             light_client::consts::FINALIZED_ROOT_INDEX_ELECTRA
-            | light_client::consts::FINALIZED_ROOT_INDEX => state.compute_finalized_root_proof(),
+            | light_client::consts::FINALIZED_ROOT_INDEX
+            | light_client::consts::FINALIZED_ROOT_INDEX_GLOAS => {
+                state.compute_finalized_root_proof()
+            }
             _ => {
                 return Err(Error::FailedToParseTest(
                     "Could not retrieve merkle proof, invalid index".to_string(),

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -1272,8 +1272,7 @@ impl<E: EthSpec + TypeName> Handler for LightClientUpdateHandler<E> {
     }
 
     fn disabled_forks(&self) -> Vec<ForkName> {
-        // TODO(gloas): remove once we have Gloas light client tests
-        vec![ForkName::Gloas, ForkName::Heze]
+        vec![ForkName::Heze]
     }
 }
 

--- a/testing/ef_tests/src/type_name.rs
+++ b/testing/ef_tests/src/type_name.rs
@@ -118,6 +118,7 @@ type_name_generic!(LightClientBootstrapCapella, "LightClientBootstrap");
 type_name_generic!(LightClientBootstrapDeneb, "LightClientBootstrap");
 type_name_generic!(LightClientBootstrapElectra, "LightClientBootstrap");
 type_name_generic!(LightClientBootstrapFulu, "LightClientBootstrap");
+type_name_generic!(LightClientBootstrapGloas, "LightClientBootstrap");
 type_name_generic!(LightClientFinalityUpdate);
 type_name_generic!(LightClientFinalityUpdateAltair, "LightClientFinalityUpdate");
 type_name_generic!(
@@ -130,12 +131,14 @@ type_name_generic!(
     "LightClientFinalityUpdate"
 );
 type_name_generic!(LightClientFinalityUpdateFulu, "LightClientFinalityUpdate");
+type_name_generic!(LightClientFinalityUpdateGloas, "LightClientFinalityUpdate");
 type_name_generic!(LightClientHeader);
 type_name_generic!(LightClientHeaderAltair, "LightClientHeader");
 type_name_generic!(LightClientHeaderCapella, "LightClientHeader");
 type_name_generic!(LightClientHeaderDeneb, "LightClientHeader");
 type_name_generic!(LightClientHeaderElectra, "LightClientHeader");
 type_name_generic!(LightClientHeaderFulu, "LightClientHeader");
+type_name_generic!(LightClientHeaderGloas, "LightClientHeader");
 type_name_generic!(LightClientOptimisticUpdate);
 type_name_generic!(
     LightClientOptimisticUpdateAltair,
@@ -157,12 +160,17 @@ type_name_generic!(
     LightClientOptimisticUpdateFulu,
     "LightClientOptimisticUpdate"
 );
+type_name_generic!(
+    LightClientOptimisticUpdateGloas,
+    "LightClientOptimisticUpdate"
+);
 type_name_generic!(LightClientUpdate);
 type_name_generic!(LightClientUpdateAltair, "LightClientUpdate");
 type_name_generic!(LightClientUpdateCapella, "LightClientUpdate");
 type_name_generic!(LightClientUpdateDeneb, "LightClientUpdate");
 type_name_generic!(LightClientUpdateElectra, "LightClientUpdate");
 type_name_generic!(LightClientUpdateFulu, "LightClientUpdate");
+type_name_generic!(LightClientUpdateGloas, "LightClientUpdate");
 type_name_generic!(PendingAttestation);
 type_name_generic!(PayloadAttestation);
 type_name!(PayloadAttestationData);

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -510,6 +510,10 @@ mod ssz_static {
             .run();
         SszStaticHandler::<LightClientBootstrapFulu<MainnetEthSpec>, MainnetEthSpec>::fulu_only()
             .run();
+        SszStaticHandler::<LightClientBootstrapGloas<MinimalEthSpec>, MinimalEthSpec>::gloas_only()
+            .run();
+        SszStaticHandler::<LightClientBootstrapGloas<MainnetEthSpec>, MainnetEthSpec>::gloas_only()
+            .run();
     }
 
     // LightClientHeader has no internal indicator of which fork it is for, so we test it separately.
@@ -545,6 +549,10 @@ mod ssz_static {
             .run();
         SszStaticHandler::<LightClientHeaderFulu<MainnetEthSpec>, MainnetEthSpec>::fulu_only()
             .run();
+        SszStaticHandler::<LightClientHeaderGloas<MinimalEthSpec>, MinimalEthSpec>::gloas_only()
+            .run();
+        SszStaticHandler::<LightClientHeaderGloas<MainnetEthSpec>, MainnetEthSpec>::gloas_only()
+            .run();
     }
 
     // LightClientOptimisticUpdate has no internal indicator of which fork it is for, so we test it separately.
@@ -562,6 +570,8 @@ mod ssz_static {
         SszStaticHandler::<LightClientOptimisticUpdateElectra<MainnetEthSpec>, MainnetEthSpec>::electra_only().run();
         SszStaticHandler::<LightClientOptimisticUpdateFulu<MinimalEthSpec>, MinimalEthSpec>::fulu_only().run();
         SszStaticHandler::<LightClientOptimisticUpdateFulu<MainnetEthSpec>, MainnetEthSpec>::fulu_only().run();
+        SszStaticHandler::<LightClientOptimisticUpdateGloas<MinimalEthSpec>, MinimalEthSpec>::gloas_only().run();
+        SszStaticHandler::<LightClientOptimisticUpdateGloas<MainnetEthSpec>, MainnetEthSpec>::gloas_only().run();
     }
 
     // LightClientFinalityUpdate has no internal indicator of which fork it is for, so we test it separately.
@@ -603,6 +613,12 @@ mod ssz_static {
         SszStaticHandler::<LightClientFinalityUpdateFulu<MainnetEthSpec>, MainnetEthSpec>::fulu_only(
         )
             .run();
+        SszStaticHandler::<LightClientFinalityUpdateGloas<MinimalEthSpec>, MinimalEthSpec>::gloas_only(
+        )
+            .run();
+        SszStaticHandler::<LightClientFinalityUpdateGloas<MainnetEthSpec>, MainnetEthSpec>::gloas_only(
+        )
+            .run();
     }
 
     // LightClientUpdate has no internal indicator of which fork it is for, so we test it separately.
@@ -635,6 +651,10 @@ mod ssz_static {
         SszStaticHandler::<LightClientUpdateFulu<MinimalEthSpec>, MinimalEthSpec>::fulu_only()
             .run();
         SszStaticHandler::<LightClientUpdateFulu<MainnetEthSpec>, MainnetEthSpec>::fulu_only()
+            .run();
+        SszStaticHandler::<LightClientUpdateGloas<MinimalEthSpec>, MinimalEthSpec>::gloas_only()
+            .run();
+        SszStaticHandler::<LightClientUpdateGloas<MainnetEthSpec>, MainnetEthSpec>::gloas_only()
             .run();
     }
 


### PR DESCRIPTION
## Issue Addressed

Adds Gloas support to light client. Fixes #9587 

## Proposed Changes

- Adds Gloas generalized-index and proof-length constants
- Introduces `LightClientHeaderGloas`
- Introduces `LightClientBootstrapGloas` with the matching sync-committee branch length.
- Wires SSZ encode/decode, context deserialization, and construction helpers
- Extends the light-client surface so Gloas is no longer rejected.

## Additional Info
Correct Merkle proofs against Gloas `BeaconBlockBody` / `BeaconState` require `ProgressiveContainer` support (EIP-7495 / EIP-7916).
- The execution-block-hash leaf is nested (`body → signed_execution_payload_bid → message → parent_block_hash`).
- Sync-committee and finalized-root proofs sit on a progressive `BeaconState`.

Gloas variants call directly into the proof generation functions rather than stubbing with a hardcoded error, currently returns `BeaconStateError::ProgressiveMerkleProofNotSupported` propagated as `LightClientError::BeaconStateError` as those functions short circuit on `fork_name().gloas_enabled()`
