### PR TITLE
Fix issue with atttester slashing

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5894,18 +5894,47 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             bls_to_execution_changes,
         } = partial_beacon_block;
 
+        let fork_name = state.fork_name_unchecked();
         let mut attester_slashings_base = Vec::new();
         let mut attester_slashings_electra = Vec::new();
         for slashing in attester_slashings {
-            match slashing {
-                AttesterSlashing::Base(slashing) => attester_slashings_base.push(slashing),
-                AttesterSlashing::Electra(slashing) => attester_slashings_electra.push(slashing),
-                // Gloas-typed slashings cannot be included in pre-Gloas blocks, and Gloas
-                // blocks are produced via `complete_partial_beacon_block_gloas`.
-                AttesterSlashing::Gloas(_) => {
-                    return Err(BlockProductionError::InvalidBlockVariant(
-                        "Gloas attester slashing in pre-Gloas block production".to_owned(),
-                    ));
+            if fork_name.electra_enabled() {
+                // Convert Base slashings left over from before the fork into the Electra type.
+                // Gloas slashings have the same SSZ bytes, only the hash tree root differs.
+                let (attestation_1, attestation_2) = match slashing {
+                    AttesterSlashing::Base(slashing) => (
+                        IndexedAttestation::Base(slashing.attestation_1),
+                        IndexedAttestation::Base(slashing.attestation_2),
+                    ),
+                    AttesterSlashing::Electra(slashing) => {
+                        attester_slashings_electra.push(slashing);
+                        continue;
+                    }
+                    AttesterSlashing::Gloas(slashing) => (
+                        IndexedAttestation::Gloas(slashing.attestation_1),
+                        IndexedAttestation::Gloas(slashing.attestation_2),
+                    ),
+                };
+                match (attestation_1.to_electra(), attestation_2.to_electra()) {
+                    (Ok(attestation_1), Ok(attestation_2)) => {
+                        attester_slashings_electra.push(AttesterSlashingElectra {
+                            attestation_1,
+                            attestation_2,
+                        })
+                    }
+                    _ => warn!(
+                        block_slot = %slot,
+                        "Dropping attester slashing that exceeds the Electra size limits"
+                    ),
+                }
+            } else {
+                match slashing {
+                    AttesterSlashing::Base(slashing) => attester_slashings_base.push(slashing),
+                    // Post-Electra slashings cannot be included in pre-Electra blocks.
+                    AttesterSlashing::Electra(_) | AttesterSlashing::Gloas(_) => warn!(
+                        block_slot = %slot,
+                        "Dropping post-Electra attester slashing in pre-Electra block production"
+                    ),
                 }
             }
         }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5899,8 +5899,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let mut attester_slashings_electra = Vec::new();
         for slashing in attester_slashings {
             if fork_name.electra_enabled() {
-                // Convert Base slashings left over from before the fork into the Electra type.
-                // Gloas slashings have the same SSZ bytes, only the hash tree root differs.
+                // Convert Base and Gloas slashings into the Electra type. The SSZ bytes are
+                // the same, only the hash tree root differs.
                 let (attestation_1, attestation_2) = match slashing {
                     AttesterSlashing::Base(slashing) => (
                         IndexedAttestation::Base(slashing.attestation_1),

--- a/beacon_node/beacon_chain/src/block_production/gloas.rs
+++ b/beacon_node/beacon_chain/src/block_production/gloas.rs
@@ -497,16 +497,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let attester_slashings = attester_slashings
             .into_iter()
-            .filter_map(|a| match a {
-                AttesterSlashing::Base(_) => None,
-                // Convert Electra slashings left over from before the fork into the Gloas type.
-                // The SSZ bytes are the same, only the hash tree root differs.
-                // TODO(post-gloas): remove this conversion once mainnet has forked to Gloas.
-                AttesterSlashing::Electra(a) => Some(AttesterSlashingGloas {
+            .map(|a| match a {
+                // Convert pre-Gloas slashings into the Gloas type. The SSZ bytes are the same,
+                // only the hash tree root differs.
+                AttesterSlashing::Base(a) => AttesterSlashingGloas {
+                    attestation_1: IndexedAttestation::Base(a.attestation_1).to_gloas(),
+                    attestation_2: IndexedAttestation::Base(a.attestation_2).to_gloas(),
+                },
+                AttesterSlashing::Electra(a) => AttesterSlashingGloas {
                     attestation_1: IndexedAttestation::Electra(a.attestation_1).to_gloas(),
                     attestation_2: IndexedAttestation::Electra(a.attestation_2).to_gloas(),
-                }),
-                AttesterSlashing::Gloas(a) => Some(a),
+                },
+                AttesterSlashing::Gloas(a) => a,
             })
             .collect::<Vec<_>>();
 

--- a/beacon_node/beacon_chain/tests/op_verification.rs
+++ b/beacon_node/beacon_chain/tests/op_verification.rs
@@ -6,7 +6,8 @@ use beacon_chain::{
     BeaconChainError,
     observed_operations::ObservationOutcome,
     test_utils::{
-        AttestationStrategy, BeaconChainHarness, BlockStrategy, DiskHarnessType, test_spec,
+        AttestationStrategy, BeaconChainHarness, BlockStrategy, DiskHarnessType,
+        EphemeralHarnessType, test_spec,
     },
 };
 use bls::Keypair;
@@ -486,4 +487,116 @@ async fn attester_slashing_duplicate_in_state() {
             AttesterSlashingInvalid::NoSlashableIndices
         ))
     ));
+}
+
+fn get_electra_harness() -> BeaconChainHarness<EphemeralHarnessType<E>> {
+    let spec = Arc::new(ForkName::Electra.make_genesis_spec(E::default_spec()));
+    let harness = BeaconChainHarness::builder(MinimalEthSpec)
+        .spec(spec)
+        .keypairs(KEYPAIRS.to_vec())
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build();
+    harness.advance_slot();
+    harness
+}
+
+#[tokio::test]
+async fn base_attester_slashing_included_in_electra_block() {
+    let harness = get_electra_harness();
+
+    let slashed_validator = 0;
+    let AttesterSlashing::Electra(slashing) =
+        harness.make_attester_slashing(vec![slashed_validator])
+    else {
+        panic!("expected Electra slashing variant");
+    };
+    // Re-type the slashing as Base. The signatures cover the `AttestationData`, so they
+    // remain valid.
+    let slashing_base = AttesterSlashing::<E>::Base(AttesterSlashingBase {
+        attestation_1: IndexedAttestationBase {
+            attesting_indices: ssz_types::VariableList::new(
+                slashing.attestation_1.attesting_indices.to_vec(),
+            )
+            .unwrap(),
+            data: slashing.attestation_1.data,
+            signature: slashing.attestation_1.signature,
+        },
+        attestation_2: IndexedAttestationBase {
+            attesting_indices: ssz_types::VariableList::new(
+                slashing.attestation_2.attesting_indices.to_vec(),
+            )
+            .unwrap(),
+            data: slashing.attestation_2.data,
+            signature: slashing.attestation_2.signature,
+        },
+    });
+
+    let ObservationOutcome::New(verified_slashing) = harness
+        .chain
+        .verify_attester_slashing_for_gossip(slashing_base)
+        .unwrap()
+    else {
+        panic!("slashing should verify");
+    };
+    harness.chain.import_attester_slashing(verified_slashing);
+
+    harness
+        .extend_chain(
+            1,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    assert!(
+        harness
+            .get_current_state()
+            .validators()
+            .get(slashed_validator as usize)
+            .unwrap()
+            .slashed
+    );
+}
+
+#[tokio::test]
+async fn gloas_attester_slashing_included_in_electra_block() {
+    let harness = get_electra_harness();
+
+    let slashed_validator = 0;
+    let AttesterSlashing::Electra(slashing) =
+        harness.make_attester_slashing(vec![slashed_validator])
+    else {
+        panic!("expected Electra slashing variant");
+    };
+    let slashing_gloas = AttesterSlashing::<E>::Gloas(AttesterSlashingGloas {
+        attestation_1: IndexedAttestation::Electra(slashing.attestation_1).to_gloas(),
+        attestation_2: IndexedAttestation::Electra(slashing.attestation_2).to_gloas(),
+    });
+
+    let ObservationOutcome::New(verified_slashing) = harness
+        .chain
+        .verify_attester_slashing_for_gossip(slashing_gloas)
+        .unwrap()
+    else {
+        panic!("slashing should verify");
+    };
+    harness.chain.import_attester_slashing(verified_slashing);
+
+    harness
+        .extend_chain(
+            1,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    assert!(
+        harness
+            .get_current_state()
+            .validators()
+            .get(slashed_validator as usize)
+            .unwrap()
+            .slashed
+    );
 }

--- a/beacon_node/beacon_chain/tests/op_verification.rs
+++ b/beacon_node/beacon_chain/tests/op_verification.rs
@@ -489,8 +489,8 @@ async fn attester_slashing_duplicate_in_state() {
     ));
 }
 
-fn get_electra_harness() -> BeaconChainHarness<EphemeralHarnessType<E>> {
-    let spec = Arc::new(ForkName::Electra.make_genesis_spec(E::default_spec()));
+fn get_fork_harness(fork_name: ForkName) -> BeaconChainHarness<EphemeralHarnessType<E>> {
+    let spec = Arc::new(fork_name.make_genesis_spec(E::default_spec()));
     let harness = BeaconChainHarness::builder(MinimalEthSpec)
         .spec(spec)
         .keypairs(KEYPAIRS.to_vec())
@@ -503,7 +503,7 @@ fn get_electra_harness() -> BeaconChainHarness<EphemeralHarnessType<E>> {
 
 #[tokio::test]
 async fn base_attester_slashing_included_in_electra_block() {
-    let harness = get_electra_harness();
+    let harness = get_fork_harness(ForkName::Electra);
 
     let slashed_validator = 0;
     let AttesterSlashing::Electra(slashing) =
@@ -561,7 +561,7 @@ async fn base_attester_slashing_included_in_electra_block() {
 
 #[tokio::test]
 async fn gloas_attester_slashing_included_in_electra_block() {
-    let harness = get_electra_harness();
+    let harness = get_fork_harness(ForkName::Electra);
 
     let slashed_validator = 0;
     let AttesterSlashing::Electra(slashing) =
@@ -577,6 +577,108 @@ async fn gloas_attester_slashing_included_in_electra_block() {
     let ObservationOutcome::New(verified_slashing) = harness
         .chain
         .verify_attester_slashing_for_gossip(slashing_gloas)
+        .unwrap()
+    else {
+        panic!("slashing should verify");
+    };
+    harness.chain.import_attester_slashing(verified_slashing);
+
+    harness
+        .extend_chain(
+            1,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    assert!(
+        harness
+            .get_current_state()
+            .validators()
+            .get(slashed_validator as usize)
+            .unwrap()
+            .slashed
+    );
+}
+
+#[tokio::test]
+async fn base_attester_slashing_included_in_gloas_block() {
+    let harness = get_fork_harness(ForkName::Gloas);
+
+    let slashed_validator = 0;
+    let AttesterSlashing::Gloas(slashing) = harness.make_attester_slashing(vec![slashed_validator])
+    else {
+        panic!("expected Gloas slashing variant");
+    };
+    // Re-type the slashing as Base. The signatures cover the `AttestationData`, so they
+    // remain valid.
+    let slashing_base = AttesterSlashing::<E>::Base(AttesterSlashingBase {
+        attestation_1: IndexedAttestationBase {
+            attesting_indices: ssz_types::VariableList::new(
+                slashing.attestation_1.attesting_indices.to_vec(),
+            )
+            .unwrap(),
+            data: slashing.attestation_1.data,
+            signature: slashing.attestation_1.signature,
+        },
+        attestation_2: IndexedAttestationBase {
+            attesting_indices: ssz_types::VariableList::new(
+                slashing.attestation_2.attesting_indices.to_vec(),
+            )
+            .unwrap(),
+            data: slashing.attestation_2.data,
+            signature: slashing.attestation_2.signature,
+        },
+    });
+
+    let ObservationOutcome::New(verified_slashing) = harness
+        .chain
+        .verify_attester_slashing_for_gossip(slashing_base)
+        .unwrap()
+    else {
+        panic!("slashing should verify");
+    };
+    harness.chain.import_attester_slashing(verified_slashing);
+
+    harness
+        .extend_chain(
+            1,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    assert!(
+        harness
+            .get_current_state()
+            .validators()
+            .get(slashed_validator as usize)
+            .unwrap()
+            .slashed
+    );
+}
+
+#[tokio::test]
+async fn electra_attester_slashing_included_in_gloas_block() {
+    let harness = get_fork_harness(ForkName::Gloas);
+
+    let slashed_validator = 0;
+    let AttesterSlashing::Gloas(slashing) = harness.make_attester_slashing(vec![slashed_validator])
+    else {
+        panic!("expected Gloas slashing variant");
+    };
+    let slashing_electra = AttesterSlashing::<E>::Electra(AttesterSlashingElectra {
+        attestation_1: IndexedAttestation::Gloas(slashing.attestation_1)
+            .to_electra()
+            .unwrap(),
+        attestation_2: IndexedAttestation::Gloas(slashing.attestation_2)
+            .to_electra()
+            .unwrap(),
+    });
+
+    let ObservationOutcome::New(verified_slashing) = harness
+        .chain
+        .verify_attester_slashing_for_gossip(slashing_electra)
         .unwrap()
     else {
         panic!("slashing should verify");

--- a/beacon_node/http_api/src/beacon/pool.rs
+++ b/beacon_node/http_api/src/beacon/pool.rs
@@ -401,24 +401,17 @@ pub fn post_beacon_pool_attester_slashings<T: BeaconChainTypes>(
              consensus_version: Option<ForkName>,
              network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>| {
                 task_spawner.blocking_json_task(Priority::P0, move || {
-                    let current_fork = chain
-                        .slot_clock
-                        .now()
-                        .map(|slot| chain.spec.fork_name_at_slot::<T::EthSpec>(slot))
-                        .ok_or_else(|| {
-                            warp_utils::reject::custom_server_error(
-                                "unable to read slot clock".to_string(),
-                            )
-                        })?;
                     let fork_name = match consensus_version {
-                        Some(fork_name) if fork_name > current_fork => {
-                            return Err(warp_utils::reject::custom_bad_request(
-                                "Eth-Consensus-Version specifies a fork that is not yet active"
-                                    .to_string(),
-                            ));
-                        }
                         Some(fork_name) => fork_name,
-                        None => current_fork,
+                        None => chain
+                            .slot_clock
+                            .now()
+                            .map(|slot| chain.spec.fork_name_at_slot::<T::EthSpec>(slot))
+                            .ok_or_else(|| {
+                                warp_utils::reject::custom_server_error(
+                                    "unable to read slot clock".to_string(),
+                                )
+                            })?,
                     };
                     let slashing = AttesterSlashing::<T::EthSpec>::context_deserialize(
                         &slashing_json,

--- a/beacon_node/http_api/src/beacon/pool.rs
+++ b/beacon_node/http_api/src/beacon/pool.rs
@@ -411,9 +411,7 @@ pub fn post_beacon_pool_attester_slashings<T: BeaconChainTypes>(
                             )
                         })?;
                     let fork_name = match consensus_version {
-                        Some(fork_name)
-                            if fork_name.gloas_enabled() && !current_fork.gloas_enabled() =>
-                        {
+                        Some(fork_name) if fork_name > current_fork => {
                             return Err(warp_utils::reject::custom_bad_request(
                                 "Eth-Consensus-Version specifies a fork that is not yet active"
                                     .to_string(),

--- a/beacon_node/http_api/src/beacon/pool.rs
+++ b/beacon_node/http_api/src/beacon/pool.rs
@@ -401,17 +401,26 @@ pub fn post_beacon_pool_attester_slashings<T: BeaconChainTypes>(
              consensus_version: Option<ForkName>,
              network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>| {
                 task_spawner.blocking_json_task(Priority::P0, move || {
+                    let current_fork = chain
+                        .slot_clock
+                        .now()
+                        .map(|slot| chain.spec.fork_name_at_slot::<T::EthSpec>(slot))
+                        .ok_or_else(|| {
+                            warp_utils::reject::custom_server_error(
+                                "unable to read slot clock".to_string(),
+                            )
+                        })?;
                     let fork_name = match consensus_version {
+                        Some(fork_name)
+                            if fork_name.gloas_enabled() && !current_fork.gloas_enabled() =>
+                        {
+                            return Err(warp_utils::reject::custom_bad_request(
+                                "Eth-Consensus-Version specifies a fork that is not yet active"
+                                    .to_string(),
+                            ));
+                        }
                         Some(fork_name) => fork_name,
-                        None => chain
-                            .slot_clock
-                            .now()
-                            .map(|slot| chain.spec.fork_name_at_slot::<T::EthSpec>(slot))
-                            .ok_or_else(|| {
-                                warp_utils::reject::custom_server_error(
-                                    "unable to read slot clock".to_string(),
-                                )
-                            })?,
+                        None => current_fork,
                     };
                     let slashing = AttesterSlashing::<T::EthSpec>::context_deserialize(
                         &slashing_json,

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -9378,7 +9378,14 @@ async fn beacon_pools_post_attester_slashings_invalid_v1() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn beacon_pools_post_attester_slashings_valid_v2() {
-    ApiTester::new()
+    let mut spec = ForkName::Fulu.make_genesis_spec(E::default_spec());
+    spec.gloas_fork_epoch = Some(Epoch::new(6));
+    let config = ApiTesterConfig {
+        spec,
+        ..<_>::default()
+    };
+
+    ApiTester::new_from_config(config)
         .await
         .test_post_beacon_pool_attester_slashings_valid_v2()
         .await

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2831,16 +2831,16 @@ impl ApiTester {
             return self;
         };
 
-        let err = self
-            .client
+        // A header for a fork that is not yet active is accepted, e.g. a slashing posted
+        // just before the fork boundary. Block production converts the variant as needed.
+        self.client
             .post_beacon_pool_attester_slashings_v2(&self.attester_slashing, future_fork)
             .await
-            .unwrap_err();
-        assert_eq!(err.status(), Some(StatusCode::BAD_REQUEST));
+            .unwrap();
 
         assert!(
-            self.network_rx.network_recv.recv().now_or_never().is_none(),
-            "rejected attester slashing should not be sent to network"
+            self.network_rx.network_recv.recv().await.is_some(),
+            "valid attester slashing should be sent to network"
         );
 
         self

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2822,6 +2822,30 @@ impl ApiTester {
         self
     }
 
+    pub async fn test_post_beacon_pool_attester_slashings_future_fork_v2(mut self) -> Self {
+        let current_fork = self
+            .chain
+            .spec
+            .fork_name_at_slot::<E>(self.chain.slot_clock.now().unwrap());
+        let Some(future_fork) = current_fork.next_fork() else {
+            return self;
+        };
+
+        let err = self
+            .client
+            .post_beacon_pool_attester_slashings_v2(&self.attester_slashing, future_fork)
+            .await
+            .unwrap_err();
+        assert_eq!(err.status(), Some(StatusCode::BAD_REQUEST));
+
+        assert!(
+            self.network_rx.network_recv.recv().now_or_never().is_none(),
+            "rejected attester slashing should not be sent to network"
+        );
+
+        self
+    }
+
     pub async fn test_get_beacon_pool_attester_slashings(self) -> Self {
         let result = self
             .client
@@ -9362,6 +9386,14 @@ async fn beacon_pools_post_attester_slashings_invalid_v2() {
     ApiTester::new()
         .await
         .test_post_beacon_pool_attester_slashings_invalid_v2()
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn beacon_pools_post_attester_slashings_future_fork_v2() {
+    ApiTester::new()
+        .await
+        .test_post_beacon_pool_attester_slashings_future_fork_v2()
         .await;
 }
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2831,10 +2831,13 @@ impl ApiTester {
             return self;
         };
 
+        // Use a fresh slashing, as `self.attester_slashing` is already in the pool.
+        let slashing = self.harness.make_attester_slashing(vec![2, 3]);
+
         // A header for a fork that is not yet active is accepted, e.g. a slashing posted
         // just before the fork boundary. Block production converts the variant as needed.
         self.client
-            .post_beacon_pool_attester_slashings_v2(&self.attester_slashing, future_fork)
+            .post_beacon_pool_attester_slashings_v2(&slashing, future_fork)
             .await
             .unwrap();
 
@@ -9378,6 +9381,8 @@ async fn beacon_pools_post_attester_slashings_valid_v2() {
     ApiTester::new()
         .await
         .test_post_beacon_pool_attester_slashings_valid_v2()
+        .await
+        .test_post_beacon_pool_attester_slashings_future_fork_v2()
         .await;
 }
 
@@ -9386,14 +9391,6 @@ async fn beacon_pools_post_attester_slashings_invalid_v2() {
     ApiTester::new()
         .await
         .test_post_beacon_pool_attester_slashings_invalid_v2()
-        .await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn beacon_pools_post_attester_slashings_future_fork_v2() {
-    ApiTester::new()
-        .await
-        .test_post_beacon_pool_attester_slashings_future_fork_v2()
         .await;
 }
 


### PR DESCRIPTION
## Issue Addressed

Block production dropped slashings whose type did not match the block's fork

1. Base slashings from before the Electra fork never make it into blocks (i dont think this matters anymore)
2. a slashing posted via the API could break block production until the slashing is included by some other proposer (see description below)

The fix converts slashings to the block's type instead of dropping them

To recreate bug no. 2 on a pre-gloas network

1. POST the real slashing with `Eth-Consensus-Version: gloas`
2. Gossip verification passes
3. It enters the pool.
4. Block production on Fulu runs the pre-Gloas path. It hits the Gloas variant and returns an error. The proposal fails.
5. The pool keeps the slashing until its validator is slashed on chain. This node cannot slash & every block errors until the validator is slashed.

This regression was introduced in the progressive container PR

AI disclosure: this PR was written with claude fable 5