### PR TITLE
Initiate a shutdown if the node cannot recover from a diverged fork choice

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -7849,9 +7849,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 impl<T: BeaconChainTypes> Drop for BeaconChain<T> {
     fn drop(&mut self) {
         let drop = || -> Result<(), Error> {
-            self.persist_fork_choice()?;
             self.persist_op_pool()?;
-            self.persist_custody_context()
+            self.persist_custody_context()?;
+            self.persist_fork_choice()
         };
 
         if let Err(e) = drop() {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4657,14 +4657,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         if let Err(e) = self.store.do_atomically_with_block_and_blobs_cache(ops) {
             error!(
-                msg = "Restoring fork choice from disk",
+                msg = "Fork choice now contains a block that the store does not",
                 error = ?e,
                 "Database write failed!"
             );
-            return Err(self
-                .handle_import_block_db_write_error(fork_choice)
-                .err()
-                .unwrap_or(e.into()));
+            self.handle_import_block_db_write_error(fork_choice, block_root);
+            return Err(e.into());
         }
 
         drop(db_span);
@@ -4738,36 +4736,43 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         Ok(block_root)
     }
 
+    /// Handle a database write failure during block import, which leaves the in-memory fork
+    /// choice containing a block that the store does not have.
+    ///
+    /// There is no reliable in-process recovery from this state. Restoring fork choice by
+    /// reading the database is likely to fail for the same reason the write failed (e.g. file
+    /// descriptor exhaustion affects reads too, see
+    /// https://github.com/sigp/lighthouse/issues/2028), and continuing to run with the
+    /// divergence wedges the node: the missing block can never be re-imported because duplicate
+    /// detection consults fork choice, and the head can never advance past it.
+    ///
+    /// Instead, poison fork choice so that it is never persisted over the last consistent
+    /// version on disk (see `persist_fork_choice`), and initiate shutdown. On restart the node
+    /// loads the consistent fork choice from disk and re-syncs the lost blocks.
     fn handle_import_block_db_write_error(
         &self,
         // We don't actually need this value, however it's always present when we call this function
         // and it needs to be dropped to prevent a dead-lock. Requiring it to be passed here is
         // defensive programming.
         fork_choice_write_lock: ForkChoiceWriteGuard<T>,
-    ) -> Result<(), BlockError> {
+        block_root: Hash256,
+    ) {
         // Clear the early attester cache to prevent attestations which we would later be unable
         // to verify due to the failure.
         self.early_attester_cache.clear();
 
-        // Since the write failed, try to revert the canonical head back to what was stored
-        // in the database. This attempts to prevent inconsistency between the database and
-        // fork choice.
-        if let Err(e) = self.canonical_head.restore_from_store(
-            fork_choice_write_lock,
-            ResetPayloadStatuses::always_reset_conditionally(
-                self.config.always_reset_payload_statuses,
-            ),
-            &self.store,
-            &self.spec,
-        ) {
-            crit!(
-                error = ?e,
-                warning = "The database is likely corrupt now, consider --purge-db",
-                "No stored fork choice found to restore from"
-            );
-            Err(BlockError::BeaconChainError(Box::new(e)))
-        } else {
-            Ok(())
+        self.canonical_head.poison_fork_choice();
+        drop(fork_choice_write_lock);
+
+        crit!(
+            ?block_root,
+            advice = "restart the node to recover the last consistent fork choice from disk",
+            "Shutting down due to database write failure"
+        );
+        if let Err(e) = self.shutdown_sender().try_send(ShutdownReason::Failure(
+            "Database write failure during block import",
+        )) {
+            crit!(error = ?e, "Failed to send shutdown signal");
         }
     }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4657,14 +4657,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         if let Err(e) = self.store.do_atomically_with_block_and_blobs_cache(ops) {
             error!(
-                msg = "Restoring fork choice from disk",
                 error = ?e,
                 "Database write failed!"
             );
-            return Err(self
-                .handle_import_block_db_write_error(fork_choice, block_root)
-                .err()
-                .unwrap_or(e.into()));
+            self.handle_import_block_db_write_error(fork_choice, block_root);
+            return Err(e.into());
         }
 
         drop(db_span);
@@ -4741,8 +4738,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Handle a database write failure during block import, which causes fork choice
     /// to contain a block that the store does not.
     ///
-    /// First, try to restore fork choice from the last version persisted to the store.
-    /// If the restore also fails, poison fork choice so that it isn't persisted and shutdown the node.
+    /// Poison fork choice so the diverged version is never persisted, and shut down the
+    /// node. On restart, the normal startup procedure loads the last consistent fork
+    /// choice from disk.
     fn handle_import_block_db_write_error(
         &self,
         // We don't actually need this value, however it's always present when we call this function
@@ -4750,44 +4748,23 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // defensive programming.
         fork_choice_write_lock: ForkChoiceWriteGuard<T>,
         block_root: Hash256,
-    ) -> Result<(), BlockError> {
+    ) {
+        drop(fork_choice_write_lock);
+
         // Clear the early attester cache to prevent attestations which we would later be unable
         // to verify due to the failure.
         self.early_attester_cache.clear();
 
-        // Since the write failed, try to revert the canonical head back to what was stored
-        // in the database. This attempts to prevent inconsistency between the database and
-        // fork choice. `restore_from_store` drops the fork choice write lock.
-        match self.canonical_head.restore_from_store(
-            fork_choice_write_lock,
-            ResetPayloadStatuses::always_reset_conditionally(
-                self.config.always_reset_payload_statuses,
-            ),
-            &self.store,
-            &self.spec,
-        ) {
-            Ok(()) => {
-                warn!(
-                    ?block_root,
-                    "Restored fork choice from disk after database write failure"
-                );
-                Ok(())
-            }
-            Err(e) => {
-                self.canonical_head.poison_fork_choice();
-                crit!(
-                    ?block_root,
-                    error = ?e,
-                    advice = "restart the node to recover the last consistent fork choice from disk",
-                    "Shutting down due to database write failure"
-                );
-                if let Err(e) = self.shutdown_sender().try_send(ShutdownReason::Failure(
-                    "Database write failure during block import",
-                )) {
-                    crit!(error = ?e, "Failed to send shutdown signal");
-                }
-                Err(BlockError::BeaconChainError(Box::new(e)))
-            }
+        self.canonical_head.poison_fork_choice();
+        crit!(
+            ?block_root,
+            advice = "restart the node to recover the last consistent fork choice from disk",
+            "Shutting down due to database write failure"
+        );
+        if let Err(e) = self.shutdown_sender().try_send(ShutdownReason::Failure(
+            "Database write failure during block import",
+        )) {
+            crit!(error = ?e, "Failed to send shutdown signal");
         }
     }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -7845,6 +7845,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
 impl<T: BeaconChainTypes> Drop for BeaconChain<T> {
     fn drop(&mut self) {
+        if self.canonical_head.fork_choice_poisoned() {
+            warn!("Skipping persistence on drop: fork choice is poisoned");
+            return;
+        }
+
         let drop = || -> Result<(), Error> {
             self.persist_op_pool()?;
             self.persist_custody_context()?;

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4657,12 +4657,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         if let Err(e) = self.store.do_atomically_with_block_and_blobs_cache(ops) {
             error!(
-                msg = "Fork choice now contains a block that the store does not",
+                msg = "Restoring fork choice from disk",
                 error = ?e,
                 "Database write failed!"
             );
-            self.handle_import_block_db_write_error(fork_choice, block_root);
-            return Err(e.into());
+            return Err(self
+                .handle_import_block_db_write_error(fork_choice, block_root)
+                .err()
+                .unwrap_or(e.into()));
         }
 
         drop(db_span);
@@ -4736,19 +4738,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         Ok(block_root)
     }
 
-    /// Handle a database write failure during block import, which leaves the in-memory fork
-    /// choice containing a block that the store does not have.
+    /// Handle a database write failure during block import, which causes fork choice
+    /// to contain a block that the store does not.
     ///
-    /// There is no reliable in-process recovery from this state. Restoring fork choice by
-    /// reading the database is likely to fail for the same reason the write failed (e.g. file
-    /// descriptor exhaustion affects reads too, see
-    /// https://github.com/sigp/lighthouse/issues/2028), and continuing to run with the
-    /// divergence wedges the node: the missing block can never be re-imported because duplicate
-    /// detection consults fork choice, and the head can never advance past it.
-    ///
-    /// Instead, poison fork choice so that it is never persisted over the last consistent
-    /// version on disk (see `persist_fork_choice`), and initiate shutdown. On restart the node
-    /// loads the consistent fork choice from disk and re-syncs the lost blocks.
+    /// First, try to restore fork choice from the last version persisted to the store.
+    /// If the restore also fails, poison fork choice so that it isn't persisted and shutdown the node.
     fn handle_import_block_db_write_error(
         &self,
         // We don't actually need this value, however it's always present when we call this function
@@ -4756,23 +4750,44 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // defensive programming.
         fork_choice_write_lock: ForkChoiceWriteGuard<T>,
         block_root: Hash256,
-    ) {
+    ) -> Result<(), BlockError> {
         // Clear the early attester cache to prevent attestations which we would later be unable
         // to verify due to the failure.
         self.early_attester_cache.clear();
 
-        self.canonical_head.poison_fork_choice();
-        drop(fork_choice_write_lock);
-
-        crit!(
-            ?block_root,
-            advice = "restart the node to recover the last consistent fork choice from disk",
-            "Shutting down due to database write failure"
-        );
-        if let Err(e) = self.shutdown_sender().try_send(ShutdownReason::Failure(
-            "Database write failure during block import",
-        )) {
-            crit!(error = ?e, "Failed to send shutdown signal");
+        // Since the write failed, try to revert the canonical head back to what was stored
+        // in the database. This attempts to prevent inconsistency between the database and
+        // fork choice. `restore_from_store` drops the fork choice write lock.
+        match self.canonical_head.restore_from_store(
+            fork_choice_write_lock,
+            ResetPayloadStatuses::always_reset_conditionally(
+                self.config.always_reset_payload_statuses,
+            ),
+            &self.store,
+            &self.spec,
+        ) {
+            Ok(()) => {
+                warn!(
+                    ?block_root,
+                    "Restored fork choice from disk after database write failure"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                self.canonical_head.poison_fork_choice();
+                crit!(
+                    ?block_root,
+                    error = ?e,
+                    advice = "restart the node to recover the last consistent fork choice from disk",
+                    "Shutting down due to database write failure"
+                );
+                if let Err(e) = self.shutdown_sender().try_send(ShutdownReason::Failure(
+                    "Database write failure during block import",
+                )) {
+                    crit!(error = ?e, "Failed to send shutdown signal");
+                }
+                Err(BlockError::BeaconChainError(Box::new(e)))
+            }
         }
     }
 

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -54,7 +54,7 @@ use fast_confirmation::{
 };
 use fork_choice::{
     ExecutionStatus, ForkChoiceStore, ForkChoiceView, ForkchoiceUpdateParameters, PayloadStatus,
-    ProtoBlock,
+    ProtoBlock, ResetPayloadStatuses,
 };
 use itertools::process_results;
 
@@ -460,8 +460,9 @@ pub struct CanonicalHead<T: BeaconChainTypes> {
     /// Per-validator committee slot assignments across the last 3 epochs.
     pub slot_assignments: Mutex<SlotAssignments>,
     /// Set when a database write failure has left fork choice containing a block that the
-    /// store does not have (see `handle_import_block_db_write_error`). Once set, fork choice
-    /// must never be persisted, as it would overwrite the last consistent version on disk.
+    /// store does not have, and restoring fork choice from the store also failed (see
+    /// `handle_import_block_db_write_error`). Once set, fork choice must never be persisted,
+    /// as it would overwrite the last consistent version on disk.
     fork_choice_poisoned: AtomicBool,
 }
 
@@ -516,6 +517,88 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         })
     }
 
+    /// Load a persisted version of `BeaconForkChoice` from the `store` and restore `self` to that
+    /// state.
+    ///
+    /// This is useful if some database corruption is expected and we wish to go back to our last
+    /// save-point.
+    pub(crate) fn restore_from_store(
+        &self,
+        // We don't actually need this value, however it's always present when we call this function
+        // and it needs to be dropped to prevent a dead-lock. Requiring it to be passed here is
+        // defensive programming.
+        mut fork_choice_write_lock: ForkChoiceWriteGuard<T>,
+        reset_payload_statuses: ResetPayloadStatuses,
+        store: &BeaconStore<T>,
+        spec: &ChainSpec,
+    ) -> Result<(), Error> {
+        let mut fork_choice =
+            <BeaconChain<T>>::load_fork_choice(store.clone(), reset_payload_statuses, spec)?
+                .ok_or(Error::MissingPersistedForkChoice)?;
+        let current_slot_for_head = fork_choice.fc_store().get_current_slot();
+        let (_, head_payload_status) = fork_choice.get_head(current_slot_for_head, spec)?;
+        let fork_choice_view = fork_choice.cached_fork_choice_view();
+        let beacon_block_root = fork_choice_view.head_block_root;
+        let beacon_block = store
+            .get_full_block(&beacon_block_root)?
+            .ok_or(Error::MissingBeaconBlock(beacon_block_root))?;
+        let current_slot = fork_choice.fc_store().get_current_slot();
+
+        let (_, beacon_state) = store
+            .get_advanced_hot_state(beacon_block_root, current_slot, beacon_block.state_root())?
+            .ok_or(Error::MissingBeaconState(beacon_block.state_root()))?;
+
+        // Load the execution envelope from the store if the head has a Full payload.
+        let execution_envelope = if head_payload_status == PayloadStatus::Full {
+            store
+                .get_payload_envelope(&beacon_block_root)?
+                .map(Arc::new)
+        } else {
+            None
+        };
+
+        let snapshot = Arc::new(BeaconSnapshot {
+            beacon_block_root,
+            execution_envelope,
+            beacon_block: Arc::new(beacon_block),
+            beacon_state,
+        });
+
+        let slot_assignments = SlotAssignments::new(&snapshot.beacon_state, spec, None)
+            .map_err(|e| Error::DBInconsistent(format!("slot assignments reset: {e:?}")))?;
+
+        let forkchoice_update_params = fork_choice.get_forkchoice_update_parameters();
+        let cached_head = CachedHead {
+            snapshot: snapshot.clone(),
+            justified_checkpoint: fork_choice_view.justified_checkpoint,
+            finalized_checkpoint: fork_choice_view.finalized_checkpoint,
+            head_payload_status,
+            head_hash: forkchoice_update_params.head_hash,
+            justified_hash: forkchoice_update_params.justified_hash,
+            finalized_hash: forkchoice_update_params.finalized_hash,
+        };
+
+        *fork_choice_write_lock = fork_choice;
+        // Avoid interleaving the fork choice and cached head locks.
+        drop(fork_choice_write_lock);
+        *self.cached_head.write() = cached_head;
+
+        // Reset FCR to the restored finalized checkpoint so it doesn't carry stale state.
+        if let Some(ref fcr_mutex) = self.fast_confirmation {
+            *fcr_mutex.lock() = <BeaconChain<T>>::new_fast_confirmation_rule(
+                fork_choice_view.finalized_checkpoint,
+                &snapshot,
+                slot_assignments.clone(),
+                store,
+                spec,
+            )
+            .map_err(|e| Error::DBInconsistent(format!("fast confirmation rule reset: {e:?}")))?;
+        }
+        *self.slot_assignments.lock() = slot_assignments;
+
+        Ok(())
+    }
+
     /// Mark the in-memory fork choice as diverged from the store, preventing it from ever
     /// being persisted (see `BeaconChain::persist_fork_choice`).
     pub fn poison_fork_choice(&self) {
@@ -523,7 +606,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
     }
 
     /// Returns `true` if a database write failure has left fork choice containing a block that
-    /// the store does not have.
+    /// the store does not have, and the store could not be read to restore fork choice.
     pub fn fork_choice_poisoned(&self) -> bool {
         self.fork_choice_poisoned.load(Ordering::Relaxed)
     }

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -54,7 +54,7 @@ use fast_confirmation::{
 };
 use fork_choice::{
     ExecutionStatus, ForkChoiceStore, ForkChoiceView, ForkchoiceUpdateParameters, PayloadStatus,
-    ProtoBlock, ResetPayloadStatuses,
+    ProtoBlock,
 };
 use itertools::process_results;
 
@@ -512,88 +512,6 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
             slot_assignments: Mutex::new(slot_assignments),
             fork_choice_poisoned: AtomicBool::new(false),
         })
-    }
-
-    /// Load a persisted version of `BeaconForkChoice` from the `store` and restore `self` to that
-    /// state.
-    ///
-    /// This is useful if some database corruption is expected and we wish to go back to our last
-    /// save-point.
-    pub(crate) fn restore_from_store(
-        &self,
-        // We don't actually need this value, however it's always present when we call this function
-        // and it needs to be dropped to prevent a dead-lock. Requiring it to be passed here is
-        // defensive programming.
-        mut fork_choice_write_lock: ForkChoiceWriteGuard<T>,
-        reset_payload_statuses: ResetPayloadStatuses,
-        store: &BeaconStore<T>,
-        spec: &ChainSpec,
-    ) -> Result<(), Error> {
-        let mut fork_choice =
-            <BeaconChain<T>>::load_fork_choice(store.clone(), reset_payload_statuses, spec)?
-                .ok_or(Error::MissingPersistedForkChoice)?;
-        let current_slot_for_head = fork_choice.fc_store().get_current_slot();
-        let (_, head_payload_status) = fork_choice.get_head(current_slot_for_head, spec)?;
-        let fork_choice_view = fork_choice.cached_fork_choice_view();
-        let beacon_block_root = fork_choice_view.head_block_root;
-        let beacon_block = store
-            .get_full_block(&beacon_block_root)?
-            .ok_or(Error::MissingBeaconBlock(beacon_block_root))?;
-        let current_slot = fork_choice.fc_store().get_current_slot();
-
-        let (_, beacon_state) = store
-            .get_advanced_hot_state(beacon_block_root, current_slot, beacon_block.state_root())?
-            .ok_or(Error::MissingBeaconState(beacon_block.state_root()))?;
-
-        // Load the execution envelope from the store if the head has a Full payload.
-        let execution_envelope = if head_payload_status == PayloadStatus::Full {
-            store
-                .get_payload_envelope(&beacon_block_root)?
-                .map(Arc::new)
-        } else {
-            None
-        };
-
-        let snapshot = Arc::new(BeaconSnapshot {
-            beacon_block_root,
-            execution_envelope,
-            beacon_block: Arc::new(beacon_block),
-            beacon_state,
-        });
-
-        let slot_assignments = SlotAssignments::new(&snapshot.beacon_state, spec, None)
-            .map_err(|e| Error::DBInconsistent(format!("slot assignments reset: {e:?}")))?;
-
-        let forkchoice_update_params = fork_choice.get_forkchoice_update_parameters();
-        let cached_head = CachedHead {
-            snapshot: snapshot.clone(),
-            justified_checkpoint: fork_choice_view.justified_checkpoint,
-            finalized_checkpoint: fork_choice_view.finalized_checkpoint,
-            head_payload_status,
-            head_hash: forkchoice_update_params.head_hash,
-            justified_hash: forkchoice_update_params.justified_hash,
-            finalized_hash: forkchoice_update_params.finalized_hash,
-        };
-
-        *fork_choice_write_lock = fork_choice;
-        // Avoid interleaving the fork choice and cached head locks.
-        drop(fork_choice_write_lock);
-        *self.cached_head.write() = cached_head;
-
-        // Reset FCR to the restored finalized checkpoint so it doesn't carry stale state.
-        if let Some(ref fcr_mutex) = self.fast_confirmation {
-            *fcr_mutex.lock() = <BeaconChain<T>>::new_fast_confirmation_rule(
-                fork_choice_view.finalized_checkpoint,
-                &snapshot,
-                slot_assignments.clone(),
-                store,
-                spec,
-            )
-            .map_err(|e| Error::DBInconsistent(format!("fast confirmation rule reset: {e:?}")))?;
-        }
-        *self.slot_assignments.lock() = slot_assignments;
-
-        Ok(())
     }
 
     /// Mark fork choice as poisoned so it is never persisted.

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1740,43 +1740,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Err(Error::ForkChoicePoisoned);
         }
 
-        let batch = {
-            let fork_choice = self.canonical_head.fork_choice_read_lock();
-            if let Some(missing_block_root) =
-                self.fork_choice_block_missing_from_store(&fork_choice)?
-            {
-                crit!(
-                    ?missing_block_root,
-                    advice = "restarting the node will recover the last consistent fork choice \
-                              from disk",
-                    "Refusing to persist diverged fork choice"
-                );
-                return Err(Error::ForkChoiceDivergedFromStore { missing_block_root });
-            }
-            vec![Self::persist_fork_choice_in_batch_standalone(
-                &fork_choice,
-                self.store.get_config(),
-            )?]
-        };
+        let batch = vec![self.persist_fork_choice_in_batch()?];
         self.store.hot_db.do_atomically(batch)?;
         Ok(())
-    }
-
-    /// Return a block root that is in fork choice but missing from the store, if any.
-    /// Pruned blocks from non-canonical forks may linger in proto-array without their
-    /// blocks being on disk, so only descendants of the finalized checkpoint are checked.
-    fn fork_choice_block_missing_from_store(
-        &self,
-        fork_choice: &BeaconForkChoice<T>,
-    ) -> Result<Option<Hash256>, Error> {
-        for node in &fork_choice.proto_array().core_proto_array().nodes {
-            if fork_choice.is_finalized_checkpoint_or_descendant(node.root())
-                && !self.store.block_exists(&node.root())?
-            {
-                return Ok(Some(node.root()));
-            }
-        }
-        Ok(None)
     }
 
     /// Return a database operation for writing fork choice to disk.

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -459,10 +459,9 @@ pub struct CanonicalHead<T: BeaconChainTypes> {
     pub fast_confirmation: Option<Mutex<FastConfirmationRule>>,
     /// Per-validator committee slot assignments across the last 3 epochs.
     pub slot_assignments: Mutex<SlotAssignments>,
-    /// Set when a database write failure has left fork choice containing a block that the
-    /// store does not have, and restoring fork choice from the store also failed (see
-    /// `handle_import_block_db_write_error`). Once set, fork choice must never be persisted,
-    /// as it would overwrite the last consistent version on disk.
+    /// Set when a database write failure has left fork choice in an inconsistent state.
+    /// Once this flag is set fork choice must never be persisted. This is to avoid
+    /// overwriting the last consistent version on disk.
     fork_choice_poisoned: AtomicBool,
 }
 
