### PR TITLE
Gate payload import on optional execution proofs

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4183,8 +4183,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
     }
 
-    /// Caches a gossip verified EIP-8025 execution proof and imports its payload envelope
-    /// immediately if the proof was the last missing component.
+    /// Caches an execution proof, importing the payload envelope if that was the last piece.
     pub async fn check_execution_proof_availability_and_import(
         self: &Arc<Self>,
         verified_proof: GossipVerifiedExecutionProof,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -34,7 +34,7 @@ use crate::envelope_times_cache::EnvelopeTimesCache;
 use crate::errors::{BeaconChainError as Error, BlockProductionError};
 use crate::events::ServerSentEventHandler;
 use crate::execution_payload::{NotifyExecutionLayer, PreparePayloadHandle, get_execution_payload};
-use crate::execution_proof_verification::ObservedExecutionProofs;
+use crate::execution_proof_verification::{GossipVerifiedExecutionProof, ObservedExecutionProofs};
 use crate::fork_choice_signal::{ForkChoiceSignalRx, ForkChoiceSignalTx};
 use crate::graffiti_calculator::{GraffitiCalculator, GraffitiSettings};
 use crate::light_client_finality_update_verification::{
@@ -4181,6 +4181,21 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .process_availability(slot, availability, || Ok(()))
                 .await?)
         }
+    }
+
+    /// Caches a gossip verified EIP-8025 execution proof and imports its payload envelope
+    /// immediately if the proof was the last missing component.
+    pub async fn check_execution_proof_availability_and_import(
+        self: &Arc<Self>,
+        verified_proof: GossipVerifiedExecutionProof,
+    ) -> Result<AvailabilityProcessingStatus, BlockError> {
+        let GossipVerifiedExecutionProof { proof, block_slot } = verified_proof;
+        let availability = self
+            .pending_payload_cache
+            .put_execution_proof(proof)
+            .map_err(BlockError::from)?;
+        self.process_payload_envelope_availability(block_slot, availability, || Ok(()))
+            .await
     }
 
     fn check_data_column_sidecar_header_signature_and_slashability<'a>(

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -12,7 +12,7 @@ use crate::kzg_utils::{build_data_column_sidecars_fulu, build_data_column_sideca
 use crate::light_client_server_cache::LightClientServerCache;
 use crate::migrate::{BackgroundMigrator, MigratorConfig};
 use crate::observed_data_sidecars::ObservedDataSidecars;
-use crate::pending_payload_cache::PendingPayloadCache;
+use crate::pending_payload_cache::{PendingPayloadCache, REQUIRED_EXECUTION_PROOFS};
 use crate::persisted_beacon_chain::PersistedBeaconChain;
 use crate::persisted_custody::load_custody_context;
 use crate::shuffling_cache::{BlockShufflingIds, ShufflingCache};
@@ -986,9 +986,12 @@ where
         debug!(?custody_context, "Loaded persisted custody context");
         let custody_context = Arc::new(custody_context);
 
-        // Payload import is gated on EIP-8025 execution proofs only when a proof engine is
-        // configured to verify them.
-        let require_execution_proof = self.proof_engine.is_some();
+        // Without a proof engine we can't verify proofs, so we don't require them.
+        let required_execution_proofs = if self.proof_engine.is_some() {
+            REQUIRED_EXECUTION_PROOFS
+        } else {
+            0
+        };
 
         let beacon_chain = BeaconChain {
             spec: self.spec.clone(),
@@ -1078,8 +1081,8 @@ where
                     self.kzg.clone(),
                     custody_context,
                     disable_get_blobs,
+                    required_execution_proofs,
                     self.spec.clone(),
-                    require_execution_proof,
                 )
                 .map_err(|e| format!("Error initializing PendingPayloadCache: {:?}", e))?,
             ),

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -986,6 +986,10 @@ where
         debug!(?custody_context, "Loaded persisted custody context");
         let custody_context = Arc::new(custody_context);
 
+        // Payload import is gated on EIP-8025 execution proofs only when a proof engine is
+        // configured to verify them.
+        let require_execution_proof = self.proof_engine.is_some();
+
         let beacon_chain = BeaconChain {
             spec: self.spec.clone(),
             config: self.chain_config,
@@ -1075,6 +1079,7 @@ where
                     custody_context,
                     disable_get_blobs,
                     self.spec.clone(),
+                    require_execution_proof,
                 )
                 .map_err(|e| format!("Error initializing PendingPayloadCache: {:?}", e))?,
             ),

