### PR TITLE
Fix lc finality zero check clean

### DIFF
--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -157,7 +157,7 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
             None => true,
         };
 
-        if is_latest_finality & !cached_parts.finalized_block_root.is_zero() {
+        if is_latest_finality {
             // Immediately after checkpoint sync the finalized block may not be available yet.
             if let Some(finalized_block) = maybe_finalized_block.as_ref() {
                 *self.latest_finality_update.write() = Some(LightClientFinalityUpdate::new(


### PR DESCRIPTION
When finalized_block_root is zero (the genesis checkpoint, before any blocks have been finalized through the normal voting process), recompute_and_cache_updates was skipping the finality update entirely due to this check:

if is_latest_finality & !cached_parts.finalized_block_root.is_zero()

The spec allows finality updates with a zero finalized header (genesis) to be valid and served to light clients. The consensus-spec-tests data collection test vectors confirm this. They expect a finality update to be produced even at genesis.

This bug was discovered while implementing the missing light_client_data_collection ef_test handler in #9666. The fix removes the is_zero() guard. The inner maybe_finalized_block check already handles the case where the finalized block is not available in the store.