### PR TITLE
Fix: use empty finalized header when finalized_block_root is zero

### DIFF
--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -157,24 +157,40 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
             None => true,
         };
 
-        if is_latest_finality & !cached_parts.finalized_block_root.is_zero() {
-            // Immediately after checkpoint sync the finalized block may not be available yet.
-            if let Some(finalized_block) = maybe_finalized_block.as_ref() {
-                *self.latest_finality_update.write() = Some(LightClientFinalityUpdate::new(
-                    &attested_block,
-                    finalized_block,
-                    cached_parts.finality_branch.clone(),
-                    sync_aggregate.clone(),
-                    signature_slot,
-                    chain_spec,
-                )?);
-            } else {
-                debug!(
-                    finalized_block_root = %cached_parts.finalized_block_root,
-                    "Finalized block not available in store for light_client server"
-                );
-            }
-        }
+	if is_latest_finality {
+	    let update = if cached_parts.finalized_block_root.is_zero() {
+	        // When finalized_checkpoint.root is ZERO_HASH, hash_tree_root(finalized_header)
+	        // cannot be proven, so finalized_header must be empty/default initialized.
+	        Some(LightClientFinalityUpdate::new_with_empty_finalized_header(
+	            &attested_block,
+	            cached_parts.finality_branch.clone(),
+	            sync_aggregate.clone(),
+	            signature_slot,
+	            chain_spec,
+	        )?)
+	    } else if let Some(finalized_block) = maybe_finalized_block.as_ref() {
+	        Some(LightClientFinalityUpdate::new(
+	            &attested_block,
+	            finalized_block,
+	            cached_parts.finality_branch.clone(),
+	            sync_aggregate.clone(),
+	            signature_slot,
+	            chain_spec,
+	        )?)
+	    } else {
+	        debug!(
+	            finalized_block_root = %cached_parts.finalized_block_root,
+	            "Finalized block not available in store for light_client server"
+	        );
+	        None
+	    };
+	    if let Some(update) = update {
+	        *self.latest_finality_update.write() = Some(update);
+	    }
+	}	
+
+
+
 
         let new_light_client_update = LightClientUpdate::new(
             sync_aggregate,
@@ -183,7 +199,11 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
             cached_parts.next_sync_committee_branch,
             cached_parts.finality_branch,
             &attested_block,
-            maybe_finalized_block.as_ref(),
+	    if cached_parts.finalized_block_root.is_zero() {
+		None
+	    } else {
+	    	maybe_finalized_block.as_ref()
+	    },
             chain_spec,
         )?;
 

--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -157,40 +157,37 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
             None => true,
         };
 
-	if is_latest_finality {
-	    let update = if cached_parts.finalized_block_root.is_zero() {
-	        // When finalized_checkpoint.root is ZERO_HASH, hash_tree_root(finalized_header)
-	        // cannot be proven, so finalized_header must be empty/default initialized.
-	        Some(LightClientFinalityUpdate::new_with_empty_finalized_header(
-	            &attested_block,
-	            cached_parts.finality_branch.clone(),
-	            sync_aggregate.clone(),
-	            signature_slot,
-	            chain_spec,
-	        )?)
-	    } else if let Some(finalized_block) = maybe_finalized_block.as_ref() {
-	        Some(LightClientFinalityUpdate::new(
-	            &attested_block,
-	            finalized_block,
-	            cached_parts.finality_branch.clone(),
-	            sync_aggregate.clone(),
-	            signature_slot,
-	            chain_spec,
-	        )?)
-	    } else {
-	        debug!(
-	            finalized_block_root = %cached_parts.finalized_block_root,
-	            "Finalized block not available in store for light_client server"
-	        );
-	        None
-	    };
-	    if let Some(update) = update {
-	        *self.latest_finality_update.write() = Some(update);
-	    }
-	}	
-
-
-
+        if is_latest_finality {
+            let update = if cached_parts.finalized_block_root.is_zero() {
+                // When finalized_checkpoint.root is ZERO_HASH, hash_tree_root(finalized_header)
+                // cannot be proven, so finalized_header must be empty/default initialized.
+                Some(LightClientFinalityUpdate::new_with_empty_finalized_header(
+                    &attested_block,
+                    cached_parts.finality_branch.clone(),
+                    sync_aggregate.clone(),
+                    signature_slot,
+                    chain_spec,
+                )?)
+            } else if let Some(finalized_block) = maybe_finalized_block.as_ref() {
+                Some(LightClientFinalityUpdate::new(
+                    &attested_block,
+                    finalized_block,
+                    cached_parts.finality_branch.clone(),
+                    sync_aggregate.clone(),
+                    signature_slot,
+                    chain_spec,
+                )?)
+            } else {
+                debug!(
+                    finalized_block_root = %cached_parts.finalized_block_root,
+                    "Finalized block not available in store for light_client server"
+                );
+                None
+            };
+            if let Some(update) = update {
+                *self.latest_finality_update.write() = Some(update);
+            }
+        }
 
         let new_light_client_update = LightClientUpdate::new(
             sync_aggregate,
@@ -199,11 +196,11 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
             cached_parts.next_sync_committee_branch,
             cached_parts.finality_branch,
             &attested_block,
-	    if cached_parts.finalized_block_root.is_zero() {
-		None
-	    } else {
-	    	maybe_finalized_block.as_ref()
-	    },
+            if cached_parts.finalized_block_root.is_zero() {
+                None
+            } else {
+                maybe_finalized_block.as_ref()
+            },
             chain_spec,
         )?;
 

