### PR TITLE
Use Gloas timings for aggregate attestations and sync committee messages

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_simulator.rs
+++ b/beacon_node/beacon_chain/src/attestation_simulator.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use task_executor::TaskExecutor;
 use tokio::time::sleep;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use types::{ChainSpec, EthSpec, Slot};
 
 /// Don't run the attestation simulator if the head slot is this many epochs
@@ -54,7 +54,11 @@ async fn attestation_simulator_service<T: BeaconChainTypes>(
                 let inner_chain = chain.clone();
                 executor.spawn(
                     async move {
-                        produce_unaggregated_attestation(inner_chain, attestation_slot);
+                        if let Some(slot) = inner_chain.slot_clock.now() && slot == attestation_slot {
+                            produce_unaggregated_attestation(inner_chain, attestation_slot);
+                        } else {
+                            warn!(%attestation_slot, "Missed attestation simulator slot due to lag");
+                        }
                     },
                     "attestation_simulator_service",
                 );

--- a/beacon_node/beacon_chain/src/attestation_simulator.rs
+++ b/beacon_node/beacon_chain/src/attestation_simulator.rs
@@ -1,10 +1,11 @@
 use crate::{BeaconChain, BeaconChainTypes};
 use slot_clock::SlotClock;
 use std::sync::Arc;
+use std::time::Duration;
 use task_executor::TaskExecutor;
 use tokio::time::sleep;
 use tracing::{debug, error};
-use types::{EthSpec, Slot};
+use types::{ChainSpec, EthSpec, Slot};
 
 /// Don't run the attestation simulator if the head slot is this many epochs
 /// behind the wall-clock slot.
@@ -23,18 +24,29 @@ pub fn start_attestation_simulator_service<T: BeaconChainTypes>(
     );
 }
 
