### PR TITLE
Align gloas proposer reorg weight logic w/ spec 

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5484,8 +5484,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Err(Box::new(DoNotReOrg::HeadDistance.into()));
         }
 
-        // TODO(gloas): reorg weight logic needs updating for Gloas. For now use
-        // total weight which is correct for pre-Gloas and conservative for post-Gloas.
         let head_weight = info.head_node.weight();
         let parent_weight = info.parent_node.weight();
 

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -193,11 +193,6 @@ where
         })
     }
 
-    /// Returns the state root of the justified state.
-    pub fn justified_state_root(&self) -> Hash256 {
-        self.justified_state_root
-    }
-
     /// Save the current state of `Self` to a `PersistedForkChoiceStore` which can be stored to the
     /// on-disk database.
     pub fn to_persisted(&self) -> PersistedForkChoiceStore {

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -120,7 +120,7 @@ pub struct BeaconForkChoiceStore<E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     unrealized_finalized_checkpoint: Checkpoint,
     proposer_boost_root: Hash256,
     equivocating_indices: BTreeSet<u64>,
-    equivocating_committee_weights: BTreeMap<Slot, u64>,
+    equivocating_committee_weights: Option<BTreeMap<Slot, u64>>,
     _phantom: PhantomData<E>,
 }
 
@@ -188,7 +188,7 @@ where
             unrealized_finalized_checkpoint: finalized_checkpoint,
             proposer_boost_root: Hash256::zero(),
             equivocating_indices: BTreeSet::new(),
-            equivocating_committee_weights: BTreeMap::new(),
+            equivocating_committee_weights: None,
             _phantom: PhantomData,
         })
     }
@@ -237,7 +237,7 @@ where
             unrealized_finalized_checkpoint: persisted.unrealized_finalized_checkpoint,
             proposer_boost_root: persisted.proposer_boost_root,
             equivocating_indices: persisted.equivocating_indices,
-            equivocating_committee_weights: BTreeMap::new(),
+            equivocating_committee_weights: None,
             _phantom: PhantomData,
         })
     }
@@ -386,11 +386,11 @@ where
         self.equivocating_indices.extend(indices);
     }
 
-    fn equivocating_committee_weights(&self) -> &BTreeMap<Slot, u64> {
-        &self.equivocating_committee_weights
+    fn equivocating_committee_weights(&self) -> Option<&BTreeMap<Slot, u64>> {
+        self.equivocating_committee_weights.as_ref()
     }
 
-    fn set_equivocating_committee_weights(&mut self, weights: BTreeMap<Slot, u64>) {
+    fn set_equivocating_committee_weights(&mut self, weights: Option<BTreeMap<Slot, u64>>) {
         self.equivocating_committee_weights = weights;
     }
 }

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -11,7 +11,7 @@ use fork_choice::ForkChoiceStore;
 use proto_array::JustifiedBalances;
 use safe_arith::ArithError;
 use ssz_derive::{Decode, Encode};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use store::{Error as StoreError, HotColdDB, ItemStore};
@@ -120,6 +120,7 @@ pub struct BeaconForkChoiceStore<E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     unrealized_finalized_checkpoint: Checkpoint,
     proposer_boost_root: Hash256,
     equivocating_indices: BTreeSet<u64>,
+    equivocating_committee_weights: BTreeMap<Slot, u64>,
     _phantom: PhantomData<E>,
 }
 
@@ -187,8 +188,14 @@ where
             unrealized_finalized_checkpoint: finalized_checkpoint,
             proposer_boost_root: Hash256::zero(),
             equivocating_indices: BTreeSet::new(),
+            equivocating_committee_weights: BTreeMap::new(),
             _phantom: PhantomData,
         })
+    }
+
+    /// Returns the state root of the justified state.
+    pub fn justified_state_root(&self) -> Hash256 {
+        self.justified_state_root
     }
 
     /// Save the current state of `Self` to a `PersistedForkChoiceStore` which can be stored to the
@@ -235,6 +242,7 @@ where
             unrealized_finalized_checkpoint: persisted.unrealized_finalized_checkpoint,
             proposer_boost_root: persisted.proposer_boost_root,
             equivocating_indices: persisted.equivocating_indices,
+            equivocating_committee_weights: BTreeMap::new(),
             _phantom: PhantomData,
         })
     }
@@ -381,6 +389,14 @@ where
 
     fn extend_equivocating_indices(&mut self, indices: impl IntoIterator<Item = u64>) {
         self.equivocating_indices.extend(indices);
+    }
+
+    fn equivocating_committee_weights(&self) -> &BTreeMap<Slot, u64> {
+        &self.equivocating_committee_weights
+    }
+
+    fn set_equivocating_committee_weights(&mut self, weights: BTreeMap<Slot, u64>) {
+        self.equivocating_committee_weights = weights;
     }
 }
 

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -47,29 +47,17 @@ impl From<ArithError> for Error {
 /// The number of validator balance sets that are cached within `BalancesCache`.
 const MAX_BALANCE_CACHE_SIZE: usize = 4;
 
-#[superstruct(
-    variants(V8),
-    variant_attributes(derive(PartialEq, Clone, Debug, Encode, Decode)),
-    no_enum
-)]
+#[derive(PartialEq, Clone, Debug)]
 pub(crate) struct CacheItem {
     pub(crate) block_root: Hash256,
     pub(crate) epoch: Epoch,
-    pub(crate) balances: Vec<u64>,
+    pub(crate) justified_balances: JustifiedBalances,
 }
 
-pub(crate) type CacheItem = CacheItemV8;
-
-#[superstruct(
-    variants(V8),
-    variant_attributes(derive(PartialEq, Clone, Default, Debug, Encode, Decode)),
-    no_enum
-)]
+#[derive(PartialEq, Clone, Default, Debug)]
 pub struct BalancesCache {
-    pub(crate) items: Vec<CacheItemV8>,
+    pub(crate) items: Vec<CacheItem>,
 }
