### PR TITLE
Fix flaky `import_gossip_block_at_current_slot` test

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -424,6 +424,22 @@ impl TestRig {
         self.chain.head_snapshot().beacon_block_root
     }
 
+    /// Wait for the head to become `expected`. Delayed data column reconstruction can import
+    /// a block on a separate work item, so the head update is not synchronous with the
+    /// gossip work journal.
+    pub async fn wait_for_head_root(&self, expected: Hash256) {
+        let result = tokio::time::timeout(STANDARD_TIMEOUT, async {
+            while self.head_root() != expected {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        assert!(
+            result.is_ok(),
+            "timed out waiting for the block to be imported and become head"
+        );
+    }
+
     pub fn enqueue_gossip_block(&self) {
         self.network_beacon_processor
             .send_gossip_beacon_block(
@@ -1262,11 +1278,8 @@ async fn import_gossip_block_at_current_slot() {
             .await;
     }
 
-    assert_eq!(
-        rig.head_root(),
-        rig.next_block.canonical_root(),
-        "block should be imported and become head"
-    );
+    rig.wait_for_head_root(rig.next_block.canonical_root())
+        .await;
 }
 
 fn fork_from_env_starts_at_fulu_or_later(spec: &ChainSpec) -> bool {


### PR DESCRIPTION
 The test `network_beacon_processor::tests::import_gossip_block_at_current_slot`
can fail on fulu or later due to a race condition

FROM CLAUDE:

The failure is a race with delayed data column reconstruction:

1. The test enqueues data columns one at a time and waits for the work journal after each.
2. Once half the columns are processed, `check_reconstruction_trigger` schedules a delayed
   reconstruction on the reprocess queue (`QUEUED_RECONSTRUCTION_DELAY`, 150 ms). Each new
   column pushes the delay back.
3. On a loaded machine, a gap between two enqueues exceeds 150 ms. Reconstruction then
   fires and imports the block on its own work item.
4. The remaining gossip columns return `DuplicateFullyImported`. That arm does not
   recompute the head; the reconstruction task does.
5. The test's final journal wait only covers the gossip column worker. The assertion then
   reads the head before the reconstruction task finishes its head recompute.

## Proposed Changes

- Add a `wait_for_head_root` helper to the network beacon processor test rig. It polls
  the head root until it matches the expected root, bounded by `STANDARD_TIMEOUT`.
- Replace the one-shot head assertion in `import_gossip_block_at_current_slot` with the
  helper.