-/// Loop indefinitely, calling `BeaconChain::produce_unaggregated_attestation` every 4s into each slot.
+/// Loop indefinitely, calling `BeaconChain::produce_unaggregated_attestation` each slot at the
+/// unaggregated attestation deadline.
 async fn attestation_simulator_service<T: BeaconChainTypes>(
     executor: TaskExecutor,
     chain: Arc<BeaconChain<T>>,
 ) {
     let slot_duration = chain.slot_clock.slot_duration();
-    let additional_delay = slot_duration / 3;
 
     loop {
-        match chain.slot_clock.duration_to_next_slot() {
-            Some(duration) => {
-                sleep(duration + additional_delay).await;
+        match chain.slot_clock.now_duration() {
+            Some(now_duration) => {
+                let (attestation_slot, Some(time_to_deadline)) =
+                    time_until_attestation_deadline::<T::EthSpec>(
+                        &chain.slot_clock,
+                        &chain.spec,
+                        now_duration,
+                    )
+                else {
+                    error!("Failed to determine current slot");
+                    sleep(slot_duration).await;
+                    continue;
+                };
+                sleep(time_to_deadline).await;
 
                 debug!("Simulating unagg. attestation production");
 
@@ -42,9 +54,7 @@ async fn attestation_simulator_service<T: BeaconChainTypes>(
                 let inner_chain = chain.clone();
                 executor.spawn(
                     async move {
-                        if let Ok(current_slot) = inner_chain.slot() {
-                            produce_unaggregated_attestation(inner_chain, current_slot);
-                        }
+                        produce_unaggregated_attestation(inner_chain, attestation_slot);
                     },
                     "attestation_simulator_service",
                 );
@@ -56,6 +66,23 @@ async fn attestation_simulator_service<T: BeaconChainTypes>(
             }
         };
     }
+}
+
+fn time_until_attestation_deadline<E: EthSpec>(
+    slot_clock: &impl SlotClock,
+    chain_spec: &ChainSpec,
+    now: Duration,
+) -> (Slot, Option<Duration>) {
+    let attestation_slot = slot_clock
+        .slot_of(now)
+        .map_or_else(|| slot_clock.genesis_slot(), |slot| slot + 1);
+    let duration_to_attestation_deadline = slot_clock
+        .start_of(attestation_slot)
+        .and_then(|slot_start| {
+            slot_start.checked_add(chain_spec.get_attestation_due::<E>(attestation_slot))
+        })
+        .and_then(|deadline| deadline.checked_sub(now));
+    (attestation_slot, duration_to_attestation_deadline)
 }
 
 pub fn produce_unaggregated_attestation<T: BeaconChainTypes>(

--- a/beacon_node/beacon_chain/src/attestation_simulator.rs
+++ b/beacon_node/beacon_chain/src/attestation_simulator.rs
@@ -42,7 +42,7 @@ async fn attestation_simulator_service<T: BeaconChainTypes>(
                         now_duration,
                     )
                 else {
-                    error!("Failed to determine current slot");
+                    error!("Failed to calculate attestation deadline");
                     sleep(slot_duration).await;
                     continue;
                 };

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5520,7 +5520,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         );
         block_delays
             .observed
-            .is_some_and(|delay| delay >= self.spec.get_unaggregated_attestation_due())
+            .is_some_and(|delay| delay >= self.spec.get_attestation_due::<T::EthSpec>(slot))
     }
 
     /// Produce a block for some `slot` upon the given `state`.

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -2115,7 +2115,7 @@ fn observe_head_block_delays<E: EthSpec, S: SlotClock>(
 
         // Determine whether the block has been set as head too late for proper attestation
         // production.
-        let late_head = attestable_delay >= spec.get_unaggregated_attestation_due();
+        let late_head = attestable_delay >= spec.get_attestation_due::<E>(head_block_slot);
 
         // If the block was enshrined as head too late for attestations to be created for it,
         // log a debug warning and increment a metric.

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1502,7 +1502,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
         }
 
-        observe_head_block_delays(
+        observe_head_block_delays::<T::EthSpec, _>(
             &mut self.block_times_cache.write(),
             &new_head_proto_block,
             new_snapshot.beacon_block.message().proposer_index(),
@@ -1970,7 +1970,7 @@ pub fn find_reorg_slot<E: EthSpec>(
         .start_slot(E::slots_per_epoch()))
 }
 
-fn observe_head_block_delays<S: SlotClock>(
+fn observe_head_block_delays<E: EthSpec, S: SlotClock>(
     block_times_cache: &mut BlockTimesCache,
     head_block: &ProtoBlock,
     head_block_proposer_index: u64,

--- a/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
@@ -75,7 +75,9 @@ impl<T: BeaconChainTypes> VerifiedLightClientFinalityUpdate<T> {
             .slot_clock
             .start_of(rcv_finality_update.signature_slot())
             .ok_or(Error::SigSlotStartIsNone)?;
-        let sync_message_due = chain.spec.get_sync_message_due();
+        let sync_message_due = chain
+            .spec
+            .get_sync_message_due::<T::EthSpec>(rcv_finality_update.signature_slot());
         if seen_timestamp + chain.spec.maximum_gossip_clock_disparity()
             < start_time + sync_message_due
         {

--- a/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
@@ -71,7 +71,9 @@ impl<T: BeaconChainTypes> VerifiedLightClientOptimisticUpdate<T> {
             .start_of(rcv_optimistic_update.signature_slot())
             .ok_or(Error::SigSlotStartIsNone)?;
 
-        let sync_message_due = chain.spec.get_sync_message_due();
+        let sync_message_due = chain
+            .spec
+            .get_sync_message_due::<T::EthSpec>(rcv_optimistic_update.signature_slot());
 
         if seen_timestamp + chain.spec.maximum_gossip_clock_disparity()
             < start_time + sync_message_due

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1536,7 +1536,7 @@ impl<E: EthSpec> ValidatorMonitor<E> {
             let delay = get_message_delay_ms(
                 seen_timestamp,
                 sync_committee_message.slot,
-                spec.get_sync_message_due(),
+                spec.get_sync_message_due::<E>(sync_committee_message.slot),
                 slot_clock,
             );
 
@@ -1624,7 +1624,7 @@ impl<E: EthSpec> ValidatorMonitor<E> {
         let delay = get_message_delay_ms(
             seen_timestamp,
             slot,
-            spec.get_contribution_message_due(),
+            spec.get_contribution_message_due::<E>(slot),
             slot_clock,
         );
 

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1308,7 +1308,7 @@ impl<E: EthSpec> ValidatorMonitor<E> {
         let delay = get_message_delay_ms(
             seen_timestamp,
             data.slot,
-            spec.get_aggregate_attestation_due(),
+            spec.get_aggregate_attestation_due::<E>(data.slot),
             slot_clock,
         );
 

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -702,7 +702,7 @@ fn late_block_logging<T: BeaconChainTypes, P: AbstractExecPayload<T::EthSpec>>(
     //
     // Check to see the thresholds are non-zero to avoid logging errors with small
     // slot times (e.g., during testing)
-    let too_late_threshold = chain.spec.get_unaggregated_attestation_due();
+    let too_late_threshold = chain.spec.get_attestation_due::<T::EthSpec>(block.slot());
     let delayed_threshold = too_late_threshold / 2;
     if delay >= too_late_threshold {
         error!(

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1622,7 +1622,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
         let verified_block = match verification_result {
             Ok(verified_block) => {
-                if block_delay >= self.chain.spec.get_unaggregated_attestation_due() {
+                if block_delay
+                    >= self
+                        .chain
+                        .spec
+                        .get_attestation_due::<T::EthSpec>(block.slot())
+                {
                     metrics::inc_counter(&metrics::BEACON_BLOCK_DELAY_GOSSIP_ARRIVED_LATE_TOTAL);
                     debug!(
                         block_root = ?verified_block.block_root,

--- a/consensus/types/src/core/chain_spec.rs
+++ b/consensus/types/src/core/chain_spec.rs
@@ -1008,9 +1008,19 @@ impl ChainSpec {
             self.attestation_due_bps
         );
         assert!(
+            self.attestation_due_bps_gloas <= BASIS_POINTS,
+            "invalid chain spec: attestation_due_bps_gloas ({}) exceeds slot duration",
+            self.attestation_due_bps_gloas
+        );
+        assert!(
             self.aggregate_due_bps <= BASIS_POINTS,
             "invalid chain spec: aggregate_due_bps ({}) exceeds slot duration",
             self.aggregate_due_bps
+        );
+        assert!(
+            self.aggregate_due_bps_gloas <= BASIS_POINTS,
+            "invalid chain spec: aggregate_due_bps_gloas ({}) exceeds slot duration",
+            self.aggregate_due_bps_gloas
         );
         assert!(
             self.sync_message_due_bps <= BASIS_POINTS,
@@ -1018,9 +1028,19 @@ impl ChainSpec {
             self.sync_message_due_bps
         );
         assert!(
+            self.sync_message_due_bps_gloas <= BASIS_POINTS,
+            "invalid chain spec: sync_message_due_bps_gloas ({}) exceeds slot duration",
+            self.sync_message_due_bps_gloas
+        );
+        assert!(
             self.contribution_due_bps <= BASIS_POINTS,
             "invalid chain spec: contribution_due_bps ({}) exceeds slot duration",
             self.contribution_due_bps
+        );
+        assert!(
+            self.contribution_due_bps_gloas <= BASIS_POINTS,
+            "invalid chain spec: contribution_due_bps_gloas ({}) exceeds slot duration",
+            self.contribution_due_bps_gloas
         );
         assert!(
             self.inclusion_list_due_bps <= BASIS_POINTS,

--- a/consensus/types/src/core/chain_spec.rs
+++ b/consensus/types/src/core/chain_spec.rs
@@ -130,8 +130,10 @@ pub struct ChainSpec {
     pub payload_attestation_due: Duration,
     aggregate_attestation_due: Duration,
     aggregate_attestation_due_gloas: Duration,
-    pub sync_message_due: Duration,
-    pub contribution_and_proof_due: Duration,
+    sync_message_due: Duration,
+    sync_message_due_gloas: Duration,
+    contribution_and_proof_due: Duration,
+    contribution_and_proof_due_gloas: Duration,
 
     /*
      * Reward and penalty quotients
@@ -952,16 +954,22 @@ impl ChainSpec {
         }
     }
 
-    /// Get the duration into a slot in which a `SignedContributionAndProof` is due.
-    /// Returns the pre-computed value from `compute_derived_values()`.
-    pub fn get_contribution_message_due(&self) -> Duration {
-        self.contribution_and_proof_due
+    /// Spec: `get_contribution_due_ms`. Returns the epoch-appropriate threshold.
+    pub fn get_contribution_message_due<E: EthSpec>(&self, slot: Slot) -> Duration {
+        if self.fork_name_at_slot::<E>(slot).gloas_enabled() {
+            self.contribution_and_proof_due_gloas
+        } else {
+            self.contribution_and_proof_due
+        }
     }
 
-    /// Get the duration into a slot in which a sync committee message is due.
-    /// Returns the pre-computed value from `compute_derived_values()`.
-    pub fn get_sync_message_due(&self) -> Duration {
-        self.sync_message_due
+    /// Spec: `get_sync_message_due_ms`. Returns the epoch-appropriate threshold.
+    pub fn get_sync_message_due<E: EthSpec>(&self, slot: Slot) -> Duration {
+        if self.fork_name_at_slot::<E>(slot).gloas_enabled() {
+            self.sync_message_due_gloas
+        } else {
+            self.sync_message_due
+        }
     }
 
     /// Calculate the duration into a slot for a given slot component
@@ -1041,9 +1049,15 @@ impl ChainSpec {
         self.sync_message_due = self
             .compute_slot_component_duration(self.sync_message_due_bps)
             .expect("invalid chain spec: cannot compute sync_message_due");
+        self.sync_message_due_gloas = self
+            .compute_slot_component_duration(self.sync_message_due_bps_gloas)
+            .expect("invalid chain spec: cannot compute sync_message_due_gloas");
         self.contribution_and_proof_due = self
             .compute_slot_component_duration(self.contribution_due_bps)
             .expect("invalid chain spec: cannot compute contribution_and_proof_due");
+        self.contribution_and_proof_due_gloas = self
+            .compute_slot_component_duration(self.contribution_due_bps_gloas)
+            .expect("invalid chain spec: cannot compute contribution_and_proof_due_gloas");
 
         self.attestation_subnet_prefix_bits = compute_attestation_subnet_prefix_bits(
             self.attestation_subnet_count,
@@ -1186,7 +1200,9 @@ impl ChainSpec {
             aggregate_attestation_due: Duration::from_millis(8000),
             aggregate_attestation_due_gloas: Duration::from_millis(6000),
             sync_message_due: Duration::from_millis(3999),
+            sync_message_due_gloas: Duration::from_millis(3000),
             contribution_and_proof_due: Duration::from_millis(8000),
+            contribution_and_proof_due_gloas: Duration::from_millis(6000),
 
             /*
              * Reward and penalty quotients
@@ -1530,7 +1546,9 @@ impl ChainSpec {
             aggregate_attestation_due: Duration::from_millis(4000),
             aggregate_attestation_due_gloas: Duration::from_millis(3000),
             sync_message_due: Duration::from_millis(1999),
+            sync_message_due_gloas: Duration::from_millis(1500),
             contribution_and_proof_due: Duration::from_millis(4000),
+            contribution_and_proof_due_gloas: Duration::from_millis(3000),
 
             // Networking Fulu
             blob_schedule: BlobSchedule::default(),
@@ -1634,7 +1652,9 @@ impl ChainSpec {
             aggregate_attestation_due: Duration::from_millis(3333),
             aggregate_attestation_due_gloas: Duration::from_millis(2500),
             sync_message_due: Duration::from_millis(1666),
+            sync_message_due_gloas: Duration::from_millis(1250),
             contribution_and_proof_due: Duration::from_millis(3333),
+            contribution_and_proof_due_gloas: Duration::from_millis(2500),
 
             /*
              * Reward and penalty quotients
@@ -3894,11 +3914,11 @@ mod yaml_tests {
         assert_eq!(agg_due, Duration::from_millis(8000)); // 12000 * 6667 / 10000
 
         // Test sync message (3333 bps = 33.33% of 12s = 4s)
-        let sync_msg_due = spec.get_sync_message_due();
+        let sync_msg_due = spec.get_sync_message_due::<MainnetEthSpec>(Slot::new(0));
         assert_eq!(sync_msg_due, Duration::from_millis(3999)); // 12000 * 3333 / 10000
 
         // Test contribution message (6667 bps = 66.67% of 12s = 8s)
-        let contribution_due = spec.get_contribution_message_due();
+        let contribution_due = spec.get_contribution_message_due::<MainnetEthSpec>(Slot::new(0));
         assert_eq!(contribution_due, Duration::from_millis(8000)); // 12000 * 6667 / 10000
 
         // Test slot duration
@@ -3985,6 +4005,20 @@ mod yaml_tests {
             custom_spec.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(4800)
         ); // 12000 * 4000 / 10000
+
+        // Test Gloas sync committee due times with custom bps
+        let mut custom_spec = custom_spec;
+        custom_spec.sync_message_due_bps_gloas = 4000;
+        custom_spec.contribution_due_bps_gloas = 6000;
+        let custom_spec = custom_spec.compute_derived_values::<MainnetEthSpec>();
+        assert_eq!(
+            custom_spec.get_sync_message_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(4800)
+        ); // 12000 * 4000 / 10000
+        assert_eq!(
+            custom_spec.get_contribution_message_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(7200)
+        ); // 12000 * 6000 / 10000
     }
 
     #[test]
@@ -4036,6 +4070,54 @@ mod yaml_tests {
     }
 
     #[test]
+    fn test_sync_message_due_is_fork_aware() {
+        type E = MainnetEthSpec;
+
+        let gloas_fork_epoch = Epoch::new(1);
+        let mut spec = ChainSpec::mainnet();
+        spec.gloas_fork_epoch = Some(gloas_fork_epoch);
+        let spec = spec.compute_derived_values::<E>();
+        let first_gloas_slot = gloas_fork_epoch.start_slot(E::slots_per_epoch());
+
+        assert_eq!(
+            spec.get_sync_message_due::<E>(first_gloas_slot - 1),
+            Duration::from_millis(3999)
+        );
+        assert_eq!(
+            spec.get_sync_message_due::<E>(first_gloas_slot),
+            Duration::from_millis(3000)
+        );
+        assert_eq!(
+            spec.get_sync_message_due::<E>(first_gloas_slot + 1),
+            Duration::from_millis(3000)
+        );
+    }
+
+    #[test]
+    fn test_contribution_message_due_is_fork_aware() {
+        type E = MainnetEthSpec;
+
+        let gloas_fork_epoch = Epoch::new(1);
+        let mut spec = ChainSpec::mainnet();
+        spec.gloas_fork_epoch = Some(gloas_fork_epoch);
+        let spec = spec.compute_derived_values::<E>();
+        let first_gloas_slot = gloas_fork_epoch.start_slot(E::slots_per_epoch());
+
+        assert_eq!(
+            spec.get_contribution_message_due::<E>(first_gloas_slot - 1),
+            Duration::from_millis(8000)
+        );
+        assert_eq!(
+            spec.get_contribution_message_due::<E>(first_gloas_slot),
+            Duration::from_millis(6000)
+        );
+        assert_eq!(
+            spec.get_contribution_message_due::<E>(first_gloas_slot + 1),
+            Duration::from_millis(6000)
+        );
+    }
+
+    #[test]
     fn test_default_duration_values_without_compute_derived_values() {
         // Verify that mainnet, minimal, and gnosis have correct pre-computed defaults
         // without needing to call compute_derived_values()
@@ -4048,9 +4130,12 @@ mod yaml_tests {
             mainnet.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(8000)
         );
-        assert_eq!(mainnet.get_sync_message_due(), Duration::from_millis(3999));
         assert_eq!(
-            mainnet.get_contribution_message_due(),
+            mainnet.get_sync_message_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(3999)
+        );
+        assert_eq!(
+            mainnet.get_contribution_message_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(8000)
         );
 
@@ -4072,6 +4157,14 @@ mod yaml_tests {
             mainnet_gloas.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(6000)
         );
+        assert_eq!(
+            mainnet_gloas.get_sync_message_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(3000)
+        );
+        assert_eq!(
+            mainnet_gloas.get_contribution_message_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(6000)
+        );
 
         // Minimal spec: 6000ms slots, 3333 bps = 1999ms, 6667 bps = 4000ms
         let minimal = ChainSpec::minimal();
@@ -4083,9 +4176,12 @@ mod yaml_tests {
             minimal.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(4000)
         );
-        assert_eq!(minimal.get_sync_message_due(), Duration::from_millis(1999));
         assert_eq!(
-            minimal.get_contribution_message_due(),
+            minimal.get_sync_message_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(1999)
+        );
+        assert_eq!(
+            minimal.get_contribution_message_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(4000)
         );
         // Minimal payload due: 6000ms slots, 5000 bps = 3000ms
@@ -4106,6 +4202,14 @@ mod yaml_tests {
             minimal_gloas.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(3000)
         );
+        assert_eq!(
+            minimal_gloas.get_sync_message_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(1500)
+        );
+        assert_eq!(
+            minimal_gloas.get_contribution_message_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(3000)
+        );
 
         // Gnosis spec: 5000ms slots, 3333 bps = 1666ms, 6667 bps = 3333ms
         let gnosis = ChainSpec::gnosis();
@@ -4117,9 +4221,12 @@ mod yaml_tests {
             gnosis.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(3333)
         );
-        assert_eq!(gnosis.get_sync_message_due(), Duration::from_millis(1666));
         assert_eq!(
-            gnosis.get_contribution_message_due(),
+            gnosis.get_sync_message_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(1666)
+        );
+        assert_eq!(
+            gnosis.get_contribution_message_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(3333)
         );
         // Gnosis payload due: 5000ms slots, 5000 bps = 2500ms
@@ -4138,6 +4245,14 @@ mod yaml_tests {
         gnosis_gloas.gloas_fork_epoch = Some(Epoch::new(0));
         assert_eq!(
             gnosis_gloas.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(2500)
+        );
+        assert_eq!(
+            gnosis_gloas.get_sync_message_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(1250)
+        );
+        assert_eq!(
+            gnosis_gloas.get_contribution_message_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(2500)
         );
     }

--- a/consensus/types/src/core/chain_spec.rs
+++ b/consensus/types/src/core/chain_spec.rs
@@ -128,7 +128,8 @@ pub struct ChainSpec {
     unaggregated_attestation_due_gloas: Duration,
     pub payload_due: Duration,
     pub payload_attestation_due: Duration,
-    pub aggregate_attestation_due: Duration,
+    aggregate_attestation_due: Duration,
+    aggregate_attestation_due_gloas: Duration,
     pub sync_message_due: Duration,
     pub contribution_and_proof_due: Duration,
 
@@ -942,10 +943,13 @@ impl ChainSpec {
         self.payload_attestation_due
     }
 
-    /// Get the duration into a slot in which an aggregated attestation is due.
-    /// Returns the pre-computed value from `compute_derived_values()`.
-    pub fn get_aggregate_attestation_due(&self) -> Duration {
-        self.aggregate_attestation_due
+    /// Spec: `get_aggregate_attestation_due_ms`. Returns the epoch-appropriate threshold.
+    pub fn get_aggregate_attestation_due<E: EthSpec>(&self, slot: Slot) -> Duration {
+        if self.fork_name_at_slot::<E>(slot).gloas_enabled() {
+            self.aggregate_attestation_due_gloas
+        } else {
+            self.aggregate_attestation_due
+        }
     }
 
     /// Get the duration into a slot in which a `SignedContributionAndProof` is due.
@@ -1031,6 +1035,9 @@ impl ChainSpec {
         self.aggregate_attestation_due = self
             .compute_slot_component_duration(self.aggregate_due_bps)
             .expect("invalid chain spec: cannot compute aggregate_attestation_due");
+        self.aggregate_attestation_due_gloas = self
+            .compute_slot_component_duration(self.aggregate_due_bps_gloas)
+            .expect("invalid chain spec: cannot compute aggregate_attestation_due_gloas");
         self.sync_message_due = self
             .compute_slot_component_duration(self.sync_message_due_bps)
             .expect("invalid chain spec: cannot compute sync_message_due");
@@ -1177,6 +1184,7 @@ impl ChainSpec {
             payload_due: Duration::from_millis(6000),
             payload_attestation_due: Duration::from_millis(9000),
             aggregate_attestation_due: Duration::from_millis(8000),
+            aggregate_attestation_due_gloas: Duration::from_millis(6000),
             sync_message_due: Duration::from_millis(3999),
             contribution_and_proof_due: Duration::from_millis(8000),
 
@@ -1520,6 +1528,7 @@ impl ChainSpec {
             payload_due: Duration::from_millis(3000),
             payload_attestation_due: Duration::from_millis(4500),
             aggregate_attestation_due: Duration::from_millis(4000),
+            aggregate_attestation_due_gloas: Duration::from_millis(3000),
             sync_message_due: Duration::from_millis(1999),
             contribution_and_proof_due: Duration::from_millis(4000),
 
@@ -1623,6 +1632,7 @@ impl ChainSpec {
             payload_due: Duration::from_millis(2500),
             payload_attestation_due: Duration::from_millis(3750),
             aggregate_attestation_due: Duration::from_millis(3333),
+            aggregate_attestation_due_gloas: Duration::from_millis(2500),
             sync_message_due: Duration::from_millis(1666),
             contribution_and_proof_due: Duration::from_millis(3333),
 
@@ -3880,7 +3890,7 @@ mod yaml_tests {
         assert_eq!(unagg_due, Duration::from_millis(3999)); // 12000 * 3333 / 10000
 
         // Test aggregate attestation (6667 bps = 66.67% of 12s = 8s)
-        let agg_due = spec.get_aggregate_attestation_due();
+        let agg_due = spec.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0));
         assert_eq!(agg_due, Duration::from_millis(8000)); // 12000 * 6667 / 10000
 
         // Test sync message (3333 bps = 33.33% of 12s = 4s)
@@ -3965,6 +3975,16 @@ mod yaml_tests {
             custom_spec.unaggregated_attestation_due_gloas,
             Duration::from_millis(6000)
         ); // 12000 * 5000 / 10000
+
+        // Test Gloas aggregate attestation due with custom bps
+        let mut custom_spec = custom_spec;
+        custom_spec.aggregate_due_bps_gloas = 4000;
+        custom_spec.gloas_fork_epoch = Some(Epoch::new(0));
+        let custom_spec = custom_spec.compute_derived_values::<MainnetEthSpec>();
+        assert_eq!(
+            custom_spec.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(4800)
+        ); // 12000 * 4000 / 10000
     }
 
     #[test]
@@ -3992,6 +4012,30 @@ mod yaml_tests {
     }
 
     #[test]
+    fn test_aggregate_attestation_due_is_fork_aware() {
+        type E = MainnetEthSpec;
+
+        let gloas_fork_epoch = Epoch::new(1);
+        let mut spec = ChainSpec::mainnet();
+        spec.gloas_fork_epoch = Some(gloas_fork_epoch);
+        let spec = spec.compute_derived_values::<E>();
+        let first_gloas_slot = gloas_fork_epoch.start_slot(E::slots_per_epoch());
+
+        assert_eq!(
+            spec.get_aggregate_attestation_due::<E>(first_gloas_slot - 1),
+            Duration::from_millis(8000)
+        );
+        assert_eq!(
+            spec.get_aggregate_attestation_due::<E>(first_gloas_slot),
+            Duration::from_millis(6000)
+        );
+        assert_eq!(
+            spec.get_aggregate_attestation_due::<E>(first_gloas_slot + 1),
+            Duration::from_millis(6000)
+        );
+    }
+
+    #[test]
     fn test_default_duration_values_without_compute_derived_values() {
         // Verify that mainnet, minimal, and gnosis have correct pre-computed defaults
         // without needing to call compute_derived_values()
@@ -4001,7 +4045,7 @@ mod yaml_tests {
             Duration::from_millis(3999)
         );
         assert_eq!(
-            mainnet.get_aggregate_attestation_due(),
+            mainnet.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(8000)
         );
         assert_eq!(mainnet.get_sync_message_due(), Duration::from_millis(3999));
@@ -4022,6 +4066,12 @@ mod yaml_tests {
             mainnet.unaggregated_attestation_due_gloas,
             Duration::from_millis(3000)
         );
+        let mut mainnet_gloas = mainnet.clone();
+        mainnet_gloas.gloas_fork_epoch = Some(Epoch::new(0));
+        assert_eq!(
+            mainnet_gloas.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(6000)
+        );
 
         // Minimal spec: 6000ms slots, 3333 bps = 1999ms, 6667 bps = 4000ms
         let minimal = ChainSpec::minimal();
@@ -4030,7 +4080,7 @@ mod yaml_tests {
             Duration::from_millis(1999)
         );
         assert_eq!(
-            minimal.get_aggregate_attestation_due(),
+            minimal.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(4000)
         );
         assert_eq!(minimal.get_sync_message_due(), Duration::from_millis(1999));
@@ -4050,6 +4100,12 @@ mod yaml_tests {
             minimal.unaggregated_attestation_due_gloas,
             Duration::from_millis(1500)
         );
+        let mut minimal_gloas = minimal.clone();
+        minimal_gloas.gloas_fork_epoch = Some(Epoch::new(0));
+        assert_eq!(
+            minimal_gloas.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(3000)
+        );
 
         // Gnosis spec: 5000ms slots, 3333 bps = 1666ms, 6667 bps = 3333ms
         let gnosis = ChainSpec::gnosis();
@@ -4058,7 +4114,7 @@ mod yaml_tests {
             Duration::from_millis(1666)
         );
         assert_eq!(
-            gnosis.get_aggregate_attestation_due(),
+            gnosis.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
             Duration::from_millis(3333)
         );
         assert_eq!(gnosis.get_sync_message_due(), Duration::from_millis(1666));
@@ -4077,6 +4133,12 @@ mod yaml_tests {
         assert_eq!(
             gnosis.unaggregated_attestation_due_gloas,
             Duration::from_millis(1250)
+        );
+        let mut gnosis_gloas = gnosis.clone();
+        gnosis_gloas.gloas_fork_epoch = Some(Epoch::new(0));
+        assert_eq!(
+            gnosis_gloas.get_aggregate_attestation_due::<MainnetEthSpec>(Slot::new(0)),
+            Duration::from_millis(2500)
         );
     }
 

--- a/consensus/types/src/core/chain_spec.rs
+++ b/consensus/types/src/core/chain_spec.rs
@@ -1043,6 +1043,16 @@ impl ChainSpec {
             self.contribution_due_bps_gloas
         );
         assert!(
+            self.payload_due_bps <= BASIS_POINTS,
+            "invalid chain spec: payload_due_bps ({}) exceeds slot duration",
+            self.payload_due_bps
+        );
+        assert!(
+            self.payload_attestation_due_bps <= BASIS_POINTS,
+            "invalid chain spec: payload_attestation_due_bps ({}) exceeds slot duration",
+            self.payload_attestation_due_bps
+        );
+        assert!(
             self.inclusion_list_due_bps <= BASIS_POINTS,
             "invalid chain spec: inclusion_list_due_bps ({}) exceeds slot duration",
             self.inclusion_list_due_bps

--- a/consensus/types/src/core/chain_spec.rs
+++ b/consensus/types/src/core/chain_spec.rs
@@ -124,8 +124,8 @@ pub struct ChainSpec {
     /*
      * Derived time values (computed at startup via `compute_derived_values()`)
      */
-    pub unaggregated_attestation_due: Duration,
-    pub unaggregated_attestation_due_gloas: Duration,
+    unaggregated_attestation_due: Duration,
+    unaggregated_attestation_due_gloas: Duration,
     pub payload_due: Duration,
     pub payload_attestation_due: Duration,
     pub aggregate_attestation_due: Duration,
@@ -921,12 +921,6 @@ impl ChainSpec {
             //1MB
             1024 * 1024,
         )
-    }
-
-    /// Get the duration into a slot in which an unaggregated attestation is due.
-    /// Returns the pre-computed value from `compute_derived_values()`.
-    pub fn get_unaggregated_attestation_due(&self) -> Duration {
-        self.unaggregated_attestation_due
     }
 
     /// Spec: `get_attestation_due_ms`. Returns the epoch-appropriate threshold.
@@ -3882,7 +3876,7 @@ mod yaml_tests {
         let spec = ChainSpec::mainnet().compute_derived_values::<MainnetEthSpec>();
 
         // Test unaggregated attestation (3333 bps = 33.33% of 12s = 4s)
-        let unagg_due = spec.get_unaggregated_attestation_due();
+        let unagg_due = spec.unaggregated_attestation_due;
         assert_eq!(unagg_due, Duration::from_millis(3999)); // 12000 * 3333 / 10000
 
         // Test aggregate attestation (6667 bps = 66.67% of 12s = 8s)
@@ -3907,21 +3901,21 @@ mod yaml_tests {
         // Edge case: 0 bps should give 0 duration
         custom_spec.attestation_due_bps = 0;
         let custom_spec = custom_spec.compute_derived_values::<MainnetEthSpec>();
-        let zero_due = custom_spec.get_unaggregated_attestation_due();
+        let zero_due = custom_spec.unaggregated_attestation_due;
         assert_eq!(zero_due, Duration::from_millis(0));
 
         // Edge case: 10000 bps (100%) should give full slot duration
         let mut custom_spec = custom_spec;
         custom_spec.attestation_due_bps = 10_000;
         let custom_spec = custom_spec.compute_derived_values::<MainnetEthSpec>();
-        let full_due = custom_spec.get_unaggregated_attestation_due();
+        let full_due = custom_spec.unaggregated_attestation_due;
         assert_eq!(full_due, Duration::from_millis(12000));
 
         // Edge case: 5000 bps (50%) should give half slot duration
         let mut custom_spec = custom_spec;
         custom_spec.attestation_due_bps = 5_000;
         let custom_spec = custom_spec.compute_derived_values::<MainnetEthSpec>();
-        let half_due = custom_spec.get_unaggregated_attestation_due();
+        let half_due = custom_spec.unaggregated_attestation_due;
         assert_eq!(half_due, Duration::from_millis(6000));
 
         // Test with different slot duration (Gnosis: 5s slots)
@@ -3929,7 +3923,7 @@ mod yaml_tests {
         custom_spec.slot_duration_ms = 5000;
         custom_spec.attestation_due_bps = 3333;
         let custom_spec = custom_spec.compute_derived_values::<MainnetEthSpec>();
-        let gnosis_due = custom_spec.get_unaggregated_attestation_due();
+        let gnosis_due = custom_spec.unaggregated_attestation_due;
         assert_eq!(gnosis_due, Duration::from_millis(1666)); // 5000 * 3333 / 10000
 
         // Test with very small slot duration
@@ -3937,7 +3931,7 @@ mod yaml_tests {
         custom_spec.slot_duration_ms = 1000; // 1 second
         custom_spec.attestation_due_bps = 3333;
         let custom_spec = custom_spec.compute_derived_values::<MainnetEthSpec>();
-        let small_due = custom_spec.get_unaggregated_attestation_due();
+        let small_due = custom_spec.unaggregated_attestation_due;
         assert_eq!(small_due, Duration::from_millis(333)); // 1000 * 3333 / 10000
 
         // Test rounding behavior with non-divisible values
@@ -3945,7 +3939,7 @@ mod yaml_tests {
         custom_spec.slot_duration_ms = 12000;
         custom_spec.attestation_due_bps = 1; // 0.01%
         let custom_spec = custom_spec.compute_derived_values::<MainnetEthSpec>();
-        let tiny_due = custom_spec.get_unaggregated_attestation_due();
+        let tiny_due = custom_spec.unaggregated_attestation_due;
         assert_eq!(tiny_due, Duration::from_millis(1)); // 12000 * 1 / 10000 = 1.2 -> 1
 
         // Test payload due (5000 bps = 50% of 12s = 6s)
@@ -3974,12 +3968,36 @@ mod yaml_tests {
     }
 
     #[test]
+    fn test_attestation_due_is_fork_aware() {
+        type E = MainnetEthSpec;
+
+        let gloas_fork_epoch = Epoch::new(1);
+        let mut spec = ChainSpec::mainnet();
+        spec.gloas_fork_epoch = Some(gloas_fork_epoch);
+        let spec = spec.compute_derived_values::<E>();
+        let first_gloas_slot = gloas_fork_epoch.start_slot(E::slots_per_epoch());
+
+        assert_eq!(
+            spec.get_attestation_due::<E>(first_gloas_slot - 1),
+            Duration::from_millis(3999)
+        );
+        assert_eq!(
+            spec.get_attestation_due::<E>(first_gloas_slot),
+            Duration::from_millis(3000)
+        );
+        assert_eq!(
+            spec.get_attestation_due::<E>(first_gloas_slot + 1),
+            Duration::from_millis(3000)
+        );
+    }
+
+    #[test]
     fn test_default_duration_values_without_compute_derived_values() {
         // Verify that mainnet, minimal, and gnosis have correct pre-computed defaults
         // without needing to call compute_derived_values()
         let mainnet = ChainSpec::mainnet();
         assert_eq!(
-            mainnet.get_unaggregated_attestation_due(),
+            mainnet.unaggregated_attestation_due,
             Duration::from_millis(3999)
         );
         assert_eq!(
@@ -4008,7 +4026,7 @@ mod yaml_tests {
         // Minimal spec: 6000ms slots, 3333 bps = 1999ms, 6667 bps = 4000ms
         let minimal = ChainSpec::minimal();
         assert_eq!(
-            minimal.get_unaggregated_attestation_due(),
+            minimal.unaggregated_attestation_due,
             Duration::from_millis(1999)
         );
         assert_eq!(
@@ -4036,7 +4054,7 @@ mod yaml_tests {
         // Gnosis spec: 5000ms slots, 3333 bps = 1666ms, 6667 bps = 3333ms
         let gnosis = ChainSpec::gnosis();
         assert_eq!(
-            gnosis.get_unaggregated_attestation_due(),
+            gnosis.unaggregated_attestation_due,
             Duration::from_millis(1666)
         );
         assert_eq!(

--- a/validator_client/validator_services/src/attestation_service.rs
+++ b/validator_client/validator_services/src/attestation_service.rs
@@ -390,15 +390,15 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
             )
             .ok_or("Failed to spawn attestation data task")?;
 
-        // If a validator needs to publish an aggregate attestation, they must do so at 2/3
-        // through the slot. This delay triggers at this time
+        // If a validator needs to publish an aggregate attestation, trigger it at the
+        // fork-appropriate aggregate due time.
         let duration_to_next_slot = self
             .slot_clock
             .duration_to_slot(slot + 1)
             .ok_or("Unable to determine duration to next slot")?;
         let aggregate_production_instant = Instant::now()
             + duration_to_next_slot
-                .checked_add(self.chain_spec.get_aggregate_attestation_due())
+                .checked_add(self.chain_spec.get_aggregate_attestation_due::<S::E>(slot))
                 .and_then(|offset| offset.checked_sub(self.chain_spec.get_slot_duration()))
                 .unwrap_or_else(|| Duration::from_secs(0));
 

--- a/validator_client/validator_services/src/sync_committee_service.rs
+++ b/validator_client/validator_services/src/sync_committee_service.rs
@@ -108,18 +108,19 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
 
         let interval_fut = async move {
             loop {
-                if let Some(duration_to_next_slot) = self.slot_clock.duration_to_next_slot() {
-                    let sync_message_slot = self
-                        .slot_clock
-                        .now()
-                        .map_or_else(|| self.slot_clock.genesis_slot(), |slot| slot + 1);
-                    let sync_message_slot_component = self
-                        .duties_service
-                        .spec
-                        .get_sync_message_due::<S::E>(sync_message_slot);
+                if let Some(now_duration) = self.slot_clock.now_duration() {
+                    let (_, Some(duration_to_sync_message_deadline)) = sync_message_deadline::<S::E>(
+                        &self.slot_clock,
+                        &self.duties_service.spec,
+                        now_duration,
+                    ) else {
+                        error!("Failed to determine sync message deadline");
+                        sleep(slot_duration).await;
+                        continue;
+                    };
 
                     // Wait for the fork-appropriate sync message due time.
-                    sleep(duration_to_next_slot + sync_message_slot_component).await;
+                    sleep(duration_to_sync_message_deadline).await;
 
                     // Do nothing if the Altair fork has not yet occurred.
                     if !self.altair_fork_activated() {
@@ -555,6 +556,23 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
     }
 }
 
+fn sync_message_deadline<E: EthSpec>(
+    slot_clock: &impl SlotClock,
+    chain_spec: &ChainSpec,
+    now: Duration,
+) -> (Slot, Option<Duration>) {
+    let sync_message_slot = slot_clock
+        .slot_of(now)
+        .map_or_else(|| slot_clock.genesis_slot(), |slot| slot + 1);
+    let duration_to_sync_message_deadline = slot_clock
+        .start_of(sync_message_slot)
+        .and_then(|slot_start| {
+            slot_start.checked_add(chain_spec.get_sync_message_due::<E>(sync_message_slot))
+        })
+        .and_then(|deadline| deadline.checked_sub(now));
+    (sync_message_slot, duration_to_sync_message_deadline)
+}
+
 fn sync_period_of_slot<E: EthSpec>(slot: Slot, spec: &ChainSpec) -> Result<u64, String> {
     slot.epoch(E::slots_per_epoch())
         .sync_committee_period(spec)
@@ -574,4 +592,55 @@ fn subscriptions_from_sync_duties(
             sync_committee_indices: duty.validator_sync_committee_indices,
             until_epoch,
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use slot_clock::ManualSlotClock;
+    use types::{Epoch, MainnetEthSpec};
+
+    #[test]
+    fn duration_to_sync_message_deadline_is_fork_aware() {
+        type E = MainnetEthSpec;
+
+        let mut spec = E::default_spec();
+        let gloas_fork_epoch = Epoch::new(1);
+        spec.gloas_fork_epoch = Some(gloas_fork_epoch);
+
+        let slot_duration = spec.get_slot_duration();
+        let genesis_time = slot_duration;
+        let slot_clock = ManualSlotClock::new(Slot::new(0), genesis_time, slot_duration);
+        let first_gloas_slot = gloas_fork_epoch.start_slot(E::slots_per_epoch());
+        let last_pre_gloas_slot = first_gloas_slot - 1;
+
+        let test_cases = [
+            (
+                "pre-genesis",
+                genesis_time - Duration::from_secs(1),
+                slot_clock.genesis_slot(),
+                Duration::from_millis(4999),
+            ),
+            (
+                "pre-Gloas",
+                slot_clock.start_of(last_pre_gloas_slot - 1).unwrap(),
+                last_pre_gloas_slot,
+                Duration::from_millis(15999),
+            ),
+            (
+                "post-Gloas",
+                slot_clock.start_of(last_pre_gloas_slot).unwrap(),
+                first_gloas_slot,
+                Duration::from_millis(15000),
+            ),
+        ];
+
+        for (case, now, expected_slot, expected_duration) in test_cases {
+            assert_eq!(
+                sync_message_deadline::<E>(&slot_clock, &spec, now),
+                (expected_slot, Some(expected_duration)),
+                "{case}"
+            );
+        }
+    }
 }

--- a/validator_client/validator_services/src/sync_committee_service.rs
+++ b/validator_client/validator_services/src/sync_committee_service.rs
@@ -106,12 +106,19 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
 
         let executor = self.executor.clone();
 
-        let sync_message_slot_component = spec.get_sync_message_due();
-
         let interval_fut = async move {
             loop {
                 if let Some(duration_to_next_slot) = self.slot_clock.duration_to_next_slot() {
-                    // Wait for contribution broadcast interval 1/3 of the way through the slot.
+                    let sync_message_slot = self
+                        .slot_clock
+                        .now()
+                        .map_or_else(|| self.slot_clock.genesis_slot(), |slot| slot + 1);
+                    let sync_message_slot_component = self
+                        .duties_service
+                        .spec
+                        .get_sync_message_due::<S::E>(sync_message_slot);
+
+                    // Wait for the fork-appropriate sync message due time.
                     sleep(duration_to_next_slot + sync_message_slot_component).await;
 
                     // Do nothing if the Altair fork has not yet occurred.
@@ -150,11 +157,11 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
             .duration_to_next_slot()
             .ok_or("Unable to determine duration to next slot")?;
 
-        // If a validator needs to publish a sync aggregate, they must do so at 2/3
-        // through the slot. This delay triggers at this time
+        // If a validator needs to publish a sync aggregate, trigger it at the
+        // fork-appropriate contribution due time.
         let aggregate_production_instant = Instant::now()
             + duration_to_next_slot
-                .checked_add(spec.get_contribution_message_due())
+                .checked_add(spec.get_contribution_message_due::<S::E>(slot))
                 .and_then(|offset| offset.checked_sub(spec.get_slot_duration()))
                 .unwrap_or_else(|| Duration::from_secs(0));
 


### PR DESCRIPTION
## Issue Addressed

Closes:

- https://github.com/sigp/lighthouse/issues/9821

## Proposed Changes

Ensure all timing related helpers are Gloas aware, and remove footguns (fork-unaware methods and publicly readable fork-unaware config fields).

## Additional Info

AI usage: Codex under heavy direction, manually reviewed.