--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -52,6 +52,15 @@ use types::{SignedExecutionPayloadBid, SignedExecutionPayloadEnvelope};
 /// eviction to prevent race conditions (#7961), so we expect this cache to be full all the time.
 const AVAILABILITY_CACHE_CAPACITY: usize = 32;
 
+/// Distinct proof systems that must prove a payload before import. More than one means a
+/// soundness bug in a single prover isn't enough to fool us.
+///
+/// Which systems count is the engine's call, we only see its `VALID`. The count is ours because
+/// we're the only ones who see the whole set.
+///
+/// TODO(9658): make configurable. https://github.com/sigp/lighthouse/issues/9658
+pub const REQUIRED_EXECUTION_PROOFS: usize = 2;
+
 /// What `update_pending_components` returns: the value that the update closure computed, next to
 /// a read guard on the entry it updated.
 type UpdatedComponents<'a, E, R> = (R, MappedRwLockReadGuard<'a, PendingComponents<E>>);
@@ -102,10 +111,9 @@ pub struct PendingPayloadCache<T: BeaconChainTypes> {
     kzg: Arc<Kzg>,
     custody_context: Arc<CustodyContext<T>>,
     disable_get_blobs: bool,
+    /// Distinct proof systems required before a payload is available. Zero disables the gate.
+    required_execution_proofs: usize,
     spec: Arc<ChainSpec>,
-    /// Whether a payload additionally requires an EIP-8025 execution proof to become available.
-    /// Only set when a proof engine is configured.
-    require_execution_proof: bool,
 }
 
 impl<T: BeaconChainTypes> PendingPayloadCache<T> {
@@ -113,16 +121,16 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         kzg: Arc<Kzg>,
         custody_context: Arc<CustodyContext<T>>,
         disable_get_blobs: bool,
+        required_execution_proofs: usize,
         spec: Arc<ChainSpec>,
-        require_execution_proof: bool,
     ) -> Result<Self, AvailabilityCheckError> {
         Ok(Self {
             availability_cache: RwLock::new(LruCache::new(AVAILABILITY_CACHE_CAPACITY)),
             kzg,
             custody_context,
             disable_get_blobs,
+            required_execution_proofs,
             spec,
-            require_execution_proof,
         })
     }
 
@@ -262,7 +270,8 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         pending_components.span.in_scope(|| {
             debug!(
                 component = "executed envelope",
-                status = pending_components.status_str(&self.custody_context),
+                status = pending_components
+                    .status_str(&self.custody_context, self.required_execution_proofs),
                 "Component added to data availability checker"
             );
         });
@@ -279,11 +288,10 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
             .or_insert_with(|| PendingComponents::new(block_root, bid));
     }
 
-    /// Insert a gossip verified EIP-8025 execution proof into the cache and perform an
-    /// availability check.
+    /// Cache an execution proof and check availability.
     ///