@@ -599,14 +598,13 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         Ok(())
     }
 
-    /// Mark the in-memory fork choice as diverged from the store, preventing it from ever
-    /// being persisted (see `BeaconChain::persist_fork_choice`).
+    /// Mark fork choice as poisoned, preventing it from ever being persisted
+    /// (see `BeaconChain::persist_fork_choice`).
     pub fn poison_fork_choice(&self) {
         self.fork_choice_poisoned.store(true, Ordering::Relaxed);
     }
 
-    /// Returns `true` if a database write failure has left fork choice containing a block that
-    /// the store does not have, and the store could not be read to restore fork choice.
+    /// Returns `true` if a database write failure has left fork choice in an inconsistent state.
     pub fn fork_choice_poisoned(&self) -> bool {
         self.fork_choice_poisoned.load(Ordering::Relaxed)
     }
@@ -1729,16 +1727,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     /// Persist fork choice to disk, writing immediately.
     ///
-    /// Fails if fork choice has been poisoned by a database write failure during block import
-    /// (see `handle_import_block_db_write_error`), or if it contains a block that is missing
-    /// from the store. Overwriting the fork choice on disk with a diverged one would cause the
-    /// next start-up to fail when resolving the head block, whereas the fork choice already on
-    /// disk allows the node to recover on restart.
+    /// Fails if fork choice has been marked as poisoned (see `handle_import_block_db_write_error`).
     pub fn persist_fork_choice(&self) -> Result<(), Error> {
         let _fork_choice_timer = metrics::start_timer(&metrics::PERSIST_FORK_CHOICE);
 
-        // This check requires no database reads, so it works even when the divergence was
-        // caused by a database fault that is still ongoing.
         if self.canonical_head.fork_choice_poisoned() {
             crit!(
                 advice = "restarting the node will recover the last consistent fork choice \
@@ -1770,9 +1762,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         Ok(())
     }
 
-    /// Return the root of a block that is in fork choice but absent from the store, if any
-    /// exists. Pruned fork blocks may linger in the proto-array without their blocks being on
-    /// disk, so only descendants of the finalized checkpoint are checked.
+    /// Return a block root that is in fork choice but missing from the store, if any.
+    /// Pruned blocks from non-canonical forks may linger in proto-array without their
+    /// blocks being on disk, so only descendants of the finalized checkpoint are checked.
     fn fork_choice_block_missing_from_store(
         &self,
         fork_choice: &BeaconForkChoice<T>,

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -54,7 +54,7 @@ use fast_confirmation::{
 };
 use fork_choice::{
     ExecutionStatus, ForkChoiceStore, ForkChoiceView, ForkchoiceUpdateParameters, PayloadStatus,
-    ProtoBlock, ResetPayloadStatuses,
+    ProtoBlock,
 };
 use itertools::process_results;
 
@@ -66,6 +66,7 @@ use state_processing::builder_deposits_cache::OnboardBuildersCache;
 use state_processing::state_advance::complete_state_advance;
 use std::ops::{Deref, DerefMut};
 use std::panic::Location;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 use store::{
@@ -458,6 +459,10 @@ pub struct CanonicalHead<T: BeaconChainTypes> {
     pub fast_confirmation: Option<Mutex<FastConfirmationRule>>,
     /// Per-validator committee slot assignments across the last 3 epochs.
     pub slot_assignments: Mutex<SlotAssignments>,
+    /// Set when a database write failure has left fork choice containing a block that the
+    /// store does not have (see `handle_import_block_db_write_error`). Once set, fork choice
+    /// must never be persisted, as it would overwrite the last consistent version on disk.
+    fork_choice_poisoned: AtomicBool,
 }
 
 impl<T: BeaconChainTypes> CanonicalHead<T> {
@@ -507,89 +512,20 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
             recompute_head_lock: Mutex::new(()),
             fast_confirmation: fcr,
             slot_assignments: Mutex::new(slot_assignments),
+            fork_choice_poisoned: AtomicBool::new(false),
         })
     }
 
-    /// Load a persisted version of `BeaconForkChoice` from the `store` and restore `self` to that
-    /// state.
-    ///
-    /// This is useful if some database corruption is expected and we wish to go back to our last
-    /// save-point.
-    pub(crate) fn restore_from_store(
-        &self,
-        // We don't actually need this value, however it's always present when we call this function
-        // and it needs to be dropped to prevent a dead-lock. Requiring it to be passed here is
-        // defensive programming.
-        mut fork_choice_write_lock: ForkChoiceWriteGuard<T>,
-        reset_payload_statuses: ResetPayloadStatuses,
-        store: &BeaconStore<T>,
-        spec: &ChainSpec,
-    ) -> Result<(), Error> {
-        let mut fork_choice =
-            <BeaconChain<T>>::load_fork_choice(store.clone(), reset_payload_statuses, spec)?
-                .ok_or(Error::MissingPersistedForkChoice)?;
-        let current_slot_for_head = fork_choice.fc_store().get_current_slot();
-        let (_, head_payload_status) = fork_choice.get_head(current_slot_for_head, spec)?;
-        let fork_choice_view = fork_choice.cached_fork_choice_view();
-        let beacon_block_root = fork_choice_view.head_block_root;
-        let beacon_block = store
-            .get_full_block(&beacon_block_root)?
-            .ok_or(Error::MissingBeaconBlock(beacon_block_root))?;
-        let current_slot = fork_choice.fc_store().get_current_slot();
+    /// Mark the in-memory fork choice as diverged from the store, preventing it from ever
+    /// being persisted (see `BeaconChain::persist_fork_choice`).
+    pub fn poison_fork_choice(&self) {
+        self.fork_choice_poisoned.store(true, Ordering::Relaxed);
+    }
 
-        let (_, beacon_state) = store
-            .get_advanced_hot_state(beacon_block_root, current_slot, beacon_block.state_root())?
-            .ok_or(Error::MissingBeaconState(beacon_block.state_root()))?;
-
-        // Load the execution envelope from the store if the head has a Full payload.
-        let execution_envelope = if head_payload_status == PayloadStatus::Full {
-            store
-                .get_payload_envelope(&beacon_block_root)?
-                .map(Arc::new)
-        } else {
-            None
-        };
-
-        let snapshot = Arc::new(BeaconSnapshot {
-            beacon_block_root,
-            execution_envelope,
-            beacon_block: Arc::new(beacon_block),
-            beacon_state,
-        });
-
-        let slot_assignments = SlotAssignments::new(&snapshot.beacon_state, spec, None)
-            .map_err(|e| Error::DBInconsistent(format!("slot assignments reset: {e:?}")))?;
-
-        let forkchoice_update_params = fork_choice.get_forkchoice_update_parameters();
-        let cached_head = CachedHead {
-            snapshot: snapshot.clone(),
-            justified_checkpoint: fork_choice_view.justified_checkpoint,
-            finalized_checkpoint: fork_choice_view.finalized_checkpoint,
-            head_payload_status,
-            head_hash: forkchoice_update_params.head_hash,
-            justified_hash: forkchoice_update_params.justified_hash,
-            finalized_hash: forkchoice_update_params.finalized_hash,
-        };
-
-        *fork_choice_write_lock = fork_choice;
-        // Avoid interleaving the fork choice and cached head locks.
-        drop(fork_choice_write_lock);
-        *self.cached_head.write() = cached_head;
-
-        // Reset FCR to the restored finalized checkpoint so it doesn't carry stale state.
-        if let Some(ref fcr_mutex) = self.fast_confirmation {
-            *fcr_mutex.lock() = <BeaconChain<T>>::new_fast_confirmation_rule(
-                fork_choice_view.finalized_checkpoint,
-                &snapshot,
-                slot_assignments.clone(),
-                store,
-                spec,
-            )
-            .map_err(|e| Error::DBInconsistent(format!("fast confirmation rule reset: {e:?}")))?;
-        }
-        *self.slot_assignments.lock() = slot_assignments;
-
-        Ok(())
+    /// Returns `true` if a database write failure has left fork choice containing a block that
+    /// the store does not have.
+    pub fn fork_choice_poisoned(&self) -> bool {
+        self.fork_choice_poisoned.load(Ordering::Relaxed)
     }
 
     /// Returns the execution status of the block at the head of the beacon chain.
@@ -1710,13 +1646,25 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     /// Persist fork choice to disk, writing immediately.
     ///
-    /// Refuses to write if fork choice contains a block that is missing from the store, as can
-    /// happen if a database write fails during block import (see
-    /// `handle_import_block_db_write_error`). Overwriting the fork choice on disk with a
-    /// diverged one would cause the next start-up to fail when resolving the head block,
-    /// whereas the fork choice already on disk allows the node to recover on restart.
+    /// Fails if fork choice has been poisoned by a database write failure during block import
+    /// (see `handle_import_block_db_write_error`), or if it contains a block that is missing
+    /// from the store. Overwriting the fork choice on disk with a diverged one would cause the
+    /// next start-up to fail when resolving the head block, whereas the fork choice already on
+    /// disk allows the node to recover on restart.
     pub fn persist_fork_choice(&self) -> Result<(), Error> {
         let _fork_choice_timer = metrics::start_timer(&metrics::PERSIST_FORK_CHOICE);
+
+        // This check requires no database reads, so it works even when the divergence was
+        // caused by a database fault that is still ongoing.
+        if self.canonical_head.fork_choice_poisoned() {
+            crit!(
+                advice = "restarting the node will recover the last consistent fork choice \
+                          from disk",
+                "Refusing to persist poisoned fork choice"
+            );
+            return Err(Error::ForkChoicePoisoned);
+        }
+
         let batch = {
             let fork_choice = self.canonical_head.fork_choice_read_lock();
             if let Some(missing_block_root) =

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -791,6 +791,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         self: &Arc<Self>,
         current_slot: Slot,
     ) -> Result<Option<JoinHandle<Option<()>>>, Error> {
+        if self.canonical_head.fork_choice_poisoned() {
+            debug!("Skipping head recomputation: fork choice is poisoned");
+            return Ok(None);
+        }
+
         let recompute_head_lock = self.canonical_head.recompute_head_lock.lock();
 
         // Take a clone of the current ("old") head.

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -459,9 +459,7 @@ pub struct CanonicalHead<T: BeaconChainTypes> {
     pub fast_confirmation: Option<Mutex<FastConfirmationRule>>,
     /// Per-validator committee slot assignments across the last 3 epochs.
     pub slot_assignments: Mutex<SlotAssignments>,
-    /// Set when a database write failure has left fork choice in an inconsistent state.
-    /// Once this flag is set fork choice must never be persisted. This is to avoid
-    /// overwriting the last consistent version on disk.
+    /// Set when fork choice has diverged from the store. Poisoned fork choice is never persisted.
     fork_choice_poisoned: AtomicBool,
 }
 
@@ -598,13 +596,12 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         Ok(())
     }
 
-    /// Mark fork choice as poisoned, preventing it from ever being persisted
-    /// (see `BeaconChain::persist_fork_choice`).
+    /// Mark fork choice as poisoned so it is never persisted.
     pub fn poison_fork_choice(&self) {
         self.fork_choice_poisoned.store(true, Ordering::Relaxed);
     }
 
-    /// Returns `true` if a database write failure has left fork choice in an inconsistent state.
+    /// Returns `true` if fork choice has diverged from the store.
     pub fn fork_choice_poisoned(&self) -> bool {
         self.fork_choice_poisoned.load(Ordering::Relaxed)
     }
@@ -1727,7 +1724,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     /// Persist fork choice to disk, writing immediately.
     ///
-    /// Fails if fork choice has been marked as poisoned (see `handle_import_block_db_write_error`).
+    /// Fails if fork choice is poisoned.
     pub fn persist_fork_choice(&self) -> Result<(), Error> {
         let _fork_choice_timer = metrics::start_timer(&metrics::PERSIST_FORK_CHOICE);
 

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1709,11 +1709,51 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     }
 
     /// Persist fork choice to disk, writing immediately.
+    ///
+    /// Refuses to write if fork choice contains a block that is missing from the store, as can
+    /// happen if a database write fails during block import (see
+    /// `handle_import_block_db_write_error`). Overwriting the fork choice on disk with a
+    /// diverged one would cause the next start-up to fail when resolving the head block,
+    /// whereas the fork choice already on disk allows the node to recover on restart.
     pub fn persist_fork_choice(&self) -> Result<(), Error> {
         let _fork_choice_timer = metrics::start_timer(&metrics::PERSIST_FORK_CHOICE);
-        let batch = vec![self.persist_fork_choice_in_batch()?];
+        let batch = {
+            let fork_choice = self.canonical_head.fork_choice_read_lock();
+            if let Some(missing_block_root) =
+                self.fork_choice_block_missing_from_store(&fork_choice)?
+            {
+                crit!(
+                    ?missing_block_root,
+                    advice = "restarting the node will recover the last consistent fork choice \
+                              from disk",
+                    "Refusing to persist diverged fork choice"
+                );
+                return Err(Error::ForkChoiceDivergedFromStore { missing_block_root });
+            }
+            vec![Self::persist_fork_choice_in_batch_standalone(
+                &fork_choice,
+                self.store.get_config(),
+            )?]
+        };
         self.store.hot_db.do_atomically(batch)?;
         Ok(())
+    }
+
+    /// Return the root of a block that is in fork choice but absent from the store, if any
+    /// exists. Pruned fork blocks may linger in the proto-array without their blocks being on
+    /// disk, so only descendants of the finalized checkpoint are checked.
+    fn fork_choice_block_missing_from_store(
+        &self,
+        fork_choice: &BeaconForkChoice<T>,
+    ) -> Result<Option<Hash256>, Error> {
+        for node in &fork_choice.proto_array().core_proto_array().nodes {
+            if fork_choice.is_finalized_checkpoint_or_descendant(node.root())
+                && !self.store.block_exists(&node.root())?
+            {
+                return Ok(Some(node.root()));
+            }
+        }
+        Ok(None)
     }
 
     /// Return a database operation for writing fork choice to disk.

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -215,6 +215,9 @@ pub enum BeaconChainError {
     },
     AttestationHeadNotInForkChoice(Hash256),
     MissingPersistedForkChoice,
+    ForkChoiceDivergedFromStore {
+        missing_block_root: Hash256,
+    },
     CommitteePromiseFailed(oneshot_broadcast::Error),
     MaxCommitteePromises(usize),
     BlsToExecutionPriorToCapella,

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -218,6 +218,7 @@ pub enum BeaconChainError {
     ForkChoiceDivergedFromStore {
         missing_block_root: Hash256,
     },
+    ForkChoicePoisoned,
     CommitteePromiseFailed(oneshot_broadcast::Error),
     MaxCommitteePromises(usize),
     BlsToExecutionPriorToCapella,

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -215,9 +215,6 @@ pub enum BeaconChainError {
     },
     AttestationHeadNotInForkChoice(Hash256),
     MissingPersistedForkChoice,
-    ForkChoiceDivergedFromStore {
-        missing_block_root: Hash256,
-    },
     ForkChoicePoisoned,
     CommitteePromiseFailed(oneshot_broadcast::Error),
     MaxCommitteePromises(usize),

--- a/beacon_node/beacon_chain/tests/store_fault_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_fault_tests.rs
@@ -23,7 +23,6 @@ use beacon_chain::{
     },
 };
 use eth2::types::SignedBlockContentsTuple;
-use store::StoreOp;
 use task_executor::ShutdownReason;
 use types::*;
 
@@ -311,52 +310,5 @@ async fn restart_after_db_write_failure_recovers() {
             .unwrap()
             .is_some(),
         "the recovered head must exist in the store"
-    );
-}
-
-/// Persisting fork choice checks the store for every block, so it refuses even when the
-/// poison flag was never set.
-#[tokio::test]
-async fn persist_refuses_diverged_fork_choice() {
-    if incompatible_fork() {
-        return;
-    }
-    let harness = BeaconChainHarness::builder(MinimalEthSpec)
-        .default_spec()
-        .deterministic_keypairs(VALIDATOR_COUNT)
-        .fresh_ephemeral_store()
-        .mock_execution_layer()
-        .build();
-
-    harness.advance_slot();
-    harness
-        .extend_chain(
-            2 * E::slots_per_epoch() as usize,
-            BlockStrategy::OnCanonicalHead,
-            AttestationStrategy::AllValidators,
-        )
-        .await;
-
-    // Delete the head block from the store, leaving fork choice referencing a block that
-    // the store does not have.
-    let head_root = harness.chain.canonical_head.cached_head().head_block_root();
-    harness
-        .chain
-        .store
-        .do_atomically_with_block_and_blobs_cache(vec![StoreOp::DeleteBlock(head_root)])
-        .unwrap();
-
-    assert!(
-        !harness.chain.canonical_head.fork_choice_poisoned(),
-        "the poison flag should not be set"
-    );
-    let err = harness.chain.persist_fork_choice().unwrap_err();
-    assert!(
-        matches!(
-            err,
-            BeaconChainError::ForkChoiceDivergedFromStore { missing_block_root }
-                if missing_block_root == head_root
-        ),
-        "persisting should refuse with the deleted block root, got: {err:?}"
     );
 }

--- a/beacon_node/beacon_chain/tests/store_fault_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_fault_tests.rs
@@ -10,10 +10,9 @@
 //! - children of the phantom block fail with `MissingBeaconBlock` instead of `ParentUnknown`,
 //! - head recomputation fails and the head cannot advance.
 //!
-//! The node first tries to restore the last persisted fork choice from disk. If the restore fails
-//! we mark fork choice as poisoned and initiate a forced shutdown. The posioned fork choice is
-//! never persisted to disk, so a restart recovers the last valid fork choice from disk and re-syncs
-//! any missing blocks, including the phantom block.
+//! On a failed write we mark fork choice as poisoned and initiate a forced shutdown. The poisoned
+//! fork choice is never persisted to disk, so a restart recovers the last valid fork choice from
+//! disk.
 
 use beacon_chain::{
     BeaconChainError, BlockError,
@@ -46,9 +45,8 @@ struct WedgedChain {
 
 /// Build a chain, then import a block while every store operation fails.
 ///
-/// The import adds the block to fork choice, then fails the database write, then fails
-/// the restore of fork choice from the store. The returned chain has a fork choice
-/// containing `phantom_root` while the store does not.
+/// The import adds the block to fork choice, then fails the database write. The returned
+/// chain has a fork choice containing `phantom_root` while the store does not.
 async fn wedged_chain() -> WedgedChain {
     let harness = BeaconChainHarness::builder(MinimalEthSpec)
         .default_spec()
@@ -130,8 +128,7 @@ async fn db_write_failure_poisons_fork_choice_and_shuts_down() {
         "the store should not contain the phantom block"
     );
 
-    // The restore from the store fails too, so the failure poisons fork choice and requests
-    // shutdown.
+    // The failure poisons fork choice and requests shutdown.
     assert!(
         harness.chain.canonical_head.fork_choice_poisoned(),
         "fork choice should be poisoned"
@@ -181,89 +178,6 @@ async fn db_write_failure_poisons_fork_choice_and_shuts_down() {
         phantom_root,
         "the head should not advance to the phantom block"
     );
-}
-
-/// A transient write failure is recoverabe by restoring fork choice from the store.
-/// No shutdown is requested.
-#[tokio::test]
-async fn transient_db_write_failure_restores_fork_choice() {
-    if incompatible_fork() {
-        return;
-    }
-    let harness = BeaconChainHarness::builder(MinimalEthSpec)
-        .default_spec()
-        .deterministic_keypairs(VALIDATOR_COUNT)
-        .fresh_ephemeral_store()
-        .mock_execution_layer()
-        .build();
-
-    harness.advance_slot();
-    harness
-        .extend_chain(
-            2 * E::slots_per_epoch() as usize,
-            BlockStrategy::OnCanonicalHead,
-            AttestationStrategy::AllValidators,
-        )
-        .await;
-
-    let head_root_before = harness.chain.canonical_head.cached_head().head_block_root();
-    let state = harness.get_current_state();
-    let slot = harness.chain.slot().unwrap() + 1;
-    let (block_contents, _) = harness.make_block(state, slot).await;
-    let block_root = block_contents.0.canonical_root();
-
-    // Fail only the block's database write. Reads and later writes succeed.
-    harness
-        .chain
-        .store
-        .hot_db
-        .inject_transient_fault_on_next_block_write();
-
-    let err = harness
-        .process_block(slot, block_root, block_contents.clone())
-        .await
-        .unwrap_err();
-    assert!(
-        matches!(err, BlockError::BeaconChainError(_)),
-        "import should fail with an internal error, got: {err:?}"
-    );
-
-    // Fork choice was restored from the store, so it no longer contains the block and is
-    // consistent with the store again.
-    assert!(
-        !harness
-            .chain
-            .canonical_head
-            .fork_choice_read_lock()
-            .contains_block(&block_root),
-        "fork choice should not contain the block after the restore"
-    );
-    assert!(
-        !harness.chain.canonical_head.fork_choice_poisoned(),
-        "fork choice should not be poisoned"
-    );
-    assert!(
-        harness.shutdown_reasons().is_empty(),
-        "the chain should not request shutdown"
-    );
-    assert_eq!(
-        harness.chain.canonical_head.cached_head().head_block_root(),
-        head_root_before,
-        "the head should be unchanged"
-    );
-
-    // The block can be re-imported and becomes the head.
-    harness
-        .process_block(slot, block_root, block_contents)
-        .await
-        .unwrap();
-    harness.chain.recompute_head_at_current_slot().await;
-    assert_eq!(
-        harness.chain.canonical_head.cached_head().head_block_root(),
-        block_root,
-        "the head should advance to the re-imported block"
-    );
-    harness.chain.persist_fork_choice().unwrap();
 }
 
 #[tokio::test]

--- a/beacon_node/beacon_chain/tests/store_fault_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_fault_tests.rs
@@ -11,8 +11,8 @@
 //! - The node refuses to re-import the missing block.
 //! - Children of the missing block fail with `MissingBeaconBlock` instead of `ParentUnknown`.
 //! - Head recomputation fails and the head cannot advance.
-//! - A graceful shutdown persists the diverged fork choice, making the next startup fail
-//!   with "Head block not found in store".
+//! - A graceful shutdown refuses to persist the diverged fork choice, so a restart
+//!   recovers the last consistent fork choice from disk.
 
 use beacon_chain::{
     BeaconChainError, BlockError,
@@ -22,7 +22,6 @@ use beacon_chain::{
     },
 };
 use eth2::types::SignedBlockContentsTuple;
-use std::panic::{AssertUnwindSafe, catch_unwind};
 use types::*;
 
 const VALIDATOR_COUNT: usize = 32;
@@ -170,44 +169,54 @@ async fn db_write_failure_diverges_fork_choice_from_store() {
     );
 }
 
-// TODO: this test asserts the *broken* behaviour. Once shutdown stops persisting a
-// known-diverged fork choice (or startup self-heals), this test should FAIL. Flip the
-// assertions to the healed behaviour as part of the fix.
 #[tokio::test]
-async fn restart_after_db_write_failure_is_fatal() {
+async fn restart_after_db_write_failure_recovers() {
     if incompatible_fork() {
         return;
     }
-    let WedgedChain { harness, .. } = wedged_chain().await;
+    let WedgedChain {
+        harness,
+        phantom_root,
+        ..
+    } = wedged_chain().await;
 
     let store = harness.chain.store.clone();
     let slot_clock = harness.chain.slot_clock.clone();
 
-    // A graceful shutdown persists the diverged fork choice (see `Drop` for
-    // `BeaconChain`).
-    harness.chain.persist_fork_choice().unwrap();
+    // A graceful shutdown refuses to persist the diverged fork choice, keeping the last
+    // consistent fork choice on disk (see `Drop` for `BeaconChain`).
+    let err = harness.chain.persist_fork_choice().unwrap_err();
+    assert!(
+        matches!(
+            err,
+            BeaconChainError::ForkChoiceDivergedFromStore { missing_block_root }
+                if missing_block_root == phantom_root
+        ),
+        "persisting should refuse with the phantom block root, got: {err:?}"
+    );
     drop(harness);
 
-    // Rebooting from the same database fails, because the persisted fork choice resolves
-    // a head block that was never written to the store.
-    let result = catch_unwind(AssertUnwindSafe(|| {
-        BeaconChainHarness::builder(MinimalEthSpec)
-            .default_spec()
-            .deterministic_keypairs(VALIDATOR_COUNT)
-            .resumed_ephemeral_store(store)
-            .mock_execution_layer()
-            .testing_slot_clock(slot_clock)
-            .build()
-    }));
+    // Rebooting from the same database succeeds, resolving the head from the last
+    // consistent fork choice on disk.
+    let harness = BeaconChainHarness::builder(MinimalEthSpec)
+        .default_spec()
+        .deterministic_keypairs(VALIDATOR_COUNT)
+        .resumed_ephemeral_store(store)
+        .mock_execution_layer()
+        .testing_slot_clock(slot_clock)
+        .build();
 
-    let panic_payload = result.expect_err("the beacon chain should fail to start");
-    let message = panic_payload
-        .downcast_ref::<String>()
-        .cloned()
-        .or_else(|| panic_payload.downcast_ref::<&str>().map(|s| s.to_string()))
-        .unwrap_or_default();
+    let head_root = harness.chain.canonical_head.cached_head().head_block_root();
+    assert_ne!(
+        head_root, phantom_root,
+        "the recovered head should not be the phantom block"
+    );
     assert!(
-        message.contains("Head block not found in store"),
-        "startup should fail on the missing head block, got: {message}"
+        harness
+            .chain
+            .get_blinded_block(&head_root)
+            .unwrap()
+            .is_some(),
+        "the recovered head must exist in the store"
     );
 }

--- a/beacon_node/beacon_chain/tests/store_fault_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_fault_tests.rs
@@ -170,8 +170,8 @@ async fn db_write_failure_poisons_fork_choice_and_shuts_down() {
         other => panic!("expected MissingBeaconBlock for the child block, got: {other:?}"),
     }
 
-    // Head recomputation cannot load the fork choice head from the store, so the head
-    // never advances to the phantom block.
+    // Head recomputation is a no-op while fork choice is poisoned, so the head never
+    // advances to the phantom block.
     harness.chain.recompute_head_at_current_slot().await;
     assert_ne!(
         harness.chain.canonical_head.cached_head().head_block_root(),

--- a/beacon_node/beacon_chain/tests/store_fault_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_fault_tests.rs
@@ -1,18 +1,20 @@
 #![cfg(not(debug_assertions))]
 
-//! Tests for divergence between fork choice and the store when the db fails
-//! during block import.
+//! Tests for the handling of database write failures during block import.
 //!
-//! If the database write for a block fails after the block has been added to
-//! fork choice, and the recovery step `handle_import_block_db_write_error` also fails,
-//! then fork choice contains a block that the store does not. These tests check for the
-//! following behaviour:
+//! If the database write for a block fails after the block has been added to the in-memory
+//! fork choice, then fork choice contains a block that the store does not. There is no
+//! reliable in-process recovery: restoring fork choice by reading the database is likely to
+//! fail for the same reason the write failed (e.g. file descriptor exhaustion affects both
+//! reads and writes), and a node that keeps running with the divergence is wedged:
 //!
-//! - The node refuses to re-import the missing block.
-//! - Children of the missing block fail with `MissingBeaconBlock` instead of `ParentUnknown`.
-//! - Head recomputation fails and the head cannot advance.
-//! - A graceful shutdown refuses to persist the diverged fork choice, so a restart
-//!   recovers the last consistent fork choice from disk.
+//! - the node refuses to re-import the phantom block (duplicate detection uses fork choice),
+//! - children of the phantom block fail with `MissingBeaconBlock` instead of `ParentUnknown`,
+//! - head recomputation fails and the head cannot advance.
+//!
+//! Instead of running wedged, the chain poisons fork choice and initiates shutdown. The
+//! poisoned fork choice is never persisted, so a restart recovers the last consistent fork
+//! choice from disk and re-syncs the phantom blocks.
 
 use beacon_chain::{
     BeaconChainError, BlockError,
@@ -22,6 +24,8 @@ use beacon_chain::{
     },
 };
 use eth2::types::SignedBlockContentsTuple;
+use store::StoreOp;
+use task_executor::ShutdownReason;
 use types::*;
 
 const VALIDATOR_COUNT: usize = 32;
@@ -44,9 +48,8 @@ struct WedgedChain {
 
 /// Build a chain, then import a block while every store operation fails.
 ///
-/// The import adds the block to fork choice, then fails the database write, then fails
-/// the recovery read. The returned chain has a fork choice containing `phantom_root`
-/// while the store does not.
+/// The import adds the block to fork choice, then fails the database write. The returned
+/// chain has a fork choice containing `phantom_root` while the store does not.
 async fn wedged_chain() -> WedgedChain {
     let harness = BeaconChainHarness::builder(MinimalEthSpec)
         .default_spec()
@@ -97,11 +100,8 @@ async fn wedged_chain() -> WedgedChain {
     }
 }
 
-// TODO: this test asserts the *broken* behaviour. Once the divergence is fixed (e.g. by
-// reverting fork choice in memory or refusing to run diverged), this test should FAIL.
-// Flip the assertions to the healed behaviour as part of the fix.
 #[tokio::test]
-async fn db_write_failure_diverges_fork_choice_from_store() {
+async fn db_write_failure_poisons_fork_choice_and_shuts_down() {
     if incompatible_fork() {
         return;
     }
@@ -130,6 +130,23 @@ async fn db_write_failure_diverges_fork_choice_from_store() {
             .is_none(),
         "the store should not contain the phantom block"
     );
+
+    // The failure poisons fork choice and requests shutdown, because there is no reliable
+    // in-process recovery from the divergence.
+    assert!(
+        harness.chain.canonical_head.fork_choice_poisoned(),
+        "fork choice should be poisoned"
+    );
+    assert_eq!(
+        harness.shutdown_reasons(),
+        vec![ShutdownReason::Failure(
+            "Database write failure during block import"
+        )],
+        "the chain should request shutdown"
+    );
+
+    // The assertions below pin the wedged behaviour that makes shutdown the only safe
+    // option. Until the process exits, the divergence is self-perpetuating:
 
     // The node refuses to re-import the phantom block, because duplicate detection only
     // checks fork choice.
@@ -183,16 +200,13 @@ async fn restart_after_db_write_failure_recovers() {
     let store = harness.chain.store.clone();
     let slot_clock = harness.chain.slot_clock.clone();
 
-    // A graceful shutdown refuses to persist the diverged fork choice, keeping the last
-    // consistent fork choice on disk (see `Drop` for `BeaconChain`).
+    // A graceful shutdown refuses to persist the poisoned fork choice, keeping the last
+    // consistent fork choice on disk (see `Drop` for `BeaconChain`). This check requires no
+    // database reads, so it holds even if the database fault is still ongoing.
     let err = harness.chain.persist_fork_choice().unwrap_err();
     assert!(
-        matches!(
-            err,
-            BeaconChainError::ForkChoiceDivergedFromStore { missing_block_root }
-                if missing_block_root == phantom_root
-        ),
-        "persisting should refuse with the phantom block root, got: {err:?}"
+        matches!(err, BeaconChainError::ForkChoicePoisoned),
+        "persisting should refuse due to the poisoned fork choice, got: {err:?}"
     );
     drop(harness);
 
@@ -218,5 +232,53 @@ async fn restart_after_db_write_failure_recovers() {
             .unwrap()
             .is_some(),
         "the recovered head must exist in the store"
+    );
+}
+
+/// The persist-time store scan is a second line of defence: it catches divergence that
+/// arose without the poison flag being set, e.g. from a database fault on a path that does
+/// not run `handle_import_block_db_write_error`.
+#[tokio::test]
+async fn persist_refuses_diverged_fork_choice() {
+    if incompatible_fork() {
+        return;
+    }
+    let harness = BeaconChainHarness::builder(MinimalEthSpec)
+        .default_spec()
+        .deterministic_keypairs(VALIDATOR_COUNT)
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build();
+
+    harness.advance_slot();
+    harness
+        .extend_chain(
+            2 * E::slots_per_epoch() as usize,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    // Delete the head block from the store, leaving fork choice referencing a block that
+    // the store does not have.
+    let head_root = harness.chain.canonical_head.cached_head().head_block_root();
+    harness
+        .chain
+        .store
+        .do_atomically_with_block_and_blobs_cache(vec![StoreOp::DeleteBlock(head_root)])
+        .unwrap();
+
+    assert!(
+        !harness.chain.canonical_head.fork_choice_poisoned(),
+        "the poison flag should not be set"
+    );
+    let err = harness.chain.persist_fork_choice().unwrap_err();
+    assert!(
+        matches!(
+            err,
+            BeaconChainError::ForkChoiceDivergedFromStore { missing_block_root }
+                if missing_block_root == head_root
+        ),
+        "persisting should refuse with the deleted block root, got: {err:?}"
     );
 }

--- a/beacon_node/beacon_chain/tests/store_fault_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_fault_tests.rs
@@ -3,18 +3,18 @@
 //! Tests for the handling of database write failures during block import.
 //!
 //! If the database write for a block fails after the block has been added to the in-memory
-//! fork choice, then fork choice contains a block that the store does not. There is no
-//! reliable in-process recovery: restoring fork choice by reading the database is likely to
-//! fail for the same reason the write failed (e.g. file descriptor exhaustion affects both
-//! reads and writes), and a node that keeps running with the divergence is wedged:
+//! fork choice, then fork choice contains a block that the store does not. A node that keeps
+//! running with the divergence is wedged:
 //!
 //! - the node refuses to re-import the phantom block (duplicate detection uses fork choice),
 //! - children of the phantom block fail with `MissingBeaconBlock` instead of `ParentUnknown`,
 //! - head recomputation fails and the head cannot advance.
 //!
-//! Instead of running wedged, the chain poisons fork choice and initiates shutdown. The
-//! poisoned fork choice is never persisted, so a restart recovers the last consistent fork
-//! choice from disk and re-syncs the phantom blocks.
+//! The chain first tries to restore fork choice from the last version persisted to the store,
+//! which recovers from a transient write failure in-process. If the restore also fails (e.g.
+//! file descriptor exhaustion affects both reads and writes), the chain poisons fork choice
+//! and initiates shutdown. The poisoned fork choice is never persisted, so a restart recovers
+//! the last consistent fork choice from disk and re-syncs the phantom blocks.
 
 use beacon_chain::{
     BeaconChainError, BlockError,
@@ -48,8 +48,9 @@ struct WedgedChain {
 
 /// Build a chain, then import a block while every store operation fails.
 ///
-/// The import adds the block to fork choice, then fails the database write. The returned
-/// chain has a fork choice containing `phantom_root` while the store does not.
+/// The import adds the block to fork choice, then fails the database write, then fails
+/// the restore of fork choice from the store. The returned chain has a fork choice
+/// containing `phantom_root` while the store does not.
 async fn wedged_chain() -> WedgedChain {
     let harness = BeaconChainHarness::builder(MinimalEthSpec)
         .default_spec()
@@ -131,8 +132,8 @@ async fn db_write_failure_poisons_fork_choice_and_shuts_down() {
         "the store should not contain the phantom block"
     );
 
-    // The failure poisons fork choice and requests shutdown, because there is no reliable
-    // in-process recovery from the divergence.
+    // The restore from the store fails too, so the failure poisons fork choice and requests
+    // shutdown.
     assert!(
         harness.chain.canonical_head.fork_choice_poisoned(),
         "fork choice should be poisoned"
@@ -184,6 +185,89 @@ async fn db_write_failure_poisons_fork_choice_and_shuts_down() {
         phantom_root,
         "the head should not advance to the phantom block"
     );
+}
+
+/// A transient write failure, where the store stays readable, is recovered in-process by
+/// restoring fork choice from the store. No shutdown is requested.
+#[tokio::test]
+async fn transient_db_write_failure_restores_fork_choice() {
+    if incompatible_fork() {
+        return;
+    }
+    let harness = BeaconChainHarness::builder(MinimalEthSpec)
+        .default_spec()
+        .deterministic_keypairs(VALIDATOR_COUNT)
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build();
+
+    harness.advance_slot();
+    harness
+        .extend_chain(
+            2 * E::slots_per_epoch() as usize,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    let head_root_before = harness.chain.canonical_head.cached_head().head_block_root();
+    let state = harness.get_current_state();
+    let slot = harness.chain.slot().unwrap() + 1;
+    let (block_contents, _) = harness.make_block(state, slot).await;
+    let block_root = block_contents.0.canonical_root();
+
+    // Fail only the block's database write. Reads and later writes succeed.
+    harness
+        .chain
+        .store
+        .hot_db
+        .inject_transient_fault_on_next_block_write();
+
+    let err = harness
+        .process_block(slot, block_root, block_contents.clone())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, BlockError::BeaconChainError(_)),
+        "import should fail with an internal error, got: {err:?}"
+    );
+
+    // Fork choice was restored from the store, so it no longer contains the block and is
+    // consistent with the store again.
+    assert!(
+        !harness
+            .chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .contains_block(&block_root),
+        "fork choice should not contain the block after the restore"
+    );
+    assert!(
+        !harness.chain.canonical_head.fork_choice_poisoned(),
+        "fork choice should not be poisoned"
+    );
+    assert!(
+        harness.shutdown_reasons().is_empty(),
+        "the chain should not request shutdown"
+    );
+    assert_eq!(
+        harness.chain.canonical_head.cached_head().head_block_root(),
+        head_root_before,
+        "the head should be unchanged"
+    );
+
+    // The block can be re-imported and becomes the head.
+    harness
+        .process_block(slot, block_root, block_contents)
+        .await
+        .unwrap();
+    harness.chain.recompute_head_at_current_slot().await;
+    assert_eq!(
+        harness.chain.canonical_head.cached_head().head_block_root(),
+        block_root,
+        "the head should advance to the re-imported block"
+    );
+    harness.chain.persist_fork_choice().unwrap();
 }
 
 #[tokio::test]

--- a/beacon_node/beacon_chain/tests/store_fault_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_fault_tests.rs
@@ -2,19 +2,18 @@
 
 //! Tests for the handling of database write failures during block import.
 //!
-//! If the database write for a block fails after the block has been added to the in-memory
-//! fork choice, then fork choice contains a block that the store does not. A node that keeps
-//! running with the divergence is wedged:
+//! If the node fails to write a block to disk after its been imported to fork choice, this puts
+//! fork choice in an inconsistent state. We call this missing block a "phantom" block.
+//! A node that continues running in this state is stuck
 //!
-//! - the node refuses to re-import the phantom block (duplicate detection uses fork choice),
+//! - the node refuses to re-import the phantom block.
 //! - children of the phantom block fail with `MissingBeaconBlock` instead of `ParentUnknown`,
 //! - head recomputation fails and the head cannot advance.
 //!
-//! The chain first tries to restore fork choice from the last version persisted to the store,
-//! which recovers from a transient write failure in-process. If the restore also fails (e.g.
-//! file descriptor exhaustion affects both reads and writes), the chain poisons fork choice
-//! and initiates shutdown. The poisoned fork choice is never persisted, so a restart recovers
-//! the last consistent fork choice from disk and re-syncs the phantom blocks.
+//! The node first tries to restore the last persisted fork choice from disk. If the restore fails
+//! we mark fork choice as poisoned and initiate a forced shutdown. The posioned fork choice is
+//! never persisted to disk, so a restart recovers the last valid fork choice from disk and re-syncs
+//! any missing blocks, including the phantom block.
 
 use beacon_chain::{
     BeaconChainError, BlockError,
@@ -146,11 +145,9 @@ async fn db_write_failure_poisons_fork_choice_and_shuts_down() {
         "the chain should request shutdown"
     );
 
-    // The assertions below pin the wedged behaviour that makes shutdown the only safe
-    // option. Until the process exits, the divergence is self-perpetuating:
-
-    // The node refuses to re-import the phantom block, because duplicate detection only
-    // checks fork choice.
+    // The assertions below pin the "stuck node" behaviour that makes shutdown the only safe
+    // option. Until the process exits the node refuses to re-import the phantom block, because
+    // duplicate detection only checks fork choice.
     let err = harness
         .process_block(phantom_slot, phantom_root, phantom_contents)
         .await
@@ -187,8 +184,8 @@ async fn db_write_failure_poisons_fork_choice_and_shuts_down() {
     );
 }
 
-/// A transient write failure, where the store stays readable, is recovered in-process by
-/// restoring fork choice from the store. No shutdown is requested.
+/// A transient write failure is recoverabe by restoring fork choice from the store.
+/// No shutdown is requested.
 #[tokio::test]
 async fn transient_db_write_failure_restores_fork_choice() {
     if incompatible_fork() {
@@ -284,9 +281,7 @@ async fn restart_after_db_write_failure_recovers() {
     let store = harness.chain.store.clone();
     let slot_clock = harness.chain.slot_clock.clone();
 
-    // A graceful shutdown refuses to persist the poisoned fork choice, keeping the last
-    // consistent fork choice on disk (see `Drop` for `BeaconChain`). This check requires no
-    // database reads, so it holds even if the database fault is still ongoing.
+    // A graceful shutdown refuses to persist the poisoned fork choice.
     let err = harness.chain.persist_fork_choice().unwrap_err();
     assert!(
         matches!(err, BeaconChainError::ForkChoicePoisoned),
@@ -319,9 +314,8 @@ async fn restart_after_db_write_failure_recovers() {
     );
 }
 
-/// The persist-time store scan is a second line of defence: it catches divergence that
-/// arose without the poison flag being set, e.g. from a database fault on a path that does
-/// not run `handle_import_block_db_write_error`.
+/// Persisting fork choice checks the store for every block, so it refuses even when the
+/// poison flag was never set.
 #[tokio::test]
 async fn persist_refuses_diverged_fork_choice() {
     if incompatible_fork() {

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -13,7 +13,6 @@ pub struct MemoryStore {
     db: RwLock<DBMap>,
     fault: AtomicBool,
     fault_armed: AtomicBool,
-    transient_fault_armed: AtomicBool,
 }
 
 impl MemoryStore {
@@ -23,7 +22,6 @@ impl MemoryStore {
             db: RwLock::new(BTreeMap::new()),
             fault: AtomicBool::new(false),
             fault_armed: AtomicBool::new(false),
-            transient_fault_armed: AtomicBool::new(false),
         }
     }
 
@@ -35,7 +33,6 @@ impl MemoryStore {
         self.fault.store(enabled, Ordering::SeqCst);
         if !enabled {
             self.fault_armed.store(false, Ordering::SeqCst);
-            self.transient_fault_armed.store(false, Ordering::SeqCst);
         }
     }
 
@@ -44,13 +41,6 @@ impl MemoryStore {
     /// Simulates resource exhaustion during a block write.
     pub fn inject_faults_on_next_block_write(&self) {
         self.fault_armed.store(true, Ordering::SeqCst);
-    }
-
-    /// Fail only the next batch that writes a block. Every operation after it succeeds.
-    ///
-    /// Simulates a transient write error, where the database is readable throughout.
-    pub fn inject_transient_fault_on_next_block_write(&self) {
-        self.transient_fault_armed.store(true, Ordering::SeqCst);
     }
 
     fn check_fault(&self) -> Result<(), Error> {
@@ -116,11 +106,6 @@ impl KeyValueStore for MemoryStore {
             self.fault_armed.store(false, Ordering::SeqCst);
             self.fault.store(true, Ordering::SeqCst);
             return self.check_fault();
-        }
-        if writes_block && self.transient_fault_armed.swap(false, Ordering::SeqCst) {
-            return Err(Error::DBError {
-                message: "Injected transient fault: write failed".to_string(),
-            });
         }
         for op in batch {
             match op {

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -13,6 +13,7 @@ pub struct MemoryStore {
     db: RwLock<DBMap>,
     fault: AtomicBool,
     fault_armed: AtomicBool,
+    transient_fault_armed: AtomicBool,
 }
 
 impl MemoryStore {
@@ -22,6 +23,7 @@ impl MemoryStore {
             db: RwLock::new(BTreeMap::new()),
             fault: AtomicBool::new(false),
             fault_armed: AtomicBool::new(false),
+            transient_fault_armed: AtomicBool::new(false),
         }
     }
 
@@ -33,6 +35,7 @@ impl MemoryStore {
         self.fault.store(enabled, Ordering::SeqCst);
         if !enabled {
             self.fault_armed.store(false, Ordering::SeqCst);
+            self.transient_fault_armed.store(false, Ordering::SeqCst);
         }
     }
 
@@ -41,6 +44,13 @@ impl MemoryStore {
     /// Simulates resource exhaustion during a block write.
     pub fn inject_faults_on_next_block_write(&self) {
         self.fault_armed.store(true, Ordering::SeqCst);
+    }
+
+    /// Fail only the next batch that writes a block. Every operation after it succeeds.
+    ///
+    /// Simulates a transient write error, where the database is readable throughout.
+    pub fn inject_transient_fault_on_next_block_write(&self) {
+        self.transient_fault_armed.store(true, Ordering::SeqCst);
     }
 
     fn check_fault(&self) -> Result<(), Error> {
@@ -96,17 +106,21 @@ impl KeyValueStore for MemoryStore {
 
     fn do_atomically(&self, batch: Vec<KeyValueStoreOp>) -> Result<(), Error> {
         self.check_fault()?;
-        if self.fault_armed.load(Ordering::SeqCst)
-            && batch.iter().any(|op| {
-                matches!(
-                    op,
-                    KeyValueStoreOp::PutKeyValue(DBColumn::BeaconBlock, _, _)
-                )
-            })
-        {
+        let writes_block = batch.iter().any(|op| {
+            matches!(
+                op,
+                KeyValueStoreOp::PutKeyValue(DBColumn::BeaconBlock, _, _)
+            )
+        });
+        if writes_block && self.fault_armed.load(Ordering::SeqCst) {
             self.fault_armed.store(false, Ordering::SeqCst);
             self.fault.store(true, Ordering::SeqCst);
             return self.check_fault();
+        }
+        if writes_block && self.transient_fault_armed.swap(false, Ordering::SeqCst) {
+            return Err(Error::DBError {
+                message: "Injected transient fault: write failed".to_string(),
+            });
         }
         for op in batch {
             match op {


### PR DESCRIPTION
## Issue Addressed

When fork choice is in an inconsistent state and cant recover, prevent it from being persisted to disk and initiate a node shutdown

## Additional Info

Depends on #9818 