-
-pub type BalancesCache = BalancesCacheV8;
 
 impl BalancesCache {
     /// Inspect the given `state` and determine the root of the block at the first slot of
@@ -98,7 +86,7 @@ impl BalancesCache {
             let item = CacheItem {
                 block_root: epoch_boundary_root,
                 epoch,
-                balances: JustifiedBalances::from_justified_state(state)?.effective_balances,
+                justified_balances: JustifiedBalances::from_justified_state(state)?,
             };
 
             if self.items.len() == MAX_BALANCE_CACHE_SIZE {
@@ -120,9 +108,9 @@ impl BalancesCache {
     /// Get the balances for the given `block_root`, if any.
     ///
     /// If some balances are found, they are cloned from the cache.
-    pub fn get(&mut self, block_root: Hash256, epoch: Epoch) -> Option<Vec<u64>> {
+    pub fn get(&mut self, block_root: Hash256, epoch: Epoch) -> Option<JustifiedBalances> {
         let i = self.position(block_root, epoch)?;
-        Some(self.items[i].balances.clone())
+        Some(self.items[i].justified_balances.clone())
     }
 }
 
@@ -333,13 +321,12 @@ where
         self.justified_checkpoint = checkpoint;
         self.justified_state_root = justified_state_root;
 
-        if let Some(balances) = self.balances_cache.get(
+        if let Some(justified_balances) = self.balances_cache.get(
             self.justified_checkpoint.root,
             self.justified_checkpoint.epoch,
         ) {
-            // NOTE: could avoid this re-calculation by introducing a `PersistedCacheItem`.
             metrics::inc_counter(&metrics::BALANCES_CACHE_HITS);
-            self.justified_balances = JustifiedBalances::from_effective_balances(balances)?;
+            self.justified_balances = justified_balances;
         } else {
             metrics::inc_counter(&metrics::BALANCES_CACHE_MISSES);
 
@@ -393,4 +380,41 @@ pub struct PersistedForkChoiceStore {
     pub unrealized_finalized_checkpoint: Checkpoint,
     pub proposer_boost_root: Hash256,
     pub equivocating_indices: BTreeSet<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use types::{MinimalEthSpec, Validator};
+
+    type E = MinimalEthSpec;
+
+    #[test]
+    fn balances_cache_hit_matches_justified_state() {
+        let spec = E::default_spec();
+        let mut state: BeaconState<E> = BeaconState::new(0, <_>::default(), &spec);
+        for i in 0..4u64 {
+            state
+                .validators_mut()
+                .push(Validator {
+                    effective_balance: 32_000_000_000,
+                    slashed: i == 1,
+                    activation_epoch: Epoch::new(0),
+                    exit_epoch: spec.far_future_epoch,
+                    withdrawable_epoch: spec.far_future_epoch,
+                    ..Default::default()
+                })
+                .unwrap();
+        }
+
+        let block_root = Hash256::repeat_byte(1);
+        let mut cache = BalancesCache::default();
+        cache.process_state(block_root, &state).unwrap();
+
+        let cached = cache.get(block_root, state.current_epoch()).unwrap();
+        let expected = JustifiedBalances::from_justified_state(&state).unwrap();
+        assert_eq!(cached, expected);
+        assert!(!cached.slashed_balances.is_empty());
+        assert!(cache.get(block_root, state.current_epoch() + 1).is_none());
+    }
 }

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -60,28 +60,16 @@ pub struct BalancesCache {
 }
 
 impl BalancesCache {
-    /// Inspect the given `state` and determine the root of the block at the first slot of
-    /// `state.current_epoch`. If there is not already some entry for the given block root, then
-    /// add the effective balances from the `state` to the cache.
-    pub fn process_state<E: EthSpec>(
+    /// Add an entry for the given epoch boundary block root, built from `state`.
+    ///
+    /// The caller must pass a `state` at the epoch boundary slot, so that the cached balances
+    /// match the checkpoint state exactly (see `on_verified_block`).
+    pub fn insert<E: EthSpec>(
         &mut self,
-        block_root: Hash256,
+        epoch_boundary_root: Hash256,
         state: &BeaconState<E>,
     ) -> Result<(), Error> {
         let epoch = state.current_epoch();
-        let epoch_boundary_slot = epoch.start_slot(E::slots_per_epoch());
-        let epoch_boundary_root = if epoch_boundary_slot == state.slot() {
-            block_root
-        } else {
-            // This call remains sensible as long as `state.block_roots` is larger than a single
-            // epoch.
-            *state.get_block_root(epoch_boundary_slot)?
-        };
-
-        // Check if there already exists a cache entry for the epoch boundary block of the current
-        // epoch. We rely on the invariant that effective balances do not change for the duration
-        // of a single epoch, so even if the block on the epoch boundary itself is skipped we can
-        // still update its cache entry from any subsequent state in that epoch.
         if self.position(epoch_boundary_root, epoch).is_none() {
             let item = CacheItem {
                 block_root: epoch_boundary_root,
@@ -274,7 +262,37 @@ where
         block_root: Hash256,
         state: &BeaconState<E>,
     ) -> Result<(), Self::Error> {
-        self.balances_cache.process_state(block_root, state)
+        let epoch = state.current_epoch();
+        let epoch_boundary_slot = epoch.start_slot(E::slots_per_epoch());
+
+        if state.slot() == epoch_boundary_slot {
+            return self.balances_cache.insert(block_root, state);
+        }
+
+        // The epoch boundary slot was skipped. We need to make sure to use the boundary state. If
+        // not, a slashing included in first post boundary block would cause us to cache incorrect
+        // balances.
+        let epoch_boundary_root = *state.get_block_root(epoch_boundary_slot)?;
+        if self
+            .balances_cache
+            .position(epoch_boundary_root, epoch)
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        let epoch_boundary_state_root = *state.get_state_root(epoch_boundary_slot)?;
+        let update_cache = true;
+        if let Some(epoch_boundary_state) = self
+            .store
+            .get_hot_state(&epoch_boundary_state_root, update_cache)
+            .map_err(Error::FailedToReadState)?
+        {
+            self.balances_cache
+                .insert(epoch_boundary_root, &epoch_boundary_state)?;
+        }
+
+        Ok(())
     }
 
     fn justified_checkpoint(&self) -> &Checkpoint {
@@ -409,7 +427,7 @@ mod tests {
 
         let block_root = Hash256::repeat_byte(1);
         let mut cache = BalancesCache::default();
-        cache.process_state(block_root, &state).unwrap();
+        cache.insert(block_root, &state).unwrap();
 
         let cached = cache.get(block_root, state.current_epoch()).unwrap();
         let expected = JustifiedBalances::from_justified_state(&state).unwrap();

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -64,6 +64,7 @@ use slot_clock::SlotClock;
 use state_processing::AllCaches;
 use state_processing::builder_deposits_cache::OnboardBuildersCache;
 use state_processing::state_advance::complete_state_advance;
+use std::collections::BTreeMap;
 use std::ops::{Deref, DerefMut};
 use std::panic::Location;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -815,7 +816,20 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let old_payload_status = old_cached_head.head_payload_status();
         let old_forkchoice_update_parameters = old_cached_head.forkchoice_update_parameters();
 
+        let equivocating_committee_weights = self.compute_equivocating_committee_weights(
+            old_cached_head.head_block_root(),
+            current_slot,
+        );
+
         let mut fork_choice_write_lock = self.canonical_head.fork_choice_write_lock();
+
+        match equivocating_committee_weights {
+            Ok(weights) => fork_choice_write_lock.set_equivocating_committee_weights(weights),
+            Err(e) => error!(
+                error = ?e,
+                "Failed to update equivocating committee weights"
+            ),
+        }
 
         // Recompute the current head via the fork choice algorithm.
         let (_, new_payload_status) = fork_choice_write_lock.get_head(current_slot, &self.spec)?;
@@ -1684,6 +1698,103 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             fork_choice_store: fork_choice.fc_store().to_persisted(),
         };
         persisted_fork_choice.as_kv_store_op(FORK_CHOICE_DB_KEY, store_config)
+    }
+
+    /// Compute the justified effective balances of equivocating validators, summed
+    /// per attestation duty slot. Used by the post-Gloas `is_head_weak` check.
+    fn compute_equivocating_committee_weights(
+        &self,
+        head_block_root: Hash256,
+        current_slot: Slot,
+    ) -> Result<BTreeMap<Slot, u64>, Error> {
+        // Don't keep track of pre-gloas equivocating committee weight. This ensures
+        // that pre-gloas `is_head_weak` is correctly calculated.
+        if !self
+            .spec
+            .fork_name_at_slot::<T::EthSpec>(current_slot)
+            .gloas_enabled()
+        {
+            return Ok(BTreeMap::new());
+        }
+
+        // TODO(gloas): once any slashing has been observed the state lookup and `equivocating_validator_balances` calculation
+        // run on every head recompute forever. We could prevent this by introducing some type of cache key like:
+        // (epoch, justified_state_root, equivocating_indices.len()).
+        let (equivocating_indices, justified_state_root) = {
+            let fork_choice_read_lock = self.canonical_head.fork_choice_read_lock();
+            let fc_store = fork_choice_read_lock.fc_store();
+            (
+                fc_store
+                    .equivocating_indices()
+                    .iter()
+                    .copied()
+                    .collect::<Vec<_>>(),
+                fc_store.justified_state_root(),
+            )
+        };
+
+        if equivocating_indices.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+
+        // The spec reads raw effective balances from the justified state, without
+        // filtering by slashed or active status.
+        let justified_state = self
+            .store
+            .get_hot_state(&justified_state_root, true)
+            .map_err(Error::DBError)?
+            .ok_or(Error::MissingBeaconState(justified_state_root))?;
+
+        let equivocating_validator_balances: Vec<(u64, u64)> = equivocating_indices
+            .iter()
+            .map(|&index| {
+                let balance = justified_state
+                    .validators()
+                    .get(index as usize)
+                    .map(|validator| validator.effective_balance)
+                    .unwrap_or(0);
+                (index, balance)
+            })
+            .collect();
+
+        let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
+        let previous_slot_epoch = current_slot
+            .saturating_sub(1u64)
+            .epoch(T::EthSpec::slots_per_epoch());
+
+        // Re-org checks evaluate at `current_slot - 1` which can fall to the
+        // previous epoch when `current_slot` is at an epoch boundary.
+        let epochs = if previous_slot_epoch == current_epoch {
+            vec![current_epoch]
+        } else {
+            vec![previous_slot_epoch, current_epoch]
+        };
+
+        let mut equivocating_committee_weights = BTreeMap::new();
+
+        for epoch in epochs {
+            let duty_weights: Vec<(Slot, u64)> =
+                self.with_committee_cache(head_block_root, epoch, |shuffling, _| {
+                    let mut duty_weights =
+                        Vec::with_capacity(equivocating_validator_balances.len());
+                    for &(index, balance) in &equivocating_validator_balances {
+                        if let Some(duty) = shuffling
+                            .committee_cache
+                            .get_attestation_duties(index as usize)?
+                        {
+                            duty_weights.push((duty.slot, balance));
+                        }
+                    }
+                    Ok(duty_weights)
+                })?;
+
+            for (slot, balance) in duty_weights {
+                let entry = equivocating_committee_weights.entry(slot).or_insert(0u64);
+                *entry = entry.saturating_add(balance);
+            }
+        }
+
+        Ok(equivocating_committee_weights)
     }
 }
 

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -816,14 +816,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let old_payload_status = old_cached_head.head_payload_status();
         let old_forkchoice_update_parameters = old_cached_head.forkchoice_update_parameters();
 
-        let equivocating_committee_weights = self.compute_equivocating_committee_weights(
-            old_cached_head.head_block_root(),
-            current_slot,
-        );
-
         let mut fork_choice_write_lock = self.canonical_head.fork_choice_write_lock();
 
-        match equivocating_committee_weights {
+        // Compute under the write lock so the weights and `get_head` see one consistent view
+        // of the equivocating indices and justified balances.
+        match self.compute_equivocating_committee_weights(&fork_choice_write_lock, current_slot) {
             Ok(weights) => fork_choice_write_lock.set_equivocating_committee_weights(weights),
             Err(e) => error!(
                 error = ?e,
@@ -1702,9 +1699,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     /// Compute the justified effective balances of equivocating validators, summed
     /// per attestation duty slot. Used by the post-Gloas `is_head_weak` check.
+    ///
+    /// Duties come from the head's `slot_assignments` cache, which covers the three epochs up
+    /// to the last head update. Every slot that `is_head_weak` evaluates is within that window.
     fn compute_equivocating_committee_weights(
         &self,
-        head_block_root: Hash256,
+        fork_choice: &BeaconForkChoice<T>,
         current_slot: Slot,
     ) -> Result<BTreeMap<Slot, u64>, Error> {
         // Don't keep track of pre-gloas equivocating committee weight. This ensures
@@ -1717,62 +1717,28 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Ok(BTreeMap::new());
         }
 
-        let equivocating_validator_balances: Vec<(u64, u64)> = {
-            let fork_choice_read_lock = self.canonical_head.fork_choice_read_lock();
-            let fc_store = fork_choice_read_lock.fc_store();
-            let justified_balances = fc_store.justified_balances();
-            fc_store
-                .equivocating_indices()
-                .iter()
-                .map(|&index| {
-                    let balance = justified_balances
-                        .effective_balances
-                        .get(index as usize)
-                        .copied()
-                        .filter(|balance| *balance != 0)
-                        .or_else(|| justified_balances.slashed_balances.get(&index).copied())
-                        .unwrap_or(0);
-                    (index, balance)
-                })
-                .collect()
-        };
-
-        if equivocating_validator_balances.is_empty() {
+        let fc_store = fork_choice.fc_store();
+        let equivocating_indices = fc_store.equivocating_indices();
+        if equivocating_indices.is_empty() {
             return Ok(BTreeMap::new());
         }
+        let justified_balances = fc_store.justified_balances();
 
-        let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
-        let previous_slot_epoch = current_slot
-            .saturating_sub(1u64)
-            .epoch(T::EthSpec::slots_per_epoch());
-
-        // Re-org checks evaluate at `current_slot - 1` which can fall to the
-        // previous epoch when `current_slot` is at an epoch boundary.
-        let epochs = if previous_slot_epoch == current_epoch {
-            vec![current_epoch]
-        } else {
-            vec![previous_slot_epoch, current_epoch]
-        };
-
+        let slot_assignments = self.canonical_head.slot_assignments.lock();
         let mut equivocating_committee_weights = BTreeMap::new();
-
-        for epoch in epochs {
-            let duty_weights: Vec<(Slot, u64)> =
-                self.with_committee_cache(head_block_root, epoch, |shuffling, _| {
-                    let mut duty_weights =
-                        Vec::with_capacity(equivocating_validator_balances.len());
-                    for &(index, balance) in &equivocating_validator_balances {
-                        if let Some(duty) = shuffling
-                            .committee_cache
-                            .get_attestation_duties(index as usize)?
-                        {
-                            duty_weights.push((duty.slot, balance));
-                        }
-                    }
-                    Ok(duty_weights)
-                })?;
-
-            for (slot, balance) in duty_weights {
+        for &index in equivocating_indices {
+            // Validators activated after the justified epoch count as zero weight (spec reads their raw balance).
+            let balance = justified_balances
+                .effective_balances
+                .get(index as usize)
+                .copied()
+                .filter(|balance| *balance != 0)
+                .or_else(|| justified_balances.slashed_balances.get(&index).copied())
+                .unwrap_or(0);
+            if balance == 0 {
+                continue;
+            }
+            for slot in slot_assignments.assigned_slots(index as usize)? {
                 let entry = equivocating_committee_weights.entry(slot).or_insert(0u64);
                 *entry = entry.saturating_add(balance);
             }

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1717,45 +1717,29 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Ok(BTreeMap::new());
         }
 
-        // TODO(gloas): once any slashing has been observed the state lookup and `equivocating_validator_balances` calculation
-        // run on every head recompute forever. We could prevent this by introducing some type of cache key like:
-        // (epoch, justified_state_root, equivocating_indices.len()).
-        let (equivocating_indices, justified_state_root) = {
+        let equivocating_validator_balances: Vec<(u64, u64)> = {
             let fork_choice_read_lock = self.canonical_head.fork_choice_read_lock();
             let fc_store = fork_choice_read_lock.fc_store();
-            (
-                fc_store
-                    .equivocating_indices()
-                    .iter()
-                    .copied()
-                    .collect::<Vec<_>>(),
-                fc_store.justified_state_root(),
-            )
+            let justified_balances = fc_store.justified_balances();
+            fc_store
+                .equivocating_indices()
+                .iter()
+                .map(|&index| {
+                    let balance = justified_balances
+                        .effective_balances
+                        .get(index as usize)
+                        .copied()
+                        .filter(|balance| *balance != 0)
+                        .or_else(|| justified_balances.slashed_balances.get(&index).copied())
+                        .unwrap_or(0);
+                    (index, balance)
+                })
+                .collect()
         };
 
-        if equivocating_indices.is_empty() {
+        if equivocating_validator_balances.is_empty() {
             return Ok(BTreeMap::new());
         }
-
-        // The spec reads raw effective balances from the justified state, without
-        // filtering by slashed or active status.
-        let justified_state = self
-            .store
-            .get_hot_state(&justified_state_root, true)
-            .map_err(Error::DBError)?
-            .ok_or(Error::MissingBeaconState(justified_state_root))?;
-
-        let equivocating_validator_balances: Vec<(u64, u64)> = equivocating_indices
-            .iter()
-            .map(|&index| {
-                let balance = justified_state
-                    .validators()
-                    .get(index as usize)
-                    .map(|validator| validator.effective_balance)
-                    .unwrap_or(0);
-                (index, balance)
-            })
-            .collect();
 
         let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
         let previous_slot_epoch = current_slot

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -822,10 +822,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // of the equivocating indices and justified balances.
         match self.compute_equivocating_committee_weights(&fork_choice_write_lock, current_slot) {
             Ok(weights) => fork_choice_write_lock.set_equivocating_committee_weights(weights),
-            Err(e) => error!(
-                error = ?e,
-                "Failed to update equivocating committee weights"
-            ),
+            Err(e) => {
+                error!(
+                    error = ?e,
+                    "Failed to update equivocating committee weights"
+                );
+                fork_choice_write_lock.set_equivocating_committee_weights(None);
+            }
         }
 
         // Recompute the current head via the fork choice algorithm.
@@ -1700,13 +1703,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Compute the justified effective balances of equivocating validators, summed
     /// per attestation duty slot. Used by the post-Gloas `is_head_weak` check.
     ///
-    /// Duties come from the head's `slot_assignments` cache, which covers the three epochs up
-    /// to the last head update. Every slot that `is_head_weak` evaluates is within that window.
+    /// Duties come from the head's `slot_assignments` cache. Returns `Ok(None)` if the
+    /// cache does not match the current head and epoch.
     fn compute_equivocating_committee_weights(
         &self,
         fork_choice: &BeaconForkChoice<T>,
         current_slot: Slot,
-    ) -> Result<BTreeMap<Slot, u64>, Error> {
+    ) -> Result<Option<BTreeMap<Slot, u64>>, Error> {
         // Don't keep track of pre-gloas equivocating committee weight. This ensures
         // that pre-gloas `is_head_weak` is correctly calculated.
         if !self
@@ -1714,17 +1717,41 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .fork_name_at_slot::<T::EthSpec>(current_slot)
             .gloas_enabled()
         {
-            return Ok(BTreeMap::new());
+            return Ok(Some(BTreeMap::new()));
         }
 
         let fc_store = fork_choice.fc_store();
         let equivocating_indices = fc_store.equivocating_indices();
         if equivocating_indices.is_empty() {
-            return Ok(BTreeMap::new());
+            return Ok(Some(BTreeMap::new()));
         }
         let justified_balances = fc_store.justified_balances();
 
         let slot_assignments = self.canonical_head.slot_assignments.lock();
+
+        let head_block_root = self.canonical_head.cached_head().head_block_root();
+        let Some(head_block) = fork_choice.get_block(&head_block_root) else {
+            return Ok(None);
+        };
+        let head_epoch = head_block.slot.epoch(T::EthSpec::slots_per_epoch());
+        let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
+        let expected_key = if current_epoch == head_epoch {
+            head_block.current_epoch_shuffling_id
+        } else if current_epoch == head_epoch.saturating_add(1u64) {
+            head_block.next_epoch_shuffling_id
+        } else {
+            // No blocks after the head, so the head is the decision block for the current epoch.
+            AttestationShufflingId::from_components(current_epoch, head_block_root)
+        };
+        if *slot_assignments.key() != expected_key {
+            debug!(
+                %current_slot,
+                ?head_block_root,
+                "Slot assignments cache is stale; equivocating committee weights unknown"
+            );
+            return Ok(None);
+        }
+
         let mut equivocating_committee_weights = BTreeMap::new();
         for &index in equivocating_indices {
             // Validators activated after the justified epoch count as zero weight (spec reads their raw balance).
@@ -1744,7 +1771,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
         }
 
-        Ok(equivocating_committee_weights)
+        Ok(Some(equivocating_committee_weights))
     }
 }
 

--- a/beacon_node/beacon_chain/tests/op_verification.rs
+++ b/beacon_node/beacon_chain/tests/op_verification.rs
@@ -769,7 +769,7 @@ async fn attester_slashing_updates_equivocating_committee_weights() {
         )
         .await;
 
-    // No equivocations: the map is empty.
+    // No equivocations: the weights are known and the map is empty.
     assert!(
         harness
             .chain
@@ -777,7 +777,7 @@ async fn attester_slashing_updates_equivocating_committee_weights() {
             .fork_choice_read_lock()
             .fc_store()
             .equivocating_committee_weights()
-            .is_empty()
+            .is_some_and(|weights| weights.is_empty())
     );
 
     // Slash a validator and import the slashing into fork choice.
@@ -812,8 +812,7 @@ async fn attester_slashing_updates_equivocating_committee_weights() {
     assert_eq!(
         fc_store
             .equivocating_committee_weights()
-            .get(&duty.slot)
-            .copied(),
+            .and_then(|weights| weights.get(&duty.slot).copied()),
         Some(expected_balance)
     );
 }
@@ -919,8 +918,7 @@ async fn equivocating_committee_weights_use_raw_justified_balances() {
     assert_eq!(
         fc_store
             .equivocating_committee_weights()
-            .get(&duty.slot)
-            .copied(),
+            .and_then(|weights| weights.get(&duty.slot).copied()),
         Some(raw_balance)
     );
 }

--- a/beacon_node/beacon_chain/tests/op_verification.rs
+++ b/beacon_node/beacon_chain/tests/op_verification.rs
@@ -11,9 +11,11 @@ use beacon_chain::{
     },
 };
 use bls::Keypair;
+use fork_choice::ForkChoiceStore;
 use state_processing::per_block_processing::errors::{
     AttesterSlashingInvalid, BlockOperationError, ExitInvalid, ProposerSlashingInvalid,
 };
+use state_processing::state_advance::complete_state_advance;
 use std::sync::{Arc, LazyLock};
 use store::StoreConfig;
 use store::database::interface::BeaconNodeBackend;
@@ -744,5 +746,181 @@ async fn electra_attester_slashing_included_in_gloas_block() {
             .get(slashed_validator as usize)
             .unwrap()
             .slashed
+    );
+}
+
+#[tokio::test]
+async fn attester_slashing_updates_equivocating_committee_weights() {
+    let spec = Arc::new(ForkName::Gloas.make_genesis_spec(E::default_spec()));
+    let harness = BeaconChainHarness::builder(MinimalEthSpec)
+        .spec(spec)
+        .keypairs(KEYPAIRS.to_vec())
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build();
+    harness.advance_slot();
+
+    // Advance to a mid-epoch slot so the weights are computed for a single epoch.
+    harness
+        .extend_chain(
+            3,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    // No equivocations: the map is empty.
+    assert!(
+        harness
+            .chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .fc_store()
+            .equivocating_committee_weights()
+            .is_empty()
+    );
+
+    // Slash a validator and import the slashing into fork choice.
+    let slashed_validator = 0;
+    let slashing = harness.make_attester_slashing(vec![slashed_validator]);
+    let ObservationOutcome::New(verified_slashing) = harness
+        .chain
+        .verify_attester_slashing_for_gossip(slashing)
+        .unwrap()
+    else {
+        panic!("slashing should verify");
+    };
+    harness.chain.import_attester_slashing(verified_slashing);
+
+    harness.chain.recompute_head_at_current_slot().await;
+
+    // The map now contains the slashed validator's justified balance at its duty slot.
+    let mut head_state = harness.get_current_state();
+    head_state
+        .build_committee_cache(RelativeEpoch::Current, &harness.chain.spec)
+        .unwrap();
+    let duty = head_state
+        .get_attestation_duties(slashed_validator as usize, RelativeEpoch::Current)
+        .unwrap()
+        .expect("slashed validator should have an attestation duty");
+
+    let fork_choice_read_lock = harness.chain.canonical_head.fork_choice_read_lock();
+    let fc_store = fork_choice_read_lock.fc_store();
+    let expected_balance =
+        fc_store.justified_balances().effective_balances[slashed_validator as usize];
+    assert!(expected_balance > 0);
+    assert_eq!(
+        fc_store
+            .equivocating_committee_weights()
+            .get(&duty.slot)
+            .copied(),
+        Some(expected_balance)
+    );
+}
+
+#[tokio::test]
+async fn equivocating_committee_weights_use_raw_justified_balances() {
+    let spec = Arc::new(ForkName::Gloas.make_genesis_spec(E::default_spec()));
+    let harness = BeaconChainHarness::builder(MinimalEthSpec)
+        .spec(spec)
+        .keypairs(KEYPAIRS.to_vec())
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build();
+    harness.advance_slot();
+
+    harness
+        .extend_chain(
+            3,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    // Slash a validator: fork choice learns of the equivocation and the op pool
+    // includes the slashing in a subsequent block.
+    let slashed_validator = 0;
+    let slashing = harness.make_attester_slashing(vec![slashed_validator]);
+    let ObservationOutcome::New(verified_slashing) = harness
+        .chain
+        .verify_attester_slashing_for_gossip(slashing)
+        .unwrap()
+    else {
+        panic!("slashing should verify");
+    };
+    harness.chain.import_attester_slashing(verified_slashing);
+    harness.advance_slot();
+
+    // Advance until the justified state has the validator marked as slashed,
+    // skipping slots where the slashed validator is the proposer.
+    while harness.get_current_slot() < Slot::new(29) {
+        let slot = harness.get_current_slot();
+        let mut state = harness.get_current_state();
+        complete_state_advance(&mut state, None, slot, &harness.chain.spec).unwrap();
+        state
+            .build_committee_cache(RelativeEpoch::Current, &harness.chain.spec)
+            .unwrap();
+        let proposer = state
+            .get_beacon_proposer_index(slot, &harness.chain.spec)
+            .unwrap();
+        if proposer != slashed_validator as usize {
+            harness
+                .extend_chain(
+                    1,
+                    BlockStrategy::OnCanonicalHead,
+                    AttestationStrategy::AllValidators,
+                )
+                .await;
+        }
+        harness.advance_slot();
+    }
+    harness.chain.recompute_head_at_current_slot().await;
+
+    let justified_state_root = harness
+        .chain
+        .canonical_head
+        .fork_choice_read_lock()
+        .fc_store()
+        .justified_state_root();
+    let justified_state = harness
+        .chain
+        .store
+        .get_hot_state(&justified_state_root, false)
+        .unwrap()
+        .expect("justified state should exist");
+    let validator = justified_state
+        .validators()
+        .get(slashed_validator as usize)
+        .unwrap();
+    assert!(
+        validator.slashed,
+        "slashing should be reflected in the justified state"
+    );
+    let raw_balance = validator.effective_balance;
+    assert!(raw_balance > 0);
+
+    let mut head_state = harness.get_current_state();
+    head_state
+        .build_committee_cache(RelativeEpoch::Current, &harness.chain.spec)
+        .unwrap();
+    let duty = head_state
+        .get_attestation_duties(slashed_validator as usize, RelativeEpoch::Current)
+        .unwrap()
+        .expect("slashed validator should have an attestation duty");
+
+    let fork_choice_read_lock = harness.chain.canonical_head.fork_choice_read_lock();
+    let fc_store = fork_choice_read_lock.fc_store();
+    // The zeroed justified balances differ from the raw balance here; a regression
+    // to reading them would make the map entry zero.
+    assert_eq!(
+        fc_store.justified_balances().effective_balances[slashed_validator as usize],
+        0
+    );
+    assert_eq!(
+        fc_store
+            .equivocating_committee_weights()
+            .get(&duty.slot)
+            .copied(),
+        Some(raw_balance)
     );
 }

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -235,7 +235,7 @@ fn build_chain_inner(
         &balances,
         Hash256::zero(), // no proposer boost
         &BTreeSet::new(),
-        &BTreeMap::new(),
+        Some(&BTreeMap::new()),
         Slot::new(CHAIN_TIP_SLOT),
         &spec,
     )

--- a/consensus/fast_confirmation/benches/fcr_bench.rs
+++ b/consensus/fast_confirmation/benches/fcr_bench.rs
@@ -8,7 +8,7 @@
 //! `get_latest_confirmed` is measured across a table of realistic (chain position, FCR run slot)
 //! scenarios — see `SCENARIOS`.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
@@ -235,6 +235,7 @@ fn build_chain_inner(
         &balances,
         Hash256::zero(), // no proposer boost
         &BTreeSet::new(),
+        &BTreeMap::new(),
         Slot::new(CHAIN_TIP_SLOT),
         &spec,
     )

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1483,8 +1483,8 @@ where
             .extend_equivocating_indices(att1_indices.intersection(&att2_indices).copied());
     }
 
-    /// Replaces the per-slot equivocating committee weights.
-    pub fn set_equivocating_committee_weights(&mut self, weights: BTreeMap<Slot, u64>) {
+    /// Replaces the per-slot equivocating committee weights. `None` marks them unknown.
+    pub fn set_equivocating_committee_weights(&mut self, weights: Option<BTreeMap<Slot, u64>>) {
         self.fc_store.set_equivocating_committee_weights(weights);
     }
 

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -588,6 +588,7 @@ where
             store.justified_balances(),
             store.proposer_boost_root(),
             store.equivocating_indices(),
+            store.equivocating_committee_weights(),
             current_slot,
             spec,
         )?;
@@ -674,6 +675,7 @@ where
                 self.fc_store.justified_balances(),
                 re_org_head_threshold,
                 re_org_parent_threshold,
+                self.fc_store().equivocating_committee_weights(),
                 max_epochs_since_finalization,
             )
             .map_err(ProposerHeadError::convert_inner_error)
@@ -1481,6 +1483,11 @@ where
             .extend_equivocating_indices(att1_indices.intersection(&att2_indices).copied());
     }
 
+    /// Replaces the per-slot equivocating committee weights.
+    pub fn set_equivocating_committee_weights(&mut self, weights: BTreeMap<Slot, u64>) {
+        self.fc_store.set_equivocating_committee_weights(weights);
+    }
+
     /// Call `on_tick` for all slots between `fc_store.get_current_slot()` and the provided
     /// `current_slot`. Returns the value of `self.fc_store.get_current_slot`.
     pub fn update_time(&mut self, current_slot: Slot) -> Result<Slot, Error<T::Error>> {
@@ -1691,6 +1698,7 @@ where
                     block_root,
                     current_slot,
                     proposer_boost_root,
+                    self.fc_store().equivocating_committee_weights(),
                     spec,
                 )
                 .map_err(Error::ProtoArrayError)

--- a/consensus/fork_choice/src/fork_choice_store.rs
+++ b/consensus/fork_choice/src/fork_choice_store.rs
@@ -90,9 +90,9 @@ pub trait ForkChoiceStore<E: EthSpec>: Sized {
     /// Adds to the set of equivocating indices.
     fn extend_equivocating_indices(&mut self, indices: impl IntoIterator<Item = u64>);
 
-    /// Gets the per-slot committee weight of equivocating validators.
-    fn equivocating_committee_weights(&self) -> &BTreeMap<Slot, u64>;
+    /// Gets the per-slot committee weight of equivocating validators, or `None` if unknown.
+    fn equivocating_committee_weights(&self) -> Option<&BTreeMap<Slot, u64>>;
 
-    /// Replaces the per-slot equivocating committee weights.
-    fn set_equivocating_committee_weights(&mut self, weights: BTreeMap<Slot, u64>);
+    /// Replaces the per-slot equivocating committee weights. `None` marks them unknown.
+    fn set_equivocating_committee_weights(&mut self, weights: Option<BTreeMap<Slot, u64>>);
 }

--- a/consensus/fork_choice/src/fork_choice_store.rs
+++ b/consensus/fork_choice/src/fork_choice_store.rs
@@ -1,5 +1,5 @@
 use proto_array::JustifiedBalances;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 use types::{AbstractExecPayload, BeaconBlockRef, BeaconState, Checkpoint, EthSpec, Hash256, Slot};
 
@@ -89,4 +89,10 @@ pub trait ForkChoiceStore<E: EthSpec>: Sized {
 
     /// Adds to the set of equivocating indices.
     fn extend_equivocating_indices(&mut self, indices: impl IntoIterator<Item = u64>);
+
+    /// Gets the per-slot committee weight of equivocating validators.
+    fn equivocating_committee_weights(&self) -> &BTreeMap<Slot, u64>;
+
+    /// Replaces the per-slot equivocating committee weights.
+    fn set_equivocating_committee_weights(&mut self, weights: BTreeMap<Slot, u64>);
 }

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -646,7 +646,7 @@ async fn justified_balances() {
 /// Check that the balances are obtained correctly when the justified state contains a slashed
 /// validator.
 ///
-/// The slashing must be included well before the justified epoch's boundary: the balances cache
+/// TODO(9691) The slashing must be included well before the justified epoch's boundary: the balances cache
 /// builds its entry from the first state processed in an epoch, so a slashing included intra-epoch
 /// (e.g. just after a skipped boundary slot) produces cached balances that differ from the
 /// checkpoint state itself.

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -14,6 +14,7 @@ use fork_choice::{
     InvalidPayloadAttestation, PayloadVerificationStatus, QueuedAttestation,
 };
 use state_processing::state_advance::complete_state_advance;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -394,27 +395,41 @@ impl ForkChoiceTest {
             .get_state(&state_root, None, CACHE_STATE_IN_TESTS)
             .unwrap()
             .unwrap();
+        let current_epoch = state.current_epoch();
+        let mut num_active_validators = 0u64;
+        let mut slashed_balances = BTreeMap::new();
         let balances = state
             .validators()
             .into_iter()
-            .map(|v| {
-                if v.is_active_at(state.current_epoch()) {
+            .enumerate()
+            .map(|(i, v)| {
+                if !v.slashed && v.is_active_at(current_epoch) {
+                    num_active_validators += 1;
                     v.effective_balance
                 } else {
+                    if v.slashed && v.is_active_at(current_epoch) {
+                        slashed_balances.insert(i as u64, v.effective_balance);
+                    }
                     0
                 }
             })
             .collect::<Vec<_>>();
 
+        let justified_balances = fc.fc_store().justified_balances();
         assert_eq!(
             &balances[..],
-            &fc.fc_store().justified_balances().effective_balances,
+            &justified_balances.effective_balances,
             "balances should match"
         );
         assert_eq!(
             balances.iter().sum::<u64>(),
-            fc.fc_store().justified_balances().total_effective_balance
+            justified_balances.total_effective_balance
         );
+        assert_eq!(
+            num_active_validators,
+            justified_balances.num_active_validators
+        );
+        assert_eq!(slashed_balances, justified_balances.slashed_balances);
     }
 
     /// Returns an attestation that is valid for some slot in the given `chain`.
@@ -626,6 +641,32 @@ async fn justified_balances() {
         .await
         .assert_justified_epoch(2)
         .check_justified_balances()
+}
+
+/// Check that the balances are obtained correctly when the justified state contains a slashed
+/// validator.
+///
+/// The slashing must be included well before the justified epoch's boundary: the balances cache
+/// builds its entry from the first state processed in an epoch, so a slashing included intra-epoch
+/// (e.g. just after a skipped boundary slot) produces cached balances that differ from the
+/// checkpoint state itself.
+#[tokio::test]
+async fn justified_balances_with_attester_slashing() {
+    let test = ForkChoiceTest::new()
+        .apply_blocks_while(|_, state| state.finalized_checkpoint().epoch == 0)
+        .await
+        .unwrap()
+        .add_previous_epoch_attester_slashing()
+        .await
+        .apply_blocks(1)
+        .await
+        .apply_blocks(2 * E::slots_per_epoch() as usize)
+        .await;
+
+    let slashed_balances =
+        test.get(|fc_store| fc_store.justified_balances().slashed_balances.clone());
+    assert_eq!(slashed_balances.len(), 1, "one attester was slashed");
+    test.check_justified_balances();
 }
 
 macro_rules! assert_invalid_block {

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -646,10 +646,8 @@ async fn justified_balances() {
 /// Check that the balances are obtained correctly when the justified state contains a slashed
 /// validator.
 ///
-/// TODO(9691) The slashing must be included well before the justified epoch's boundary: the balances cache
-/// builds its entry from the first state processed in an epoch, so a slashing included intra-epoch
-/// (e.g. just after a skipped boundary slot) produces cached balances that differ from the
-/// checkpoint state itself.
+/// The slashing is included two epochs before the head so that it is present in the justified
+/// checkpoint state.
 #[tokio::test]
 async fn justified_balances_with_attester_slashing() {
     let test = ForkChoiceTest::new()
@@ -666,6 +664,32 @@ async fn justified_balances_with_attester_slashing() {
     let slashed_balances =
         test.get(|fc_store| fc_store.justified_balances().slashed_balances.clone());
     assert_eq!(slashed_balances.len(), 1, "one attester was slashed");
+    test.check_justified_balances();
+}
+
+/// Regression test for a slashing included just after a skipped epoch boundary slot (#9691).
+///
+/// The slashing postdates the justified checkpoint state, so it must not appear in the justified
+/// balances even though it is present in the state that populates the balances cache entry.
+#[tokio::test]
+async fn justified_balances_with_slashing_after_skipped_boundary() {
+    let test = ForkChoiceTest::new()
+        .apply_blocks_while(|_, state| state.finalized_checkpoint().epoch == 0)
+        .await
+        .unwrap()
+        .add_previous_epoch_attester_slashing()
+        .await
+        .apply_blocks(1)
+        .await
+        .apply_blocks(E::slots_per_epoch() as usize)
+        .await;
+
+    let slashed_balances =
+        test.get(|fc_store| fc_store.justified_balances().slashed_balances.clone());
+    assert!(
+        slashed_balances.is_empty(),
+        "the slashing postdates the justified checkpoint state"
+    );
     test.check_justified_balances();
 }
 

--- a/consensus/proto_array/benches/find_head.rs
+++ b/consensus/proto_array/benches/find_head.rs
@@ -1,7 +1,7 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use fixed_bytes::FixedBytesExtended;
 use proto_array::{Block, ExecutionStatus, JustifiedBalances, ProtoArrayForkChoice};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 use types::{
     AttestationShufflingId, Checkpoint, Epoch, EthSpec, ExecutionBlockHash, Hash256,
@@ -82,6 +82,7 @@ fn build_chain(num_blocks: u64, gloas: bool) -> (ProtoArrayForkChoice, types::Ch
 fn bench_find_head(c: &mut Criterion) {
     let mut group = c.benchmark_group("find_head");
     let equivocating_indices = BTreeSet::new();
+    let equivocating_committee_weights = BTreeMap::new();
     let finalized_checkpoint = Checkpoint {
         epoch: Epoch::new(0),
         root: get_root(0),
@@ -103,6 +104,7 @@ fn bench_find_head(c: &mut Criterion) {
                             &balances,
                             Hash256::zero(),
                             &equivocating_indices,
+                            &equivocating_committee_weights,
                             Slot::new(num_blocks),
                             &spec,
                         )

--- a/consensus/proto_array/benches/find_head.rs
+++ b/consensus/proto_array/benches/find_head.rs
@@ -104,7 +104,7 @@ fn bench_find_head(c: &mut Criterion) {
                             &balances,
                             Hash256::zero(),
                             &equivocating_indices,
-                            &equivocating_committee_weights,
+                            Some(&equivocating_committee_weights),
                             Slot::new(num_blocks),
                             &spec,
                         )

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -10,7 +10,7 @@ use crate::{InvalidationOperation, JustifiedBalances};
 use fixed_bytes::FixedBytesExtended;
 use serde::{Deserialize, Serialize};
 use ssz::BitVector;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 use types::{
     AttestationShufflingId, ChainSpec, Checkpoint, Epoch, EthSpec, ExecutionBlockHash, Hash256,
@@ -177,6 +177,7 @@ impl ForkChoiceTestDefinition {
         )
         .expect("should create fork choice struct");
         let equivocating_indices = BTreeSet::new();
+        let equivocating_committee_weights = BTreeMap::new();
         let mut last_current_slot = Slot::new(0);
 
         for (op_index, op) in self.operations.into_iter().enumerate() {
@@ -199,6 +200,7 @@ impl ForkChoiceTestDefinition {
                             &justified_balances,
                             Hash256::zero(),
                             &equivocating_indices,
+                            &equivocating_committee_weights,
                             current_slot,
                             &spec,
                         )
@@ -223,6 +225,7 @@ impl ForkChoiceTestDefinition {
                         &head,
                         current_slot,
                         Hash256::zero(),
+                        &equivocating_committee_weights,
                         &spec,
                         payload_status,
                         op_index,
@@ -247,6 +250,7 @@ impl ForkChoiceTestDefinition {
                             &justified_balances,
                             proposer_boost_root,
                             &equivocating_indices,
+                            &equivocating_committee_weights,
                             Slot::new(0),
                             &spec,
                         )
@@ -264,6 +268,7 @@ impl ForkChoiceTestDefinition {
                         &head,
                         Slot::new(0),
                         proposer_boost_root,
+                        &equivocating_committee_weights,
                         &spec,
                         payload_status,
                         op_index,
@@ -284,6 +289,7 @@ impl ForkChoiceTestDefinition {
                         &justified_balances,
                         Hash256::zero(),
                         &equivocating_indices,
+                        &equivocating_committee_weights,
                         Slot::new(0),
                         &spec,
                     );
@@ -607,6 +613,7 @@ impl ForkChoiceTestDefinition {
                             &block_root,
                             current_slot.unwrap_or(last_current_slot),
                             proposer_boost_root.unwrap_or_else(Hash256::zero),
+                            &equivocating_committee_weights,
                             &spec,
                         )
                         .unwrap();
@@ -666,11 +673,13 @@ fn get_checkpoint(i: u64) -> Checkpoint {
 
 /// Checks that `get_canonical_payload_status` agrees with the `payload_status`
 /// returned by `find_head` for the head block.
+#[allow(clippy::too_many_arguments)]
 fn assert_canonical_payload_status_matches_find_head(
     fork_choice: &ProtoArrayForkChoice,
     head: &Hash256,
     current_slot: Slot,
     proposer_boost_root: Hash256,
+    equivocating_committee_weights: &BTreeMap<Slot, u64>,
     spec: &ChainSpec,
     expected: PayloadStatus,
     op_index: usize,
@@ -679,6 +688,7 @@ fn assert_canonical_payload_status_matches_find_head(
         head,
         current_slot,
         proposer_boost_root,
+        equivocating_committee_weights,
         spec,
     ) {
         Ok(actual) => assert_eq!(

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -200,7 +200,7 @@ impl ForkChoiceTestDefinition {
                             &justified_balances,
                             Hash256::zero(),
                             &equivocating_indices,
-                            &equivocating_committee_weights,
+                            Some(&equivocating_committee_weights),
                             current_slot,
                             &spec,
                         )
@@ -225,7 +225,7 @@ impl ForkChoiceTestDefinition {
                         &head,
                         current_slot,
                         Hash256::zero(),
-                        &equivocating_committee_weights,
+                        Some(&equivocating_committee_weights),
                         &spec,
                         payload_status,
                         op_index,
@@ -250,7 +250,7 @@ impl ForkChoiceTestDefinition {
                             &justified_balances,
                             proposer_boost_root,
                             &equivocating_indices,
-                            &equivocating_committee_weights,
+                            Some(&equivocating_committee_weights),
                             Slot::new(0),
                             &spec,
                         )
@@ -268,7 +268,7 @@ impl ForkChoiceTestDefinition {
                         &head,
                         Slot::new(0),
                         proposer_boost_root,
-                        &equivocating_committee_weights,
+                        Some(&equivocating_committee_weights),
                         &spec,
                         payload_status,
                         op_index,
@@ -289,7 +289,7 @@ impl ForkChoiceTestDefinition {
                         &justified_balances,
                         Hash256::zero(),
                         &equivocating_indices,
-                        &equivocating_committee_weights,
+                        Some(&equivocating_committee_weights),
                         Slot::new(0),
                         &spec,
                     );
@@ -613,7 +613,7 @@ impl ForkChoiceTestDefinition {
                             &block_root,
                             current_slot.unwrap_or(last_current_slot),
                             proposer_boost_root.unwrap_or_else(Hash256::zero),
-                            &equivocating_committee_weights,
+                            Some(&equivocating_committee_weights),
                             &spec,
                         )
                         .unwrap();
@@ -679,7 +679,7 @@ fn assert_canonical_payload_status_matches_find_head(
     head: &Hash256,
     current_slot: Slot,
     proposer_boost_root: Hash256,
-    equivocating_committee_weights: &BTreeMap<Slot, u64>,
+    equivocating_committee_weights: Option<&BTreeMap<Slot, u64>>,
     spec: &ChainSpec,
     expected: PayloadStatus,
     op_index: usize,

--- a/consensus/proto_array/src/justified_balances.rs
+++ b/consensus/proto_array/src/justified_balances.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use safe_arith::{ArithError, SafeArith};
 use types::{BeaconState, EthSpec};
 
@@ -12,6 +14,9 @@ pub struct JustifiedBalances {
     pub total_effective_balance: u64,
     /// The number of active validators included in `self.effective_balances`.
     pub num_active_validators: u64,
+    /// A mapping from a slashed validator index to its effective balance active at the current
+    /// epoch.
+    pub slashed_balances: BTreeMap<u64, u64>,
 }
 
 impl JustifiedBalances {
@@ -19,17 +24,22 @@ impl JustifiedBalances {
         let current_epoch = state.current_epoch();
         let mut total_effective_balance = 0u64;
         let mut num_active_validators = 0u64;
+        let mut slashed_balances = BTreeMap::new();
 
         let effective_balances = state
             .validators()
             .iter()
-            .map(|validator| {
+            .enumerate()
+            .map(|(i, validator)| {
                 if !validator.slashed && validator.is_active_at(current_epoch) {
                     total_effective_balance.safe_add_assign(validator.effective_balance)?;
                     num_active_validators.safe_add_assign(1)?;
 
                     Ok(validator.effective_balance)
                 } else {
+                    if validator.slashed && validator.is_active_at(current_epoch) {
+                        slashed_balances.insert(i as u64, validator.effective_balance);
+                    }
                     Ok(0)
                 }
             })
@@ -39,6 +49,7 @@ impl JustifiedBalances {
             effective_balances,
             total_effective_balance,
             num_active_validators,
+            slashed_balances,
         })
     }
 

--- a/consensus/proto_array/src/justified_balances.rs
+++ b/consensus/proto_array/src/justified_balances.rs
@@ -68,6 +68,83 @@ impl JustifiedBalances {
             effective_balances,
             total_effective_balance,
             num_active_validators,
+            slashed_balances: BTreeMap::new(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use types::{ChainSpec, Epoch, MinimalEthSpec, Validator};
+
+    type E = MinimalEthSpec;
+
+    fn push_validator(
+        state: &mut BeaconState<E>,
+        spec: &ChainSpec,
+        effective_balance: u64,
+        slashed: bool,
+        activation_epoch: Epoch,
+    ) {
+        state
+            .validators_mut()
+            .push(Validator {
+                effective_balance,
+                slashed,
+                activation_epoch,
+                exit_epoch: spec.far_future_epoch,
+                withdrawable_epoch: spec.far_future_epoch,
+                ..Default::default()
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn from_justified_state_handles_slashed_and_inactive_validators() {
+        let spec = E::default_spec();
+        let mut state: BeaconState<E> = BeaconState::new(0, <_>::default(), &spec);
+        let epoch = state.current_epoch();
+
+        push_validator(&mut state, &spec, 32_000_000_000, false, epoch);
+        push_validator(&mut state, &spec, 31_000_000_000, true, epoch);
+        push_validator(
+            &mut state,
+            &spec,
+            30_000_000_000,
+            false,
+            spec.far_future_epoch,
+        );
+        push_validator(
+            &mut state,
+            &spec,
+            29_000_000_000,
+            true,
+            spec.far_future_epoch,
+        );
+
+        let justified_balances = JustifiedBalances::from_justified_state(&state).unwrap();
+
+        assert_eq!(
+            justified_balances.effective_balances,
+            vec![32_000_000_000, 0, 0, 0]
+        );
+        assert_eq!(justified_balances.total_effective_balance, 32_000_000_000);
+        assert_eq!(justified_balances.num_active_validators, 1);
+        assert_eq!(
+            justified_balances.slashed_balances,
+            BTreeMap::from([(1, 31_000_000_000)])
+        );
+    }
+
+    #[test]
+    fn from_effective_balances_has_empty_slashed_balances() {
+        let justified_balances =
+            JustifiedBalances::from_effective_balances(vec![32_000_000_000, 0, 31_000_000_000])
+                .unwrap();
+
+        assert_eq!(justified_balances.total_effective_balance, 63_000_000_000);
+        assert_eq!(justified_balances.num_active_validators, 2);
+        assert!(justified_balances.slashed_balances.is_empty());
     }
 }

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -8,7 +8,7 @@ use ssz::BitVector;
 use ssz::Encode;
 use ssz::four_byte_option_impl;
 use ssz_derive::{Decode, Encode};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Duration;
 use superstruct::superstruct;
 use typenum::U512;
@@ -166,11 +166,6 @@ pub struct ProtoNode {
     /// to detect equivocations at the parent's slot.
     #[superstruct(only(V29), partial_getter(copy))]
     pub proposer_index: u64,
-    /// Weight from equivocating validators that voted for this block.
-    /// Used by `is_head_weak` to match the spec's monotonicity guarantee:
-    /// more attestations can only increase head weight, never decrease it.
-    #[superstruct(only(V29), partial_getter(copy))]
-    pub equivocating_attestation_score: u64,
 }
 
 impl ProtoNode {
@@ -198,6 +193,27 @@ impl ProtoNode {
                 .unwrap_or_else(|_| self.weight()),
             PayloadStatus::Full => self.full_payload_weight().unwrap_or_else(|_| self.weight()),
         }
+    }
+
+    /// Head weight for re-org checks, including equivocating validators' weight
+    pub fn head_weight_for_reorg(&self, equivocating_committee_weight: u64) -> u64 {
+        self.attestation_score(PayloadStatus::Pending)
+            .saturating_add(equivocating_committee_weight)
+    }
+
+    /// Spec: `is_head_weak`.
+    pub fn is_head_weak(
+        &self,
+        re_org_head_weight_threshold: u64,
+        equivocating_committee_weight: u64,
+    ) -> bool {
+        self.head_weight_for_reorg(equivocating_committee_weight) < re_org_head_weight_threshold
+    }
+
+    /// Spec: `is_parent_strong`. `PayloadStatus::Pending` measures support regardless
+    /// of payload status. https://github.com/ethereum/consensus-specs/issues/5305
+    pub fn is_parent_strong(&self, re_org_parent_weight_threshold: u64) -> bool {
+        self.attestation_score(PayloadStatus::Pending) > re_org_parent_weight_threshold
     }
 
     /// Checks if `timely` matches our view of payload timeliness.
@@ -297,8 +313,6 @@ pub struct NodeDelta {
     pub empty_delta: i64,
     /// Weight change from `PayloadStatus::Full` votes.
     pub full_delta: i64,
-    /// Weight from equivocating validators that voted for this node.
-    pub equivocating_attestation_delta: u64,
 }
 
 impl NodeDelta {
@@ -355,7 +369,6 @@ impl NodeDelta {
             delta,
             empty_delta: 0,
             full_delta: 0,
-            equivocating_attestation_delta: 0,
         }
     }
 
@@ -487,9 +500,6 @@ impl ProtoArray {
                     apply_delta(node.empty_payload_weight, node_empty_delta, node_index)?;
                 node.full_payload_weight =
                     apply_delta(node.full_payload_weight, node_full_delta, node_index)?;
-                node.equivocating_attestation_score = node
-                    .equivocating_attestation_score
-                    .saturating_add(node_delta.equivocating_attestation_delta);
             }
 
             // Update the parent delta (if any).
@@ -655,7 +665,6 @@ impl ProtoArray {
                         && time_into_slot < spec.get_attestation_due::<E>(current_slot)),
                 block_timeliness_ptc_threshold: is_anchor
                     || (is_current_slot && time_into_slot < spec.get_payload_attestation_due()),
-                equivocating_attestation_score: 0,
             })
         };
 
@@ -700,35 +709,6 @@ impl ProtoArray {
         Ok(())
     }
 
-    /// Spec: `is_head_weak`.
-    // TODO(gloas): the spec adds weight from equivocating validators in the
-    // head slot's *committees*, regardless of who they voted for. We approximate
-    // with `equivocating_attestation_score` which only tracks equivocating
-    // validators whose vote pointed at this block. This under-counts when an
-    // equivocating validator is in the committee but voted for a different fork,
-    // which could allow a re-org the spec wouldn't. In practice the deviation
-    // is small — it requires equivocating validators voting for competing forks
-    // AND the head weight to be exactly at the reorg threshold boundary.
-    // Fixing this properly requires committee computation from BeaconState,
-    // which is not available in proto_array. The fix would be to pass
-    // pre-computed equivocating committee weight from the beacon_chain caller.
-    fn is_head_weak<E: EthSpec>(
-        &self,
-        head_node: &ProtoNode,
-        justified_balances: &JustifiedBalances,
-        spec: &ChainSpec,
-    ) -> bool {
-        let reorg_threshold =
-            calculate_committee_fraction::<E>(justified_balances, spec.reorg_head_weight_threshold)
-                .unwrap_or(0);
-
-        let head_weight = head_node
-            .attestation_score(PayloadStatus::Pending)
-            .saturating_add(head_node.equivocating_attestation_score().unwrap_or(0));
-
-        head_weight < reorg_threshold
-    }
-
     /// Spec's `should_apply_proposer_boost` for Gloas.
     ///
     /// Returns `true` if the proposer boost should be kept. Returns `false` if the
@@ -738,6 +718,7 @@ impl ProtoArray {
         &self,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         spec: &ChainSpec,
     ) -> Result<bool, Error> {
         if proposer_boost_root.is_zero() {
@@ -767,7 +748,16 @@ impl ProtoArray {
         }
 
         // Apply proposer boost if `parent` is not weak
-        if !self.is_head_weak::<E>(parent, justified_balances, spec) {
+        let re_org_head_weight_threshold =
+            calculate_committee_fraction::<E>(justified_balances, spec.reorg_head_weight_threshold)
+                .unwrap_or(0);
+
+        let equivocating_committee_weight = equivocating_committee_weights
+            .get(&parent.slot())
+            .copied()
+            .unwrap_or(0);
+
+        if !parent.is_head_weak(re_org_head_weight_threshold, equivocating_committee_weight) {
             return Ok(true);
         }
 
@@ -1076,6 +1066,7 @@ impl ProtoArray {
         best_finalized_checkpoint: Checkpoint,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         spec: &ChainSpec,
     ) -> Result<(Hash256, PayloadStatus), Error> {
         let justified_index = self
@@ -1107,6 +1098,7 @@ impl ProtoArray {
             best_finalized_checkpoint,
             proposer_boost_root,
             justified_balances,
+            equivocating_committee_weights,
             spec,
         )?;
 
@@ -1241,6 +1233,7 @@ impl ProtoArray {
         best_finalized_checkpoint: Checkpoint,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         spec: &ChainSpec,
     ) -> Result<IndexedForkChoiceNode, Error> {
         let mut head = IndexedForkChoiceNode {
@@ -1258,8 +1251,12 @@ impl ProtoArray {
         )?;
 
         // Compute once rather than per-child per-level.
-        let apply_proposer_boost =
-            self.should_apply_proposer_boost::<E>(proposer_boost_root, justified_balances, spec)?;
+        let apply_proposer_boost = self.should_apply_proposer_boost::<E>(
+            proposer_boost_root,
+            justified_balances,
+            equivocating_committee_weights,
+            spec,
+        )?;
 
         loop {
             let children: Vec<_> = if head.payload_status == PayloadStatus::Pending {
@@ -1314,6 +1311,7 @@ impl ProtoArray {
         current_slot: Slot,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         spec: &ChainSpec,
     ) -> Result<PayloadStatus, Error> {
         let proto_node_index = *self.indices.get(&root).ok_or(Error::NodeUnknown(root))?;
@@ -1342,8 +1340,12 @@ impl ProtoArray {
 
         // Matches the hoisting optimization in `find_head`: `get_weight`'s spec-level
         // `should_apply_proposer_boost` check is precomputed once.
-        let apply_proposer_boost =
-            self.should_apply_proposer_boost::<E>(proposer_boost_root, justified_balances, spec)?;
+        let apply_proposer_boost = self.should_apply_proposer_boost::<E>(
+            proposer_boost_root,
+            justified_balances,
+            equivocating_committee_weights,
+            spec,
+        )?;
 
         let full_weight = self.get_weight::<E>(
             &full_fc,

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -718,7 +718,7 @@ impl ProtoArray {
         &self,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
-        equivocating_committee_weights: &BTreeMap<Slot, u64>,
+        equivocating_committee_weights: Option<&BTreeMap<Slot, u64>>,
         spec: &ChainSpec,
     ) -> Result<bool, Error> {
         if proposer_boost_root.is_zero() {
@@ -752,6 +752,10 @@ impl ProtoArray {
             calculate_committee_fraction::<E>(justified_balances, spec.reorg_head_weight_threshold)
                 .unwrap_or(0);
 
+        // With unknown weights we can't tell whether the head is weak, so keep the boost.
+        let Some(equivocating_committee_weights) = equivocating_committee_weights else {
+            return Ok(true);
+        };
         let equivocating_committee_weight = equivocating_committee_weights
             .get(&parent.slot())
             .copied()
@@ -1066,7 +1070,7 @@ impl ProtoArray {
         best_finalized_checkpoint: Checkpoint,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
-        equivocating_committee_weights: &BTreeMap<Slot, u64>,
+        equivocating_committee_weights: Option<&BTreeMap<Slot, u64>>,
         spec: &ChainSpec,
     ) -> Result<(Hash256, PayloadStatus), Error> {
         let justified_index = self
@@ -1233,7 +1237,7 @@ impl ProtoArray {
         best_finalized_checkpoint: Checkpoint,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
-        equivocating_committee_weights: &BTreeMap<Slot, u64>,
+        equivocating_committee_weights: Option<&BTreeMap<Slot, u64>>,
         spec: &ChainSpec,
     ) -> Result<IndexedForkChoiceNode, Error> {
         let mut head = IndexedForkChoiceNode {
@@ -1311,7 +1315,7 @@ impl ProtoArray {
         current_slot: Slot,
         proposer_boost_root: Hash256,
         justified_balances: &JustifiedBalances,
-        equivocating_committee_weights: &BTreeMap<Slot, u64>,
+        equivocating_committee_weights: Option<&BTreeMap<Slot, u64>>,
         spec: &ChainSpec,
     ) -> Result<PayloadStatus, Error> {
         let proto_node_index = *self.indices.get(&root).ok_or(Error::NodeUnknown(root))?;

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -415,6 +415,7 @@ pub enum DoNotReOrg {
     HeadNotLate,
     NotProposing,
     ReOrgsDisabled,
+    EquivocatingWeightsUnknown,
 }
 
 impl std::fmt::Display for DoNotReOrg {
@@ -459,6 +460,9 @@ impl std::fmt::Display for DoNotReOrg {
             }
             Self::ReOrgsDisabled => {
                 write!(f, "re-orgs disabled in config")
+            }
+            Self::EquivocatingWeightsUnknown => {
+                write!(f, "equivocating committee weights unknown")
             }
         }
     }
@@ -655,7 +659,7 @@ impl ProtoArrayForkChoice {
         justified_state_balances: &JustifiedBalances,
         proposer_boost_root: Hash256,
         equivocating_indices: &BTreeSet<u64>,
-        equivocating_committee_weights: &BTreeMap<Slot, u64>,
+        equivocating_committee_weights: Option<&BTreeMap<Slot, u64>>,
         current_slot: Slot,
         spec: &ChainSpec,
     ) -> Result<(Hash256, PayloadStatus), String> {
@@ -709,7 +713,7 @@ impl ProtoArrayForkChoice {
         justified_balances: &JustifiedBalances,
         re_org_head_threshold: ReOrgThreshold,
         re_org_parent_threshold: ReOrgThreshold,
-        equivocating_committee_weights: &BTreeMap<Slot, u64>,
+        equivocating_committee_weights: Option<&BTreeMap<Slot, u64>>,
         max_epochs_since_finalization: Epoch,
     ) -> Result<ProposerHeadInfo, ProposerHeadError<Error>> {
         let info = self.get_proposer_head_info::<E>(
@@ -727,6 +731,10 @@ impl ProtoArrayForkChoice {
             return Err(DoNotReOrg::HeadDistance.into());
         }
 
+        // With unknown weights we can't tell whether the head is weak, so don't re-org.
+        let Some(equivocating_committee_weights) = equivocating_committee_weights else {
+            return Err(DoNotReOrg::EquivocatingWeightsUnknown.into());
+        };
         let equivocating_committee_weight = equivocating_committee_weights
             .get(&info.head_node.slot())
             .copied()
@@ -1091,7 +1099,7 @@ impl ProtoArrayForkChoice {
         block_root: &Hash256,
         current_slot: Slot,
         proposer_boost_root: Hash256,
-        equivocating_committee_weights: &BTreeMap<Slot, u64>,
+        equivocating_committee_weights: Option<&BTreeMap<Slot, u64>>,
         spec: &ChainSpec,
     ) -> Result<PayloadStatus, Error> {
         self.proto_array.get_canonical_payload_status::<E>(
@@ -2396,7 +2404,7 @@ mod test_compute_deltas {
                 &justified_balances,
                 Hash256::zero(),
                 &equivocating_indices,
-                &no_equivocating_weights,
+                Some(&no_equivocating_weights),
                 Slot::new(3),
                 &spec,
             )
@@ -2416,7 +2424,7 @@ mod test_compute_deltas {
                 &justified_balances,
                 re_org_head_threshold,
                 re_org_parent_threshold,
-                &no_equivocating_weights,
+                Some(&no_equivocating_weights),
                 max_epochs_since_finalization,
             )
             .expect("head should be weak without equivocating committee weight");
@@ -2431,7 +2439,7 @@ mod test_compute_deltas {
             &justified_balances,
             re_org_head_threshold,
             re_org_parent_threshold,
-            &equivocating_committee_weights,
+            Some(&equivocating_committee_weights),
             max_epochs_since_finalization,
         ) {
             Err(ProposerHeadError::DoNotReOrg(DoNotReOrg::HeadNotWeak { head_weight, .. })) => {
@@ -2534,7 +2542,7 @@ mod test_compute_deltas {
                 &justified_balances,
                 boosted_root,
                 &equivocating_indices,
-                &no_equivocating_weights,
+                Some(&no_equivocating_weights),
                 Slot::new(2),
                 &spec,
             )
@@ -2551,7 +2559,7 @@ mod test_compute_deltas {
                 &justified_balances,
                 boosted_root,
                 &equivocating_indices,
-                &equivocating_committee_weights,
+                Some(&equivocating_committee_weights),
                 Slot::new(2),
                 &spec,
             )

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     fmt,
     time::Duration,
 };
@@ -655,6 +655,7 @@ impl ProtoArrayForkChoice {
         justified_state_balances: &JustifiedBalances,
         proposer_boost_root: Hash256,
         equivocating_indices: &BTreeSet<u64>,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         current_slot: Slot,
         spec: &ChainSpec,
     ) -> Result<(Hash256, PayloadStatus), String> {
@@ -691,6 +692,7 @@ impl ProtoArrayForkChoice {
                 finalized_checkpoint,
                 proposer_boost_root,
                 new_balances,
+                equivocating_committee_weights,
                 spec,
             )
             .map_err(|e| format!("find_head failed: {:?}", e))
@@ -707,6 +709,7 @@ impl ProtoArrayForkChoice {
         justified_balances: &JustifiedBalances,
         re_org_head_threshold: ReOrgThreshold,
         re_org_parent_threshold: ReOrgThreshold,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         max_epochs_since_finalization: Epoch,
     ) -> Result<ProposerHeadInfo, ProposerHeadError<Error>> {
         let info = self.get_proposer_head_info::<E>(
@@ -724,27 +727,32 @@ impl ProtoArrayForkChoice {
             return Err(DoNotReOrg::HeadDistance.into());
         }
 
+        let equivocating_committee_weight = equivocating_committee_weights
+            .get(&info.head_node.slot())
+            .copied()
+            .unwrap_or(0);
+
         // Only re-org if the head's weight is less than the heads configured committee fraction.
-        let head_weight = info.head_node.weight();
-        let re_org_head_weight_threshold = info.re_org_head_weight_threshold;
-        let weak_head = head_weight < re_org_head_weight_threshold;
-        if !weak_head {
+        if !info.head_node.is_head_weak(
+            info.re_org_head_weight_threshold,
+            equivocating_committee_weight,
+        ) {
             return Err(DoNotReOrg::HeadNotWeak {
-                head_weight,
-                re_org_head_weight_threshold,
+                head_weight: info
+                    .head_node
+                    .head_weight_for_reorg(equivocating_committee_weight),
+                re_org_head_weight_threshold: info.re_org_head_weight_threshold,
             }
             .into());
         }
 
-        // Spec: `is_parent_strong`. Use `PayloadStatus::Pending` to avoid weight split
-        // between payload statuses. https://github.com/ethereum/consensus-specs/issues/5305
-        let parent_pending_weight = info.parent_node.attestation_score(PayloadStatus::Pending);
-        let re_org_parent_weight_threshold = info.re_org_parent_weight_threshold;
-        let parent_strong = parent_pending_weight > re_org_parent_weight_threshold;
-        if !parent_strong {
+        if !info
+            .parent_node
+            .is_parent_strong(info.re_org_parent_weight_threshold)
+        {
             return Err(DoNotReOrg::ParentNotStrong {
-                parent_weight: parent_pending_weight,
-                re_org_parent_weight_threshold,
+                parent_weight: info.parent_node.attestation_score(PayloadStatus::Pending),
+                re_org_parent_weight_threshold: info.re_org_parent_weight_threshold,
             }
             .into());
         }
@@ -1083,6 +1091,7 @@ impl ProtoArrayForkChoice {
         block_root: &Hash256,
         current_slot: Slot,
         proposer_boost_root: Hash256,
+        equivocating_committee_weights: &BTreeMap<Slot, u64>,
         spec: &ChainSpec,
     ) -> Result<PayloadStatus, Error> {
         self.proto_array.get_canonical_payload_status::<E>(
@@ -1090,6 +1099,7 @@ impl ProtoArrayForkChoice {
             current_slot,
             proposer_boost_root,
             &self.balances,
+            equivocating_committee_weights,
             spec,
         )
     }
@@ -1235,7 +1245,6 @@ fn compute_deltas(
             delta: 0,
             empty_delta: 0,
             full_delta: 0,
-            equivocating_attestation_delta: 0,
         };
         indices.len()
     ];
@@ -1277,11 +1286,6 @@ fn compute_deltas(
                         block_slot(current_delta_index)?,
                     );
                     node_delta.sub_payload_delta(status, old_balance, current_delta_index)?;
-
-                    // Track equivocating weight for `is_head_weak` monotonicity.
-                    node_delta.equivocating_attestation_delta = node_delta
-                        .equivocating_attestation_delta
-                        .saturating_add(old_balance);
                 }
 
                 vote.current_root = Hash256::zero();
@@ -2309,5 +2313,249 @@ mod test_compute_deltas {
         assert_eq!(deltas[0].delta, 0);
         assert_eq!(deltas[0].empty_delta, 0);
         assert_eq!(deltas[0].full_delta, 0);
+    }
+
+    #[test]
+    fn equivocating_committee_weight_prevents_reorg() {
+        let mut spec = MainnetEthSpec::default_spec();
+        spec.gloas_fork_epoch = Some(Epoch::new(0));
+
+        let genesis_root = hash_from_index(0);
+        let parent_root = hash_from_index(1);
+        let head_root = hash_from_index(2);
+        let genesis_checkpoint = Checkpoint {
+            epoch: Epoch::new(0),
+            root: genesis_root,
+        };
+        let junk_shuffling_id =
+            AttestationShufflingId::from_components(Epoch::new(0), Hash256::zero());
+
+        let mut fork_choice = ProtoArrayForkChoice::new::<MainnetEthSpec>(
+            Slot::new(0),
+            Slot::new(0),
+            Hash256::zero(),
+            genesis_checkpoint,
+            genesis_checkpoint,
+            junk_shuffling_id.clone(),
+            junk_shuffling_id.clone(),
+            ExecutionStatus::Optimistic(ExecutionBlockHash::zero()),
+            Some(ExecutionBlockHash::zero()),
+            Some(ExecutionBlockHash::from_root(genesis_root)),
+            0,
+            &spec,
+        )
+        .unwrap();
+
+        // Chain: genesis (slot 0) <- parent (slot 1) <- head (slot 2).
+        for (slot, root, parent) in [(1, parent_root, genesis_root), (2, head_root, parent_root)] {
+            let block = Block {
+                slot: Slot::new(slot),
+                root,
+                parent_root: Some(parent),
+                state_root: Hash256::zero(),
+                target_root: genesis_root,
+                current_epoch_shuffling_id: junk_shuffling_id.clone(),
+                next_epoch_shuffling_id: junk_shuffling_id.clone(),
+                justified_checkpoint: genesis_checkpoint,
+                finalized_checkpoint: genesis_checkpoint,
+                execution_status: ExecutionStatus::Optimistic(ExecutionBlockHash::from_root(root)),
+                unrealized_justified_checkpoint: Some(genesis_checkpoint),
+                unrealized_finalized_checkpoint: Some(genesis_checkpoint),
+                // Mismatched parent payload hash keeps each block on its parent's Empty
+                // path, which the head walk follows when no payload envelopes are received.
+                execution_payload_parent_hash: Some(ExecutionBlockHash::from_root(
+                    hash_from_index(99),
+                )),
+                execution_payload_block_hash: Some(ExecutionBlockHash::from_root(root)),
+                proposer_index: Some(0),
+                payload_received: false,
+            };
+            fork_choice
+                .process_block::<MainnetEthSpec>(block, Slot::new(slot), &spec, Duration::ZERO)
+                .unwrap();
+        }
+
+        // Two validators attest to the parent; nobody attests to the head.
+        for validator in 0..2 {
+            fork_choice
+                .process_attestation(validator, parent_root, Slot::new(1), false)
+                .unwrap();
+        }
+
+        // 32 validators with balance 32: committee weight = 1024 / 32 = 32.
+        // Head threshold (20%) = 6, parent threshold (160%) = 51.
+        // Parent weight = 2 * 32 = 64 > 51 (strong); head weight = 0 < 6 (weak).
+        let justified_balances = JustifiedBalances::from_effective_balances(vec![32; 32]).unwrap();
+        let equivocating_indices = BTreeSet::new();
+        let no_equivocating_weights = BTreeMap::new();
+
+        let (head, _) = fork_choice
+            .find_head::<MainnetEthSpec>(
+                genesis_checkpoint,
+                genesis_checkpoint,
+                &justified_balances,
+                Hash256::zero(),
+                &equivocating_indices,
+                &no_equivocating_weights,
+                Slot::new(3),
+                &spec,
+            )
+            .unwrap();
+        assert_eq!(head, head_root);
+
+        let re_org_head_threshold = ReOrgThreshold(spec.reorg_head_weight_threshold);
+        let re_org_parent_threshold = ReOrgThreshold(spec.reorg_parent_weight_threshold);
+        let max_epochs_since_finalization = Epoch::new(spec.reorg_max_epochs_since_finalization);
+
+        // Control: without equivocating committee weight the head is weak and the
+        // re-org is permitted.
+        let info = fork_choice
+            .get_proposer_head::<MainnetEthSpec>(
+                Slot::new(3),
+                head_root,
+                &justified_balances,
+                re_org_head_threshold,
+                re_org_parent_threshold,
+                &no_equivocating_weights,
+                max_epochs_since_finalization,
+            )
+            .expect("head should be weak without equivocating committee weight");
+        assert_eq!(info.parent_node.root(), parent_root);
+
+        // Equivocating committee weight at the head's slot pushes it over the
+        // threshold: the head is no longer weak and the re-org is rejected.
+        let equivocating_committee_weights = BTreeMap::from_iter([(Slot::new(2), 32)]);
+        match fork_choice.get_proposer_head::<MainnetEthSpec>(
+            Slot::new(3),
+            head_root,
+            &justified_balances,
+            re_org_head_threshold,
+            re_org_parent_threshold,
+            &equivocating_committee_weights,
+            max_epochs_since_finalization,
+        ) {
+            Err(ProposerHeadError::DoNotReOrg(DoNotReOrg::HeadNotWeak { head_weight, .. })) => {
+                assert_eq!(head_weight, 32);
+            }
+            other => panic!("expected HeadNotWeak, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn equivocating_committee_weight_prevents_boost_invalidation() {
+        let mut spec = MainnetEthSpec::default_spec();
+        spec.gloas_fork_epoch = Some(Epoch::new(0));
+
+        let genesis_root = hash_from_index(0);
+        let parent_root = hash_from_index(1);
+        let equivocating_root = hash_from_index(2);
+        let boosted_root = hash_from_index(3);
+        let competing_root = hash_from_index(4);
+        let genesis_checkpoint = Checkpoint {
+            epoch: Epoch::new(0),
+            root: genesis_root,
+        };
+        let junk_shuffling_id =
+            AttestationShufflingId::from_components(Epoch::new(0), Hash256::zero());
+
+        let mut fork_choice = ProtoArrayForkChoice::new::<MainnetEthSpec>(
+            Slot::new(0),
+            Slot::new(0),
+            Hash256::zero(),
+            genesis_checkpoint,
+            genesis_checkpoint,
+            junk_shuffling_id.clone(),
+            junk_shuffling_id.clone(),
+            ExecutionStatus::Optimistic(ExecutionBlockHash::zero()),
+            Some(ExecutionBlockHash::zero()),
+            Some(ExecutionBlockHash::from_root(genesis_root)),
+            0,
+            &spec,
+        )
+        .unwrap();
+
+        // Tree: genesis <- {parent, equivocating} at slot 1 (same proposer), and
+        // {boosted, competing} at slot 2 as children of parent.
+        for (slot, root, parent, proposer_index) in [
+            (1, parent_root, genesis_root, 0),
+            (1, equivocating_root, genesis_root, 0),
+            (2, boosted_root, parent_root, 1),
+            (2, competing_root, parent_root, 2),
+        ] {
+            let block = Block {
+                slot: Slot::new(slot),
+                root,
+                parent_root: Some(parent),
+                state_root: Hash256::zero(),
+                target_root: genesis_root,
+                current_epoch_shuffling_id: junk_shuffling_id.clone(),
+                next_epoch_shuffling_id: junk_shuffling_id.clone(),
+                justified_checkpoint: genesis_checkpoint,
+                finalized_checkpoint: genesis_checkpoint,
+                execution_status: ExecutionStatus::Optimistic(ExecutionBlockHash::from_root(root)),
+                unrealized_justified_checkpoint: Some(genesis_checkpoint),
+                unrealized_finalized_checkpoint: Some(genesis_checkpoint),
+                // Mismatched parent payload hash keeps each block on its parent's Empty
+                // path, which the head walk follows when no payload envelopes are received.
+                execution_payload_parent_hash: Some(ExecutionBlockHash::from_root(
+                    hash_from_index(99),
+                )),
+                execution_payload_block_hash: Some(ExecutionBlockHash::from_root(root)),
+                proposer_index: Some(proposer_index),
+                payload_received: false,
+            };
+            fork_choice
+                .process_block::<MainnetEthSpec>(block, Slot::new(slot), &spec, Duration::ZERO)
+                .unwrap();
+        }
+
+        // Validator 0 (balance 4) attests to the competing block; this is the
+        // parent's entire subtree weight.
+        fork_choice
+            .process_attestation(0, competing_root, Slot::new(2), false)
+            .unwrap();
+
+        // Total balance = 31 * 32 + 4 = 996, committee weight = 996 / 32 = 31.
+        // Head-weak threshold (20%) = 6, proposer boost (40%) = 12.
+        // Parent weight = 4 < 6 (weak); boost 12 beats competing weight 4.
+        let mut balances = vec![32; 32];
+        balances[0] = 4;
+        let justified_balances = JustifiedBalances::from_effective_balances(balances).unwrap();
+        let equivocating_indices = BTreeSet::new();
+        let no_equivocating_weights = BTreeMap::new();
+
+        // Control: the parent is weak and the same proposer produced an equivocating
+        // block at the parent's slot, so the boost is invalidated and the competing
+        // block wins on attestation weight.
+        let (head, _) = fork_choice
+            .find_head::<MainnetEthSpec>(
+                genesis_checkpoint,
+                genesis_checkpoint,
+                &justified_balances,
+                boosted_root,
+                &equivocating_indices,
+                &no_equivocating_weights,
+                Slot::new(2),
+                &spec,
+            )
+            .unwrap();
+        assert_eq!(head, competing_root);
+
+        // Equivocating committee weight at the parent's slot makes the parent
+        // not weak, so the boost is kept and the boosted block wins.
+        let equivocating_committee_weights = BTreeMap::from_iter([(Slot::new(1), 32)]);
+        let (head, _) = fork_choice
+            .find_head::<MainnetEthSpec>(
+                genesis_checkpoint,
+                genesis_checkpoint,
+                &justified_balances,
+                boosted_root,
+                &equivocating_indices,
+                &equivocating_committee_weights,
+                Slot::new(2),
+                &spec,
+            )
+            .unwrap();
+        assert_eq!(head, boosted_root);
     }
 }

--- a/consensus/types/src/state/slot_assignments.rs
+++ b/consensus/types/src/state/slot_assignments.rs
@@ -136,6 +136,27 @@ impl SlotAssignments {
         &self.assignments[2].key
     }
 
+    /// The slots `val_idx` attests in across the window epochs, in ascending epoch order.
+    pub fn assigned_slots(&self, val_idx: usize) -> Result<Vec<Slot>, BeaconStateError> {
+        let mut slots = Vec::with_capacity(self.assignments.len());
+        let mut prev_epoch_start = None;
+        for assignment in &self.assignments {
+            // Near genesis the window epochs saturate and repeat; count each epoch once.
+            if prev_epoch_start == Some(assignment.epoch_start_slot) {
+                continue;
+            }
+            prev_epoch_start = Some(assignment.epoch_start_slot);
+            if let Some(slot) = assigned_slot(
+                &assignment.committee_cache,
+                assignment.epoch_start_slot,
+                val_idx,
+            )? {
+                slots.push(slot);
+            }
+        }
+        Ok(slots)
+    }
+
     /// True if `val_idx` attests in any window epoch at a slot within `[start, end]`.
     pub fn is_in_range(
         &self,


### PR DESCRIPTION
## Issue Addressed

#9593

## Proposed Changes

is_head_weak now takes into account justified balances of slashed validators. I've also refactored things slightly so that we dont have two implementations of is_parent_strong and is_parent_weak and added test coverage for these changes.

I deleted `equivocating_attestation_score` from `ProtoNode`. We compute a `BTreeMap<Slot, u64>` of equivocator weight per duty slot in `canonical_head` and pass it into` proto_array.`

Other changes: 
- `is_head_weak` and `is_parent_strong` become `ProtoNode` methods, so the re-org path and the boost path share the same functions. 
- - Added a `SlotAssignments::assigned_slots` helper and added four new tests.

Depends on #9830 
