### PR TITLE
Fix Phase0 nightly beacon chain tests

### DIFF
--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -396,6 +396,10 @@ async fn light_client_updates_test() {
 async fn get_light_client_updates_crosses_256_period_boundary() {
     let db_path = tempdir().unwrap();
     let spec = test_spec::<E>();
+    let Some(_) = spec.altair_fork_epoch else {
+        // No-op prior to Altair.
+        return;
+    };
 
     if spec.is_gloas_scheduled() {
         return;
@@ -4514,6 +4518,10 @@ async fn schema_downgrade_to_min_version_full_node_dense_diffs() {
 async fn light_client_update_schema_v30_migration() {
     let db_path = tempdir().unwrap();
     let spec = test_spec::<E>();
+    let Some(_) = spec.altair_fork_epoch else {
+        // No-op prior to Altair.
+        return;
+    };
     if spec.is_gloas_scheduled() {
         return;
     }

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -394,17 +394,17 @@ async fn light_client_updates_test() {
 /// switching to big-endian keys.
 #[tokio::test]
 async fn get_light_client_updates_crosses_256_period_boundary() {
-    let db_path = tempdir().unwrap();
     let spec = test_spec::<E>();
-    let Some(_) = spec.altair_fork_epoch else {
+    if spec.altair_fork_epoch.is_none() {
         // No-op prior to Altair.
         return;
-    };
+    }
 
     if spec.is_gloas_scheduled() {
         return;
     }
 
+    let db_path = tempdir().unwrap();
     let store = get_store_generic(&db_path, StoreConfig::default(), spec.clone());
 
     let below = 100u64;
@@ -4516,16 +4516,16 @@ async fn schema_downgrade_to_min_version_full_node_dense_diffs() {
 
 #[tokio::test]
 async fn light_client_update_schema_v30_migration() {
-    let db_path = tempdir().unwrap();
     let spec = test_spec::<E>();
-    let Some(_) = spec.altair_fork_epoch else {
+    if spec.altair_fork_epoch.is_none() {
         // No-op prior to Altair.
         return;
-    };
+    }
     if spec.is_gloas_scheduled() {
         return;
     }
 
+    let db_path = tempdir().unwrap();
     let store = get_store_generic(&db_path, StoreConfig::default(), spec.clone());
 
     // Write entries directly under the OLD little-endian key encoding, bypassing

--- a/beacon_node/beacon_chain/tests/unrealized_checkpoints.rs
+++ b/beacon_node/beacon_chain/tests/unrealized_checkpoints.rs
@@ -14,7 +14,10 @@ use beacon_chain::{
 };
 use state_processing::per_epoch_processing::{self, base::ValidatorStatuses};
 use std::sync::Arc;
-use types::{Checkpoint, Epoch, EthSpec, MinimalEthSpec, consts::altair::TIMELY_TARGET_FLAG_INDEX};
+use types::{
+    BeaconState, ChainSpec, Checkpoint, Epoch, EthSpec, MinimalEthSpec,
+    consts::altair::TIMELY_TARGET_FLAG_INDEX,
+};
 
 type E = MinimalEthSpec;
 
@@ -305,11 +308,7 @@ where
                     .expect("should recompute child justification and finalization");
             (current_target_balance, justification_and_finalization)
         } else {
-            let mut validator_statuses = ValidatorStatuses::new(&child_state, &harness.chain.spec)
-                .expect("should initialize Phase0 validator statuses");
-            validator_statuses
-                .process_attestations(&child_state)
-                .expect("should process Phase0 attestations");
+            let validator_statuses = base_validator_statuses(&child_state, &harness.chain.spec);
             let current_target_balance = validator_statuses
                 .total_balances
                 .current_epoch_target_attesters();
@@ -352,10 +351,18 @@ where
     }
 }
 
-fn current_epoch_target_attesters(
-    state: &types::BeaconState<E>,
-    spec: &types::ChainSpec,
-) -> Vec<u64> {
+/// Builds the Phase0 `ValidatorStatuses` for `state`, mirroring the fork choice `on_block` logic
+/// used to compute unrealized checkpoints for pre-Altair blocks.
+fn base_validator_statuses(state: &BeaconState<E>, spec: &ChainSpec) -> ValidatorStatuses {
+    let mut validator_statuses =
+        ValidatorStatuses::new(state, spec).expect("should initialize Phase0 validator statuses");
+    validator_statuses
+        .process_attestations(state)
+        .expect("should process Phase0 attestations");
+    validator_statuses
+}
+
+fn current_epoch_target_attesters(state: &BeaconState<E>, spec: &ChainSpec) -> Vec<u64> {
     if state.fork_name_unchecked().altair_enabled() {
         state
             .current_epoch_participation()
@@ -370,11 +377,7 @@ fn current_epoch_target_attesters(
             })
             .collect()
     } else {
-        let mut validator_statuses = ValidatorStatuses::new(state, spec)
-            .expect("should initialize Phase0 validator statuses");
-        validator_statuses
-            .process_attestations(state)
-            .expect("should process Phase0 attestations");
+        let validator_statuses = base_validator_statuses(state, spec);
         validator_statuses
             .statuses
             .iter()

--- a/beacon_node/beacon_chain/tests/unrealized_checkpoints.rs
+++ b/beacon_node/beacon_chain/tests/unrealized_checkpoints.rs
@@ -12,7 +12,7 @@ use beacon_chain::{
         AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType, test_spec,
     },
 };
-use state_processing::per_epoch_processing;
+use state_processing::per_epoch_processing::{self, base::ValidatorStatuses};
 use std::sync::Arc;
 use types::{Checkpoint, Epoch, EthSpec, MinimalEthSpec, consts::altair::TIMELY_TARGET_FLAG_INDEX};
 
@@ -211,20 +211,10 @@ where
         .get_beacon_proposer_index(child_slot, &harness.chain.spec)
         .expect("should get child proposer") as u64;
 
-    let (_, _, _, current_participation, _, _, _, _) = parent_state
-        .mutable_validator_fields()
-        .expect("parent state should have Altair validator fields");
     // Slash this epoch's timely-target voters (they count toward the current-epoch target balance),
     // excluding the child proposer, to drop target balance below the 2/3 justification threshold.
-    let slash_indices = current_participation
-        .iter()
-        .enumerate()
-        .filter_map(|(index, flags)| {
-            flags
-                .has_flag(TIMELY_TARGET_FLAG_INDEX)
-                .ok()
-                .and_then(|has_flag| has_flag.then_some(index as u64))
-        })
+    let slash_indices = current_epoch_target_attesters(&parent_state, &harness.chain.spec)
+        .into_iter()
         .filter(|index| *index != child_proposer)
         .take(slash_count_needed as usize)
         .collect::<Vec<_>>();
@@ -304,13 +294,34 @@ where
     let child_total_active_balance = child_state
         .get_total_active_balance()
         .expect("should get child total active balance");
-    let child_current_target_balance = child_state
-        .progressive_balances_cache()
-        .current_epoch_target_attesting_balance()
-        .expect("should get child current target balance");
-    let child_justification_and_finalization =
-        per_epoch_processing::altair::process_justification_and_finalization(&child_state)
-            .expect("should recompute child justification and finalization");
+    let (child_current_target_balance, child_justification_and_finalization) =
+        if child_state.fork_name_unchecked().altair_enabled() {
+            let current_target_balance = child_state
+                .progressive_balances_cache()
+                .current_epoch_target_attesting_balance()
+                .expect("should get child current target balance");
+            let justification_and_finalization =
+                per_epoch_processing::altair::process_justification_and_finalization(&child_state)
+                    .expect("should recompute child justification and finalization");
+            (current_target_balance, justification_and_finalization)
+        } else {
+            let mut validator_statuses = ValidatorStatuses::new(&child_state, &harness.chain.spec)
+                .expect("should initialize Phase0 validator statuses");
+            validator_statuses
+                .process_attestations(&child_state)
+                .expect("should process Phase0 attestations");
+            let current_target_balance = validator_statuses
+                .total_balances
+                .current_epoch_target_attesters();
+            let justification_and_finalization =
+                per_epoch_processing::base::process_justification_and_finalization(
+                    &child_state,
+                    &validator_statuses.total_balances,
+                    &harness.chain.spec,
+                )
+                .expect("should recompute child justification and finalization");
+            (current_target_balance, justification_and_finalization)
+        };
     let expected_child_justified =
         child_justification_and_finalization.current_justified_checkpoint();
     let expected_child_finalized = child_justification_and_finalization.finalized_checkpoint();
@@ -338,5 +349,41 @@ where
         expected_child_justified,
         expected_child_finalized,
         parent_epoch,
+    }
+}
+
+fn current_epoch_target_attesters(
+    state: &types::BeaconState<E>,
+    spec: &types::ChainSpec,
+) -> Vec<u64> {
+    if state.fork_name_unchecked().altair_enabled() {
+        state
+            .current_epoch_participation()
+            .expect("Altair state should have participation flags")
+            .iter()
+            .enumerate()
+            .filter_map(|(index, flags)| {
+                flags
+                    .has_flag(TIMELY_TARGET_FLAG_INDEX)
+                    .ok()
+                    .and_then(|has_flag| has_flag.then_some(index as u64))
+            })
+            .collect()
+    } else {
+        let mut validator_statuses = ValidatorStatuses::new(state, spec)
+            .expect("should initialize Phase0 validator statuses");
+        validator_statuses
+            .process_attestations(state)
+            .expect("should process Phase0 attestations");
+        validator_statuses
+            .statuses
+            .iter()
+            .enumerate()
+            .filter_map(|(index, status)| {
+                status
+                    .is_current_epoch_target_attester
+                    .then_some(index as u64)
+            })
+            .collect()
     }
 }


### PR DESCRIPTION
## Issue Addressed

The Phase0 beacon-chain job in the [nightly run](https://github.com/sigp/lighthouse/actions/runs/31304192484/job/93221787736) failed in five tests. The tests assumed Altair state fields or types.

## Proposed Changes

- Skip two light-client database tests before Altair, where light-client updates do not exist.
- Use Phase0 `ValidatorStatuses` and Base justification logic in the unrealized-checkpoint fixture.

This retains Phase0 coverage for the fork-choice slashing regression.

## Additional Info

The five focused tests pass under Phase0 and Altair with the `portable` feature. The full Phase0 beacon-chain target passes 470 tests.

`cargo check` also passes.
