### PR TITLE
Do not fatally ban peers for DataColumnsByRange ResourceUnavailable

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -570,10 +570,15 @@ impl<E: EthSpec> PeerManager<E> {
             RPCError::ErrorResponse(code, _) => match code {
                 RpcErrorResponse::Unknown => PeerAction::HighToleranceError,
                 RpcErrorResponse::ResourceUnavailable => {
-                    // Don't ban on this because we want to retry with a block by root request.
+                    // Don't ban on this. For the by-root protocols we retry with a block-by-root
+                    // request; for `DataColumnsByRange` this response is a legitimate "peer has not
+                    // custody-backfilled that range yet" signal (e.g. on a young network or right
+                    // after Fulu activation), not misbehaviour, so it must not be a fatal offense.
                     if matches!(
                         protocol,
-                        Protocol::BlobsByRoot | Protocol::DataColumnsByRoot
+                        Protocol::BlobsByRoot
+                            | Protocol::DataColumnsByRoot
+                            | Protocol::DataColumnsByRange
                     ) {
                         return;
                     }


### PR DESCRIPTION
## Issue Addressed

Fixes #9873.

## Proposed Changes

Add `Protocol::DataColumnsByRange` to the `RpcErrorResponse::ResourceUnavailable` exemption in the RPC-error → `PeerAction` map (`peer_manager/mod.rs`), so a `data_column_sidecars_by_range` response of `ResourceUnavailable` no longer maps to `PeerAction::Fatal`.

That response is legitimate: the peer simply hasn't finished **custody-backfilling** the requested range yet (the server logs `"columns pruned within boundary"` / `"Req outside availability period"`, but it isn't pruning — `earliest_custodied_data_column_epoch()` is just still ahead of the request start on a young network). Only the by-root DAS protocols were exempted, so an outgoing by-range custody-backfill request that hit this instantly banned the peer (−100). On an all-Lighthouse PeerDAS network, nodes ban each other during backfill and the chain partitions.

## Reproduced

`ethereum-package` (kurtosis), minimal preset, all-Lighthouse, `fulu_fork_epoch: 0`, **no Gloas**, released clients (`ethereum/client-go:stable` + `ethpandaops/lighthouse:stable`/`:unstable`, both **v8.2.2**), 5 nodes. Every node bans its peers on `data_column_sidecars_by_range` `ResourceUnavailable` around slot ~33 and the network shatters into one head per node (0 peers each). Reproduced on both **stable and unstable**, independent of Gloas and EL; a mixed CL set (LH+Teku+Lodestar) does not partition. Full write-up in #9873.

## Credit

This exact change was already made on the glamsterdam devnet branches by @eserilev — [af13f1b8a](https://github.com/sigp/lighthouse/commit/af13f1b8a9b2b1d025fb938e48f077231af867f9) ("do not penalize", `glamsterdam-devnet-4`) and [80a7b2a27](https://github.com/sigp/lighthouse/commit/80a7b2a27f4ac87bb72cc4fefe5b7271edbdd6ff) ("Fix", `glamsterdam-devnet-5-penalize-peers`) — but was never upstreamed to `unstable`, so released `stable`/`unstable` still ban. This PR forward-ports it (Co-authored-by @eserilev).

## Additional Info

`Protocol::BlobsByRange` may warrant the same treatment for symmetry (it is likewise absent from this exemption while present in the other error arms), but I have only reproduced the data-column case, so this PR is scoped to `DataColumnsByRange`. Happy to add `BlobsByRange` if maintainers agree.
