### PR TITLE
Delete stream_blocks_fallback and unused eth_getBlockByHash reconstru…

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_block_streamer.rs
+++ b/beacon_node/beacon_chain/src/beacon_block_streamer.rs
@@ -246,31 +246,7 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
         Ok(bodies)
     }
 
-    // used when the execution engine doesn't support the payload bodies methods
-    async fn stream_blocks_fallback(
-        self: Arc<Self>,
-        block_roots: Vec<Hash256>,
-        sender: UnboundedSender<(Hash256, Arc<BlockResult<T::EthSpec>>)>,
-    ) {
-        debug!("Using slower fallback method of eth_getBlockByHash()");
-        for root in block_roots {
-            let cached_block = self.check_caches(root);
-            let block_result = if cached_block.is_some() {
-                Ok(cached_block)
-            } else {
-                self.beacon_chain
-                    .get_block(&root)
-                    .await
-                    .map(|opt_block| opt_block.map(Arc::new))
-            };
-
-            if sender.send((root, Arc::new(block_result))).is_err() {
-                break;
-            }
-        }
-    }
-
-    async fn stream_blocks(
+    pub async fn stream(
         self: Arc<Self>,
         block_roots: Vec<Hash256>,
         sender: UnboundedSender<(Hash256, Arc<BlockResult<T::EthSpec>>)>,
@@ -358,26 +334,6 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
         );
     }
 
-    pub async fn stream(
-        self: Arc<Self>,
-        block_roots: Vec<Hash256>,
-        sender: UnboundedSender<(Hash256, Arc<BlockResult<T::EthSpec>>)>,
-    ) {
-        match self.execution_layer.get_engine_capabilities(None).await {
-            Ok(capabilities) if capabilities.get_payload_bodies_by_hash_v1 => {
-                self.stream_blocks(block_roots, sender).await;
-            }
-            Ok(_) => {
-                // use the fallback method
-                self.stream_blocks_fallback(block_roots, sender).await;
-            }
-            Err(e) => {
-                let error = BeaconChainError::EngineGetCapabilititesFailed(Box::new(e));
-                send_errors(block_roots, sender, error);
-            }
-        }
-    }
-
     pub fn launch_stream(
         self: Arc<Self>,
         block_roots: Vec<Hash256>,
@@ -390,19 +346,6 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
         let executor = self.beacon_chain.task_executor.clone();
         executor.spawn(self.stream(block_roots, block_tx), "get_blocks_sender");
         UnboundedReceiverStream::new(block_rx)
-    }
-}
-
-fn send_errors<E: EthSpec>(
-    block_roots: Vec<Hash256>,
-    sender: UnboundedSender<(Hash256, Arc<BlockResult<E>>)>,
-    beacon_chain_error: BeaconChainError,
-) {
-    let result = Arc::new(Err(beacon_chain_error));
-    for root in block_roots {
-        if sender.send((root, result.clone())).is_err() {
-            break;
-        }
     }
 }
 

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -149,9 +149,7 @@ pub enum BeaconChainError {
     ExecutionLayerMissing,
     BlockVariantLacksExecutionPayload(Hash256),
     ExecutionLayerErrorPayloadReconstruction(ExecutionBlockHash, Box<execution_layer::Error>),
-    EngineGetCapabilititesFailed(Box<execution_layer::Error>),
     ExecutionLayerGetBlockByNumberFailed(Box<execution_layer::Error>),
-    ExecutionLayerGetBlockByHashFailed(Box<execution_layer::Error>),
     BlockHashMissingFromExecutionLayer(ExecutionBlockHash),
     InconsistentPayloadReconstructed {
         slot: Slot,

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -29,9 +29,6 @@ pub const RETURN_FULL_TRANSACTION_OBJECTS: bool = false;
 pub const ETH_GET_BLOCK_BY_NUMBER: &str = "eth_getBlockByNumber";
 pub const ETH_GET_BLOCK_BY_NUMBER_TIMEOUT: Duration = Duration::from_secs(1);
 
-pub const ETH_GET_BLOCK_BY_HASH: &str = "eth_getBlockByHash";
-pub const ETH_GET_BLOCK_BY_HASH_TIMEOUT: Duration = Duration::from_secs(1);
-
 pub const ETH_SYNCING: &str = "eth_syncing";
 pub const ETH_SYNCING_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -765,20 +762,6 @@ impl HttpJsonRpc {
             ETH_GET_BLOCK_BY_NUMBER,
             params,
             ETH_GET_BLOCK_BY_NUMBER_TIMEOUT * self.execution_timeout_multiplier,
-        )
-        .await
-    }
-
-    pub async fn get_block_by_hash(
-        &self,
-        block_hash: ExecutionBlockHash,
-    ) -> Result<Option<ExecutionBlock>, Error> {
-        let params = json!([block_hash, RETURN_FULL_TRANSACTION_OBJECTS]);
-
-        self.rpc_request(
-            ETH_GET_BLOCK_BY_HASH,
-            params,
-            ETH_GET_BLOCK_BY_HASH_TIMEOUT * self.execution_timeout_multiplier,
         )
         .await
     }
@@ -1796,33 +1779,6 @@ mod test {
             .assert_auth_failure(|client| async move {
                 client
                     .get_block_by_number(BlockByNumberQuery::Tag(LATEST_TAG))
-                    .await
-            })
-            .await;
-    }
-
-    #[tokio::test]
-    async fn get_block_by_hash_request() {
-        Tester::new(true)
-            .assert_request_equals(
-                |client| async move {
-                    let _ = client
-                        .get_block_by_hash(ExecutionBlockHash::repeat_byte(1))
-                        .await;
-                },
-                json!({
-                    "id": STATIC_ID,
-                    "jsonrpc": JSONRPC_VERSION,
-                    "method": ETH_GET_BLOCK_BY_HASH,
-                    "params": [HASH_01, false]
-                }),
-            )
-            .await;
-
-        Tester::new(false)
-            .assert_auth_failure(|client| async move {
-                client
-                    .get_block_by_hash(ExecutionBlockHash::repeat_byte(1))
                     .await
             })
             .await;

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -295,11 +295,6 @@ impl<E: EthSpec> ExecutionBlockGenerator<E> {
         self.blocks.get(&hash).cloned()
     }
 
-    pub fn execution_block_by_hash(&self, hash: ExecutionBlockHash) -> Option<ExecutionBlock> {
-        self.block_by_hash(hash)
-            .map(|block| block.as_execution_block(self.terminal_total_difficulty))
-    }
-
     pub fn execution_payload_by_hash(
         &self,
         hash: ExecutionBlockHash,

--- a/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
+++ b/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
@@ -64,41 +64,6 @@ pub async fn handle_rpc<E: EthSpec>(
                 )),
             }
         }
