### PR TITLE
Update VC `--monitoring-endpoint` help text

### DIFF
--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -104,11 +104,11 @@ Options:
       --monitoring-endpoint <ADDRESS>
           Enables the monitoring service for sending system metrics to a remote
           endpoint. This can be used to monitor your setup on certain services
-          (e.g. beaconcha.in). This flag sets the endpoint where the beacon node
-          metrics will be sent. Note: This will send information to a remote
-          sever which may identify and associate your validators, IP address and
-          other personal information. Always use a HTTPS connection and never
-          provide an untrusted URL.
+          (e.g. beaconcha.in). This flag sets the endpoint where the validator
+          client metrics will be sent. Note: This will send information to a
+          remote sever which may identify and associate your validators, IP
+          address and other personal information. Always use a HTTPS connection
+          and never provide an untrusted URL.
       --monitoring-endpoint-period <SECONDS>
           Defines how many seconds to wait between each message sent to the
           monitoring-endpoint. [default: 60]

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -351,7 +351,7 @@ pub struct ValidatorClient {
         value_name = "ADDRESS",
         help = "Enables the monitoring service for sending system metrics to a remote endpoint. \
                 This can be used to monitor your setup on certain services (e.g. beaconcha.in). \
-                This flag sets the endpoint where the beacon node metrics will be sent. \
+                This flag sets the endpoint where the validator client metrics will be sent. \
                 Note: This will send information to a remote sever which may identify and associate your \
                 validators, IP address and other personal information. Always use a HTTPS connection \
                 and never provide an untrusted URL.",


### PR DESCRIPTION
There is a user asking about the `--monitoring-endpoint`. I take a quick look at the help text and notice that the VC flag is mentioning beacon node metrics, instead of validator client metrics. 

Updated the help text to mention validator client metrics.
