### PR TITLE
Remove the non-standard `late_head` SSE event

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -42,13 +42,12 @@ use crate::{
     BeaconChain, BeaconChainError as Error, BeaconChainTypes, BeaconSnapshot,
     beacon_chain::{BeaconForkChoice, BeaconStore, FORK_CHOICE_DB_KEY, OverrideForkchoiceUpdate},
     block_times_cache::BlockTimesCache,
-    events::ServerSentEventHandler,
     metrics,
     validator_monitor::get_slot_delay_ms,
 };
 use eth2::beacon_response::ForkVersionedResponse;
 use eth2::types::{
-    EventKind, SseChainReorg, SseFastConfirmation, SseFinalizedCheckpoint, SseHeadV2, SseLateHead,
+    EventKind, SseChainReorg, SseFastConfirmation, SseFinalizedCheckpoint, SseHeadV2,
 };
 use fast_confirmation::{
     Error as FastConfirmationError, FastConfirmationRule, metrics as fcr_metrics,
@@ -1507,14 +1506,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             &mut self.block_times_cache.write(),
             &new_head_proto_block,
             new_snapshot.beacon_block.message().proposer_index(),
-            new_snapshot
-                .beacon_block
-                .message()
-                .body()
-                .graffiti()
-                .as_utf8_lossy(),
             &self.slot_clock,
-            self.event_handler.as_ref(),
             &self.spec,
         );
 
@@ -1978,13 +1970,11 @@ pub fn find_reorg_slot<E: EthSpec>(
         .start_slot(E::slots_per_epoch()))
 }
 