-    /// A proof can only unblock the payload the first time one is seen for a block root, so
-    /// later proofs of other types report `MissingComponents` without re-running the check.
+    /// Only the proof that reaches the requirement can unblock the payload, so repeats and
+    /// extras skip the check rather than importing twice.
     pub fn put_execution_proof(
         &self,
         proof: Arc<SignedExecutionProof>,
@@ -293,7 +301,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
             .get_bid(&block_root)
             .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
 
-        let (is_first_proof, pending_components) =
+        let (inserted, pending_components) =
             self.update_pending_components(block_root, &bid, |pending_components| {
                 pending_components.insert_execution_proof(proof)
             })?;
@@ -301,15 +309,17 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         pending_components.span.in_scope(|| {
             debug!(
                 component = "execution proof",
-                status = pending_components.status_str(&self.custody_context),
+                status = pending_components
+                    .status_str(&self.custody_context, self.required_execution_proofs),
                 "Component added to data availability checker"
             );
         });
 
-        if is_first_proof {
-            self.check_availability(block_root, pending_components)
-        } else {
-            Ok(Availability::MissingComponents(block_root))
+        match inserted {
+            Some(count) if count <= self.required_execution_proofs => {
+                self.check_availability(block_root, pending_components)
+            }
+            _ => Ok(Availability::MissingComponents(block_root)),
         }
     }
 
@@ -441,7 +451,8 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         pending_components.span.in_scope(|| {
             debug!(
                 component = "data_columns",
-                status = pending_components.status_str(&self.custody_context),
+                status = pending_components
+                    .status_str(&self.custody_context, self.required_execution_proofs),
                 "Component added to data availability checker"
             );
         });
@@ -542,7 +553,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         pending_components: MappedRwLockReadGuard<'_, PendingComponents<T::EthSpec>>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
         if let Some(available_envelope) = pending_components
-            .make_available(&self.custody_context, self.require_execution_proof)?
+            .make_available(&self.custody_context, self.required_execution_proofs)?
         {
             // Explicitly drop read lock before acquiring write lock
             drop(pending_components);
@@ -694,19 +705,23 @@ mod data_availability_checker_tests {
         setup_with(node_custody, NumBlobs::Number(0))
     }
 
-    /// Same as `setup`, but with payload import gated on an EIP-8025 execution proof.
+    /// `setup`, with the proof gate on.
     fn setup_gated(node_custody: NodeCustodyType) -> Setup {
-        setup_full(node_custody, NumBlobs::Number(NUM_BLOBS), true)
+        setup_full(
+            node_custody,
+            NumBlobs::Number(NUM_BLOBS),
+            REQUIRED_EXECUTION_PROOFS,
+        )
     }
 
     fn setup_with(node_custody: NodeCustodyType, num_blobs: NumBlobs) -> Setup {
-        setup_full(node_custody, num_blobs, false)
+        setup_full(node_custody, num_blobs, 0)
     }
 
     fn setup_full(
         node_custody: NodeCustodyType,
         num_blobs: NumBlobs,
-        require_execution_proof: bool,
+        required_execution_proofs: usize,
     ) -> Setup {
         create_test_tracing_subscriber();
         let spec = Arc::new(ForkName::Gloas.make_genesis_spec(E::default_spec()));
@@ -729,8 +744,8 @@ mod data_availability_checker_tests {
                 kzg,
                 custody_context,
                 false,
+                required_execution_proofs,
                 spec.clone(),
-                require_execution_proof,
             )
             .expect("create cache"),
         );
@@ -800,8 +815,7 @@ mod data_availability_checker_tests {
         }
     }
 
-    /// Hand-rolled execution proof with bypassed verification; the cache only inspects
-    /// `beacon_block_root` and `proof_type`, never the proof data or the signature.
+    /// Unverified proof: the cache only reads `beacon_block_root` and `proof_type`.
     fn execution_proof(block_root: Hash256, proof_type: ProofType) -> SignedExecutionProof {
         SignedExecutionProof {
             message: ExecutionProof {
@@ -987,57 +1001,29 @@ mod data_availability_checker_tests {
 
     // ─── Tier 4: EIP-8025 execution proof gating ────────────────────────────
 
-    /// With no proof engine configured, a payload is available without any execution proof.
-    #[tokio::test]
-    async fn execution_proof_not_required_by_default() {
-        let s = setup(NodeCustodyType::Fullnode);
-        s.put_envelope();
-        assert_available(s.put_columns(s.custody.clone()));
-    }
-
-    /// With a proof engine configured, the envelope and every column are not enough. The
-    /// execution proof is the last missing component.
+    /// Envelope and columns alone don't import: the gate wants proofs from
+    /// `REQUIRED_EXECUTION_PROOFS` distinct provers. Repeats of one type don't count, and a proof
+    /// beyond the requirement doesn't import the envelope a second time.
     #[tokio::test]
     async fn execution_proof_gates_availability() {
         let s = setup_gated(NodeCustodyType::Fullnode);
         s.put_envelope();
         assert_missing(s.put_columns(s.custody.clone()));
-        let envelope = assert_available(s.put_proof(0));
+
+        // One prover, however many proofs, is never enough.
+        for _ in 0..=REQUIRED_EXECUTION_PROOFS {
+            assert_missing(s.put_proof(0));
+        }
+
+        // Distinct provers up to the requirement flip it to available.
+        let mut availability = None;
+        for proof_type in 1..REQUIRED_EXECUTION_PROOFS {
+            availability = Some(s.put_proof(proof_type as ProofType));
+        }
+        let envelope = assert_available(availability.expect("gate needs two provers or more"));
         assert_eq!(envelope.block_root, s.block_root);
-    }
 
-    /// A proof that arrives before the envelope is retained and does not make the payload
-    /// available on its own.
-    #[tokio::test]
-    async fn execution_proof_arrives_first() {
-        let s = setup_gated(NodeCustodyType::Fullnode);
-        assert_missing(s.put_proof(0));
-        assert_missing(s.put_columns(s.custody.clone()));
-        assert_available(s.put_envelope());
-    }
-
-    /// Once a payload is available, a proof of a second type must not make it available again,
-    /// which would import the same envelope twice.
-    #[tokio::test]
-    async fn second_execution_proof_does_not_re_import() {
-        let s = setup_gated(NodeCustodyType::Fullnode);
-        s.put_envelope();
-        s.put_columns(s.custody.clone());
-        assert_available(s.put_proof(0));
-        assert_missing(s.put_proof(1));
-    }
-
-    /// A proof for a block root with no cached bid is rejected rather than creating an entry
-    /// that can never become available.
-    #[tokio::test]
-    async fn execution_proof_for_unknown_block_root_errors() {
-        let s = setup_gated(NodeCustodyType::Fullnode);
-        let unknown = Hash256::random();
-        assert!(matches!(
-            s.cache
-                .put_execution_proof(Arc::new(execution_proof(unknown, 0))),
-            Err(AvailabilityCheckError::MissingBid(root)) if root == unknown
-        ));
+        assert_missing(s.put_proof(REQUIRED_EXECUTION_PROOFS as ProofType));
     }
 
     // ────────── Gloas partial column merge ─────────────────────────────────

--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -41,6 +41,7 @@ use crate::metrics::{
 use crate::observed_data_sidecars::ObservationStrategy;
 use crate::partial_data_column_assembler::PartialMergeResult;
 use pending_components::{PendingComponents, ReconstructColumnsDecision};
+use types::execution::SignedExecutionProof;
 use types::{SignedExecutionPayloadBid, SignedExecutionPayloadEnvelope};
 
 /// The LRU Cache stores `PendingComponents`, which store the block root, the execution payload bid, and its associated column data.
@@ -102,6 +103,9 @@ pub struct PendingPayloadCache<T: BeaconChainTypes> {
     custody_context: Arc<CustodyContext<T>>,
     disable_get_blobs: bool,
     spec: Arc<ChainSpec>,
+    /// Whether a payload additionally requires an EIP-8025 execution proof to become available.
+    /// Only set when a proof engine is configured.
+    require_execution_proof: bool,
 }
 
 impl<T: BeaconChainTypes> PendingPayloadCache<T> {
@@ -110,6 +114,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         custody_context: Arc<CustodyContext<T>>,
         disable_get_blobs: bool,
         spec: Arc<ChainSpec>,
+        require_execution_proof: bool,
     ) -> Result<Self, AvailabilityCheckError> {
         Ok(Self {
             availability_cache: RwLock::new(LruCache::new(AVAILABILITY_CACHE_CAPACITY)),
@@ -117,6 +122,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
             custody_context,
             disable_get_blobs,
             spec,
+            require_execution_proof,
         })
     }
 
@@ -271,6 +277,40 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         write_lock
             .entry(block_root)
             .or_insert_with(|| PendingComponents::new(block_root, bid));
+    }
+
+    /// Insert a gossip verified EIP-8025 execution proof into the cache and perform an
+    /// availability check.
+    ///
+    /// A proof can only unblock the payload the first time one is seen for a block root, so
+    /// later proofs of other types report `MissingComponents` without re-running the check.
+    pub fn put_execution_proof(
+        &self,
+        proof: Arc<SignedExecutionProof>,
+    ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
+        let block_root = proof.beacon_block_root();
+        let bid = self
+            .get_bid(&block_root)
+            .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
+
+        let (is_first_proof, pending_components) =
+            self.update_pending_components(block_root, &bid, |pending_components| {
+                pending_components.insert_execution_proof(proof)
+            })?;
+
+        pending_components.span.in_scope(|| {
+            debug!(
+                component = "execution proof",
+                status = pending_components.status_str(&self.custody_context),
+                "Component added to data availability checker"
+            );
+        });
+
+        if is_first_proof {
+            self.check_availability(block_root, pending_components)
+        } else {
+            Ok(Availability::MissingComponents(block_root))
+        }
     }
 
     /// Perform KZG verification on RPC custody columns and insert them into the cache.
@@ -501,8 +541,8 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         block_root: Hash256,
         pending_components: MappedRwLockReadGuard<'_, PendingComponents<T::EthSpec>>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
-        if let Some(available_envelope) =
-            pending_components.make_available(&self.custody_context)?
+        if let Some(available_envelope) = pending_components
+            .make_available(&self.custody_context, self.require_execution_proof)?
         {
             // Explicitly drop read lock before acquiring write lock
             drop(pending_components);
@@ -632,6 +672,7 @@ mod data_availability_checker_tests {
     use slot_clock::{SlotClock, TestingSlotClock};
     use ssz_types::ProgressiveVariableList;
     use std::time::Duration;
+    use types::execution::{ExecutionProof, ProofData, ProofType, PublicInput};
     use types::{
         Cell, CellBitmap, ExecutionPayloadEnvelope, ExecutionPayloadGloas, ExecutionRequestsGloas,
         ForkName, MinimalEthSpec, PartialDataColumnGloas, PartialDataColumnSidecarGloas,
@@ -653,7 +694,20 @@ mod data_availability_checker_tests {
         setup_with(node_custody, NumBlobs::Number(0))
     }
 
+    /// Same as `setup`, but with payload import gated on an EIP-8025 execution proof.
+    fn setup_gated(node_custody: NodeCustodyType) -> Setup {
+        setup_full(node_custody, NumBlobs::Number(NUM_BLOBS), true)
+    }
+
     fn setup_with(node_custody: NodeCustodyType, num_blobs: NumBlobs) -> Setup {
+        setup_full(node_custody, num_blobs, false)
+    }
+
+    fn setup_full(
+        node_custody: NodeCustodyType,
+        num_blobs: NumBlobs,
+        require_execution_proof: bool,
+    ) -> Setup {
         create_test_tracing_subscriber();
         let spec = Arc::new(ForkName::Gloas.make_genesis_spec(E::default_spec()));
         let kzg = get_kzg(&spec);
@@ -671,8 +725,14 @@ mod data_availability_checker_tests {
             spec.clone(),
         ));
         let cache = Arc::new(
-            PendingPayloadCache::<T>::new(kzg, custody_context, false, spec.clone())
-                .expect("create cache"),
+            PendingPayloadCache::<T>::new(
+                kzg,
+                custody_context,
+                false,
+                spec.clone(),
+                require_execution_proof,
+            )
+            .expect("create cache"),
         );
 
         let mut u = test_unstructured();
@@ -731,6 +791,29 @@ mod data_availability_checker_tests {
             self.cache
                 .cached_data_column_indexes(&self.block_root)
                 .expect("entry")
+        }
+
+        fn put_proof(&self, proof_type: ProofType) -> Availability<E> {
+            self.cache
+                .put_execution_proof(Arc::new(execution_proof(self.block_root, proof_type)))
+                .expect("put execution proof")
+        }
+    }
+
+    /// Hand-rolled execution proof with bypassed verification; the cache only inspects
+    /// `beacon_block_root` and `proof_type`, never the proof data or the signature.
+    fn execution_proof(block_root: Hash256, proof_type: ProofType) -> SignedExecutionProof {
+        SignedExecutionProof {
+            message: ExecutionProof {
+                proof_data: ProofData::new(vec![1_u8]).expect("proof data"),
+                proof_type,
+                public_input: PublicInput {
+                    new_payload_request_root: Hash256::random(),
+                },
+                beacon_block_root: block_root,
+            },
+            validator_index: 0,
+            signature: bls::Signature::infinity().expect("infinity sig"),
         }
     }
 
@@ -900,6 +983,61 @@ mod data_availability_checker_tests {
 
         s.put_columns(vec![last]);
         assert_lengths_match(&s);
+    }
+
+    // ─── Tier 4: EIP-8025 execution proof gating ────────────────────────────
+
+    /// With no proof engine configured, a payload is available without any execution proof.
+    #[tokio::test]
+    async fn execution_proof_not_required_by_default() {
+        let s = setup(NodeCustodyType::Fullnode);
+        s.put_envelope();
+        assert_available(s.put_columns(s.custody.clone()));
+    }
+
+    /// With a proof engine configured, the envelope and every column are not enough. The
+    /// execution proof is the last missing component.
+    #[tokio::test]
+    async fn execution_proof_gates_availability() {
+        let s = setup_gated(NodeCustodyType::Fullnode);
+        s.put_envelope();
+        assert_missing(s.put_columns(s.custody.clone()));
+        let envelope = assert_available(s.put_proof(0));
+        assert_eq!(envelope.block_root, s.block_root);
+    }
+
+    /// A proof that arrives before the envelope is retained and does not make the payload
+    /// available on its own.
+    #[tokio::test]
+    async fn execution_proof_arrives_first() {
+        let s = setup_gated(NodeCustodyType::Fullnode);
+        assert_missing(s.put_proof(0));
+        assert_missing(s.put_columns(s.custody.clone()));
+        assert_available(s.put_envelope());
+    }
+
+    /// Once a payload is available, a proof of a second type must not make it available again,
+    /// which would import the same envelope twice.
+    #[tokio::test]
+    async fn second_execution_proof_does_not_re_import() {
+        let s = setup_gated(NodeCustodyType::Fullnode);
+        s.put_envelope();
+        s.put_columns(s.custody.clone());
+        assert_available(s.put_proof(0));
+        assert_missing(s.put_proof(1));
+    }
+
+    /// A proof for a block root with no cached bid is rejected rather than creating an entry
+    /// that can never become available.
+    #[tokio::test]
+    async fn execution_proof_for_unknown_block_root_errors() {
+        let s = setup_gated(NodeCustodyType::Fullnode);
+        let unknown = Hash256::random();
+        assert!(matches!(
+            s.cache
+                .put_execution_proof(Arc::new(execution_proof(unknown, 0))),
+            Err(AvailabilityCheckError::MissingBid(root)) if root == unknown
+        ));
     }
 
     // ────────── Gloas partial column merge ─────────────────────────────────

--- a/beacon_node/beacon_chain/src/pending_payload_cache/pending_components.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/pending_components.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{Span, debug, debug_span};
 use types::DataColumnSidecar;
+use types::execution::{ProofType, SignedExecutionProof};
 use types::{ColumnIndex, EthSpec, Hash256, SignedExecutionPayloadBid};
 
 /// This represents the components of a payload pending data availability.
@@ -27,6 +28,9 @@ pub struct PendingComponents<E: EthSpec> {
     pub envelope: Option<AvailabilityPendingExecutedEnvelope<E>>,
     /// A column entry in this map may only have some cells filled in (i.e. a partial data column)
     pub verified_data_columns: HashMap<ColumnIndex, PendingColumn<E>>,
+    /// Gossip verified EIP-8025 execution proofs, keyed by proof type. Only populated when a
+    /// proof engine is configured, since proofs are neither requested nor verified otherwise.
+    pub execution_proofs: HashMap<ProofType, Arc<SignedExecutionProof>>,
     pub reconstruction_started: bool,
     /// True once the local `getBlobs` attempt has settled. It is set whether or not the EL
     /// returned anything. Until then, republished partials request no cells, because the EL
@@ -197,6 +201,16 @@ impl<E: EthSpec> PendingComponents<E> {
         }
     }
 
+    /// Inserts a gossip verified execution proof into the cache.
+    ///
+    /// Returns `true` if this is the first proof for this payload, i.e. the insert may have
+    /// unblocked the execution proof requirement in `make_available`.
+    pub fn insert_execution_proof(&mut self, proof: Arc<SignedExecutionProof>) -> bool {
+        let is_first_proof = self.execution_proofs.is_empty();
+        self.execution_proofs.insert(proof.proof_type(), proof);
+        is_first_proof
+    }
+
     /// Inserts an executed payload envelope into the cache.
     pub fn insert_executed_payload_envelope(
         &mut self,
@@ -215,10 +229,12 @@ impl<E: EthSpec> PendingComponents<E> {
         self.num_completed_columns() >= num_expected_columns
     }
 
-    /// Returns `Some` if the envelope and all required data columns have been received.
+    /// Returns `Some` if the envelope, all required data columns, and (if
+    /// `require_execution_proof` is set) an execution proof have been received.
     pub fn make_available<T>(
         &self,
         custody_context: &CustodyContext<T>,
+        require_execution_proof: bool,
     ) -> Result<Option<AvailableExecutedEnvelope<E>>, AvailabilityCheckError>
     where
         T: BeaconChainTypes<EthSpec = E>,
@@ -227,6 +243,12 @@ impl<E: EthSpec> PendingComponents<E> {
         let Some(envelope) = &self.envelope else {
             return Ok(None);
         };
+
+        // Gate the payload on an EIP-8025 execution proof. Proofs are recursive, so a single
+        // proof of any type is enough to consider this payload proven.
+        if require_execution_proof && self.execution_proofs.is_empty() {
+            return Ok(None);
+        }
 
         let AvailabilityPendingExecutedEnvelope {
             envelope,
@@ -287,6 +309,7 @@ impl<E: EthSpec> PendingComponents<E> {
             bid,
             envelope: None,
             verified_data_columns: HashMap::new(),
+            execution_proofs: HashMap::new(),
             reconstruction_started: false,
             local_fetch_settled: false,
             span,
@@ -299,10 +322,11 @@ impl<E: EthSpec> PendingComponents<E> {
     {
         let num_columns_required = self.num_columns_required(custody_context);
         format!(
-            "envelope {}, data_columns {}/{}",
+            "envelope {}, data_columns {}/{}, execution_proofs {}",
             self.envelope.is_some(),
             self.num_completed_columns(),
-            num_columns_required
+            num_columns_required,
+            self.execution_proofs.len()
         )
     }
 }

--- a/beacon_node/beacon_chain/src/pending_payload_cache/pending_components.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/pending_components.rs
@@ -28,8 +28,8 @@ pub struct PendingComponents<E: EthSpec> {
     pub envelope: Option<AvailabilityPendingExecutedEnvelope<E>>,
     /// A column entry in this map may only have some cells filled in (i.e. a partial data column)
     pub verified_data_columns: HashMap<ColumnIndex, PendingColumn<E>>,
-    /// Gossip verified EIP-8025 execution proofs, keyed by proof type. Only populated when a
-    /// proof engine is configured, since proofs are neither requested nor verified otherwise.
+    /// Execution proofs keyed by proof type, so repeats from one prover count once. Empty
+    /// without a proof engine.
     pub execution_proofs: HashMap<ProofType, Arc<SignedExecutionProof>>,
     pub reconstruction_started: bool,
     /// True once the local `getBlobs` attempt has settled. It is set whether or not the EL
@@ -201,14 +201,17 @@ impl<E: EthSpec> PendingComponents<E> {
         }
     }
 
-    /// Inserts a gossip verified execution proof into the cache.
-    ///
-    /// Returns `true` if this is the first proof for this payload, i.e. the insert may have
-    /// unblocked the execution proof requirement in `make_available`.
-    pub fn insert_execution_proof(&mut self, proof: Arc<SignedExecutionProof>) -> bool {
-        let is_first_proof = self.execution_proofs.is_empty();
-        self.execution_proofs.insert(proof.proof_type(), proof);
-        is_first_proof
+    /// Inserts an execution proof, returning the distinct proof type count, or `None` if we
+    /// already had this type.
+    pub fn insert_execution_proof(&mut self, proof: Arc<SignedExecutionProof>) -> Option<usize> {
+        if self
+            .execution_proofs
+            .insert(proof.proof_type(), proof)
+            .is_some()
+        {
+            return None;
+        }
+        Some(self.execution_proofs.len())
     }
 
     /// Inserts an executed payload envelope into the cache.
@@ -229,12 +232,11 @@ impl<E: EthSpec> PendingComponents<E> {
         self.num_completed_columns() >= num_expected_columns
     }
 
-    /// Returns `Some` if the envelope, all required data columns, and (if
-    /// `require_execution_proof` is set) an execution proof have been received.
+    /// Returns `Some` once the envelope, the required columns and enough proofs have arrived.
     pub fn make_available<T>(
         &self,
         custody_context: &CustodyContext<T>,
-        require_execution_proof: bool,
+        required_execution_proofs: usize,
     ) -> Result<Option<AvailableExecutedEnvelope<E>>, AvailabilityCheckError>
     where
         T: BeaconChainTypes<EthSpec = E>,
@@ -244,9 +246,8 @@ impl<E: EthSpec> PendingComponents<E> {
             return Ok(None);
         };
 
-        // Gate the payload on an EIP-8025 execution proof. Proofs are recursive, so a single
-        // proof of any type is enough to consider this payload proven.
-        if require_execution_proof && self.execution_proofs.is_empty() {
+        // Proofs are recursive, so we only need them for this payload, not its ancestors.
+        if self.execution_proofs.len() < required_execution_proofs {
             return Ok(None);
         }
 
@@ -316,18 +317,31 @@ impl<E: EthSpec> PendingComponents<E> {
         }
     }
 
-    pub fn status_str<T>(&self, custody_context: &CustodyContext<T>) -> String
+    pub fn status_str<T>(
+        &self,
+        custody_context: &CustodyContext<T>,
+        required_execution_proofs: usize,
+    ) -> String
     where
         T: BeaconChainTypes<EthSpec = E>,
     {
         let num_columns_required = self.num_columns_required(custody_context);
-        format!(
-            "envelope {}, data_columns {}/{}, execution_proofs {}",
-            self.envelope.is_some(),
-            self.num_completed_columns(),
-            num_columns_required,
-            self.execution_proofs.len()
-        )
+        if required_execution_proofs == 0 {
+            format!(
+                "envelope {}, data_columns {}/{}",
+                self.envelope.is_some(),
+                self.num_completed_columns(),
+                num_columns_required
+            )
+        } else {
+            format!(
+                "envelope {}, data_columns {}/{}, execution_proofs {}",
+                self.envelope.is_some(),
+                self.num_completed_columns(),
+                num_columns_required,
+                self.execution_proofs.len()
+            )
+        }
     }
 }
 

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -4159,8 +4159,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 );
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Accept);
 
-                // Cache the proof so it can unblock the payload envelope of its block, which is
-                // only importable once proven when a proof engine is configured.
+                // This may be the proof the block's envelope was waiting on.
                 match self
                     .chain
                     .check_execution_proof_availability_and_import(verified)
@@ -4172,6 +4171,10 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             %slot,
                             "Execution payload envelope imported after execution proof"
                         );
+                        self.chain.recompute_head_at_current_slot().await;
+                        // The payload envelope is imported (`is_payload_received` is now true);
+                        // release any attestations awaiting this block's payload.
+                        self.notify_payload_envelope_imported(block_root, EnvelopeSource::Gossip);
                     }
                     Ok(AvailabilityProcessingStatus::MissingComponents(..)) => {}
                     Err(error) => {

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -4158,6 +4158,31 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "Verified execution proof from gossip"
                 );
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Accept);
+
+                // Cache the proof so it can unblock the payload envelope of its block, which is
+                // only importable once proven when a proof engine is configured.
+                match self
+                    .chain
+                    .check_execution_proof_availability_and_import(verified)
+                    .await
+                {
+                    Ok(AvailabilityProcessingStatus::Imported(slot, block_root)) => {
+                        info!(
+                            ?block_root,
+                            %slot,
+                            "Execution payload envelope imported after execution proof"
+                        );
+                    }
+                    Ok(AvailabilityProcessingStatus::MissingComponents(..)) => {}
+                    Err(error) => {
+                        debug!(
+                            %beacon_block_root,
+                            proof_type,
+                            ?error,
+                            "Could not cache execution proof"
+                        );
+                    }
+                }
             }
             Err(error) => {
                 debug!(%beacon_block_root, proof_type, ?error, "Could not verify execution proof");


### PR DESCRIPTION
## Issue Addressed

- Part 2 of https://github.com/sigp/lighthouse/issues/9658

## Proposed Changes

Gates importability of gloas payloads only if enough valid proofs have been received. The proofs are not stored and thrown away. This PR allows to collect and simulate how waiting for proof arrival affects performance of validators due the additional delay.