--- a/consensus/types/src/light_client/light_client_finality_update.rs
+++ b/consensus/types/src/light_client/light_client_finality_update.rs
@@ -173,8 +173,62 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
         Ok(finality_update)
     }
 
+    pub fn new_with_empty_finalized_header(
+
+	    attested_block: &SignedBlindedBeaconBlock<E>,
+	    finality_branch: Vec<Hash256>,
+	    sync_aggregate: SyncAggregate<E>,
+	    signature_slot: Slot,
+	    chain_spec: &ChainSpec,
+	) -> Result<Self, LightClientError> {
+	    let finality_update = match attested_block
+	        .fork_name(chain_spec)
+	        .map_err(|_| LightClientError::InconsistentFork)?
+	    {
+	        ForkName::Altair | ForkName::Bellatrix => {
+	            Self::Altair(LightClientFinalityUpdateAltair {
+	                attested_header: LightClientHeaderAltair::block_to_light_client_header(
+	                    attested_block,
+	                )?,
+	                finalized_header: LightClientHeaderAltair::default(),
+	                finality_branch: finality_branch
+	                    .try_into()
+	                    .map_err(LightClientError::SszTypesError)?,
+	                sync_aggregate,
+	                signature_slot,
+	            })
+	        }
+	        ForkName::Capella => Self::Capella(LightClientFinalityUpdateCapella {
+	            attested_header: LightClientHeaderCapella::block_to_light_client_header(
+	                attested_block,
+	            )?,
+	            finalized_header: LightClientHeaderCapella::default(),
+	            finality_branch: finality_branch
+	                .try_into()
+	                .map_err(LightClientError::SszTypesError)?,
+	            sync_aggregate,
+	            signature_slot,
+	        }),
+	        ForkName::Deneb => Self::Deneb(LightClientFinalityUpdateDeneb {
+	            attested_header: LightClientHeaderDeneb::block_to_light_client_header(
+	                attested_block,
+	            )?,
+	            finalized_header: LightClientHeaderDeneb::default(),
+	            finality_branch: finality_branch
+	                .try_into()
+	                .map_err(LightClientError::SszTypesError)?,
+	            sync_aggregate,
+	            signature_slot,
+	        }),
+	        _ => return Err(LightClientError::InconsistentFork),
+	    };
+	    Ok(finality_update)
+	}
+
+
+
     pub fn map_with_fork_name<F, R>(&self, func: F) -> R
