### PR TITLE
Pin geth image in gloas genesis-sync CI

### DIFF
--- a/scripts/tests/genesis-sync-config-gloas.yaml
+++ b/scripts/tests/genesis-sync-config-gloas.yaml
@@ -2,23 +2,27 @@
 participants:
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    el_type: geth
+    el_image: ethpandaops/geth:master
     supernode: true
     count: 2
   # nodes without validators, used for testing sync.
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    el_type: geth
+    el_image: ethpandaops/geth:master
     supernode: true
     validator_count: 0
   - cl_type: lighthouse
     cl_image: lighthouse:local
+    el_type: geth
+    el_image: ethpandaops/geth:master
     supernode: false
     validator_count: 0
 network_params:
   gloas_fork_epoch: 0
   slot_duration_ms: 6000
   preset: "minimal"
-ethereum_genesis_generator_params:
-    image: ethpandaops/ethereum-genesis-generator:6.1.4
 additional_services:
   - tx_fuzz
   - spamoor


### PR DESCRIPTION
CI is failing for genesis-sync Gloas. Pin the geth version to `ethpandaops/geth:master`, similar to what we do for the Fulu config file: `genesis-sync-config-fulu.yaml` 

Also remove the pin ethereum-genesis-generator version. 

Tested locally and it works