-        ETH_GET_BLOCK_BY_HASH => {
-            let hash = params
-                .get(0)
-                .and_then(JsonValue::as_str)
-                .ok_or_else(|| "missing/invalid params[0] value".to_string())
-                .and_then(|s| {
-                    s.parse()
-                        .map_err(|e| format!("unable to parse hash: {:?}", e))
-                })
-                .map_err(|s| (s, BAD_PARAMS_ERROR_CODE))?;
-
-            // If we have a static response set, just return that.
-            if let Some(response) = *ctx.static_get_block_by_hash_response.lock() {
-                return Ok(serde_json::to_value(response).unwrap());
-            }
-
-            let full_tx = params
-                .get(1)
-                .and_then(JsonValue::as_bool)
-                .ok_or_else(|| "missing/invalid params[1] value".to_string())
-                .map_err(|s| (s, BAD_PARAMS_ERROR_CODE))?;
-            if full_tx {
-                Err((
-                    "full_tx support has been removed".to_string(),
-                    BAD_PARAMS_ERROR_CODE,
-                ))
-            } else {
-                Ok(serde_json::to_value(
-                    ctx.execution_block_generator
-                        .read()
-                        .execution_block_by_hash(hash),
-                )
-                .unwrap())
-            }
-        }
         ENGINE_NEW_PAYLOAD_V1
         | ENGINE_NEW_PAYLOAD_V2
         | ENGINE_NEW_PAYLOAD_V3

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::engine_api::auth::JwtKey;
 use crate::engine_api::{
-    ExecutionBlock, PayloadStatusV1, PayloadStatusV1Status, auth::Auth, http::JSONRPC_VERSION,
+    PayloadStatusV1, PayloadStatusV1Status, auth::Auth, http::JSONRPC_VERSION,
 };
 use crate::json_structures::JsonClientVersionV1;
 use bytes::Bytes;
@@ -162,7 +162,6 @@ impl<E: EthSpec> MockServer<E> {
             preloaded_responses,
             static_new_payload_response: <_>::default(),
             static_forkchoice_updated_response: <_>::default(),
-            static_get_block_by_hash_response: <_>::default(),
             hook: <_>::default(),
             new_payload_statuses: <_>::default(),
             fcu_payload_statuses: <_>::default(),
@@ -402,16 +401,6 @@ impl<E: EthSpec> MockServer<E> {
         self.set_forkchoice_updated_response(Self::invalid_terminal_block_status());
     }
 
-    /// This will make the node appear like it is syncing.
-    pub fn all_get_block_by_hash_requests_return_none(&self) {
-        *self.ctx.static_get_block_by_hash_response.lock() = Some(None);
-    }
-
-    /// The node will respond "naturally"; it will return blocks if they're known to it.
-    pub fn all_get_block_by_hash_requests_return_natural_value(&self) {
-        *self.ctx.static_get_block_by_hash_response.lock() = None;
-    }
-
     /// Disables any static payload responses so the execution block generator will do its own
     /// verification.
     pub fn full_payload_verification(&self) {
@@ -536,7 +525,6 @@ pub struct Context<E: EthSpec> {
     pub previous_request: Arc<Mutex<Option<serde_json::Value>>>,
     pub static_new_payload_response: Arc<Mutex<Option<StaticNewPayloadResponse>>>,
     pub static_forkchoice_updated_response: Arc<Mutex<Option<PayloadStatusV1>>>,
-    pub static_get_block_by_hash_response: Arc<Mutex<Option<Option<ExecutionBlock>>>>,
     pub hook: Arc<Mutex<Hook>>,
 
     // Canned responses by block hash.


### PR DESCRIPTION
## Description

- Delete `stream_blocks_fallback`. Reconstruction always uses `engine_getPayloadBodiesByHashV1`.
- Remove unused `eth_getBlockByHash` client, mock, and error-variant code.

`eth_getBlockByNumber` and `get_payload_for_header` are unchanged.

Closes #9621

## Test plan

- [ ] `cargo nextest run -p beacon_chain check_all_blocks_from_altair_to_fulu`
- [ ] `cargo nextest run -p execution_layer`