-    where
+ 	   where
         F: Fn(ForkName) -> R,
     {
         match self {

--- a/consensus/types/src/light_client/light_client_finality_update.rs
+++ b/consensus/types/src/light_client/light_client_finality_update.rs
@@ -174,61 +174,58 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
     }
 
     pub fn new_with_empty_finalized_header(
-
-	    attested_block: &SignedBlindedBeaconBlock<E>,
-	    finality_branch: Vec<Hash256>,
-	    sync_aggregate: SyncAggregate<E>,
-	    signature_slot: Slot,
-	    chain_spec: &ChainSpec,
-	) -> Result<Self, LightClientError> {
-	    let finality_update = match attested_block
-	        .fork_name(chain_spec)
-	        .map_err(|_| LightClientError::InconsistentFork)?
-	    {
-	        ForkName::Altair | ForkName::Bellatrix => {
-	            Self::Altair(LightClientFinalityUpdateAltair {
-	                attested_header: LightClientHeaderAltair::block_to_light_client_header(
-	                    attested_block,
-	                )?,
-	                finalized_header: LightClientHeaderAltair::default(),
-	                finality_branch: finality_branch
-	                    .try_into()
-	                    .map_err(LightClientError::SszTypesError)?,
-	                sync_aggregate,
-	                signature_slot,
-	            })
-	        }
-	        ForkName::Capella => Self::Capella(LightClientFinalityUpdateCapella {
-	            attested_header: LightClientHeaderCapella::block_to_light_client_header(
-	                attested_block,
-	            )?,
-	            finalized_header: LightClientHeaderCapella::default(),
-	            finality_branch: finality_branch
-	                .try_into()
-	                .map_err(LightClientError::SszTypesError)?,
-	            sync_aggregate,
-	            signature_slot,
-	        }),
-	        ForkName::Deneb => Self::Deneb(LightClientFinalityUpdateDeneb {
-	            attested_header: LightClientHeaderDeneb::block_to_light_client_header(
-	                attested_block,
-	            )?,
-	            finalized_header: LightClientHeaderDeneb::default(),
-	            finality_branch: finality_branch
-	                .try_into()
-	                .map_err(LightClientError::SszTypesError)?,
-	            sync_aggregate,
-	            signature_slot,
-	        }),
-	        _ => return Err(LightClientError::InconsistentFork),
-	    };
-	    Ok(finality_update)
-	}
-
-
+        attested_block: &SignedBlindedBeaconBlock<E>,
+        finality_branch: Vec<Hash256>,
+        sync_aggregate: SyncAggregate<E>,
+        signature_slot: Slot,
+        chain_spec: &ChainSpec,
+    ) -> Result<Self, LightClientError> {
+        let finality_update = match attested_block
+            .fork_name(chain_spec)
+            .map_err(|_| LightClientError::InconsistentFork)?
+        {
+            ForkName::Altair | ForkName::Bellatrix => {
+                Self::Altair(LightClientFinalityUpdateAltair {
+                    attested_header: LightClientHeaderAltair::block_to_light_client_header(
+                        attested_block,
+                    )?,
+                    finalized_header: LightClientHeaderAltair::default(),
+                    finality_branch: finality_branch
+                        .try_into()
+                        .map_err(LightClientError::SszTypesError)?,
+                    sync_aggregate,
+                    signature_slot,
+                })
+            }
+            ForkName::Capella => Self::Capella(LightClientFinalityUpdateCapella {
+                attested_header: LightClientHeaderCapella::block_to_light_client_header(
+                    attested_block,
+                )?,
+                finalized_header: LightClientHeaderCapella::default(),
+                finality_branch: finality_branch
+                    .try_into()
+                    .map_err(LightClientError::SszTypesError)?,
+                sync_aggregate,
+                signature_slot,
+            }),
+            ForkName::Deneb => Self::Deneb(LightClientFinalityUpdateDeneb {
+                attested_header: LightClientHeaderDeneb::block_to_light_client_header(
+                    attested_block,
+                )?,
+                finalized_header: LightClientHeaderDeneb::default(),
+                finality_branch: finality_branch
+                    .try_into()
+                    .map_err(LightClientError::SszTypesError)?,
+                sync_aggregate,
+                signature_slot,
+            }),
+            _ => return Err(LightClientError::InconsistentFork),
+        };
+        Ok(finality_update)
+    }
 
     pub fn map_with_fork_name<F, R>(&self, func: F) -> R
- 	   where
+    where
         F: Fn(ForkName) -> R,
     {
         match self {


### PR DESCRIPTION
When finalized_checkpoint.root is ZERO_HASH (at genesis, before any blocks have been finalized), recompute_and_cache_updates was fetching the genesis block stored under Hash256::zero() as an alias and using it as the finalized_header in both LightClientFinalityUpdate and LightClientUpdate.

The spec requires the finalized_header to be empty (default initialized) in this case because hash_tree_root(finalized_header) cannot be proven when finalized_checkpoint.root is ZERO_HASH. The finality_branch proves the finalized checkpoint field in the attested state, and since that field is zero, the corresponding header must also be zeroed out.

This bug was discovered while implementing the missing light_client_data_collection ef_test handler in #9666. The fix adds new_with_empty_finalized_header to LightClientFinalityUpdate and uses it when finalized_block_root.is_zero(), and applies the same logic to the LightClientUpdate call site.

Related to #9816 which fixed the finality update being skipped entirely at genesis.