-fn observe_head_block_delays<E: EthSpec, S: SlotClock>(
+fn observe_head_block_delays<S: SlotClock>(
     block_times_cache: &mut BlockTimesCache,
     head_block: &ProtoBlock,
     head_block_proposer_index: u64,
-    head_block_graffiti: String,
     slot_clock: &S,
-    event_handler: Option<&ServerSentEventHandler<E>>,
     spec: &ChainSpec,
 ) {
     let Some(block_time_set_as_head) = slot_clock.now_duration() else {
@@ -1993,7 +1983,6 @@ fn observe_head_block_delays<E: EthSpec, S: SlotClock>(
     };
     let head_block_root = head_block.root;
     let head_block_slot = head_block.slot;
-    let head_block_is_optimistic = head_block.execution_status.is_optimistic_or_invalid();
 
     // Calculate the total delay between the start of the slot and when it was set as head.
     let block_delay_total = get_slot_delay_ms(block_time_set_as_head, head_block_slot, slot_clock);
@@ -2139,24 +2128,6 @@ fn observe_head_block_delays<E: EthSpec, S: SlotClock>(
                 set_as_head_time_ms = format_delay(&block_delays.set_as_head),
                 "Delayed head block"
             );
-            if let Some(event_handler) = event_handler
-                && event_handler.has_late_head_subscribers()
-            {
-                let peer_info = block_times_cache.get_peer_info(head_block_root);
-                event_handler.register(EventKind::LateHead(SseLateHead {
-                    slot: head_block_slot,
-                    block: head_block_root,
-                    peer_id: peer_info.id,
-                    peer_client: peer_info.client,
-                    proposer_index: head_block_proposer_index,
-                    proposer_graffiti: head_block_graffiti,
-                    block_delay: block_delay_total,
-                    observed_delay: block_delays.observed,
-                    imported_delay: block_delays.imported,
-                    set_as_head_delay: block_delays.set_as_head,
-                    execution_optimistic: head_block_is_optimistic,
-                }));
-            }
         } else {
             debug!(
                 block_root = ?head_block_root,

--- a/beacon_node/beacon_chain/src/events.rs
+++ b/beacon_node/beacon_chain/src/events.rs
@@ -19,7 +19,6 @@ pub struct ServerSentEventHandler<E: EthSpec> {
     chain_reorg_tx: Sender<EventKind<E>>,
     contribution_tx: Sender<EventKind<E>>,
     payload_attributes_tx: Sender<EventKind<E>>,
-    late_head: Sender<EventKind<E>>,
     light_client_finality_update_tx: Sender<EventKind<E>>,
     light_client_optimistic_update_tx: Sender<EventKind<E>>,
     proposer_slashing_tx: Sender<EventKind<E>>,
@@ -53,7 +52,6 @@ impl<E: EthSpec> ServerSentEventHandler<E> {
         let (chain_reorg_tx, _) = broadcast::channel(capacity);
         let (contribution_tx, _) = broadcast::channel(capacity);
         let (payload_attributes_tx, _) = broadcast::channel(capacity);
-        let (late_head, _) = broadcast::channel(capacity);
         let (light_client_finality_update_tx, _) = broadcast::channel(capacity);
         let (light_client_optimistic_update_tx, _) = broadcast::channel(capacity);
         let (proposer_slashing_tx, _) = broadcast::channel(capacity);
@@ -81,7 +79,6 @@ impl<E: EthSpec> ServerSentEventHandler<E> {
             chain_reorg_tx,
             contribution_tx,
             payload_attributes_tx,
-            late_head,
             light_client_finality_update_tx,
             light_client_optimistic_update_tx,
             proposer_slashing_tx,
@@ -155,10 +152,6 @@ impl<E: EthSpec> ServerSentEventHandler<E> {
                 .payload_attributes_tx
                 .send(kind)
                 .map(|count| log_count("payload attributes", count)),
-            EventKind::LateHead(_) => self
-                .late_head
-                .send(kind)
-                .map(|count| log_count("late head", count)),
             EventKind::LightClientFinalityUpdate(_) => self
                 .light_client_finality_update_tx
                 .send(kind)
@@ -265,10 +258,6 @@ impl<E: EthSpec> ServerSentEventHandler<E> {
         self.payload_attributes_tx.subscribe()
     }
 
-    pub fn subscribe_late_head(&self) -> Receiver<EventKind<E>> {
-        self.late_head.subscribe()
-    }
-
     pub fn subscribe_light_client_finality_update(&self) -> Receiver<EventKind<E>> {
         self.light_client_finality_update_tx.subscribe()
     }
@@ -367,10 +356,6 @@ impl<E: EthSpec> ServerSentEventHandler<E> {
 
     pub fn has_payload_attributes_subscribers(&self) -> bool {
         self.payload_attributes_tx.receiver_count() > 0
-    }
-
-    pub fn has_late_head_subscribers(&self) -> bool {
-        self.late_head.receiver_count() > 0
     }
 
     pub fn has_proposer_slashing_subscribers(&self) -> bool {

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -3235,9 +3235,6 @@ pub async fn serve<T: BeaconChainTypes>(
                                 api_types::EventTopic::PayloadAttributes => {
                                     event_handler.subscribe_payload_attributes()
                                 }
-                                api_types::EventTopic::LateHead => {
-                                    event_handler.subscribe_late_head()
-                                }
                                 api_types::EventTopic::LightClientFinalityUpdate => {
                                     event_handler.subscribe_light_client_finality_update()
                                 }

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -24,7 +24,6 @@ use ssz_derive::{Decode, Encode};
 use std::fmt::{self, Display};
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
 use superstruct::superstruct;
 
 // TODO(mac): Temporary module and re-export hack to expose old `consensus/types` via `eth2/types`.
@@ -1208,21 +1207,6 @@ pub struct SseChainReorg {
     pub execution_optimistic: bool,
 }
 
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
-pub struct SseLateHead {
-    pub slot: Slot,
-    pub block: Hash256,
-    pub proposer_index: u64,
-    pub peer_id: Option<String>,
-    pub peer_client: Option<String>,
-    pub proposer_graffiti: String,
-    pub block_delay: Duration,
-    pub observed_delay: Option<Duration>,
-    pub imported_delay: Option<Duration>,
-    pub set_as_head_delay: Option<Duration>,
-    pub execution_optimistic: bool,
-}
-
 #[superstruct(
     variants(V1, V2, V3),
     variant_attributes(derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize))
@@ -1336,7 +1320,6 @@ pub enum EventKind<E: EthSpec> {
     VoluntaryExit(SignedVoluntaryExit),
     ChainReorg(SseChainReorg),
     ContributionAndProof(Box<SignedContributionAndProof<E>>),
-    LateHead(SseLateHead),
     LightClientFinalityUpdate(Box<BeaconResponse<LightClientFinalityUpdate<E>>>),
     LightClientOptimisticUpdate(Box<BeaconResponse<LightClientOptimisticUpdate<E>>>),
     PayloadAttributes(VersionedSsePayloadAttributes),
@@ -1368,7 +1351,6 @@ impl<E: EthSpec> EventKind<E> {
             EventKind::ChainReorg(_) => "chain_reorg",
             EventKind::ContributionAndProof(_) => "contribution_and_proof",
             EventKind::PayloadAttributes(_) => "payload_attributes",
-            EventKind::LateHead(_) => "late_head",
             EventKind::LightClientFinalityUpdate(_) => "light_client_finality_update",
             EventKind::LightClientOptimisticUpdate(_) => "light_client_optimistic_update",
             EventKind::ProposerSlashing(_) => "proposer_slashing",
@@ -1421,9 +1403,6 @@ impl<E: EthSpec> EventKind<E> {
                 serde_json::from_str(data)
                     .map_err(|e| ServerError::InvalidServerSentEvent(format!("Head: {:?}", e)))?,
             ))),
-            "late_head" => Ok(EventKind::LateHead(serde_json::from_str(data).map_err(
-                |e| ServerError::InvalidServerSentEvent(format!("Late Head: {:?}", e)),
-            )?)),
             "voluntary_exit" => Ok(EventKind::VoluntaryExit(
                 serde_json::from_str(data).map_err(|e| {
                     ServerError::InvalidServerSentEvent(format!("Voluntary Exit: {:?}", e))
@@ -1547,7 +1526,6 @@ pub enum EventTopic {
     FinalizedCheckpoint,
     ChainReorg,
     ContributionAndProof,
-    LateHead,
     PayloadAttributes,
     LightClientFinalityUpdate,
     LightClientOptimisticUpdate,
@@ -1581,7 +1559,6 @@ impl FromStr for EventTopic {
             "chain_reorg" => Ok(EventTopic::ChainReorg),
             "contribution_and_proof" => Ok(EventTopic::ContributionAndProof),
             "payload_attributes" => Ok(EventTopic::PayloadAttributes),
-            "late_head" => Ok(EventTopic::LateHead),
             "light_client_finality_update" => Ok(EventTopic::LightClientFinalityUpdate),
             "light_client_optimistic_update" => Ok(EventTopic::LightClientOptimisticUpdate),
             "attester_slashing" => Ok(EventTopic::AttesterSlashing),
@@ -1615,7 +1592,6 @@ impl fmt::Display for EventTopic {
             EventTopic::ChainReorg => write!(f, "chain_reorg"),
             EventTopic::ContributionAndProof => write!(f, "contribution_and_proof"),
             EventTopic::PayloadAttributes => write!(f, "payload_attributes"),
-            EventTopic::LateHead => write!(f, "late_head"),
             EventTopic::LightClientFinalityUpdate => write!(f, "light_client_finality_update"),
             EventTopic::LightClientOptimisticUpdate => write!(f, "light_client_optimistic_update"),
             EventTopic::AttesterSlashing => write!(f, "attester_slashing"),


### PR DESCRIPTION
## Issue Addressed

Closes #9824

## Proposed Changes

- Remove the non-standard `late_head` SSE event (the associated type and the `/eth/v1/events` wiring)
- The late-head detection logic is still kept. The PR doesn't remove the debug log and the `BEACON_BLOCK_DELAY_HEAD_SLOT_START_EXCEEDED_TOTAL` metric that is fired in this case

## Additional Info

I thoroughly searched for usages of this event, but couldn't find any public consumers:
- Using the github's code search API
- Checked each existing CL client's repos