### PR TITLE
Export canonical process metrics via prometheus ProcessCollector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.2",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -4157,7 +4157,7 @@ version = "0.1.0"
 dependencies = [
  "eth2",
  "metrics",
- "procfs",
+ "procfs 0.18.0",
  "psutil",
 ]
 
@@ -5663,6 +5663,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -6895,7 +6901,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -7060,13 +7066,36 @@ dependencies = [
 
 [[package]]
 name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.10.0",
+ "hex",
+ "lazy_static",
+ "procfs-core 0.16.0",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
  "bitflags 2.10.0",
- "procfs-core",
- "rustix",
+ "procfs-core 0.18.0",
+ "rustix 1.1.2",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.10.0",
+ "hex",
 ]
 
 [[package]]
@@ -7088,8 +7117,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs 0.16.0",
  "thiserror 1.0.69",
 ]
 
@@ -7846,6 +7877,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -7853,7 +7897,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -8913,7 +8957,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -8923,7 +8967,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.60.2",
 ]
 

--- a/common/health_metrics/src/metrics.rs
+++ b/common/health_metrics/src/metrics.rs
@@ -9,28 +9,10 @@ pub static PROCESS_NUM_THREADS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
         "Number of threads used by the current process",
     )
 });
-pub static PROCESS_RES_MEM: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
-    try_create_int_gauge(
-        "process_resident_memory_bytes",
-        "Resident memory used by the current process",
-    )
-});
-pub static PROCESS_VIRT_MEM: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
-    try_create_int_gauge(
-        "process_virtual_memory_bytes",
-        "Virtual memory used by the current process",
-    )
-});
 pub static PROCESS_SHR_MEM: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
     try_create_int_gauge(
         "process_shared_memory_bytes",
         "Shared memory used by the current process",
-    )
-});
-pub static PROCESS_SECONDS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
-    try_create_int_gauge(
-        "process_cpu_seconds_total",
-        "Total cpu time taken by the current process",
     )
 });
 pub static SYSTEM_VIRT_MEM_TOTAL: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
@@ -128,14 +110,15 @@ pub fn scrape_health_metrics() {
 }
 
 pub fn scrape_process_health_metrics() {
+    // Exports `process_cpu_seconds_total`, `process_resident_memory_bytes`,
+    // `process_virtual_memory_bytes` and friends with the correct metric types.
+    register_process_collector();
+
     // This will silently fail if we are unable to observe the health. This is desired behaviour
     // since we don't support `Health` for all platforms.
     if let Ok(health) = ProcessHealth::observe() {
         set_gauge(&PROCESS_NUM_THREADS, health.pid_num_threads);
-        set_gauge(&PROCESS_RES_MEM, health.pid_mem_resident_set_size as i64);
-        set_gauge(&PROCESS_VIRT_MEM, health.pid_mem_virtual_memory_size as i64);
         set_gauge(&PROCESS_SHR_MEM, health.pid_mem_shared_memory_size as i64);
-        set_gauge(&PROCESS_SECONDS, health.pid_process_seconds_total as i64);
     }
 }
 
@@ -186,5 +169,21 @@ pub fn scrape_system_health_metrics() {
             &NETWORK_BYTES_SENT,
             health.network_node_bytes_total_transmit as i64,
         );
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_cpu_seconds_total_is_a_counter() {
+        scrape_process_health_metrics();
+
+        let metric = gather()
+            .into_iter()
+            .find(|metric| metric.get_name() == "process_cpu_seconds_total")
+            .expect("process_cpu_seconds_total should be registered");
+        assert_eq!(metric.get_field_type(), MetricType::COUNTER);
     }
 }

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.2.0"
 edition = { workspace = true }
 
 [dependencies]
-prometheus = { workspace = true }
+prometheus = { workspace = true, features = ["process"] }

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -308,6 +308,21 @@ pub fn inc_counter_by(counter: &Result<IntCounter>, value: u64) {
     }
 }
 
+/// Registers the prometheus `ProcessCollector`, which exports the canonical process metrics
+/// (`process_cpu_seconds_total`, `process_resident_memory_bytes`, etc.) with correct metric
+/// types. Only supported on Linux; no-op elsewhere.
+pub fn register_process_collector() {
+    #[cfg(target_os = "linux")]
+    {
+        static REGISTER: std::sync::Once = std::sync::Once::new();
+        REGISTER.call_once(|| {
+            let _ = prometheus::register(Box::new(
+                prometheus::process_collector::ProcessCollector::for_self(),
+            ));
+        });
+    }
+}
+
 pub fn set_gauge_vec(int_gauge_vec: &Result<IntGaugeVec>, name: &[&str], value: i64) {
     if let Some(gauge) = get_int_gauge(int_gauge_vec, name) {
         gauge.set(value);


### PR DESCRIPTION
🤖 automated (dapplion's agent): opened on dapplion's request after local testing.

## Issue Addressed

Closes #3108

Alternative to #9488 and #7802.

## Proposed Changes

Instead of hand-rolling the counter update (#9488) or resetting the counter on each scrape (#7802, racy under concurrent scrapes), register the `prometheus` crate's built-in `ProcessCollector`, which exports the canonical process metrics with the correct types and reads `/proc` at gather time:

- `process_cpu_seconds_total` (counter — fixes #3108)
- `process_resident_memory_bytes`
- `process_virtual_memory_bytes`
- `process_start_time_seconds`, `process_open_fds`, `process_max_fds`, `process_threads` (new)

The hand-rolled `process_cpu_seconds_total`, `process_resident_memory_bytes` and `process_virtual_memory_bytes` gauges are removed; their names (and values) are unchanged, so existing dashboards keep working. `process_num_threads` and `process_shared_memory_bytes` are kept as the collector does not provide them.

## Additional Info

- The collector is Linux-only (like the existing `ProcessHealth`-based metrics); registration is a no-op elsewhere, and the `process_collector` module is cfg-gated inside `prometheus` so non-Linux builds are unaffected.
- The `process` feature pulls in `procfs 0.16` alongside the workspace's `procfs 0.18`; `deny.toml` allows multiple versions and `procfs` is not on the deny list.
- Tested on a live mainnet BN: `process_cpu_seconds_total` is exported with `# TYPE ... counter` and increases monotonically across scrapes, including 4 concurrent scrapes.