### PR TITLE
Gloas payload attributes use the wrong withdrawals after an empty parent

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5238,6 +5238,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 )
             };
 
+        let parent_has_payload_bid = parent_bid_block_hash
+            .is_some_and(|block_hash| block_hash != ExecutionBlockHash::default());
         let parent_payload_status = if let Some(block_hash) = parent_bid_block_hash
             && block_hash != ExecutionBlockHash::default()
             && forkchoice_update_params.head_hash == Some(block_hash)
@@ -5264,6 +5266,16 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             proposal_slot,
             &self.spec,
         )?;
+
+        if parent_has_payload_bid && parent_payload_status == fork_choice::PayloadStatus::Empty {
+            // The state has already deducted these withdrawals, but they remain pending for the
+            // execution layer after an empty parent.
+            return advanced_state
+                .payload_expected_withdrawals()?
+                .to_vec()
+                .try_into()
+                .map_err(Error::SszTypesError);
+        }
 
         // For Gloas, when the head payload is Full, we need to apply the parent's
         // execution requests to the state to get the correct withdrawals.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -555,6 +555,33 @@ impl<E: EthSpec> BeaconBlockResponseWrapper<E> {
     }
 }
 
+fn gloas_parent_payload_status(
+    parent_bid_block_hash: Option<ExecutionBlockHash>,
+    head_hash: Option<ExecutionBlockHash>,
+) -> Option<fork_choice::PayloadStatus> {
+    parent_bid_block_hash.map(|block_hash| {
+        if block_hash != ExecutionBlockHash::default() && head_hash == Some(block_hash) {
+            fork_choice::PayloadStatus::Full
+        } else {
+            fork_choice::PayloadStatus::Empty
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_hash_gloas_bid_is_an_empty_parent() {
+        assert_eq!(
+            gloas_parent_payload_status(Some(ExecutionBlockHash::default()), None),
+            Some(fork_choice::PayloadStatus::Empty)
+        );
+        assert_eq!(gloas_parent_payload_status(None, None), None);
+    }
+}
+
 /// The components produced when the local beacon node creates a new block to extend the chain
 pub struct BeaconBlockResponse<E: EthSpec, Payload: AbstractExecPayload<E>> {
     /// The newly produced beacon block
@@ -5204,7 +5231,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }))
     }
 
-    pub fn get_expected_withdrawals(
+    pub fn compute_withdrawals_for_payload_attributes(
         &self,
         forkchoice_update_params: &ForkchoiceUpdateParameters,
         proposal_slot: Slot,
@@ -5238,16 +5265,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 )
             };
 
-        let parent_has_payload_bid = parent_bid_block_hash
-            .is_some_and(|block_hash| block_hash != ExecutionBlockHash::default());
-        let parent_payload_status = if let Some(block_hash) = parent_bid_block_hash
-            && block_hash != ExecutionBlockHash::default()
-            && forkchoice_update_params.head_hash == Some(block_hash)
-        {
-            fork_choice::PayloadStatus::Full
-        } else {
-            fork_choice::PayloadStatus::Empty
-        };
+        let parent_payload_status =
+            gloas_parent_payload_status(parent_bid_block_hash, forkchoice_update_params.head_hash);
+
+        if parent_payload_status == Some(fork_choice::PayloadStatus::Empty) {
+            // The state has already deducted these withdrawals, but they remain pending for the
+            // execution layer after an empty parent.
+            return unadvanced_state
+                .payload_expected_withdrawals()?
+                .to_vec()
+                .try_into()
+                .map_err(Error::SszTypesError);
+        }
 
         // Advance the state using the partial method.
         // TODO(gloas): we might want to optimise this further by using:
@@ -5267,19 +5296,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             &self.spec,
         )?;
 
-        if parent_has_payload_bid && parent_payload_status == fork_choice::PayloadStatus::Empty {
-            // The state has already deducted these withdrawals, but they remain pending for the
-            // execution layer after an empty parent.
-            return advanced_state
-                .payload_expected_withdrawals()?
-                .to_vec()
-                .try_into()
-                .map_err(Error::SszTypesError);
-        }
-
         // For Gloas, when the head payload is Full, we need to apply the parent's
         // execution requests to the state to get the correct withdrawals.
