### PR TITLE
Add tests to check for divergence between fork choice and the store

### DIFF
--- a/beacon_node/beacon_chain/tests/main.rs
+++ b/beacon_node/beacon_chain/tests/main.rs
@@ -10,6 +10,7 @@ mod payload_invalidation;
 mod prepare_payload;
 mod rewards;
 mod schema_stability;
+mod store_fault_tests;
 mod store_tests;
 mod sync_committee_verification;
 mod tests;

--- a/beacon_node/beacon_chain/tests/store_fault_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_fault_tests.rs
@@ -1,0 +1,219 @@
+#![cfg(not(debug_assertions))]
+
+//! Tests for the divergence between fork choice and the store when the database fails
+//! during block import.
+//!
+//! If the database write for a block fails after the block has been added to the in-memory
+//! fork choice, and the recovery read in `handle_import_block_db_write_error` also fails
+//! (e.g. due to file descriptor exhaustion affecting both reads and writes), then fork
+//! choice contains a block that the store does not. These tests pin the resulting
+//! behaviour:
+//!
+//! - the node refuses to re-import the lost block (duplicate detection uses fork choice),
+//! - children of the lost block fail with `MissingBeaconBlock` instead of `ParentUnknown`,
+//! - head recomputation fails and the head cannot advance,
+//! - a graceful shutdown persists the diverged fork choice, making the next startup fail
+//!   with "Head block not found in store".
+
+use beacon_chain::{
+    BeaconChainError, BlockError,
+    test_utils::{
+        AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
+        fork_name_from_env,
+    },
+};
+use eth2::types::SignedBlockContentsTuple;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use types::*;
+
+const VALIDATOR_COUNT: usize = 32;
+
+type E = MinimalEthSpec;
+
+fn incompatible_fork() -> bool {
+    fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled())
+}
+
+struct WedgedChain {
+    harness: BeaconChainHarness<EphemeralHarnessType<E>>,
+    /// Root of the block that is in fork choice but not in the store.
+    phantom_root: Hash256,
+    phantom_slot: Slot,
+    phantom_contents: SignedBlockContentsTuple<E>,
+    /// Post-state of the phantom block, for building a child block.
+    post_state: BeaconState<E>,
+}
+
+/// Build a chain, then import a block whilst every store operation fails.
+///
+/// The import adds the block to fork choice, then fails the database write, then fails
+/// the recovery read. The returned chain has a fork choice containing `phantom_root`
+/// whilst the store does not.
+async fn wedged_chain() -> WedgedChain {
+    let harness = BeaconChainHarness::builder(MinimalEthSpec)
+        .default_spec()
+        .deterministic_keypairs(VALIDATOR_COUNT)
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build();
+
+    harness.advance_slot();
+    harness
+        .extend_chain(
+            2 * E::slots_per_epoch() as usize,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    let state = harness.get_current_state();
+    let slot = harness.chain.slot().unwrap() + 1;
+    let (phantom_contents, post_state) = harness.make_block(state, slot).await;
+    let phantom_root = phantom_contents.0.canonical_root();
+
+    // Fail the block's database write and every store operation after it, simulating
+    // file descriptor exhaustion striking at the moment of the write.
+    harness
+        .chain
+        .store
+        .hot_db
+        .inject_faults_on_next_block_write();
+
+    let err = harness
+        .process_block(slot, phantom_root, phantom_contents.clone())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, BlockError::BeaconChainError(_)),
+        "import should fail with an internal error, got: {err:?}"
+    );
+
+    // The resource exhaustion passes, but the damage is done.
+    harness.chain.store.hot_db.inject_faults(false);
+
+    WedgedChain {
+        harness,
+        phantom_root,
+        phantom_slot: slot,
+        phantom_contents,
+        post_state,
+    }
+}
+
+// TODO: this test asserts the *broken* behaviour. Once the divergence is fixed (e.g. by
+// reverting fork choice in memory or refusing to run diverged), this test should FAIL.
+// Flip the assertions to the healed behaviour as part of the fix.
+#[tokio::test]
+async fn db_write_failure_diverges_fork_choice_from_store() {
+    if incompatible_fork() {
+        return;
+    }
+    let WedgedChain {
+        harness,
+        phantom_root,
+        phantom_slot,
+        phantom_contents,
+        post_state,
+    } = wedged_chain().await;
+
+    // The divergence: fork choice contains the block, the store does not.
+    assert!(
+        harness
+            .chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .contains_block(&phantom_root),
+        "fork choice should contain the phantom block"
+    );
+    assert!(
+        harness
+            .chain
+            .get_blinded_block(&phantom_root)
+            .unwrap()
+            .is_none(),
+        "the store should not contain the phantom block"
+    );
+
+    // The node refuses to re-import the lost block, because duplicate detection only
+    // checks fork choice.
+    let err = harness
+        .process_block(phantom_slot, phantom_root, phantom_contents)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, BlockError::DuplicateFullyImported(root) if root == phantom_root),
+        "re-import should be treated as a duplicate, got: {err:?}"
+    );
+
+    // A child of the lost block fails with `MissingBeaconBlock` rather than
+    // `ParentUnknown`, because the parent lookup checks fork choice before the store.
+    let child_slot = phantom_slot + 1;
+    let (child_contents, _) = harness.make_block(post_state, child_slot).await;
+    let child_root = child_contents.0.canonical_root();
+    let err = harness
+        .process_block(child_slot, child_root, child_contents)
+        .await
+        .unwrap_err();
+    match err {
+        BlockError::BeaconChainError(e) => assert!(
+            matches!(*e, BeaconChainError::MissingBeaconBlock(root) if root == phantom_root),
+            "child import should fail on the missing parent, got: {e:?}"
+        ),
+        other => panic!("expected MissingBeaconBlock for the child block, got: {other:?}"),
+    }
+
+    // Head recomputation cannot load the fork choice head from the store, so the head
+    // never advances to the phantom block.
+    harness.chain.recompute_head_at_current_slot().await;
+    assert_ne!(
+        harness
+            .chain
+            .canonical_head
+            .cached_head()
+            .head_block_root(),
+        phantom_root,
+        "the head should not advance to the phantom block"
+    );
+}
+
+// TODO: this test asserts the *broken* behaviour. Once shutdown stops persisting a
+// known-diverged fork choice (or startup self-heals), this test should FAIL. Flip the
+// assertions to the healed behaviour as part of the fix.
+#[tokio::test]
+async fn restart_after_db_write_failure_is_fatal() {
+    if incompatible_fork() {
+        return;
+    }
+    let WedgedChain { harness, .. } = wedged_chain().await;
+
+    let store = harness.chain.store.clone();
+    let slot_clock = harness.chain.slot_clock.clone();
+
+    // A graceful shutdown persists the diverged fork choice (see `Drop` for
+    // `BeaconChain`).
+    harness.chain.persist_fork_choice().unwrap();
+    drop(harness);
+
+    // Rebooting from the same database fails, because the persisted fork choice resolves
+    // a head block that was never written to the store.
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        BeaconChainHarness::builder(MinimalEthSpec)
+            .default_spec()
+            .deterministic_keypairs(VALIDATOR_COUNT)
+            .resumed_ephemeral_store(store)
+            .mock_execution_layer()
+            .testing_slot_clock(slot_clock)
+            .build()
+    }));
+
+    let panic_payload = result.expect_err("the beacon chain should fail to start");
+    let message = panic_payload
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| panic_payload.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_default();
+    assert!(
+        message.contains("Head block not found in store"),
+        "startup should fail on the missing head block, got: {message}"
+    );
+}

