### PR TITLE
Current slot timers

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_simulator.rs
+++ b/beacon_node/beacon_chain/src/attestation_simulator.rs
@@ -1,11 +1,10 @@
 use crate::{BeaconChain, BeaconChainTypes};
 use slot_clock::SlotClock;
 use std::sync::Arc;
-use std::time::Duration;
 use task_executor::TaskExecutor;
 use tokio::time::sleep;
 use tracing::{debug, error, warn};
-use types::{ChainSpec, EthSpec, Slot};
+use types::{EthSpec, Slot};
 
 /// Don't run the attestation simulator if the head slot is this many epochs
 /// behind the wall-clock slot.
@@ -31,22 +30,25 @@ async fn attestation_simulator_service<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
 ) {
     let slot_duration = chain.slot_clock.slot_duration();
+    let mut last_slot = None;
 
     loop {
         match chain.slot_clock.now_duration() {
             Some(now_duration) => {
-                let (attestation_slot, Some(time_to_deadline)) =
-                    time_until_attestation_deadline::<T::EthSpec>(
-                        &chain.slot_clock,
-                        &chain.spec,
+                let Some((attestation_slot, time_to_deadline)) =
+                    chain.slot_clock.duration_to_deadline_after(
                         now_duration,
+                        |slot| chain.spec.get_attestation_due::<T::EthSpec>(slot),
+                        last_slot,
                     )
                 else {
-                    error!("Failed to calculate attestation deadline");
+                    error!("Failed to determine attestation deadline");
                     sleep(slot_duration).await;
                     continue;
                 };
                 sleep(time_to_deadline).await;
+                // Consume before spawn so a zero wait cannot spin the loop.
+                last_slot = Some(attestation_slot);
 
                 debug!("Simulating unagg. attestation production");
 
@@ -70,23 +72,6 @@ async fn attestation_simulator_service<T: BeaconChainTypes>(
             }
         };
     }
-}
-
-fn time_until_attestation_deadline<E: EthSpec>(
-    slot_clock: &impl SlotClock,
-    chain_spec: &ChainSpec,
-    now: Duration,
-) -> (Slot, Option<Duration>) {
-    let attestation_slot = slot_clock
-        .slot_of(now)
-        .map_or_else(|| slot_clock.genesis_slot(), |slot| slot + 1);
-    let duration_to_attestation_deadline = slot_clock
-        .start_of(attestation_slot)
-        .and_then(|slot_start| {
-            slot_start.checked_add(chain_spec.get_attestation_due::<E>(attestation_slot))
-        })
-        .and_then(|deadline| deadline.checked_sub(now));
-    (attestation_slot, duration_to_attestation_deadline)
 }
 
 pub fn produce_unaggregated_attestation<T: BeaconChainTypes>(

--- a/common/slot_clock/src/lib.rs
+++ b/common/slot_clock/src/lib.rs
@@ -53,6 +53,56 @@ pub trait SlotClock: Send + Sync + Sized + Clone {
     /// Returns the duration until the next slot.
     fn duration_to_next_slot(&self) -> Option<Duration>;
 
+    /// Returns the soonest slot whose deadline has not yet elapsed, and the wait until that
+    /// deadline.
+    ///
+    /// The deadline for a slot is `start_of(slot) + offset_for_slot(slot)`. If `now` is at or
+    /// before the current slot's deadline, that slot is returned (the wait may be zero).
+    /// Otherwise the next slot is returned.
+    ///
+    /// `now` should be a single snapshot from `now_duration()`.
+    fn duration_to_deadline<F: Fn(Slot) -> Duration>(
+        &self,
+        now: Duration,
+        offset_for_slot: F,
+    ) -> Option<(Slot, Duration)> {
+        let current_slot = self.slot_of(now).unwrap_or_else(|| self.genesis_slot());
+        let current_deadline = self
+            .start_of(current_slot)?
+            .checked_add(offset_for_slot(current_slot))?;
+        if let Some(wait) = current_deadline.checked_sub(now) {
+            return Some((current_slot, wait));
+        }
+        let next_slot = current_slot + 1;
+        let next_deadline = self
+            .start_of(next_slot)?
+            .checked_add(offset_for_slot(next_slot))?;
+        next_deadline.checked_sub(now).map(|wait| (next_slot, wait))
+    }
+
+    /// Like [`Self::duration_to_deadline`], skipping any slot `<= after`.
+    ///
+    /// Duty loops pass the last attempted slot so a zero wait cannot spin on that slot.
+    fn duration_to_deadline_after<F: Fn(Slot) -> Duration>(
+        &self,
+        now: Duration,
+        offset_for_slot: F,
+        after: Option<Slot>,
+    ) -> Option<(Slot, Duration)> {
+        let (slot, wait) = self.duration_to_deadline(now, &offset_for_slot)?;
+        let Some(after) = after else {
+            return Some((slot, wait));
+        };
+        if slot > after {
+            return Some((slot, wait));
+        }
+        let next_slot = after + 1;
+        let next_deadline = self
+            .start_of(next_slot)?
+            .checked_add(offset_for_slot(next_slot))?;
+        next_deadline.checked_sub(now).map(|wait| (next_slot, wait))
+    }
+
     /// Returns the duration until the first slot of the next epoch.
     fn duration_to_next_epoch(&self, slots_per_epoch: u64) -> Option<Duration>;
 
@@ -119,4 +169,201 @@ pub fn timestamp_now() -> Duration {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SLOT_DURATION: Duration = Duration::from_secs(12);
+    const GENESIS_DURATION: Duration = Duration::from_secs(12);
+    const OFFSET: Duration = Duration::from_secs(4);
+    const PRE_FORK_OFFSET: Duration = Duration::from_secs(4);
+    const POST_FORK_OFFSET: Duration = Duration::from_secs(3);
+    const FORK_SLOT: Slot = Slot::new(32);
+
+    fn clock() -> ManualSlotClock {
+        ManualSlotClock::new(Slot::new(0), GENESIS_DURATION, SLOT_DURATION)
+    }
+
+    fn constant_offset(_slot: Slot) -> Duration {
+        OFFSET
+    }
+
+    fn fork_aware_offset(slot: Slot) -> Duration {
+        if slot >= FORK_SLOT {
+            POST_FORK_OFFSET
+        } else {
+            PRE_FORK_OFFSET
+        }
+    }
+
+    #[test]
+    fn duration_to_deadline_pre_genesis() {
+        let clock = clock();
+        let now = GENESIS_DURATION - Duration::from_secs(1);
+        assert_eq!(
+            clock.duration_to_deadline(now, constant_offset),
+            Some((Slot::new(0), Duration::from_secs(5)))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_at_slot_start() {
+        let clock = clock();
+        let now = clock.start_of(Slot::new(0)).unwrap();
+        assert_eq!(
+            clock.duration_to_deadline(now, constant_offset),
+            Some((Slot::new(0), OFFSET))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_one_ms_before_due() {
+        let clock = clock();
+        let now = clock.start_of(Slot::new(0)).unwrap() + OFFSET - Duration::from_millis(1);
+        assert_eq!(
+            clock.duration_to_deadline(now, constant_offset),
+            Some((Slot::new(0), Duration::from_millis(1)))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_exactly_at_due() {
+        let clock = clock();
+        let now = clock.start_of(Slot::new(0)).unwrap() + OFFSET;
+        assert_eq!(
+            clock.duration_to_deadline(now, constant_offset),
+            Some((Slot::new(0), Duration::ZERO))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_one_ms_after_due() {
+        let clock = clock();
+        let now = clock.start_of(Slot::new(0)).unwrap() + OFFSET + Duration::from_millis(1);
+        let expected_wait = SLOT_DURATION - OFFSET - Duration::from_millis(1) + OFFSET;
+        assert_eq!(
+            clock.duration_to_deadline(now, constant_offset),
+            Some((Slot::new(1), expected_wait))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_uses_current_slot_offset_at_fork_boundary() {
+        let clock = clock();
+        let last_pre_fork = FORK_SLOT - 1;
+        let now = clock.start_of(last_pre_fork).unwrap();
+        assert_eq!(
+            clock.duration_to_deadline(now, fork_aware_offset),
+            Some((last_pre_fork, PRE_FORK_OFFSET))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_uses_next_slot_offset_after_current_deadline() {
+        let clock = clock();
+        let last_pre_fork = FORK_SLOT - 1;
+        let now =
+            clock.start_of(last_pre_fork).unwrap() + PRE_FORK_OFFSET + Duration::from_millis(1);
+        let expected_wait =
+            SLOT_DURATION - PRE_FORK_OFFSET - Duration::from_millis(1) + POST_FORK_OFFSET;
+        assert_eq!(
+            clock.duration_to_deadline(now, fork_aware_offset),
+            Some((FORK_SLOT, expected_wait))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_at_fork_slot_start() {
+        let clock = clock();
+        let now = clock.start_of(FORK_SLOT).unwrap();
+        assert_eq!(
+            clock.duration_to_deadline(now, fork_aware_offset),
+            Some((FORK_SLOT, POST_FORK_OFFSET))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_non_zero_genesis_slot() {
+        let genesis_slot = Slot::new(1);
+        let genesis_duration = Duration::from_secs(10);
+        let slot_duration = Duration::from_secs(1);
+        let offset = Duration::from_millis(200);
+        let clock = ManualSlotClock::new(genesis_slot, genesis_duration, slot_duration);
+        let now = genesis_duration;
+        assert_eq!(
+            clock.duration_to_deadline(now, |_| offset),
+            Some((genesis_slot, offset))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_pre_genesis_with_non_zero_genesis_slot() {
+        let genesis_slot = Slot::new(1);
+        let genesis_duration = Duration::from_secs(10);
+        let slot_duration = Duration::from_secs(1);
+        let offset = Duration::from_millis(200);
+        let clock = ManualSlotClock::new(genesis_slot, genesis_duration, slot_duration);
+        let now = Duration::from_secs(5);
+        assert_eq!(
+            clock.duration_to_deadline(now, |_| offset),
+            Some((genesis_slot, Duration::from_secs(5) + offset))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_after_none_matches_duration_to_deadline() {
+        let clock = clock();
+        let now = clock.start_of(Slot::new(0)).unwrap();
+        assert_eq!(
+            clock.duration_to_deadline_after(now, constant_offset, None),
+            clock.duration_to_deadline(now, constant_offset)
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_after_exact_due_skips_attempted_slot() {
+        let clock = clock();
+        let slot = Slot::new(0);
+        let now = clock.start_of(slot).unwrap() + OFFSET;
+        let expected_wait = SLOT_DURATION - OFFSET + OFFSET;
+        assert_eq!(
+            clock.duration_to_deadline_after(now, constant_offset, Some(slot)),
+            Some((Slot::new(1), expected_wait))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_after_before_due_skips_attempted_slot() {
+        let clock = clock();
+        let slot = Slot::new(0);
+        let now = clock.start_of(slot).unwrap();
+        let expected_wait = SLOT_DURATION + OFFSET;
+        assert_eq!(
+            clock.duration_to_deadline_after(now, constant_offset, Some(slot)),
+            Some((Slot::new(1), expected_wait))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_after_already_in_next_slot_before_due() {
+        let clock = clock();
+        let now = clock.start_of(Slot::new(1)).unwrap() + Duration::from_secs(1);
+        assert_eq!(
+            clock.duration_to_deadline_after(now, constant_offset, Some(Slot::new(0))),
+            Some((Slot::new(1), OFFSET - Duration::from_secs(1)))
+        );
+    }
+
+    #[test]
+    fn duration_to_deadline_after_past_next_deadline_skips_to_slot_after_current() {
+        let clock = clock();
+        let now = clock.start_of(Slot::new(1)).unwrap() + OFFSET + Duration::from_millis(1);
+        let expected_wait = SLOT_DURATION - OFFSET - Duration::from_millis(1) + OFFSET;
+        assert_eq!(
+            clock.duration_to_deadline_after(now, constant_offset, Some(Slot::new(0))),
+            Some((Slot::new(2), expected_wait))
+        );
+    }
 }

--- a/validator_client/validator_services/src/attestation_service.rs
+++ b/validator_client/validator_services/src/attestation_service.rs
@@ -107,7 +107,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationServiceBuil
                     .ok_or("Cannot build AttestationService without chain_spec")?,
                 head_monitor_rx: self.head_monitor_rx,
                 disable: self.disable,
-                latest_attested_slot: Mutex::new(Slot::default()),
+                latest_attested_slot: Mutex::new(None),
             }),
         })
     }
@@ -123,7 +123,7 @@ pub struct Inner<S, T> {
     chain_spec: Arc<ChainSpec>,
     head_monitor_rx: Option<Mutex<mpsc::Receiver<HeadEvent>>>,
     disable: bool,
-    latest_attested_slot: Mutex<Slot>,
+    latest_attested_slot: Mutex<Option<Slot>>,
 }
 
 /// Attempts to produce attestations for all known validators at the fork-aware attestation
@@ -156,17 +156,13 @@ fn attestation_deadline<E: EthSpec>(
     slot_clock: &impl SlotClock,
     chain_spec: &ChainSpec,
     now: Duration,
-) -> (Slot, Option<Duration>) {
-    let attestation_slot = slot_clock
-        .slot_of(now)
-        .map_or_else(|| slot_clock.genesis_slot(), |slot| slot + 1);
-    let duration_to_attestation_deadline = slot_clock
-        .start_of(attestation_slot)
-        .and_then(|slot_start| {
-            slot_start.checked_add(chain_spec.get_attestation_due::<E>(attestation_slot))
-        })
-        .and_then(|deadline| deadline.checked_sub(now));
-    (attestation_slot, duration_to_attestation_deadline)
+    after: Option<Slot>,
+) -> Option<(Slot, Duration)> {
+    slot_clock.duration_to_deadline_after(
+        now,
+        |slot| chain_spec.get_attestation_due::<E>(slot),
+        after,
+    )
 }
 
 impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, T> {
@@ -197,11 +193,16 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
                     sleep(slot_duration).await;
                     continue;
                 };
-                let (attestation_slot, duration_to_attestation_deadline) =
-                    attestation_deadline::<S::E>(&self.slot_clock, &self.chain_spec, now);
-                let Some(duration_to_attestation_deadline) = duration_to_attestation_deadline
+                let last_slot = *self.latest_attested_slot.lock().await;
+                let Some((target_slot, duration_to_attestation_deadline)) =
+                    attestation_deadline::<S::E>(
+                        &self.slot_clock,
+                        &self.chain_spec,
+                        now,
+                        last_slot,
+                    )
                 else {
-                    error!(%attestation_slot, "Failed to determine attestation deadline");
+                    error!("Failed to determine attestation deadline");
                     sleep(slot_duration).await;
                     continue;
                 };
@@ -209,7 +210,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
                 let beacon_node_data = if self.head_monitor_rx.is_some() {
                     tokio::select! {
                         _ = sleep(duration_to_attestation_deadline) => None,
-                        event = self.poll_for_head_events() =>
+                        event = self.poll_for_head_events(target_slot) =>
                             event.map(|event| (event.beacon_node_index, event.beacon_block_root)),
                     }
                 } else {
@@ -217,26 +218,40 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
                     None
                 };
 
-                let Some(current_slot) = self.slot_clock.now() else {
+                let Some(now_slot) = self.slot_clock.now() else {
                     error!("Failed to read slot clock after trigger");
                     continue;
                 };
 
-                let mut last_slot = self.latest_attested_slot.lock().await;
-
-                if current_slot <= *last_slot {
-                    debug!(%current_slot, "Attestation already initiated for the slot");
+                // Sleep can overshoot into a later slot. Consume the target only when the
+                // deadline fired so a head event for the wrong slot does not skip production.
+                if now_slot != target_slot {
+                    if beacon_node_data.is_none() {
+                        warn!(
+                            %target_slot,
+                            %now_slot,
+                            "Missed attestation slot due to lag"
+                        );
+                        let mut last_slot = self.latest_attested_slot.lock().await;
+                        *last_slot = Some(target_slot);
+                    }
                     continue;
                 }
 
-                match self.spawn_attestation_tasks(beacon_node_data).await {
-                    Ok(_) => {
-                        *last_slot = current_slot;
-                    }
-                    Err(e) => {
-                        crit!(error = e, "Failed to spawn attestation tasks");
-                    }
+                let mut last_slot = self.latest_attested_slot.lock().await;
+                if last_slot.is_some_and(|s| target_slot <= s) {
+                    debug!(%target_slot, "Attestation already initiated for the slot");
+                    continue;
                 }
+
+                if let Err(e) = self
+                    .spawn_attestation_tasks(target_slot, beacon_node_data)
+                    .await
+                {
+                    crit!(error = e, "Failed to spawn attestation tasks");
+                }
+                // Consume the slot after any attempt so a zero wait cannot spin the loop.
+                *last_slot = Some(target_slot);
             }
         };
 
@@ -244,7 +259,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
         Ok(())
     }
 
-    async fn poll_for_head_events(&self) -> Option<HeadEvent> {
+    async fn poll_for_head_events(&self, target_slot: Slot) -> Option<HeadEvent> {
         let Some(receiver) = &self.head_monitor_rx else {
             return None;
         };
@@ -252,13 +267,11 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
         loop {
             match receiver.recv().await {
                 Some(head_event) => {
-                    // Only return head events for the current slot - this ensures the
-                    // block for this slot has been produced before triggering attestation
-                    let current_slot = self.slot_clock.now()?;
-                    if head_event.slot == current_slot {
+                    // Only return head events for `target_slot`. A head for an earlier slot
+                    // must not trigger a late attestation.
+                    if head_event.slot == target_slot {
                         return Some(head_event);
                     }
-                    // Head event is for a previous slot, keep waiting
                 }
                 None => {
                     warn!("Head monitor channel closed unexpectedly");
@@ -273,10 +286,9 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> AttestationService<S, 
     /// aggregates to the beacon node.
     async fn spawn_attestation_tasks(
         &self,
+        slot: Slot,
         beacon_node_data: Option<(usize, Hash256)>,
     ) -> Result<(), String> {
-        let slot = self.slot_clock.now().ok_or("Failed to read slot clock")?;
-
         // Create and publish an `Attestation` for all validators only once
         // as the committee_index is not included in AttestationData post-Electra
         let attestation_duties: Vec<_> = self.duties_service.attesters(slot).into_iter().collect();
@@ -877,26 +889,58 @@ mod tests {
                 Duration::from_millis(4999),
             ),
             (
-                "pre-Gloas",
-                slot_clock.start_of(last_pre_gloas_slot - 1).unwrap(),
+                "pre-Gloas slot start",
+                slot_clock.start_of(last_pre_gloas_slot).unwrap(),
                 last_pre_gloas_slot,
-                Duration::from_millis(15999),
+                spec.get_attestation_due::<E>(last_pre_gloas_slot),
             ),
             (
-                "post-Gloas",
-                slot_clock.start_of(last_pre_gloas_slot).unwrap(),
+                "first Gloas slot start",
+                slot_clock.start_of(first_gloas_slot).unwrap(),
                 first_gloas_slot,
-                Duration::from_millis(15000),
+                spec.get_attestation_due::<E>(first_gloas_slot),
+            ),
+            (
+                "1ms past current-slot due",
+                slot_clock.start_of(last_pre_gloas_slot).unwrap()
+                    + spec.get_attestation_due::<E>(last_pre_gloas_slot)
+                    + Duration::from_millis(1),
+                first_gloas_slot,
+                slot_duration
+                    - spec.get_attestation_due::<E>(last_pre_gloas_slot)
+                    - Duration::from_millis(1)
+                    + spec.get_attestation_due::<E>(first_gloas_slot),
             ),
         ];
 
         for (case, now, expected_slot, expected_duration) in test_cases {
             assert_eq!(
-                attestation_deadline::<E>(&slot_clock, &spec, now),
-                (expected_slot, Some(expected_duration)),
+                attestation_deadline::<E>(&slot_clock, &spec, now, None),
+                Some((expected_slot, expected_duration)),
                 "{case}"
             );
         }
+    }
+
+    #[test]
+    fn duration_to_attestation_deadline_after_skips_attempted_slot() {
+        type E = MainnetEthSpec;
+
+        let spec = E::default_spec();
+        let slot_duration = spec.get_slot_duration();
+        let genesis_time = slot_duration;
+        let slot_clock = ManualSlotClock::new(Slot::new(0), genesis_time, slot_duration);
+        let slot = Slot::new(0);
+        let due = spec.get_attestation_due::<E>(slot);
+        let now = slot_clock.start_of(slot).unwrap() + due;
+
+        assert_eq!(
+            attestation_deadline::<E>(&slot_clock, &spec, now, Some(slot)),
+            Some((
+                Slot::new(1),
+                slot_duration - due + spec.get_attestation_due::<E>(Slot::new(1))
+            ))
+        );
     }
 
     /// This test is to ensure that a `tokio_timer::Sleep` with an instant in the past will still

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -79,6 +79,10 @@ const _: () = assert!({
 const MIN_ATTESTATION_SUBSCRIPTION_LOOKAHEAD: u64 = 2;
 const _: () = assert!(ATTESTATION_SUBSCRIPTION_OFFSETS[0] > MIN_ATTESTATION_SUBSCRIPTION_LOOKAHEAD);
 
+/// How long to wait before retrying index resolution when attester/sync/PTC duties would
+/// otherwise no-op on an empty index map at cold start.
+const INDICES_READY_RETRY: Duration = Duration::from_millis(200);
+
 // The info in the enum variants is displayed in logging, clippy thinks it's dead code.
 #[derive(Debug)]
 pub enum Error<T> {
@@ -623,6 +627,9 @@ pub fn start_update_service<S: ValidatorStore + 'static, T: SlotClock + 'static>
 
     /*
      * Spawn the task which keeps track of local block proposal duties.
+     *
+     * Sleep until the next slot start before polling. A mid-slot restart must not notify
+     * BlockService for the current slot or it would attempt a late block.
      */
     let duties_service = core_duties_service.clone();
     core_duties_service.executor.spawn(
@@ -656,17 +663,17 @@ pub fn start_update_service<S: ValidatorStore + 'static, T: SlotClock + 'static>
 
     /*
      * Spawn the task which keeps track of local attestation duties.
+     *
+     * Poll before sleeping so current-slot attestation production can see duties on a mid-slot
+     * restart. Resolve indices first: `poll_beacon_attesters` no-ops while the index map is
+     * empty, which would otherwise skip the current slot on a cold start.
      */
     let duties_service = core_duties_service.clone();
     core_duties_service.executor.spawn(
         async move {
+            let mut indices_fast_retry_until = None;
             loop {
-                if let Some(duration) = duties_service.slot_clock.duration_to_next_slot() {
-                    sleep(duration).await;
-                } else {
-                    // Just sleep for one slot if we are unable to read the system clock, this gives
-                    // us an opportunity for the clock to eventually come good.
-                    sleep(duties_service.slot_clock.slot_duration()).await;
+                if !poll_indices_or_wait(&duties_service, &mut indices_fast_retry_until).await {
                     continue;
                 }
 
@@ -676,16 +683,32 @@ pub fn start_update_service<S: ValidatorStore + 'static, T: SlotClock + 'static>
                        "Failed to poll beacon attesters"
                     );
                 }
+
+                if let Some(duration) = duties_service.slot_clock.duration_to_next_slot() {
+                    sleep(duration).await;
+                } else {
+                    // Just sleep for one slot if we are unable to read the system clock, this gives
+                    // us an opportunity for the clock to eventually come good.
+                    sleep(duties_service.slot_clock.slot_duration()).await;
+                }
             }
         },
         "duties_service_attesters",
     );
 
     // Spawn the task which keeps track of local sync committee duties.
+    //
+    // Poll indices first: `poll_sync_committee_duties` no-ops while the index map is empty,
+    // which would otherwise skip the current slot on a cold start.
     let duties_service = core_duties_service.clone();
     core_duties_service.executor.spawn(
         async move {
+            let mut indices_fast_retry_until = None;
             loop {
+                if !poll_indices_or_wait(&duties_service, &mut indices_fast_retry_until).await {
+                    continue;
+                }
+
                 if let Err(e) = poll_sync_committee_duties(&duties_service).await {
                     error!(
                         error = ?e,
@@ -712,10 +735,14 @@ pub fn start_update_service<S: ValidatorStore + 'static, T: SlotClock + 'static>
 
     // Spawn the task which keeps track of local PTC duties.
     // Only start PTC duties service if Gloas fork is scheduled.
+    //
+    // Poll indices first: `poll_beacon_ptc_attesters` no-ops while the index map is empty,
+    // which would otherwise skip the current slot on a cold start.
     if core_duties_service.spec.is_gloas_scheduled() {
         let duties_service = core_duties_service.clone();
         core_duties_service.executor.spawn(
             async move {
+                let mut indices_fast_retry_until = None;
                 loop {
                     // Check if we've reached the Gloas fork epoch before polling
                     let Some(current_slot) = duties_service.slot_clock.now() else {
@@ -737,6 +764,10 @@ pub fn start_update_service<S: ValidatorStore + 'static, T: SlotClock + 'static>
                         } else {
                             sleep(duties_service.slot_clock.slot_duration()).await;
                         }
+                        continue;
+                    }
+
+                    if !poll_indices_or_wait(&duties_service, &mut indices_fast_retry_until).await {
                         continue;
                     }
 
@@ -764,6 +795,65 @@ pub fn start_update_service<S: ValidatorStore + 'static, T: SlotClock + 'static>
             "duties_service_ptc",
         );
     }
+}
+
+/// Returns true when this VC has voting keys but none of them have resolved indices yet.
+///
+/// An empty keystore must return false so the attester/sync/PTC loops sleep until the next slot
+/// instead of spinning.
+fn waiting_for_validator_indices<S: ValidatorStore, T: SlotClock>(
+    duties_service: &DutiesService<S, T>,
+) -> bool {
+    let local_pubkeys: Vec<_> = duties_service
+        .validator_store
+        .voting_pubkeys(DoppelgangerStatus::ignored);
+    if local_pubkeys.is_empty() {
+        return false;
+    }
+    local_pubkeys.iter().all(|pubkey| {
+        duties_service
+            .validator_store
+            .validator_index(pubkey)
+            .is_none()
+    })
+}
+
+/// Poll validator indices. Returns `true` when the caller should fetch duties.
+///
+/// While indices are unknown, retries every `INDICES_READY_RETRY` through the next slot,
+/// then waits until each following slot.
+async fn poll_indices_or_wait<S: ValidatorStore, T: SlotClock + 'static>(
+    duties_service: &DutiesService<S, T>,
+    fast_retry_until: &mut Option<Slot>,
+) -> bool {
+    poll_validator_indices(duties_service).await;
+    if !waiting_for_validator_indices(duties_service) {
+        return true;
+    }
+
+    let Some(slot) = duties_service.slot_clock.now() else {
+        sleep(duties_service.slot_clock.slot_duration()).await;
+        return false;
+    };
+
+    let until = *fast_retry_until.get_or_insert(slot + 1);
+    if slot <= until {
+        let wait = duties_service
+            .slot_clock
+            .duration_to_next_slot()
+            .filter(|d| !d.is_zero())
+            .map(|to_next| to_next.min(INDICES_READY_RETRY))
+            .unwrap_or(INDICES_READY_RETRY);
+        sleep(wait).await;
+        return false;
+    }
+
+    if let Some(duration) = duties_service.slot_clock.duration_to_next_slot() {
+        sleep(duration).await;
+    } else {
+        sleep(duties_service.slot_clock.slot_duration()).await;
+    }
+    false
 }
 
 /// Iterate through all the voting pubkeys in the `ValidatorStore` and attempt to learn any unknown

--- a/validator_client/validator_services/src/payload_attestation_service.rs
+++ b/validator_client/validator_services/src/payload_attestation_service.rs
@@ -6,9 +6,10 @@ use logging::crit;
 use slot_clock::SlotClock;
 use std::ops::Deref;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use task_executor::TaskExecutor;
 use tokio::time::sleep;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use types::{ChainSpec, EthSpec, PayloadAttestationData, Slot};
 use validator_store::ValidatorStore;
 
@@ -19,6 +20,10 @@ pub struct Inner<S, T> {
     beacon_nodes: Arc<BeaconNodeFallback<T>>,
     executor: TaskExecutor,
     chain_spec: Arc<ChainSpec>,
+    /// Last slot for which a payload-attestation attempt was made. `u64::MAX` means none.
+    ///
+    /// Prevents a zero wait from spinning or double-publishing the same slot.
+    latest_attempted_slot: AtomicU64,
 }
 
 pub struct PayloadAttestationService<S, T> {
@@ -62,6 +67,7 @@ where
                 beacon_nodes,
                 executor,
                 chain_spec,
+                latest_attempted_slot: AtomicU64::new(u64::MAX),
             }),
         }
     }
@@ -91,6 +97,10 @@ where
             return Ok(());
         };
 
+        // Consume the slot after any attempt so a zero wait cannot spin the loop.
+        self.latest_attempted_slot
+            .store(attestation_slot.as_u64(), Ordering::SeqCst);
+
         let Some((duties, attestation_data)) = self
             .produce_payload_attestation_data(attestation_slot)
             .await?
@@ -116,18 +126,16 @@ where
 
     async fn wait_for_attestation_slot(&self) -> Option<Slot> {
         let slot_duration = self.chain_spec.get_slot_duration();
-        let payload_attestation_due = self.chain_spec.get_payload_attestation_due();
-
-        let Some(duration_to_next_slot) = self.slot_clock.duration_to_next_slot() else {
+        let Some(now) = self.slot_clock.now_duration() else {
             error!("Failed to read slot clock");
             sleep(slot_duration).await;
             return None;
         };
 
-        let Some(current_slot) = self.slot_clock.now() else {
-            error!("Failed to read slot clock after trigger");
-            return None;
-        };
+        let current_slot = self
+            .slot_clock
+            .slot_of(now)
+            .unwrap_or_else(|| self.slot_clock.genesis_slot());
 
         if !self
             .chain_spec
@@ -137,19 +145,38 @@ where
             let duration_to_next_epoch = self
                 .slot_clock
                 .duration_to_next_epoch(S::E::slots_per_epoch())
-                .unwrap_or_else(|| {
-                    self.chain_spec.get_slot_duration() * S::E::slots_per_epoch() as u32
-                });
+                .unwrap_or_else(|| slot_duration * S::E::slots_per_epoch() as u32);
             sleep(duration_to_next_epoch).await;
             return None;
         }
 
-        sleep(duration_to_next_slot + payload_attestation_due).await;
-
-        let Some(attestation_slot) = self.slot_clock.now() else {
-            error!("Failed to read slot clock after sleep");
+        let last = self.latest_attempted_slot.load(Ordering::SeqCst);
+        let after = (last != u64::MAX).then(|| Slot::new(last));
+        let Some((attestation_slot, wait)) = self.slot_clock.duration_to_deadline_after(
+            now,
+            |_| self.chain_spec.get_payload_attestation_due(),
+            after,
+        ) else {
+            error!("Failed to determine payload attestation deadline");
+            sleep(slot_duration).await;
             return None;
         };
+
+        sleep(wait).await;
+
+        // Sleep can overshoot into a later slot. Consume the target and skip so we never
+        // produce a late payload attestation.
+        let now_slot = self.slot_clock.now();
+        if now_slot != Some(attestation_slot) {
+            warn!(
+                %attestation_slot,
+                ?now_slot,
+                "Missed payload attestation slot due to lag"
+            );
+            self.latest_attempted_slot
+                .store(attestation_slot.as_u64(), Ordering::SeqCst);
+            return None;
+        }
 
         Some(attestation_slot)
     }
@@ -304,6 +331,7 @@ mod tests {
     use eth2::types::PtcDuty;
     use futures::FutureExt;
     use slot_clock::ManualSlotClock;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
     use types::{
         Epoch, ForkName, Hash256, PayloadAttestationData, PayloadAttestationMessage, Slot,
@@ -391,30 +419,118 @@ mod tests {
         let service_wait = service.wait_for_attestation_slot();
         tokio::pin!(service_wait);
 
-        // This first call of .now_or_never() starts the timer and registers the sleep timer with tokio
-        // It calls sleep(duration_to_next_slot + payload_attestation_due).await which registers a timer with a deadline of 21s
+        // Gloas is enabled at genesis in this harness, so we wait until the current slot's
+        // payload attestation due time (not the next slot).
         assert!(service_wait.as_mut().now_or_never().is_none());
 
-        let duration_to_next_slot = harness.service.slot_clock.duration_to_next_slot().unwrap();
         let payload_attestation_due = harness.service.chain_spec.get_payload_attestation_due();
-        let duration_to_wait = duration_to_next_slot + payload_attestation_due;
-        // Advance both slot_clock and tokio::time to 21s (the sleep deadline)
+        // Advance both slot_clock and tokio::time to the sleep deadline.
         // The timer hasn't fired yet because tokio requires time to be strictly past the deadline.
-        // so the following assert! should return None
-        // This verifies that the function wait_for_attestation_slot waits for the correct duration before returning a slot.
-        advance_time(&harness.service.slot_clock, duration_to_wait).await;
+        advance_time(&harness.service.slot_clock, payload_attestation_due).await;
         assert!(
             service_wait.as_mut().now_or_never().is_none(),
             "Function should return None before the sleep duration has elapsed"
         );
 
-        // Advance time for 1 more second, the sleep should have completed and the function should return Some(attestation_slot)
-        // slot_clock is now at 22s, which is slot 1
-        // Removing this advance_time should cause the following assert_eq! to fail
+        // Advance time for 1 more second so the sleep completes. Target is the current slot (0).
+        advance_time(&harness.service.slot_clock, Duration::from_secs(1)).await;
+        assert_eq!(
+            service_wait.as_mut().now_or_never().unwrap(),
+            Some(Slot::new(0))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_attestation_slot_after_deadline_uses_next_slot() {
+        tokio::time::pause();
+
+        let harness = TestHarness::new_with_validators(1).await;
+        let payload_attestation_due = harness.service.chain_spec.get_payload_attestation_due();
+        // Advance past the current slot's PTC deadline before waiting.
+        advance_time(
+            &harness.service.slot_clock,
+            payload_attestation_due + Duration::from_millis(1),
+        )
+        .await;
+
+        let service_wait = harness.service.wait_for_attestation_slot();
+        tokio::pin!(service_wait);
+        assert!(service_wait.as_mut().now_or_never().is_none());
+
+        let (target_slot, wait) = harness
+            .service
+            .slot_clock
+            .duration_to_deadline(harness.service.slot_clock.now_duration().unwrap(), |_| {
+                payload_attestation_due
+            })
+            .unwrap();
+        assert_eq!(target_slot, Slot::new(1));
+
+        advance_time(&harness.service.slot_clock, wait).await;
+        assert!(service_wait.as_mut().now_or_never().is_none());
         advance_time(&harness.service.slot_clock, Duration::from_secs(1)).await;
         assert_eq!(
             service_wait.as_mut().now_or_never().unwrap(),
             Some(Slot::new(1))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_attestation_slot_after_consumed_slot_uses_next() {
+        tokio::time::pause();
+
+        let harness = TestHarness::new_with_validators(1).await;
+        let payload_attestation_due = harness.service.chain_spec.get_payload_attestation_due();
+        harness
+            .service
+            .latest_attempted_slot
+            .store(0, Ordering::SeqCst);
+
+        let service_wait = harness.service.wait_for_attestation_slot();
+        tokio::pin!(service_wait);
+        assert!(service_wait.as_mut().now_or_never().is_none());
+
+        let (target_slot, wait) = harness
+            .service
+            .slot_clock
+            .duration_to_deadline_after(
+                harness.service.slot_clock.now_duration().unwrap(),
+                |_| payload_attestation_due,
+                Some(Slot::new(0)),
+            )
+            .unwrap();
+        assert_eq!(target_slot, Slot::new(1));
+
+        advance_time(&harness.service.slot_clock, wait).await;
+        assert!(service_wait.as_mut().now_or_never().is_none());
+        advance_time(&harness.service.slot_clock, Duration::from_secs(1)).await;
+        assert_eq!(
+            service_wait.as_mut().now_or_never().unwrap(),
+            Some(Slot::new(1))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_attestation_slot_lag_skips_and_consumes() {
+        tokio::time::pause();
+
+        let harness = TestHarness::new_with_validators(1).await;
+        let slot_duration = harness.service.chain_spec.get_slot_duration();
+
+        let service_wait = harness.service.wait_for_attestation_slot();
+        tokio::pin!(service_wait);
+        assert!(service_wait.as_mut().now_or_never().is_none());
+
+        // Advance past the end of slot 0 so the sleep completes in slot 1.
+        advance_time(
+            &harness.service.slot_clock,
+            slot_duration + Duration::from_secs(1),
+        )
+        .await;
+        assert_eq!(service_wait.as_mut().now_or_never().unwrap(), None);
+        assert_eq!(
+            harness.service.latest_attempted_slot.load(Ordering::SeqCst),
+            0
         );
     }
 

--- a/validator_client/validator_services/src/sync_committee_service.rs
+++ b/validator_client/validator_services/src/sync_committee_service.rs
@@ -9,7 +9,7 @@ use slot_clock::SlotClock;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use task_executor::TaskExecutor;
 use tokio::time::{Duration, Instant, sleep, sleep_until};
 use tracing::{Instrument, debug, error, info, info_span, instrument, trace, warn};
@@ -51,6 +51,10 @@ pub struct Inner<S: ValidatorStore, T: SlotClock + 'static> {
     ///
     /// This acts as a latch that fires once upon start-up, and then never again.
     first_subscription_done: AtomicBool,
+    /// Last slot for which a sync-message attempt was made. `u64::MAX` means none.
+    ///
+    /// Prevents a zero wait from spinning or double-publishing the same slot.
+    latest_attempted_slot: AtomicU64,
 }
 
 impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S, T> {
@@ -69,6 +73,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
                 beacon_nodes,
                 executor,
                 first_subscription_done: AtomicBool::new(false),
+                latest_attempted_slot: AtomicU64::new(u64::MAX),
             }),
         }
     }
@@ -109,11 +114,16 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
         let interval_fut = async move {
             loop {
                 if let Some(now_duration) = self.slot_clock.now_duration() {
-                    let (_, Some(duration_to_sync_message_deadline)) = sync_message_deadline::<S::E>(
-                        &self.slot_clock,
-                        &self.duties_service.spec,
-                        now_duration,
-                    ) else {
+                    let last = self.latest_attempted_slot.load(Ordering::SeqCst);
+                    let after = (last != u64::MAX).then(|| Slot::new(last));
+                    let Some((sync_slot, duration_to_sync_message_deadline)) =
+                        sync_message_deadline::<S::E>(
+                            &self.slot_clock,
+                            &self.duties_service.spec,
+                            now_duration,
+                            after,
+                        )
+                    else {
                         error!("Failed to determine sync message deadline");
                         sleep(slot_duration).await;
                         continue;
@@ -122,12 +132,30 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
                     // Wait for the fork-appropriate sync message due time.
                     sleep(duration_to_sync_message_deadline).await;
 
+                    // Sleep can overshoot into a later slot. Consume the target and skip so we
+                    // never produce a late sync message.
+                    let now_slot = self.slot_clock.now();
+                    if now_slot != Some(sync_slot) {
+                        warn!(
+                            %sync_slot,
+                            ?now_slot,
+                            "Missed sync committee slot due to lag"
+                        );
+                        self.latest_attempted_slot
+                            .store(sync_slot.as_u64(), Ordering::SeqCst);
+                        continue;
+                    }
+
+                    // Consume the slot after any attempt so a zero wait cannot spin the loop.
+                    self.latest_attempted_slot
+                        .store(sync_slot.as_u64(), Ordering::SeqCst);
+
                     // Do nothing if the Altair fork has not yet occurred.
                     if !self.altair_fork_activated() {
                         continue;
                     }
 
-                    if let Err(e) = self.spawn_contribution_tasks().await {
+                    if let Err(e) = self.spawn_contribution_tasks(sync_slot).await {
                         crit!(
                             error = ?e,
                             "Failed to spawn sync contribution tasks"
@@ -150,12 +178,12 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> SyncCommitteeService<S
         Ok(())
     }
 
-    async fn spawn_contribution_tasks(&self) -> Result<(), String> {
+    async fn spawn_contribution_tasks(&self, slot: Slot) -> Result<(), String> {
         let spec = &self.duties_service.spec;
-        let slot = self.slot_clock.now().ok_or("Failed to read slot clock")?;
+        // Bound contribution timing to `slot`, not a later wall-clock slot.
         let duration_to_next_slot = self
             .slot_clock
-            .duration_to_next_slot()
+            .duration_to_slot(slot + 1)
             .ok_or("Unable to determine duration to next slot")?;
 
         // If a validator needs to publish a sync aggregate, trigger it at the
@@ -560,17 +588,13 @@ fn sync_message_deadline<E: EthSpec>(
     slot_clock: &impl SlotClock,
     chain_spec: &ChainSpec,
     now: Duration,
-) -> (Slot, Option<Duration>) {
-    let sync_message_slot = slot_clock
-        .slot_of(now)
-        .map_or_else(|| slot_clock.genesis_slot(), |slot| slot + 1);
-    let duration_to_sync_message_deadline = slot_clock
-        .start_of(sync_message_slot)
-        .and_then(|slot_start| {
-            slot_start.checked_add(chain_spec.get_sync_message_due::<E>(sync_message_slot))
-        })
-        .and_then(|deadline| deadline.checked_sub(now));
-    (sync_message_slot, duration_to_sync_message_deadline)
+    after: Option<Slot>,
+) -> Option<(Slot, Duration)> {
+    slot_clock.duration_to_deadline_after(
+        now,
+        |slot| chain_spec.get_sync_message_due::<E>(slot),
+        after,
+    )
 }
 
 fn sync_period_of_slot<E: EthSpec>(slot: Slot, spec: &ChainSpec) -> Result<u64, String> {
@@ -622,25 +646,57 @@ mod tests {
                 Duration::from_millis(4999),
             ),
             (
-                "pre-Gloas",
-                slot_clock.start_of(last_pre_gloas_slot - 1).unwrap(),
+                "pre-Gloas slot start",
+                slot_clock.start_of(last_pre_gloas_slot).unwrap(),
                 last_pre_gloas_slot,
-                Duration::from_millis(15999),
+                spec.get_sync_message_due::<E>(last_pre_gloas_slot),
             ),
             (
-                "post-Gloas",
-                slot_clock.start_of(last_pre_gloas_slot).unwrap(),
+                "first Gloas slot start",
+                slot_clock.start_of(first_gloas_slot).unwrap(),
                 first_gloas_slot,
-                Duration::from_millis(15000),
+                spec.get_sync_message_due::<E>(first_gloas_slot),
+            ),
+            (
+                "1ms past current-slot due",
+                slot_clock.start_of(last_pre_gloas_slot).unwrap()
+                    + spec.get_sync_message_due::<E>(last_pre_gloas_slot)
+                    + Duration::from_millis(1),
+                first_gloas_slot,
+                slot_duration
+                    - spec.get_sync_message_due::<E>(last_pre_gloas_slot)
+                    - Duration::from_millis(1)
+                    + spec.get_sync_message_due::<E>(first_gloas_slot),
             ),
         ];
 
         for (case, now, expected_slot, expected_duration) in test_cases {
             assert_eq!(
-                sync_message_deadline::<E>(&slot_clock, &spec, now),
-                (expected_slot, Some(expected_duration)),
+                sync_message_deadline::<E>(&slot_clock, &spec, now, None),
+                Some((expected_slot, expected_duration)),
                 "{case}"
             );
         }
+    }
+
+    #[test]
+    fn duration_to_sync_message_deadline_after_skips_attempted_slot() {
+        type E = MainnetEthSpec;
+
+        let spec = E::default_spec();
+        let slot_duration = spec.get_slot_duration();
+        let genesis_time = slot_duration;
+        let slot_clock = ManualSlotClock::new(Slot::new(0), genesis_time, slot_duration);
+        let slot = Slot::new(0);
+        let due = spec.get_sync_message_due::<E>(slot);
+        let now = slot_clock.start_of(slot).unwrap() + due;
+
+        assert_eq!(
+            sync_message_deadline::<E>(&slot_clock, &spec, now, Some(slot)),
+            Some((
+                Slot::new(1),
+                slot_duration - due + spec.get_sync_message_due::<E>(Slot::new(1))
+            ))
+        );
     }
 }


### PR DESCRIPTION
## Description

Duty timers always slept until the next slot, even when the current slot's deadline had not elapsed. A restart skipped up to one slot of attestations, sync messages and PTC, and Gloas PTC was skipped at the fork slot.

Schedule the current slot when its deadline is still in the future (`wait == 0` included). Skip if it has already passed. Proposer duties still wait for the next slot start, so we do not produce late blocks. Attester, sync and PTC duty fetches poll first, after resolving validator indices.

Based on #9823.

Closes #9826

## Test plan

- [x] `cargo test -p slot_clock`
- [x] `cargo nextest run -p validator_services attestation_service::tests sync_committee_service::tests payload_attestation_service::tests`