### PR TITLE
Sign payload attestations concurrently in the VC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9960,6 +9960,7 @@ dependencies = [
  "eth2",
  "eth2_keystore",
  "ethereum_ssz",
+ "futures",
  "initialized_validators",
  "lighthouse_validator_store",
  "mockito",

--- a/testing/validator_test_rig/Cargo.toml
+++ b/testing/validator_test_rig/Cargo.toml
@@ -10,6 +10,7 @@ bls = { workspace = true }
 eth2 = { workspace = true }
 eth2_keystore = { workspace = true }
 ethereum_ssz = { workspace = true }
+futures = { workspace = true }
 initialized_validators = { workspace = true }
 lighthouse_validator_store = { workspace = true }
 mockito = { workspace = true }

--- a/testing/validator_test_rig/src/lib.rs
+++ b/testing/validator_test_rig/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod mock_beacon_node;
+pub mod mock_validator_store;
 pub mod validator_client_harness;

--- a/testing/validator_test_rig/src/mock_validator_store.rs
+++ b/testing/validator_test_rig/src/mock_validator_store.rs
@@ -1,0 +1,190 @@
+use bls::{PublicKeyBytes, Signature};
+use futures::future::{BoxFuture, FutureExt};
+use futures::{Stream, stream};
+use std::future::Future;
+use std::sync::Arc;
+use types::{
+    Address, Epoch, ExecutionPayloadEnvelope, Graffiti, MainnetEthSpec, PayloadAttestationData,
+    PayloadAttestationMessage, ProposerPreferences, SelectionProof, SignedAggregateAndProof,
+    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedProposerPreferences,
+    SignedValidatorRegistrationData, SingleAttestation, Slot, SyncCommitteeMessage,
+    SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData,
+};
+use validator_store::{
+    AggregateToSign, AttestationToSign, ContributionToSign, DoppelgangerStatus,
+    Error as StoreError, ProposalData, SignedBlock, SyncMessageToSign, UnsignedBlock,
+    ValidatorStore,
+};
+
+type SignPayloadAttestationFn = Box<
+    dyn Fn(
+            PublicKeyBytes,
+            PayloadAttestationData,
+        ) -> BoxFuture<'static, Result<PayloadAttestationMessage, StoreError<()>>>
+        + Send
+        + Sync,
+>;
+
+/// A `ValidatorStore` test double for driving validator services without keystores.
+///
+/// Methods without a hook panic, so a test only exercises the calls it explicitly expects.
+pub struct MockValidatorStore {
+    sign_payload_attestation: SignPayloadAttestationFn,
+}
+
+impl MockValidatorStore {
+    pub fn with_sign_payload_attestation<F, Fut>(hook: F) -> Self
+    where
+        F: Fn(PublicKeyBytes, PayloadAttestationData) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<PayloadAttestationMessage, StoreError<()>>> + Send + 'static,
+    {
+        Self {
+            sign_payload_attestation: Box::new(move |pubkey, data| hook(pubkey, data).boxed()),
+        }
+    }
+}
+
+impl ValidatorStore for MockValidatorStore {
+    type Error = ();
+    type E = MainnetEthSpec;
+
+    async fn sign_payload_attestation(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        data: PayloadAttestationData,
+    ) -> Result<PayloadAttestationMessage, StoreError<Self::Error>> {
+        (self.sign_payload_attestation)(validator_pubkey, data).await
+    }
+
+    fn validator_index(&self, _pubkey: &PublicKeyBytes) -> Option<u64> {
+        unimplemented!()
+    }
+
+    fn voting_pubkeys<I, F>(&self, _filter_func: F) -> I
+    where
+        I: FromIterator<PublicKeyBytes>,
+        F: Fn(DoppelgangerStatus) -> Option<PublicKeyBytes>,
+    {
+        unimplemented!()
+    }
+
+    fn doppelganger_protection_allows_signing(&self, _validator_pubkey: PublicKeyBytes) -> bool {
+        unimplemented!()
+    }
+
+    fn num_voting_validators(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn graffiti(&self, _validator_pubkey: &PublicKeyBytes) -> Option<Graffiti> {
+        unimplemented!()
+    }
+
+    fn get_fee_recipient(&self, _validator_pubkey: &PublicKeyBytes) -> Option<Address> {
+        unimplemented!()
+    }
+
+    fn determine_builder_boost_factor(&self, _validator_pubkey: &PublicKeyBytes) -> Option<u64> {
+        unimplemented!()
+    }
+
+    async fn randao_reveal(
+        &self,
+        _validator_pubkey: PublicKeyBytes,
+        _signing_epoch: Epoch,
+    ) -> Result<Signature, StoreError<Self::Error>> {
+        unimplemented!()
+    }
+
+    fn set_validator_index(&self, _validator_pubkey: &PublicKeyBytes, _index: u64) {
+        unimplemented!()
+    }
+
+    async fn sign_block(
+        &self,
+        _validator_pubkey: PublicKeyBytes,
+        _block: UnsignedBlock<Self::E>,
+        _current_slot: Slot,
+    ) -> Result<SignedBlock<Self::E>, StoreError<Self::Error>> {
+        unimplemented!()
+    }
+
+    fn sign_attestations(
+        self: &Arc<Self>,
+        _attestations: Vec<AttestationToSign>,
+    ) -> impl Stream<Item = Result<Vec<SingleAttestation>, StoreError<Self::Error>>> + Send {
+        stream::empty()
+    }
+
+    async fn sign_validator_registration_data(
+        &self,
+        _validator_registration_data: ValidatorRegistrationData,
+    ) -> Result<SignedValidatorRegistrationData, StoreError<Self::Error>> {
+        unimplemented!()
+    }
+
+    async fn produce_selection_proof(
+        &self,
+        _validator_pubkey: PublicKeyBytes,
+        _slot: Slot,
+    ) -> Result<SelectionProof, StoreError<Self::Error>> {
+        unimplemented!()
+    }
+
+    async fn produce_sync_selection_proof(
+        &self,
+        _validator_pubkey: &PublicKeyBytes,
+        _slot: Slot,
+        _subnet_id: SyncSubnetId,
+    ) -> Result<SyncSelectionProof, StoreError<Self::Error>> {
+        unimplemented!()
+    }
+
+    fn sign_aggregate_and_proofs(
+        self: &Arc<Self>,
+        _aggregates: Vec<AggregateToSign<Self::E>>,
+    ) -> impl Stream<Item = Result<Vec<SignedAggregateAndProof<Self::E>>, StoreError<Self::Error>>> + Send
+    {
+        stream::empty()
+    }
+
+    fn sign_sync_committee_signatures(
+        self: &Arc<Self>,
+        _messages: Vec<SyncMessageToSign>,
+    ) -> impl Stream<Item = Result<Vec<SyncCommitteeMessage>, StoreError<Self::Error>>> + Send {
+        stream::empty()
+    }
+
+    fn sign_sync_committee_contributions(
+        self: &Arc<Self>,
+        _contributions: Vec<ContributionToSign<Self::E>>,
+    ) -> impl Stream<
+        Item = Result<Vec<SignedContributionAndProof<Self::E>>, StoreError<Self::Error>>,
+    > + Send {
+        stream::empty()
+    }
+
+    fn prune_slashing_protection_db(&self, _current_epoch: Epoch, _first_run: bool) {
+        unimplemented!()
+    }
+
+    async fn sign_execution_payload_envelope(
+        &self,
+        _validator_pubkey: PublicKeyBytes,
+        _envelope: ExecutionPayloadEnvelope<Self::E>,
+    ) -> Result<SignedExecutionPayloadEnvelope<Self::E>, StoreError<Self::Error>> {
+        unimplemented!()
+    }
+
+    async fn sign_proposer_preferences(
+        &self,
+        _validator_pubkey: PublicKeyBytes,
+        _preferences: ProposerPreferences,
+    ) -> Result<SignedProposerPreferences, StoreError<Self::Error>> {
+        unimplemented!()
+    }
+
+    fn proposal_data(&self, _pubkey: &PublicKeyBytes) -> Option<ProposalData> {
+        unimplemented!()
+    }
+}

--- a/testing/validator_test_rig/src/mock_validator_store.rs
+++ b/testing/validator_test_rig/src/mock_validator_store.rs
@@ -57,7 +57,7 @@ impl ValidatorStore for MockValidatorStore {
     }
 
     fn validator_index(&self, _pubkey: &PublicKeyBytes) -> Option<u64> {
-        unimplemented!()
+        panic!("MockValidatorStore::validator_index called without a hook")
     }
 
     fn voting_pubkeys<I, F>(&self, _filter_func: F) -> I
@@ -65,27 +65,27 @@ impl ValidatorStore for MockValidatorStore {
         I: FromIterator<PublicKeyBytes>,
         F: Fn(DoppelgangerStatus) -> Option<PublicKeyBytes>,
     {
-        unimplemented!()
+        panic!("MockValidatorStore::voting_pubkeys called without a hook")
     }
 
     fn doppelganger_protection_allows_signing(&self, _validator_pubkey: PublicKeyBytes) -> bool {
-        unimplemented!()
+        panic!("MockValidatorStore::doppelganger_protection_allows_signing called without a hook")
     }
 
     fn num_voting_validators(&self) -> usize {
-        unimplemented!()
+        panic!("MockValidatorStore::num_voting_validators called without a hook")
     }
 
     fn graffiti(&self, _validator_pubkey: &PublicKeyBytes) -> Option<Graffiti> {
-        unimplemented!()
+        panic!("MockValidatorStore::graffiti called without a hook")
     }
 
     fn get_fee_recipient(&self, _validator_pubkey: &PublicKeyBytes) -> Option<Address> {
-        unimplemented!()
+        panic!("MockValidatorStore::get_fee_recipient called without a hook")
     }
 
     fn determine_builder_boost_factor(&self, _validator_pubkey: &PublicKeyBytes) -> Option<u64> {
-        unimplemented!()
+        panic!("MockValidatorStore::determine_builder_boost_factor called without a hook")
     }
 
     async fn randao_reveal(
@@ -93,11 +93,11 @@ impl ValidatorStore for MockValidatorStore {
         _validator_pubkey: PublicKeyBytes,
         _signing_epoch: Epoch,
     ) -> Result<Signature, StoreError<Self::Error>> {
-        unimplemented!()
+        panic!("MockValidatorStore::randao_reveal called without a hook")
     }
 
     fn set_validator_index(&self, _validator_pubkey: &PublicKeyBytes, _index: u64) {
-        unimplemented!()
+        panic!("MockValidatorStore::set_validator_index called without a hook")
     }
 
     async fn sign_block(
@@ -106,7 +106,7 @@ impl ValidatorStore for MockValidatorStore {
         _block: UnsignedBlock<Self::E>,
         _current_slot: Slot,
     ) -> Result<SignedBlock<Self::E>, StoreError<Self::Error>> {
-        unimplemented!()
+        panic!("MockValidatorStore::sign_block called without a hook")
     }
 
     fn sign_attestations(
@@ -120,7 +120,7 @@ impl ValidatorStore for MockValidatorStore {
         &self,
         _validator_registration_data: ValidatorRegistrationData,
     ) -> Result<SignedValidatorRegistrationData, StoreError<Self::Error>> {
-        unimplemented!()
+        panic!("MockValidatorStore::sign_validator_registration_data called without a hook")
     }
 
     async fn produce_selection_proof(
@@ -128,7 +128,7 @@ impl ValidatorStore for MockValidatorStore {
         _validator_pubkey: PublicKeyBytes,
         _slot: Slot,
     ) -> Result<SelectionProof, StoreError<Self::Error>> {
-        unimplemented!()
+        panic!("MockValidatorStore::produce_selection_proof called without a hook")
     }
 
     async fn produce_sync_selection_proof(
@@ -137,7 +137,7 @@ impl ValidatorStore for MockValidatorStore {
         _slot: Slot,
         _subnet_id: SyncSubnetId,
     ) -> Result<SyncSelectionProof, StoreError<Self::Error>> {
-        unimplemented!()
+        panic!("MockValidatorStore::produce_sync_selection_proof called without a hook")
     }
 
     fn sign_aggregate_and_proofs(
@@ -165,7 +165,7 @@ impl ValidatorStore for MockValidatorStore {
     }
 
     fn prune_slashing_protection_db(&self, _current_epoch: Epoch, _first_run: bool) {
-        unimplemented!()
+        panic!("MockValidatorStore::prune_slashing_protection_db called without a hook")
     }
 
     async fn sign_execution_payload_envelope(
@@ -173,7 +173,7 @@ impl ValidatorStore for MockValidatorStore {
         _validator_pubkey: PublicKeyBytes,
         _envelope: ExecutionPayloadEnvelope<Self::E>,
     ) -> Result<SignedExecutionPayloadEnvelope<Self::E>, StoreError<Self::Error>> {
-        unimplemented!()
+        panic!("MockValidatorStore::sign_execution_payload_envelope called without a hook")
     }
 
     async fn sign_proposer_preferences(
@@ -181,10 +181,10 @@ impl ValidatorStore for MockValidatorStore {
         _validator_pubkey: PublicKeyBytes,
         _preferences: ProposerPreferences,
     ) -> Result<SignedProposerPreferences, StoreError<Self::Error>> {
-        unimplemented!()
+        panic!("MockValidatorStore::sign_proposer_preferences called without a hook")
     }
 
     fn proposal_data(&self, _pubkey: &PublicKeyBytes) -> Option<ProposalData> {
-        unimplemented!()
+        panic!("MockValidatorStore::proposal_data called without a hook")
     }
 }

--- a/validator_client/validator_services/src/payload_attestation_service.rs
+++ b/validator_client/validator_services/src/payload_attestation_service.rs
@@ -331,10 +331,10 @@ mod tests {
         }
     }
 
-    fn build_service<St: ValidatorStore + 'static>(
+    fn build_service<S: ValidatorStore + 'static>(
         harness: &ValidatorClientHarness,
-        store: Arc<St>,
-    ) -> PayloadAttestationService<St, ManualSlotClock> {
+        store: Arc<S>,
+    ) -> PayloadAttestationService<S, ManualSlotClock> {
         let duties_service = Arc::new(
             DutiesServiceBuilder::new()
                 .validator_store(store.clone())

--- a/validator_client/validator_services/src/payload_attestation_service.rs
+++ b/validator_client/validator_services/src/payload_attestation_service.rs
@@ -1,6 +1,7 @@
 use crate::duties_service::DutiesService;
 use beacon_node_fallback::BeaconNodeFallback;
 use eth2::types::PtcDuty;
+use futures::future::join_all;
 use logging::crit;
 use slot_clock::SlotClock;
 use std::ops::Deref;
@@ -210,20 +211,30 @@ where
 
     /// Sign `attestation_data` for each duty and publish the resulting messages, preferring SSZ
     /// and falling back to JSON.
+    ///
+    /// All signatures are requested concurrently, with no cap: `ValidatorStore` implementations
+    /// backed by remote signers (e.g. distributed validators awaiting a threshold of co-signers)
+    /// may not resolve any signature until all are requested.
     async fn sign_and_publish(
         &self,
         slot: Slot,
         duties: Vec<PtcDuty>,
         attestation_data: PayloadAttestationData,
     ) -> Result<(), String> {
-        let mut messages = Vec::with_capacity(duties.len());
+        let signing_futures = duties.iter().map(|duty| {
+            let data = attestation_data.clone();
+            async move {
+                let result = self
+                    .validator_store
+                    .sign_payload_attestation(duty.pubkey, data)
+                    .await;
+                (duty, result)
+            }
+        });
 
-        for duty in &duties {
-            match self
-                .validator_store
-                .sign_payload_attestation(duty.pubkey, attestation_data.clone())
-                .await
-            {
+        let mut messages = Vec::with_capacity(duties.len());
+        for (duty, result) in join_all(signing_futures).await {
+            match result {
                 Ok(message) => {
                     messages.push(message);
                 }
@@ -289,11 +300,15 @@ where
 mod tests {
     use super::*;
     use crate::duties_service::DutiesServiceBuilder;
+    use bls::{PublicKeyBytes, Signature};
     use eth2::types::PtcDuty;
     use futures::FutureExt;
     use slot_clock::ManualSlotClock;
     use std::time::Duration;
-    use types::{Epoch, ForkName, Hash256, PayloadAttestationData, Slot};
+    use types::{
+        Epoch, ForkName, Hash256, PayloadAttestationData, PayloadAttestationMessage, Slot,
+    };
+    use validator_test_rig::mock_validator_store::MockValidatorStore;
     use validator_test_rig::validator_client_harness::{S, ValidatorClientHarness};
 
     struct TestHarness {
@@ -304,47 +319,60 @@ mod tests {
     impl TestHarness {
         async fn new_with_validators(num_validators: usize) -> Self {
             let harness = ValidatorClientHarness::new(num_validators).await;
-
-            let duties_service = Arc::new(
-                DutiesServiceBuilder::new()
-                    .validator_store(harness.validator_store.clone())
-                    .slot_clock(harness.slot_clock.clone())
-                    .beacon_nodes(harness.beacon_nodes.clone())
-                    .executor(harness.test_runtime.task_executor.clone())
-                    .spec(harness.spec.clone())
-                    .build()
-                    .unwrap(),
-            );
-
-            let service = PayloadAttestationService::new(
-                duties_service,
-                harness.validator_store.clone(),
-                harness.slot_clock.clone(),
-                harness.beacon_nodes.clone(),
-                harness.test_runtime.task_executor.clone(),
-                harness.spec.clone(),
-            );
-
+            let service = build_service(&harness, harness.validator_store.clone());
             Self { harness, service }
         }
 
         fn insert_ptc_duties(&self, slot: Slot) {
-            let duties = self
-                .harness
-                .pubkeys
-                .iter()
-                .enumerate()
-                .map(|(i, pubkey)| PtcDuty {
-                    pubkey: *pubkey,
-                    validator_index: i as u64,
-                    slot,
-                })
-                .collect();
-            self.service
-                .duties_service
-                .ptc_duties
-                .write()
-                .insert(Epoch::new(0), (Hash256::ZERO, duties));
+            self.service.duties_service.ptc_duties.write().insert(
+                Epoch::new(0),
+                (Hash256::ZERO, ptc_duties(&self.harness.pubkeys, slot)),
+            );
+        }
+    }
+
+    fn build_service<St: ValidatorStore + 'static>(
+        harness: &ValidatorClientHarness,
+        store: Arc<St>,
+    ) -> PayloadAttestationService<St, ManualSlotClock> {
+        let duties_service = Arc::new(
+            DutiesServiceBuilder::new()
+                .validator_store(store.clone())
+                .slot_clock(harness.slot_clock.clone())
+                .beacon_nodes(harness.beacon_nodes.clone())
+                .executor(harness.test_runtime.task_executor.clone())
+                .spec(harness.spec.clone())
+                .build()
+                .unwrap(),
+        );
+        PayloadAttestationService::new(
+            duties_service,
+            store,
+            harness.slot_clock.clone(),
+            harness.beacon_nodes.clone(),
+            harness.test_runtime.task_executor.clone(),
+            harness.spec.clone(),
+        )
+    }
+
+    fn ptc_duties(pubkeys: &[PublicKeyBytes], slot: Slot) -> Vec<PtcDuty> {
+        pubkeys
+            .iter()
+            .enumerate()
+            .map(|(i, pubkey)| PtcDuty {
+                pubkey: *pubkey,
+                validator_index: i as u64,
+                slot,
+            })
+            .collect()
+    }
+
+    fn attestation_data(slot: Slot) -> PayloadAttestationData {
+        PayloadAttestationData {
+            beacon_block_root: Hash256::ZERO,
+            slot,
+            payload_present: true,
+            blob_data_available: true,
         }
     }
 
@@ -671,6 +699,101 @@ mod tests {
         );
         // mock_ssz is only hit once
         // this is to verify that a single call to the POST endpoint can publish multiple messages in one go
+        mock_ssz.expect(1).assert();
+    }
+
+    #[tokio::test]
+    async fn failed_signer_does_not_block_siblings() {
+        let mut test_harness = TestHarness::new_with_validators(1).await;
+
+        let attestation_slot = Slot::new(1);
+        let mock_ssz = test_harness
+            .harness
+            .mock_beacon_node_1
+            .mock_post_beacon_pool_payload_attestations_ssz(Duration::from_secs(0));
+
+        // The unknown pubkey fails signing; listed first so a failure cannot mask the
+        // sibling's publish.
+        let duties = vec![
+            PtcDuty {
+                pubkey: PublicKeyBytes::empty(),
+                validator_index: 99,
+                slot: attestation_slot,
+            },
+            PtcDuty {
+                pubkey: test_harness.harness.pubkeys[0],
+                validator_index: 0,
+                slot: attestation_slot,
+            },
+        ];
+
+        test_harness
+            .service
+            .sign_and_publish(attestation_slot, duties, attestation_data(attestation_slot))
+            .await
+            .unwrap();
+
+        let messages = test_harness
+            .harness
+            .mock_beacon_node_1
+            .payload_attestation_message
+            .lock()
+            .unwrap();
+        assert_eq!(
+            messages.len(),
+            1,
+            "the known validator should still publish"
+        );
+        mock_ssz.expect(1).assert();
+    }
+
+    /// A slot's duties must all be signed concurrently. With a serial per-duty loop this
+    /// deadlocks (the first signature cannot resolve until the others are requested) and
+    /// the test fails via timeout.
+    #[tokio::test]
+    async fn multi_duty_slot_signs_concurrently() {
+        let mut harness = ValidatorClientHarness::new(3).await;
+
+        let attestation_slot = Slot::new(1);
+        let mock_ssz = harness
+            .mock_beacon_node_1
+            .mock_post_beacon_pool_payload_attestations_ssz(Duration::from_secs(0));
+
+        // No signature resolves until all three are requested, emulating an external signer.
+        let barrier = Arc::new(tokio::sync::Barrier::new(3));
+        let service = build_service(
+            &harness,
+            Arc::new(MockValidatorStore::with_sign_payload_attestation(
+                move |_, data| {
+                    let barrier = barrier.clone();
+                    async move {
+                        barrier.wait().await;
+                        Ok(PayloadAttestationMessage {
+                            validator_index: 0,
+                            data,
+                            signature: Signature::empty(),
+                        })
+                    }
+                },
+            )),
+        );
+        let duties = ptc_duties(&harness.pubkeys, attestation_slot);
+        let data = attestation_data(attestation_slot);
+
+        tokio::time::timeout(
+            Duration::from_secs(30),
+            service.sign_and_publish(attestation_slot, duties, data),
+        )
+        .await
+        .expect("signing must not deadlock when signatures resolve only after all are requested")
+        .unwrap();
+
+        let messages = harness
+            .mock_beacon_node_1
+            .payload_attestation_message
+            .lock()
+            .unwrap();
+        assert_eq!(messages.len(), 3, "all duties should publish");
         mock_ssz.expect(1).assert();
     }
 }


### PR DESCRIPTION
## Proposed Changes

Sign a slot's payload attestations concurrently in the payload attestation service, instead of awaiting each duty's signature sequentially.

- All signatures are requested via `join_all` before any is awaited; a failed signer still doesn't block its siblings.
- Publish behavior is unchanged: one batched SSZ POST with JSON fallback.
- Adds a `MockValidatorStore` to `validator_test_rig` and a regression test that fails via timeout if signing reverts to serial.

## Additional Info

`ValidatorStore` is also implemented by DVT clients (e.g. Anchor), where `sign_payload_attestation` awaits distributed signature collection and serial signing can deadlock when a slot has multiple PTC duties (sigp/anchor#1217). For Lighthouse itself behavior is effectively unchanged: local signatures resolve immediately and publish in the same single batch as today.

Verified with `cargo nextest run -p validator_services payload_attestation`, `cargo fmt --all -- --check`, `cargo check`, and scoped Clippy.

## AI Assistance Disclosure

**Tools used**: Claude Code Fable 5