-        if parent_payload_status == fork_choice::PayloadStatus::Full {
+        if parent_payload_status == Some(fork_choice::PayloadStatus::Full) {
             let envelope = if parent_block_root == head_block_root {
                 cached_head.snapshot.execution_envelope.clone()
             } else {
@@ -6634,7 +6653,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let withdrawals = if prepare_slot_fork.capella_enabled() {
                 let chain = self.clone();
                 self.spawn_blocking_handle(
-                    move || chain.get_expected_withdrawals(&forkchoice_update_params, prepare_slot),
+                    move || {
+                        chain.compute_withdrawals_for_payload_attributes(
+                            &forkchoice_update_params,
+                            prepare_slot,
+                        )
+                    },
                     "prepare_beacon_proposer_withdrawals",
                 )
                 .await?

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -568,20 +568,6 @@ fn gloas_parent_payload_status(
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn zero_hash_gloas_bid_is_an_empty_parent() {
-        assert_eq!(
-            gloas_parent_payload_status(Some(ExecutionBlockHash::default()), None),
-            Some(fork_choice::PayloadStatus::Empty)
-        );
-        assert_eq!(gloas_parent_payload_status(None, None), None);
-    }
-}
-
 /// The components produced when the local beacon node creates a new block to extend the chain
 pub struct BeaconBlockResponse<E: EthSpec, Payload: AbstractExecPayload<E>> {
     /// The newly produced beacon block
@@ -7828,5 +7814,19 @@ impl ChainSegmentResult {
             ChainSegmentResult::Failed { error, .. } => Err(error),
             ChainSegmentResult::Successful { .. } => Ok(()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_hash_gloas_bid_is_an_empty_parent() {
+        assert_eq!(
+            gloas_parent_payload_status(Some(ExecutionBlockHash::default()), None),
+            Some(fork_choice::PayloadStatus::Empty)
+        );
+        assert_eq!(gloas_parent_payload_status(None, None), None);
     }
 }

--- a/beacon_node/beacon_chain/tests/prepare_payload.rs
+++ b/beacon_node/beacon_chain/tests/prepare_payload.rs
@@ -261,7 +261,7 @@ async fn prepare_payload_generic(
         get_expected_withdrawals(&advanced_empty_state, &spec)
             .unwrap()
             .into();
-    let carried_withdrawals = advanced_empty_state
+    let carried_withdrawals = unadvanced_empty_state
         .payload_expected_withdrawals()
         .unwrap()
         .to_vec();

--- a/beacon_node/beacon_chain/tests/prepare_payload.rs
+++ b/beacon_node/beacon_chain/tests/prepare_payload.rs
@@ -261,6 +261,10 @@ async fn prepare_payload_generic(
         get_expected_withdrawals(&advanced_empty_state, &spec)
             .unwrap()
             .into();
+    let carried_withdrawals = advanced_empty_state
+        .payload_expected_withdrawals()
+        .unwrap()
+        .to_vec();
     let withdrawals_unadvanced_full: Withdrawals<E> =
         get_expected_withdrawals(&unadvanced_full_state, &spec)
             .unwrap()
@@ -274,6 +278,15 @@ async fn prepare_payload_generic(
         withdrawals_advanced_empty, withdrawals_advanced_full,
         "Applying execution requests should change the expected withdrawals"
     );
+
+    if parent_payload_status == PayloadStatus::Empty {
+        assert!(!carried_withdrawals.is_empty());
+        assert_ne!(
+            carried_withdrawals,
+            withdrawals_advanced_empty.to_vec(),
+            "Carried withdrawals should differ from a freshly computed batch"
+        );
+    }
 
     let expect_state_advance_to_change_withdrawals =
         prepare_slot.epoch(E::slots_per_epoch()) > parent_block_slot.epoch(E::slots_per_epoch());
@@ -334,13 +347,12 @@ async fn prepare_payload_generic(
     let expected_withdrawals: Vec<Withdrawal> = if parent_payload_status == PayloadStatus::Full {
         withdrawals_advanced_full.to_vec()
     } else {
-        withdrawals_advanced_empty.to_vec()
+        carried_withdrawals
     };
 
     assert_eq!(
         actual_withdrawals, &expected_withdrawals,
-        "prepare_beacon_proposer should use withdrawals computed from the \
-         {parent_payload_status:?} state"
+        "prepare_beacon_proposer should use withdrawals for the {parent_payload_status:?} parent"
     );
 }
 

--- a/beacon_node/http_api/tests/gloas_reorg_tests.rs
+++ b/beacon_node/http_api/tests/gloas_reorg_tests.rs
@@ -833,11 +833,7 @@ pub async fn proposer_boost_re_org_test(
     } else {
         state_b.clone()
     };
-    let expected_withdrawals = if matches!(
-        expected_first_update_lookahead,
-        ExpectedFirstUpdateLookahead::BlockProduction
-    ) && expected_parent_payload_status == PayloadStatus::Empty
-    {
+    let expected_withdrawals = if expected_parent_payload_status == PayloadStatus::Empty {
         parent_state_advanced
             .payload_expected_withdrawals()
             .unwrap()


### PR DESCRIPTION
## Issue Addressed

When a Gloas payload is not published, the next payload must reuse the withdrawals carried in `state.payload_expected_withdrawals`. Payload attributes currently calculate a new batch instead. If the batches differ, an external builder using those attributes cannot produce a payload that passes reveal validation. The carried withdrawals remain pending after another empty parent, so the same external-builder path cannot recover on later slots until a correct payload lands.

This is the same empty-parent case fixed for local payload production in #9014.

## Proposed Changes

- Use `state.payload_expected_withdrawals` after an empty Gloas parent.
- Keep the existing behaviour for full parents, genesis, and the fork boundary.
- Add regression coverage with non-empty carried withdrawals.