### PR TITLE
Count peers after registering the connection, not before

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -265,13 +265,6 @@ impl<E: EthSpec> PeerManager<E> {
             "Connection established"
         );
 
-        // Update the prometheus metrics
-        if self.metrics_enabled {
-            metrics::inc_counter(&metrics::PEER_CONNECT_EVENT_COUNT);
-
-            self.update_peer_count_metrics();
-        }
-
         // NOTE: We don't register peers that we are disconnecting immediately. The network service
         // does not need to know about these peers.
         match endpoint {
@@ -286,6 +279,13 @@ impl<E: EthSpec> PeerManager<E> {
                     .push(PeerManagerEvent::PeerConnectedOutgoing(peer_id));
             }
         };
+
+        // Update the prometheus metrics
+        if self.metrics_enabled {
+            metrics::inc_counter(&metrics::PEER_CONNECT_EVENT_COUNT);
+
+            self.update_peer_count_metrics();
+        }
     }
 
     fn on_connection_closed(


### PR DESCRIPTION
## Issue Addressed

None open. Found while investigating a permanent one-peer discrepancy between `libp2p_peers` and the beacon API on a small network.

## Proposed Changes

`update_peer_count_metrics()` runs at the top of `on_connection_established`, before `inject_connect_ingoing`/`inject_connect_outgoing` records the peer as `Connected` in the peer db. The gauges it sets — `libp2p_peers`, `libp2p_peers_multi`, `libp2p_peers_per_client` — are therefore sampled from a state where the new connection does not exist yet, so they report one peer fewer than are connected.

Because that helper only runs on connection events (`heartbeat()` does not call it), the value then stays one short until the next disconnect. `on_connection_closed` already updates *after* deregistering the peer, which is why the count is never too high.

This moves the whole metrics block to after the `match endpoint` block, which leaves `on_connection_established` with the same shape as `on_connection_closed`: register the connection, then observe the peer db. `PEER_CONNECT_EVENT_COUNT` moves with it, since an event counter does not depend on the ordering.

## Additional Info

Reproduced on a three node network (statically peered, `--target-peers 2`), stopping and restarting one node so both event paths are exercised. Three nodes rather than two on purpose: with two, a peer loss is invisible, because the reported value and the true count both collapse to `0`.

Counts below are peers seen by one node, so a fully meshed trio reads `2`.

On the published `v8.2.1` image, `libp2p_peers` stayed at `1` for the whole cycle while the real count moved:

| | `libp2p_peers` | `/eth/v1/node/peer_count` |
| --- | --- | --- |
| all three nodes running | 1 | `connected: 2` |
| one node stopped | 1 | `connected: 1` |
| that node started again | 1 | `connected: 2` |

So the gauge is not merely one low, it is stale: it happens to read correctly only in the moment the true count descends past it, and goes wrong again on the next connection. On a stable network the last event is always a connection, which is why it looks like a permanent off-by-one.

With this branch, the same cycle tracks throughout:

| | `libp2p_peers` | `/eth/v1/node/peer_count` |
| --- | --- | --- |
| all three nodes running | 2 | `connected: 2` |
| one node stopped | 1 | `connected: 1` |
| that node started again | 2 | `connected: 2` |

The gauge's own help text is `Count of libp2p peers currently connected`, so the reported value contradicts its stated contract. Note that `common/monitoring_api/src/gather.rs` re-exports this gauge as `network_peers_connected`, so the monitoring endpoint carries the same offset.

The ordering dates back to #5404, which consolidated the previously incremental gauge updates into `update_peer_count_metrics()`.