--- a/beacon_node/beacon_chain/tests/store_fault_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_fault_tests.rs
@@ -1,18 +1,17 @@
 #![cfg(not(debug_assertions))]
 
-//! Tests for the divergence between fork choice and the store when the database fails
+//! Tests for divergence between fork choice and the store when the db fails
 //! during block import.
 //!
-//! If the database write for a block fails after the block has been added to the in-memory
-//! fork choice, and the recovery read in `handle_import_block_db_write_error` also fails
-//! (e.g. due to file descriptor exhaustion affecting both reads and writes), then fork
-//! choice contains a block that the store does not. These tests pin the resulting
-//! behaviour:
+//! If the database write for a block fails after the block has been added to
+//! fork choice, and the recovery step `handle_import_block_db_write_error` also fails,
+//! then fork choice contains a block that the store does not. These tests check for the
+//! following behaviour:
 //!
-//! - the node refuses to re-import the lost block (duplicate detection uses fork choice),
-//! - children of the lost block fail with `MissingBeaconBlock` instead of `ParentUnknown`,
-//! - head recomputation fails and the head cannot advance,
-//! - a graceful shutdown persists the diverged fork choice, making the next startup fail
+//! - The node refuses to re-import the missing block.
+//! - Children of the missing block fail with `MissingBeaconBlock` instead of `ParentUnknown`.
+//! - Head recomputation fails and the head cannot advance.
+//! - A graceful shutdown persists the diverged fork choice, making the next startup fail
 //!   with "Head block not found in store".
 
 use beacon_chain::{
@@ -36,7 +35,7 @@ fn incompatible_fork() -> bool {
 
 struct WedgedChain {
     harness: BeaconChainHarness<EphemeralHarnessType<E>>,
-    /// Root of the block that is in fork choice but not in the store.
+    /// Root of the block that is in fork choice but not in the store, i.e. the phantom block.
     phantom_root: Hash256,
     phantom_slot: Slot,
     phantom_contents: SignedBlockContentsTuple<E>,
@@ -44,11 +43,11 @@ struct WedgedChain {
     post_state: BeaconState<E>,
 }
 
-/// Build a chain, then import a block whilst every store operation fails.
+/// Build a chain, then import a block while every store operation fails.
 ///
 /// The import adds the block to fork choice, then fails the database write, then fails
 /// the recovery read. The returned chain has a fork choice containing `phantom_root`
-/// whilst the store does not.
+/// while the store does not.
 async fn wedged_chain() -> WedgedChain {
     let harness = BeaconChainHarness::builder(MinimalEthSpec)
         .default_spec()
@@ -71,8 +70,7 @@ async fn wedged_chain() -> WedgedChain {
     let (phantom_contents, post_state) = harness.make_block(state, slot).await;
     let phantom_root = phantom_contents.0.canonical_root();
 
-    // Fail the block's database write and every store operation after it, simulating
-    // file descriptor exhaustion striking at the moment of the write.
+    // Fail the block's database write and every store operation after it.
     harness
         .chain
         .store
@@ -116,7 +114,7 @@ async fn db_write_failure_diverges_fork_choice_from_store() {
         post_state,
     } = wedged_chain().await;
 
-    // The divergence: fork choice contains the block, the store does not.
+    // fork choice contains the phantom block, the store does not.
     assert!(
         harness
             .chain
@@ -134,7 +132,7 @@ async fn db_write_failure_diverges_fork_choice_from_store() {
         "the store should not contain the phantom block"
     );
 
-    // The node refuses to re-import the lost block, because duplicate detection only
+    // The node refuses to re-import the phantom block, because duplicate detection only
     // checks fork choice.
     let err = harness
         .process_block(phantom_slot, phantom_root, phantom_contents)
@@ -145,7 +143,7 @@ async fn db_write_failure_diverges_fork_choice_from_store() {
         "re-import should be treated as a duplicate, got: {err:?}"
     );
 
-    // A child of the lost block fails with `MissingBeaconBlock` rather than
+    // A child of the phantom block fails with `MissingBeaconBlock` rather than
     // `ParentUnknown`, because the parent lookup checks fork choice before the store.
     let child_slot = phantom_slot + 1;
     let (child_contents, _) = harness.make_block(post_state, child_slot).await;
@@ -166,11 +164,7 @@ async fn db_write_failure_diverges_fork_choice_from_store() {
     // never advances to the phantom block.
     harness.chain.recompute_head_at_current_slot().await;
     assert_ne!(
-        harness
-            .chain
-            .canonical_head
-            .cached_head()
-            .head_block_root(),
+        harness.chain.canonical_head.cached_head().head_block_root(),
         phantom_root,
         "the head should not advance to the phantom block"
     );

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -4,12 +4,15 @@ use crate::{
 };
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 type DBMap = BTreeMap<BytesKey, Vec<u8>>;
 
 /// A thread-safe `BTreeMap` wrapper.
 pub struct MemoryStore {
     db: RwLock<DBMap>,
+    fault: AtomicBool,
+    fault_armed: AtomicBool,
 }
 
 impl MemoryStore {
@@ -17,6 +20,36 @@ impl MemoryStore {
     pub fn open() -> Self {
         Self {
             db: RwLock::new(BTreeMap::new()),
+            fault: AtomicBool::new(false),
+            fault_armed: AtomicBool::new(false),
+        }
+    }
+
+    /// Enable or disable fault injection.
+    ///
+    /// While enabled, every database read and write returns an error. This simulates a database
+    /// suffering resource exhaustion (e.g. file descriptor exhaustion).
+    pub fn inject_faults(&self, enabled: bool) {
+        self.fault.store(enabled, Ordering::SeqCst);
+        if !enabled {
+            self.fault_armed.store(false, Ordering::SeqCst);
+        }
+    }
+
+    /// Set fault injection to trigger on the next batch that writes a block.
+    ///
+    /// Simulates resource exhaustion during a block write.
+    pub fn inject_faults_on_next_block_write(&self) {
+        self.fault_armed.store(true, Ordering::SeqCst);
+    }
+
+    fn check_fault(&self) -> Result<(), Error> {
+        if self.fault.load(Ordering::SeqCst) {
+            Err(Error::DBError {
+                message: "Injected fault: too many open files".to_string(),
+            })
+        } else {
+            Ok(())
         }
     }
 }
@@ -24,12 +57,14 @@ impl MemoryStore {
 impl KeyValueStore for MemoryStore {
     /// Get the value of some key from the database. Returns `None` if the key does not exist.
     fn get_bytes(&self, col: DBColumn, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+        self.check_fault()?;
         let column_key = BytesKey::from_vec(get_key_for_col(col, key));
         Ok(self.db.read().get(&column_key).cloned())
     }
 
     /// Puts a key in the database.
     fn put_bytes(&self, col: DBColumn, key: &[u8], val: &[u8]) -> Result<(), Error> {
+        self.check_fault()?;
         let column_key = BytesKey::from_vec(get_key_for_col(col, key));
         self.db.write().insert(column_key, val.to_vec());
         Ok(())
@@ -46,18 +81,33 @@ impl KeyValueStore for MemoryStore {
 
     /// Return true if some key exists in some column.
     fn key_exists(&self, col: DBColumn, key: &[u8]) -> Result<bool, Error> {
+        self.check_fault()?;
         let column_key = BytesKey::from_vec(get_key_for_col(col, key));
         Ok(self.db.read().contains_key(&column_key))
     }
 
     /// Delete some key from the database.
     fn key_delete(&self, col: DBColumn, key: &[u8]) -> Result<(), Error> {
+        self.check_fault()?;
         let column_key = BytesKey::from_vec(get_key_for_col(col, key));
         self.db.write().remove(&column_key);
         Ok(())
     }
 
     fn do_atomically(&self, batch: Vec<KeyValueStoreOp>) -> Result<(), Error> {
+        self.check_fault()?;
+        if self.fault_armed.load(Ordering::SeqCst)
+            && batch.iter().any(|op| {
+                matches!(
+                    op,
+                    KeyValueStoreOp::PutKeyValue(DBColumn::BeaconBlock, _, _)
+                )
+            })
+        {
+            self.fault_armed.store(false, Ordering::SeqCst);
+            self.fault.store(true, Ordering::SeqCst);
+            return self.check_fault();
+        }
         for op in batch {
             match op {
                 KeyValueStoreOp::PutKeyValue(col, key, value) => {
@@ -121,6 +171,7 @@ impl KeyValueStore for MemoryStore {
     }
 
     fn delete_batch(&self, col: DBColumn, ops: HashSet<&[u8]>) -> Result<(), DBError> {
+        self.check_fault()?;
         for op in ops {
             let column_key = get_key_for_col(col, op);
             self.db.write().remove(&BytesKey::from_vec(column_key));
@@ -133,6 +184,7 @@ impl KeyValueStore for MemoryStore {
         column: DBColumn,
         mut f: impl FnMut(&[u8]) -> Result<bool, Error>,
     ) -> Result<(), Error> {
+        self.check_fault()?;
         self.db.write().retain(|key, value| {
             if key.remove_column_variable(column).is_some() {
                 !f(value).unwrap_or(false)


### PR DESCRIPTION
## Issue Addressed
An "overloaded" lighthouse node can fail to write to the database (for example due to file descriptor exhaustion). In these conditions the recovery step `handle_import_block_db_write_error` will fail as well. This ends up putting the node in an inconsistent state where fork choice and the database have diverged (fork choice contains a block that the db does not, a "phantom" block).

This PR adds tests to recreate this situation and prove that, in these conditions, fork choice can diverge from the store. In a subsequent PR I will add fixes to prevent this divergence and update these tests accordingly.  
