### PR TITLE
fix: remove parenthesis for historical backfill

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -933,7 +933,8 @@ where
             let backfill_epoch_range = if cfg!(feature = "test_backfill") {
                 3
             } else {
-                self.spec.min_validator_withdrawability_delay.as_u64() + self.spec.churn_limit_quotient.as_u64() / 2
+                self.spec.min_validator_withdrawability_delay.as_u64()
+                    + self.spec.churn_limit_quotient / 2
             };
 
             match slot_clock.now() {

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -933,9 +933,7 @@ where
             let backfill_epoch_range = if cfg!(feature = "test_backfill") {
                 3
             } else {
-                (self.spec.min_validator_withdrawability_delay + self.spec.churn_limit_quotient)
-                    .as_u64()
-                    / 2
+                self.spec.min_validator_withdrawability_delay.as_u64() + self.spec.churn_limit_quotient.as_u64() / 2
             };
 
             match slot_clock.now() {


### PR DESCRIPTION
(modified this in web UI, so probably doesn't compile)

## Issue Addressed

This was computing (256 + 65536)/ 2 =32,896 epochs. I believe it should be 256 + 65536/2 = 33,024 

Which issue # does this PR address?

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
