### PR TITLE
Fix clippy lints for Rust 1.98

### DIFF
--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -178,6 +178,10 @@ impl ForkChoiceTest {
     }
 
     /// Build the chain whilst `predicate` returns `true` and `process_block_result` does not error.
+    ///
+    /// Both variants intentionally carry the whole test harness (`Ok` to continue, `Err` to stop
+    /// with the state at that point), so boxing only the error would not shrink anything useful.
+    #[allow(clippy::result_large_err)]
     pub async fn apply_blocks_while<F>(self, mut predicate: F) -> Result<Self, Self>
     where
         F: FnMut(BeaconBlockRef<'_, E>, &BeaconState<E>) -> bool,

--- a/consensus/proto_array/src/fork_choice_test_definition/execution_status.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition/execution_status.rs
@@ -2,415 +2,393 @@ use super::*;
 
 pub fn get_execution_status_test_definition_01() -> ForkChoiceTestDefinition {
     let balances = vec![1; 2];
-    let mut ops = vec![];
-
-    // Ensure that the head starts at the finalized block.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+    let ops = vec![
+        // Ensure that the head starts at the finalized block.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(0),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a block with a hash of 2.
+        //
+        //          0
+        //         /
+        //        2
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(2),
+            parent_root: get_root(0),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(0),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a block with a hash of 2.
-    //
-    //          0
-    //         /
-    //        2
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(2),
-        parent_root: get_root(0),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is 2
+        //
+        //          0
+        //         /
+        // head-> 2
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a block with a hash of 1 that comes off the genesis block (this is a fork compared
+        // to the previous block).
+        //
+        //          0
+        //         / \
+        //        2   1
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is 2
-    //
-    //          0
-    //         /
-    // head-> 2
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is still 2
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a vote to block 1
+        //
+        //          0
+        //         / \
+        //        2   1 <- +vote
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(2),
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a block with a hash of 1 that comes off the genesis block (this is a fork compared
-    // to the previous block).
-    //
-    //          0
-    //         / \
-    //        2   1
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is now 1, because 1 has a vote.
+        //
+        //          0
+        //         / \
+        //        2   1 <- head
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(1),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 1,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is still 2
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 1,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 0,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a vote to block 1
-    //
-    //          0
-    //         / \
-    //        2   1 <- +vote
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(2),
-    });
-
-    // Ensure that the head is now 1, because 1 has a vote.
-    //
-    //          0
-    //         / \
-    //        2   1 <- head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a vote to block 2
+        //
+        //           0
+        //          / \
+        // +vote-> 2   1
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(2),
+            attestation_slot: Slot::new(2),
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is 2 since 1 and 2 both have a vote
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(1),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 0,
-    });
-
-    // Add a vote to block 2
-    //
-    //           0
-    //          / \
-    // +vote-> 2   1
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(2),
-        attestation_slot: Slot::new(2),
-    });
-
-    // Ensure that the head is 2 since 1 and 2 both have a vote
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 2,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 1,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 2,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 1,
-    });
-
-    // Add block 3.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(3),
-        parent_root: get_root(1),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 1,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add block 3.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(3),
+            parent_root: get_root(1),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is still 2
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    //            |
-    //            3
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is still 2
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        //            |
+        //            3
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 2,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 2,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(3),
-        weight: 0,
-    });
-
-    // Move validator #0 vote from 1 to 3
-    //
-    //          0
-    //         / \
-    //        2   1 <- -vote
-    //            |
-    //            3 <- +vote
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(3),
-        attestation_slot: Slot::new(3),
-    });
-
-    // Ensure that the head is still 2
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    //            |
-    //            3
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 1,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 1,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 2,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(3),
-        weight: 1,
-    });
-
-    // Invalidate the payload of 3.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3 <- INVALID
-    ops.push(Operation::InvalidatePayload {
-        head_block_root: get_root(3),
-        latest_valid_ancestor_root: Some(get_hash(1)),
-    });
-
-    // Ensure that the head is still 2.
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    //            |
-    //            3 <- INVALID
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(3),
+            weight: 0,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Move validator #0 vote from 1 to 3
+        //
+        //          0
+        //         / \
+        //        2   1 <- -vote
+        //            |
+        //            3 <- +vote
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(3),
+            attestation_slot: Slot::new(3),
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Invalidation of 3 should have removed upstream weight.
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 1,
-    });
-    // Invalidation of 3 should have removed upstream weight.
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 0,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 1,
-    });
-    // Invalidation should have removed weight.
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(3),
-        weight: 0,
-    });
-
-    // Move a vote from 2 to 1. This is slashable, but that's not relevant here.
-    //
-    //           0
-    //          / \
-    // -vote-> 2   1 <- +vote
-    //             |
-    //             3 <- INVALID
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(3),
-    });
-
-    // Ensure that the head has switched back to 1
-    //
-    //          0
-    //         / \
-    //        2   1 <-head
-    //            |
-    //            3 <- INVALID
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is still 2
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        //            |
+        //            3
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 2,
         },
-        justified_state_balances: balances,
-        expected_head: get_root(1),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 0,
-    });
-    // Invalidation should have removed weight.
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(3),
-        weight: 0,
-    });
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 1,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 1,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(3),
+            weight: 1,
+        },
+        // Invalidate the payload of 3.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3 <- INVALID
+        Operation::InvalidatePayload {
+            head_block_root: get_root(3),
+            latest_valid_ancestor_root: Some(get_hash(1)),
+        },
+        // Ensure that the head is still 2.
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        //            |
+        //            3 <- INVALID
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Invalidation of 3 should have removed upstream weight.
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 1,
+        },
+        // Invalidation of 3 should have removed upstream weight.
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 0,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 1,
+        },
+        // Invalidation should have removed weight.
+        Operation::AssertWeight {
+            block_root: get_root(3),
+            weight: 0,
+        },
+        // Move a vote from 2 to 1. This is slashable, but that's not relevant here.
+        //
+        //           0
+        //          / \
+        // -vote-> 2   1 <- +vote
+        //             |
+        //             3 <- INVALID
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(3),
+        },
+        // Ensure that the head has switched back to 1
+        //
+        //          0
+        //         / \
+        //        2   1 <-head
+        //            |
+        //            3 <- INVALID
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances,
+            expected_head: get_root(1),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 1,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 1,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 0,
+        },
+        // Invalidation should have removed weight.
+        Operation::AssertWeight {
+            block_root: get_root(3),
+            weight: 0,
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),
@@ -431,375 +409,355 @@ pub fn get_execution_status_test_definition_01() -> ForkChoiceTestDefinition {
 
 pub fn get_execution_status_test_definition_02() -> ForkChoiceTestDefinition {
     let balances = vec![1; 2];
-    let mut ops = vec![];
-
-    // Ensure that the head starts at the finalized block.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+    let ops = vec![
+        // Ensure that the head starts at the finalized block.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(0),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a block with a hash of 2.
+        //
+        //          0
+        //         /
+        //        2
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(2),
+            parent_root: get_root(0),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(0),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a block with a hash of 2.
-    //
-    //          0
-    //         /
-    //        2
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(2),
-        parent_root: get_root(0),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is 2
+        //
+        //          0
+        //         /
+        // head-> 2
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a block with a hash of 1 that comes off the genesis block (this is a fork compared
+        // to the previous block).
+        //
+        //          0
+        //         / \
+        //        2   1
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is 2
-    //
-    //          0
-    //         /
-    // head-> 2
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is still 2
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a vote to block 1
+        //
+        //          0
+        //         / \
+        //        2   1 <- +vote
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(2),
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a block with a hash of 1 that comes off the genesis block (this is a fork compared
-    // to the previous block).
-    //
-    //          0
-    //         / \
-    //        2   1
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is now 1, because 1 has a vote.
+        //
+        //          0
+        //         / \
+        //        2   1 <- head
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(1),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 1,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is still 2
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 1,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 0,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a vote to block 1
-    //
-    //          0
-    //         / \
-    //        2   1 <- +vote
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(2),
-    });
-
-    // Ensure that the head is now 1, because 1 has a vote.
-    //
-    //          0
-    //         / \
-    //        2   1 <- head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a vote to block 2
+        //
+        //           0
+        //          / \
+        // +vote-> 2   1
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(2),
+            attestation_slot: Slot::new(2),
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is 2 since 1 and 2 both have a vote
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(1),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 0,
-    });
-
-    // Add a vote to block 2
-    //
-    //           0
-    //          / \
-    // +vote-> 2   1
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(2),
-        attestation_slot: Slot::new(2),
-    });
-
-    // Ensure that the head is 2 since 1 and 2 both have a vote
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 2,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 1,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 2,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 1,
-    });
-
-    // Add block 3.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(3),
-        parent_root: get_root(1),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 1,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add block 3.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(3),
+            parent_root: get_root(1),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is still 2
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    //            |
-    //            3
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is still 2
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        //            |
+        //            3
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 2,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 2,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 1,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(3),
-        weight: 0,
-    });
-
-    // Move validator #0 vote from 1 to 3
-    //
-    //          0
-    //         / \
-    //        2   1 <- -vote
-    //            |
-    //            3 <- +vote
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(3),
-        attestation_slot: Slot::new(3),
-    });
-
-    // Move validator #1 vote from 2 to 3
-    //
-    //          0
-    //         / \
-    // -vote->2   1
-    //            |
-    //            3 <- +vote
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(3),
-        attestation_slot: Slot::new(3),
-    });
-
-    // Ensure that the head is now 3.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3 <-head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 1,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 1,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(3),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 2,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 2,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 0,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(3),
-        weight: 2,
-    });
-
-    // Invalidate the payload of 3.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3 <- INVALID
-    ops.push(Operation::InvalidatePayload {
-        head_block_root: get_root(3),
-        latest_valid_ancestor_root: Some(get_hash(1)),
-    });
-
-    // Ensure that the head is now 2.
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    //            |
-    //            3 <- INVALID
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(3),
+            weight: 0,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Move validator #0 vote from 1 to 3
+        //
+        //          0
+        //         / \
+        //        2   1 <- -vote
+        //            |
+        //            3 <- +vote
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(3),
+            attestation_slot: Slot::new(3),
         },
-        justified_state_balances: balances,
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Invalidation of 3 should have removed upstream weight.
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 0,
-    });
-    // Invalidation of 3 should have removed upstream weight.
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 0,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 0,
-    });
-    // Invalidation should have removed weight.
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(3),
-        weight: 0,
-    });
+        // Move validator #1 vote from 2 to 3
+        //
+        //          0
+        //         / \
+        // -vote->2   1
+        //            |
+        //            3 <- +vote
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(3),
+            attestation_slot: Slot::new(3),
+        },
+        // Ensure that the head is now 3.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3 <-head
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(3),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 2,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 2,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 0,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(3),
+            weight: 2,
+        },
+        // Invalidate the payload of 3.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3 <- INVALID
+        Operation::InvalidatePayload {
+            head_block_root: get_root(3),
+            latest_valid_ancestor_root: Some(get_hash(1)),
+        },
+        // Ensure that the head is now 2.
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        //            |
+        //            3 <- INVALID
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances,
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Invalidation of 3 should have removed upstream weight.
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 0,
+        },
+        // Invalidation of 3 should have removed upstream weight.
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 0,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 0,
+        },
+        // Invalidation should have removed weight.
+        Operation::AssertWeight {
+            block_root: get_root(3),
+            weight: 0,
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),
@@ -820,308 +778,292 @@ pub fn get_execution_status_test_definition_02() -> ForkChoiceTestDefinition {
 
 pub fn get_execution_status_test_definition_03() -> ForkChoiceTestDefinition {
     let balances = vec![1_000; 2_000];
-    let mut ops = vec![];
-
-    // Ensure that the head starts at the finalized block.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+    let ops = vec![
+        // Ensure that the head starts at the finalized block.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(0),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a block with a hash of 2.
+        //
+        //          0
+        //         /
+        //        2
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(2),
+            parent_root: get_root(0),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(0),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a block with a hash of 2.
-    //
-    //          0
-    //         /
-    //        2
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(2),
-        parent_root: get_root(0),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is 2
+        //
+        //          0
+        //         /
+        // head-> 2
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a block with a hash of 1 that comes off the genesis block (this is a fork compared
+        // to the previous block).
+        //
+        //          0
+        //         / \
+        //        2   1
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is 2
-    //
-    //          0
-    //         /
-    // head-> 2
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is still 2
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a vote to block 1
+        //
+        //          0
+        //         / \
+        //        2   1 <- +vote
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(2),
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a block with a hash of 1 that comes off the genesis block (this is a fork compared
-    // to the previous block).
-    //
-    //          0
-    //         / \
-    //        2   1
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is now 1, because 1 has a vote.
+        //
+        //          0
+        //         / \
+        //        2   1 <- head
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(1),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 1_000,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is still 2
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 1_000,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 0,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a vote to block 1
-    //
-    //          0
-    //         / \
-    //        2   1 <- +vote
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(2),
-    });
-
-    // Ensure that the head is now 1, because 1 has a vote.
-    //
-    //          0
-    //         / \
-    //        2   1 <- head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add another vote to 1
+        //
+        //           0
+        //          / \
+        //         2   1 <- +vote
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(2),
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is 1.
+        //
+        //          0
+        //         / \
+        //        2   1 <- head
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(1),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(1),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 1_000,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 1_000,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 0,
-    });
-
-    // Add another vote to 1
-    //
-    //           0
-    //          / \
-    //         2   1 <- +vote
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(2),
-    });
-
-    // Ensure that the head is 1.
-    //
-    //          0
-    //         / \
-    //        2   1 <- head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 2_000,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 2_000,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(1),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 2_000,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 2_000,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 0,
-    });
-
-    // Add block 3.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(3),
-        parent_root: get_root(1),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 0,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add block 3.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(3),
+            parent_root: get_root(1),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is now 3, applying a proposer boost to 3 as well.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3 <- head
-    ops.push(Operation::ProposerBoostFindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is now 3, applying a proposer boost to 3 as well.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3 <- head
+        Operation::ProposerBoostFindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(3),
+            proposer_boost_root: get_root(3),
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Stored weights are pure attestation scores (proposer boost is applied
+        // on-the-fly in the walk's `get_weight`, not baked into `node.weight()`).
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 2_000,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(3),
-        proposer_boost_root: get_root(3),
-    });
-
-    // Stored weights are pure attestation scores (proposer boost is applied
-    // on-the-fly in the walk's `get_weight`, not baked into `node.weight()`).
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 2_000,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 2_000,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 0,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(3),
-        weight: 0,
-    });
-
-    // Invalidate the payload of 3.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3 <- INVALID
-    ops.push(Operation::InvalidatePayload {
-        head_block_root: get_root(3),
-        latest_valid_ancestor_root: Some(get_hash(1)),
-    });
-
-    // Ensure that the head is now 1, maintaining the proposer boost on the invalid block.
-    //
-    //          0
-    //         / \
-    //        2   1 <- head
-    //            |
-    //            3 <- INVALID
-    ops.push(Operation::ProposerBoostFindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 2_000,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 0,
         },
-        justified_state_balances: balances,
-        expected_head: get_root(1),
-        proposer_boost_root: get_root(3),
-    });
-
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(0),
-        weight: 2_000,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(1),
-        weight: 2_000,
-    });
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(2),
-        weight: 0,
-    });
-    // The proposer boost should be reverted due to the invalid payload.
-    ops.push(Operation::AssertWeight {
-        block_root: get_root(3),
-        weight: 0,
-    });
+        Operation::AssertWeight {
+            block_root: get_root(3),
+            weight: 0,
+        },
+        // Invalidate the payload of 3.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3 <- INVALID
+        Operation::InvalidatePayload {
+            head_block_root: get_root(3),
+            latest_valid_ancestor_root: Some(get_hash(1)),
+        },
+        // Ensure that the head is now 1, maintaining the proposer boost on the invalid block.
+        //
+        //          0
+        //         / \
+        //        2   1 <- head
+        //            |
+        //            3 <- INVALID
+        Operation::ProposerBoostFindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances,
+            expected_head: get_root(1),
+            proposer_boost_root: get_root(3),
+        },
+        Operation::AssertWeight {
+            block_root: get_root(0),
+            weight: 2_000,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(1),
+            weight: 2_000,
+        },
+        Operation::AssertWeight {
+            block_root: get_root(2),
+            weight: 0,
+        },
+        // The proposer boost should be reverted due to the invalid payload.
+        Operation::AssertWeight {
+            block_root: get_root(3),
+            weight: 0,
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),

--- a/consensus/proto_array/src/fork_choice_test_definition/ffg_updates.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition/ffg_updates.rs
@@ -2,112 +2,108 @@ use super::*;
 
 pub fn get_ffg_case_01_test_definition() -> ForkChoiceTestDefinition {
     let balances = vec![1; 2];
-    let mut ops = vec![];
-
-    // Ensure that the head starts at the finalized block.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(0),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Build the following tree (stick? lol).
-    //
-    //            0 <- just: 0, fin: 0
-    //            |
-    //            1 <- just: 0, fin: 0
-    //            |
-    //            2 <- just: 1, fin: 0
-    //            |
-    //            3 <- just: 2, fin: 1
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(2),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(1),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(3),
-        root: get_root(3),
-        parent_root: get_root(2),
-        justified_checkpoint: get_checkpoint(2),
-        finalized_checkpoint: get_checkpoint(1),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that with justified epoch 0 we find 3
-    //
-    //            0 <- start
-    //            |
-    //            1
-    //            |
-    //            2
-    //            |
-    //            3 <- head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(3),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Ensure that with justified epoch 1 we find 3
-    //
-    //            0
-    //            |
-    //            1
-    //            |
-    //            2 <- start
-    //            |
-    //            3 <- head
-    //
-    // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
-    // to elect head blocks that have a higher justified checkpoint than the
-    // store.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(1),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(3),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Ensure that with justified epoch 2 we find 3
-    //
-    //            0
-    //            |
-    //            1
-    //            |
-    //            2
-    //            |
-    //            3 <- start + head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(2),
-        finalized_checkpoint: get_checkpoint(1),
-        justified_state_balances: balances,
-        expected_head: get_root(3),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
+    let ops = vec![
+        // Ensure that the head starts at the finalized block.
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(0),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Build the following tree (stick? lol).
+        //
+        //            0 <- just: 0, fin: 0
+        //            |
+        //            1 <- just: 0, fin: 0
+        //            |
+        //            2 <- just: 1, fin: 0
+        //            |
+        //            3 <- just: 2, fin: 1
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(2),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(1),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(3),
+            root: get_root(3),
+            parent_root: get_root(2),
+            justified_checkpoint: get_checkpoint(2),
+            finalized_checkpoint: get_checkpoint(1),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
+        },
+        // Ensure that with justified epoch 0 we find 3
+        //
+        //            0 <- start
+        //            |
+        //            1
+        //            |
+        //            2
+        //            |
+        //            3 <- head
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(3),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Ensure that with justified epoch 1 we find 3
+        //
+        //            0
+        //            |
+        //            1
+        //            |
+        //            2 <- start
+        //            |
+        //            3 <- head
+        //
+        // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
+        // to elect head blocks that have a higher justified checkpoint than the
+        // store.
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(1),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(3),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Ensure that with justified epoch 2 we find 3
+        //
+        //            0
+        //            |
+        //            1
+        //            |
+        //            2
+        //            |
+        //            3 <- start + head
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(2),
+            finalized_checkpoint: get_checkpoint(1),
+            justified_state_balances: balances,
+            expected_head: get_root(3),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+    ];
 
     // END OF TESTS
     ForkChoiceTestDefinition {
@@ -123,434 +119,424 @@ pub fn get_ffg_case_01_test_definition() -> ForkChoiceTestDefinition {
 
 pub fn get_ffg_case_02_test_definition() -> ForkChoiceTestDefinition {
     let balances = vec![1; 2];
-    let mut ops = vec![];
-
-    // Ensure that the head starts at the finalized block.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(0),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Build the following tree.
-    //
-    //                       0
-    //                      / \
-    //  just: 0, fin: 0 -> 1   2 <- just: 0, fin: 0
-    //                     |   |
-    //  just: 1, fin: 0 -> 3   4 <- just: 0, fin: 0
-    //                     |   |
-    //  just: 1, fin: 0 -> 5   6 <- just: 0, fin: 0
-    //                     |   |
-    //  just: 1, fin: 0 -> 7   8 <- just: 1, fin: 0
-    //                     |   |
-    //  just: 2, fin: 0 -> 9  10 <- just: 2, fin: 0
-
-    //  Left branch
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(3),
-        parent_root: get_root(1),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(1),
+    let ops = vec![
+        // Ensure that the head starts at the finalized block.
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(0),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(3),
-        root: get_root(5),
-        parent_root: get_root(3),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
+        // Build the following tree.
+        //
+        //                       0
+        //                      / \
+        //  just: 0, fin: 0 -> 1   2 <- just: 0, fin: 0
+        //                     |   |
+        //  just: 1, fin: 0 -> 3   4 <- just: 0, fin: 0
+        //                     |   |
+        //  just: 1, fin: 0 -> 5   6 <- just: 0, fin: 0
+        //                     |   |
+        //  just: 1, fin: 0 -> 7   8 <- just: 1, fin: 0
+        //                     |   |
+        //  just: 2, fin: 0 -> 9  10 <- just: 2, fin: 0
+        //  Left branch
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
             root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(4),
-        root: get_root(7),
-        parent_root: get_root(5),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(1),
-        },
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(5),
-        root: get_root(9),
-        parent_root: get_root(7),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
             root: get_root(3),
+            parent_root: get_root(1),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(1),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    //  Right branch
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(2),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(4),
-        parent_root: get_root(2),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(3),
-        root: get_root(6),
-        parent_root: get_root(4),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(4),
-        root: get_root(8),
-        parent_root: get_root(6),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
+        Operation::ProcessBlock {
+            slot: Slot::new(3),
+            root: get_root(5),
+            parent_root: get_root(3),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(1),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(4),
+            root: get_root(7),
+            parent_root: get_root(5),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(1),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(5),
+            root: get_root(9),
+            parent_root: get_root(7),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(3),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
+        },
+        //  Right branch
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
             root: get_root(2),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(5),
-        root: get_root(10),
-        parent_root: get_root(8),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
             root: get_root(4),
+            parent_root: get_root(2),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that if we start at 0 we find 10 (just: 0, fin: 0).
-    //
-    //           0  <-- start
-    //          / \
-    //         1   2
-    //         |   |
-    //         3   4
-    //         |   |
-    //         5   6
-    //         |   |
-    //         7   8
-    //         |   |
-    //         9  10 <-- head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(10),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-    // Same as above, but with justified epoch 2.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(4),
-        },
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(10),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-    // Same as above, but with justified epoch 3.
-    //
-    // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
-    // to elect head blocks that have a higher justified checkpoint than the
-    // store.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(3),
+        Operation::ProcessBlock {
+            slot: Slot::new(3),
             root: get_root(6),
+            parent_root: get_root(4),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(10),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a vote to 1.
-    //
-    //                 0
-    //                / \
-    //    +1 vote -> 1   2
-    //               |   |
-    //               3   4
-    //               |   |
-    //               5   6
-    //               |   |
-    //               7   8
-    //               |   |
-    //               9  10
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(0),
-    });
-
-    // Ensure that if we start at 0 we find 9 (just: 0, fin: 0).
-    //
-    //           0  <-- start
-    //          / \
-    //         1   2
-    //         |   |
-    //         3   4
-    //         |   |
-    //         5   6
-    //         |   |
-    //         7   8
-    //         |   |
-    // head -> 9  10
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(9),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-    // Save as above but justified epoch 2.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(3),
+        Operation::ProcessBlock {
+            slot: Slot::new(4),
+            root: get_root(8),
+            parent_root: get_root(6),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(2),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(9),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-    // Save as above but justified epoch 3.
-    //
-    // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
-    // to elect head blocks that have a higher justified checkpoint than the
-    // store.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(3),
-            root: get_root(5),
+        Operation::ProcessBlock {
+            slot: Slot::new(5),
+            root: get_root(10),
+            parent_root: get_root(8),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(4),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(9),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a vote to 2.
-    //
-    //                 0
-    //                / \
-    //               1   2 <- +1 vote
-    //               |   |
-    //               3   4
-    //               |   |
-    //               5   6
-    //               |   |
-    //               7   8
-    //               |   |
-    //               9  10
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(2),
-        attestation_slot: Slot::new(0),
-    });
-
-    // Ensure that if we start at 0 we find 10 (just: 0, fin: 0).
-    //
-    //           0  <-- start
-    //          / \
-    //         1   2
-    //         |   |
-    //         3   4
-    //         |   |
-    //         5   6
-    //         |   |
-    //         7   8
-    //         |   |
-    //         9  10 <-- head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(10),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-    // Same as above but justified epoch 2.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(4),
+        // Ensure that if we start at 0 we find 10 (just: 0, fin: 0).
+        //
+        //           0  <-- start
+        //          / \
+        //         1   2
+        //         |   |
+        //         3   4
+        //         |   |
+        //         5   6
+        //         |   |
+        //         7   8
+        //         |   |
+        //         9  10 <-- head
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(10),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(10),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-    // Same as above but justified epoch 3.
-    //
-    // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
-    // to elect head blocks that have a higher justified checkpoint than the
-    // store.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(3),
-            root: get_root(6),
+        // Same as above, but with justified epoch 2.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(4),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(10),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(10),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Ensure that if we start at 1 we find 9 (just: 0, fin: 0).
-    //
-    //            0
-    //           / \
-    //  start-> 1   2
-    //          |   |
-    //          3   4
-    //          |   |
-    //          5   6
-    //          |   |
-    //          7   8
-    //          |   |
-    //  head -> 9  10
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(0),
-            root: get_root(1),
+        // Same as above, but with justified epoch 3.
+        //
+        // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
+        // to elect head blocks that have a higher justified checkpoint than the
+        // store.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(3),
+                root: get_root(6),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(10),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(9),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-    // Same as above but justified epoch 2.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(3),
+        // Add a vote to 1.
+        //
+        //                 0
+        //                / \
+        //    +1 vote -> 1   2
+        //               |   |
+        //               3   4
+        //               |   |
+        //               5   6
+        //               |   |
+        //               7   8
+        //               |   |
+        //               9  10
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(0),
         },
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(9),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-    // Same as above but justified epoch 3.
-    //
-    // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
-    // to elect head blocks that have a higher justified checkpoint than the
-    // store.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(3),
-            root: get_root(5),
+        // Ensure that if we start at 0 we find 9 (just: 0, fin: 0).
+        //
+        //           0  <-- start
+        //          / \
+        //         1   2
+        //         |   |
+        //         3   4
+        //         |   |
+        //         5   6
+        //         |   |
+        //         7   8
+        //         |   |
+        // head -> 9  10
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(9),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(9),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Ensure that if we start at 2 we find 10 (just: 0, fin: 0).
-    //
-    //            0
-    //           / \
-    //          1   2 <- start
-    //          |   |
-    //          3   4
-    //          |   |
-    //          5   6
-    //          |   |
-    //          7   8
-    //          |   |
-    //          9  10 <- head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(10),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-    // Same as above but justified epoch 2.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(4),
+        // Save as above but justified epoch 2.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(3),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(9),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(10),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-    // Same as above but justified epoch 3.
-    //
-    // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
-    // to elect head blocks that have a higher justified checkpoint than the
-    // store.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(3),
-            root: get_root(6),
+        // Save as above but justified epoch 3.
+        //
+        // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
+        // to elect head blocks that have a higher justified checkpoint than the
+        // store.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(3),
+                root: get_root(5),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(9),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: balances,
-        expected_head: get_root(10),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
+        // Add a vote to 2.
+        //
+        //                 0
+        //                / \
+        //               1   2 <- +1 vote
+        //               |   |
+        //               3   4
+        //               |   |
+        //               5   6
+        //               |   |
+        //               7   8
+        //               |   |
+        //               9  10
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(2),
+            attestation_slot: Slot::new(0),
+        },
+        // Ensure that if we start at 0 we find 10 (just: 0, fin: 0).
+        //
+        //           0  <-- start
+        //          / \
+        //         1   2
+        //         |   |
+        //         3   4
+        //         |   |
+        //         5   6
+        //         |   |
+        //         7   8
+        //         |   |
+        //         9  10 <-- head
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(10),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Same as above but justified epoch 2.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(4),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(10),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Same as above but justified epoch 3.
+        //
+        // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
+        // to elect head blocks that have a higher justified checkpoint than the
+        // store.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(3),
+                root: get_root(6),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(10),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Ensure that if we start at 1 we find 9 (just: 0, fin: 0).
+        //
+        //            0
+        //           / \
+        //  start-> 1   2
+        //          |   |
+        //          3   4
+        //          |   |
+        //          5   6
+        //          |   |
+        //          7   8
+        //          |   |
+        //  head -> 9  10
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(0),
+                root: get_root(1),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(9),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Same as above but justified epoch 2.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(3),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(9),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Same as above but justified epoch 3.
+        //
+        // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
+        // to elect head blocks that have a higher justified checkpoint than the
+        // store.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(3),
+                root: get_root(5),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(9),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Ensure that if we start at 2 we find 10 (just: 0, fin: 0).
+        //
+        //            0
+        //           / \
+        //          1   2 <- start
+        //          |   |
+        //          3   4
+        //          |   |
+        //          5   6
+        //          |   |
+        //          7   8
+        //          |   |
+        //          9  10 <- head
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(10),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Same as above but justified epoch 2.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(4),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(10),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Same as above but justified epoch 3.
+        //
+        // Since https://github.com/ethereum/consensus-specs/pull/3431 it is valid
+        // to elect head blocks that have a higher justified checkpoint than the
+        // store.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(3),
+                root: get_root(6),
+            },
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: balances,
+            expected_head: get_root(10),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+    ];
 
     // END OF TESTS
     ForkChoiceTestDefinition {

--- a/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
@@ -8,160 +8,152 @@ fn gloas_spec() -> ChainSpec {
 }
 
 pub fn get_gloas_chain_following_test_definition() -> ForkChoiceTestDefinition {
-    let mut ops = vec![];
-
-    // Build two branches off genesis where one child extends parent's payload chain (Full)
-    // and the other does not (Empty).
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(0)),
-        execution_payload_block_hash: Some(get_hash(1)),
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(2),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(99)),
-        execution_payload_block_hash: Some(get_hash(2)),
-    });
-
-    // Extend both branches to verify that head selection follows the selected chain.
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(3),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(1)),
-        execution_payload_block_hash: Some(get_hash(3)),
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(4),
-        parent_root: get_root(2),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(100)),
-        execution_payload_block_hash: Some(get_hash(4)),
-    });
-
-    // Mark root_1 as having received its execution payload so that
-    // its FULL virtual node exists in the Gloas fork choice tree.
-    ops.push(Operation::ProcessExecutionPayloadEnvelope {
-        block_root: get_root(1),
-    });
-
-    ops.push(Operation::AssertParentPayloadStatus {
-        block_root: get_root(1),
-        expected_status: PayloadStatus::Full,
-    });
-    ops.push(Operation::AssertParentPayloadStatus {
-        block_root: get_root(2),
-        expected_status: PayloadStatus::Empty,
-    });
-
-    // With equal full/empty parent weights, tiebreak decides which chain to follow.
-    ops.push(Operation::SetPayloadTiebreak {
-        block_root: get_root(0),
-        is_timely: true,
-        is_data_available: true,
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1],
-        expected_head: get_root(3),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Cross-slot attestation with payload_present=true to Full branch (root 3, slot 2).
-    // vote_slot=3 differs from block_slot=2 and payload_present=true, so it counts as Full weight.
-    ops.push(Operation::ProcessGloasAttestation {
-        validator_index: 0,
-        block_root: get_root(3),
-        attestation_slot: Slot::new(3),
-        payload_present: true,
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1],
-        expected_head: get_root(3),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Full weight propagated up: root 0 and root 1 should show Full.
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(0),
-        expected_status: PayloadStatus::Full,
-        current_slot: None,
-        proposer_boost_root: None,
-    });
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(1),
-        expected_status: PayloadStatus::Full,
-        current_slot: None,
-        proposer_boost_root: None,
-    });
-    // Root 2 has no payload received, so it's always Empty.
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(2),
-        expected_status: PayloadStatus::Empty,
-        current_slot: None,
-        proposer_boost_root: None,
-    });
-
-    // Cross-slot attestations with payload_present=false to Empty branch (root 4, slot 2).
-    // Two validators so Empty branch outweighs Full branch.
-    ops.push(Operation::ProcessGloasAttestation {
-        validator_index: 1,
-        block_root: get_root(4),
-        attestation_slot: Slot::new(3),
-        payload_present: false,
-    });
-    ops.push(Operation::ProcessGloasAttestation {
-        validator_index: 2,
-        block_root: get_root(4),
-        attestation_slot: Slot::new(3),
-        payload_present: false,
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1, 1, 1],
-        expected_head: get_root(4),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Empty weight now dominates, so root 0 flips to Empty.
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(0),
-        expected_status: PayloadStatus::Empty,
-        current_slot: None,
-        proposer_boost_root: None,
-    });
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(2),
-        expected_status: PayloadStatus::Empty,
-        current_slot: None,
-        proposer_boost_root: None,
-    });
-    // Root 1 (Full branch) still has 1 Full vote and 0 Empty, so it stays Full.
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(1),
-        expected_status: PayloadStatus::Full,
-        current_slot: None,
-        proposer_boost_root: None,
-    });
+    let ops = vec![
+        // Build two branches off genesis where one child extends parent's payload chain (Full)
+        // and the other does not (Empty).
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(0)),
+            execution_payload_block_hash: Some(get_hash(1)),
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(2),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(99)),
+            execution_payload_block_hash: Some(get_hash(2)),
+        },
+        // Extend both branches to verify that head selection follows the selected chain.
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(3),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(1)),
+            execution_payload_block_hash: Some(get_hash(3)),
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(4),
+            parent_root: get_root(2),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(100)),
+            execution_payload_block_hash: Some(get_hash(4)),
+        },
+        // Mark root_1 as having received its execution payload so that
+        // its FULL virtual node exists in the Gloas fork choice tree.
+        Operation::ProcessExecutionPayloadEnvelope {
+            block_root: get_root(1),
+        },
+        Operation::AssertParentPayloadStatus {
+            block_root: get_root(1),
+            expected_status: PayloadStatus::Full,
+        },
+        Operation::AssertParentPayloadStatus {
+            block_root: get_root(2),
+            expected_status: PayloadStatus::Empty,
+        },
+        // With equal full/empty parent weights, tiebreak decides which chain to follow.
+        Operation::SetPayloadTiebreak {
+            block_root: get_root(0),
+            is_timely: true,
+            is_data_available: true,
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1],
+            expected_head: get_root(3),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Cross-slot attestation with payload_present=true to Full branch (root 3, slot 2).
+        // vote_slot=3 differs from block_slot=2 and payload_present=true, so it counts as Full weight.
+        Operation::ProcessGloasAttestation {
+            validator_index: 0,
+            block_root: get_root(3),
+            attestation_slot: Slot::new(3),
+            payload_present: true,
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1],
+            expected_head: get_root(3),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Full weight propagated up: root 0 and root 1 should show Full.
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(0),
+            expected_status: PayloadStatus::Full,
+            current_slot: None,
+            proposer_boost_root: None,
+        },
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(1),
+            expected_status: PayloadStatus::Full,
+            current_slot: None,
+            proposer_boost_root: None,
+        },
+        // Root 2 has no payload received, so it's always Empty.
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(2),
+            expected_status: PayloadStatus::Empty,
+            current_slot: None,
+            proposer_boost_root: None,
+        },
+        // Cross-slot attestations with payload_present=false to Empty branch (root 4, slot 2).
+        // Two validators so Empty branch outweighs Full branch.
+        Operation::ProcessGloasAttestation {
+            validator_index: 1,
+            block_root: get_root(4),
+            attestation_slot: Slot::new(3),
+            payload_present: false,
+        },
+        Operation::ProcessGloasAttestation {
+            validator_index: 2,
+            block_root: get_root(4),
+            attestation_slot: Slot::new(3),
+            payload_present: false,
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1, 1, 1],
+            expected_head: get_root(4),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Empty weight now dominates, so root 0 flips to Empty.
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(0),
+            expected_status: PayloadStatus::Empty,
+            current_slot: None,
+            proposer_boost_root: None,
+        },
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(2),
+            expected_status: PayloadStatus::Empty,
+            current_slot: None,
+            proposer_boost_root: None,
+        },
+        // Root 1 (Full branch) still has 1 Full vote and 0 Empty, so it stays Full.
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(1),
+            expected_status: PayloadStatus::Full,
+            current_slot: None,
+            proposer_boost_root: None,
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),
@@ -175,107 +167,104 @@ pub fn get_gloas_chain_following_test_definition() -> ForkChoiceTestDefinition {
 }
 
 pub fn get_gloas_payload_probe_test_definition() -> ForkChoiceTestDefinition {
-    let mut ops = vec![];
-
-    // Block 1 at slot 1: child of genesis. Genesis has execution_payload_block_hash=zero
-    // (no execution payload at genesis), so all children have parent_payload_status=Empty.
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(0)),
-        execution_payload_block_hash: Some(get_hash(1)),
-    });
-
-    // One Full and one Empty vote for the same head block: tie probes via runtime tiebreak,
-    // which defaults to Empty unless timely+data-available evidence is set.
-    ops.push(Operation::ProcessPayloadAttestation {
-        validator_index: 0,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(2),
-        payload_present: true,
-        blob_data_available: false,
-    });
-    ops.push(Operation::ProcessPayloadAttestation {
-        validator_index: 1,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(2),
-        payload_present: false,
-        blob_data_available: false,
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1, 1],
-        expected_head: get_root(1),
-        current_slot: Slot::new(0),
-        // With MainnetEthSpec PTC_SIZE=512 and a 256-bit threshold, 1 bit set is not timely, so Empty.
-        expected_payload_status: Some(PayloadStatus::Empty),
-    });
-    // PTC votes write to bitfields only, not to full/empty weight.
-    // Weight is 0 because no CL attestations target this block.
-    ops.push(Operation::AssertPayloadWeights {
-        block_root: get_root(1),
-        expected_full_weight: 0,
-        expected_empty_weight: 0,
-    });
-
-    // Flip validator 0 to Empty; both bits now clear.
-    ops.push(Operation::ProcessPayloadAttestation {
-        validator_index: 0,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(3),
-        payload_present: false,
-        blob_data_available: false,
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1, 1],
-        expected_head: get_root(1),
-        current_slot: Slot::new(0),
-        expected_payload_status: Some(PayloadStatus::Empty),
-    });
-    ops.push(Operation::AssertPayloadWeights {
-        block_root: get_root(1),
-        expected_full_weight: 0,
-        expected_empty_weight: 0,
-    });
-
-    // Same-slot attestation to a new head candidate should be Pending (no payload bucket change).
-    // Root 5 is an Empty child of root_1 (parent_hash doesn't match root_1's block_hash),
-    // so it's reachable through root_1's Empty direction (root_1 has no payload_received).
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(3),
-        root: get_root(5),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(101)),
-        execution_payload_block_hash: Some(get_hash(5)),
-    });
-    ops.push(Operation::ProcessPayloadAttestation {
-        validator_index: 2,
-        block_root: get_root(5),
-        attestation_slot: Slot::new(3),
-        payload_present: true,
-        blob_data_available: false,
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1, 1, 1],
-        expected_head: get_root(5),
-        current_slot: Slot::new(0),
-        expected_payload_status: Some(PayloadStatus::Empty),
-    });
-    ops.push(Operation::AssertPayloadWeights {
-        block_root: get_root(5),
-        expected_full_weight: 0,
-        expected_empty_weight: 0,
-    });
+    let ops = vec![
+        // Block 1 at slot 1: child of genesis. Genesis has execution_payload_block_hash=zero
+        // (no execution payload at genesis), so all children have parent_payload_status=Empty.
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(0)),
+            execution_payload_block_hash: Some(get_hash(1)),
+        },
+        // One Full and one Empty vote for the same head block: tie probes via runtime tiebreak,
+        // which defaults to Empty unless timely+data-available evidence is set.
+        Operation::ProcessPayloadAttestation {
+            validator_index: 0,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(2),
+            payload_present: true,
+            blob_data_available: false,
+        },
+        Operation::ProcessPayloadAttestation {
+            validator_index: 1,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(2),
+            payload_present: false,
+            blob_data_available: false,
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1, 1],
+            expected_head: get_root(1),
+            current_slot: Slot::new(0),
+            // With MainnetEthSpec PTC_SIZE=512 and a 256-bit threshold, 1 bit set is not timely, so Empty.
+            expected_payload_status: Some(PayloadStatus::Empty),
+        },
+        // PTC votes write to bitfields only, not to full/empty weight.
+        // Weight is 0 because no CL attestations target this block.
+        Operation::AssertPayloadWeights {
+            block_root: get_root(1),
+            expected_full_weight: 0,
+            expected_empty_weight: 0,
+        },
+        // Flip validator 0 to Empty; both bits now clear.
+        Operation::ProcessPayloadAttestation {
+            validator_index: 0,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(3),
+            payload_present: false,
+            blob_data_available: false,
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1, 1],
+            expected_head: get_root(1),
+            current_slot: Slot::new(0),
+            expected_payload_status: Some(PayloadStatus::Empty),
+        },
+        Operation::AssertPayloadWeights {
+            block_root: get_root(1),
+            expected_full_weight: 0,
+            expected_empty_weight: 0,
+        },
+        // Same-slot attestation to a new head candidate should be Pending (no payload bucket change).
+        // Root 5 is an Empty child of root_1 (parent_hash doesn't match root_1's block_hash),
+        // so it's reachable through root_1's Empty direction (root_1 has no payload_received).
+        Operation::ProcessBlock {
+            slot: Slot::new(3),
+            root: get_root(5),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(101)),
+            execution_payload_block_hash: Some(get_hash(5)),
+        },
+        Operation::ProcessPayloadAttestation {
+            validator_index: 2,
+            block_root: get_root(5),
+            attestation_slot: Slot::new(3),
+            payload_present: true,
+            blob_data_available: false,
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1, 1, 1],
+            expected_head: get_root(5),
+            current_slot: Slot::new(0),
+            expected_payload_status: Some(PayloadStatus::Empty),
+        },
+        Operation::AssertPayloadWeights {
+            block_root: get_root(5),
+            expected_full_weight: 0,
+            expected_empty_weight: 0,
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),
@@ -293,96 +282,92 @@ pub fn get_gloas_payload_probe_test_definition() -> ForkChoiceTestDefinition {
 /// Test that CL attestation weight can flip the head between Full/Empty branches,
 /// overriding the tiebreaker.
 pub fn get_gloas_find_head_vote_transition_test_definition() -> ForkChoiceTestDefinition {
-    let mut ops = vec![];
-
-    // Competing branches with distinct payload ancestry (Full vs Empty from genesis).
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(0)),
-        execution_payload_block_hash: Some(get_hash(1)),
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(2),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(99)),
-        execution_payload_block_hash: Some(get_hash(2)),
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(3),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(1)),
-        execution_payload_block_hash: Some(get_hash(3)),
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(4),
-        parent_root: get_root(2),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(100)),
-        execution_payload_block_hash: Some(get_hash(4)),
-    });
-
-    // Mark root_1 as having received its execution payload so that
-    // its FULL virtual node exists in the Gloas fork choice tree.
-    ops.push(Operation::ProcessExecutionPayloadEnvelope {
-        block_root: get_root(1),
-    });
-
-    // Equal branch weights: tiebreak FULL picks branch rooted at 3.
-    ops.push(Operation::SetPayloadTiebreak {
-        block_root: get_root(0),
-        is_timely: true,
-        is_data_available: true,
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1],
-        expected_head: get_root(3),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // CL attestation to Empty branch (root 4) from validator 0 flips the head to 4.
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(4),
-        attestation_slot: Slot::new(3),
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1],
-        expected_head: get_root(4),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // CL attestation back to Full branch (root 3) returns the head to 3.
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(3),
-        attestation_slot: Slot::new(4),
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1],
-        expected_head: get_root(3),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
+    let ops = vec![
+        // Competing branches with distinct payload ancestry (Full vs Empty from genesis).
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(0)),
+            execution_payload_block_hash: Some(get_hash(1)),
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(2),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(99)),
+            execution_payload_block_hash: Some(get_hash(2)),
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(3),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(1)),
+            execution_payload_block_hash: Some(get_hash(3)),
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(4),
+            parent_root: get_root(2),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(100)),
+            execution_payload_block_hash: Some(get_hash(4)),
+        },
+        // Mark root_1 as having received its execution payload so that
+        // its FULL virtual node exists in the Gloas fork choice tree.
+        Operation::ProcessExecutionPayloadEnvelope {
+            block_root: get_root(1),
+        },
+        // Equal branch weights: tiebreak FULL picks branch rooted at 3.
+        Operation::SetPayloadTiebreak {
+            block_root: get_root(0),
+            is_timely: true,
+            is_data_available: true,
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1],
+            expected_head: get_root(3),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // CL attestation to Empty branch (root 4) from validator 0 flips the head to 4.
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(4),
+            attestation_slot: Slot::new(3),
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1],
+            expected_head: get_root(4),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // CL attestation back to Full branch (root 3) returns the head to 3.
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(3),
+            attestation_slot: Slot::new(4),
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1],
+            expected_head: get_root(3),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),
@@ -398,87 +383,84 @@ pub fn get_gloas_find_head_vote_transition_test_definition() -> ForkChoiceTestDe
 /// CL attestation weight overrides payload preference tiebreaker.
 pub fn get_gloas_weight_priority_over_payload_preference_test_definition()
 -> ForkChoiceTestDefinition {
-    let mut ops = vec![];
-
-    // Build two branches where one child extends payload (Full) and the other doesn't (Empty).
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(0)),
-        execution_payload_block_hash: Some(get_hash(1)),
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(2),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(99)),
-        execution_payload_block_hash: Some(get_hash(2)),
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(3),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(1)),
-        execution_payload_block_hash: Some(get_hash(3)),
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(4),
-        parent_root: get_root(2),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(100)),
-        execution_payload_block_hash: Some(get_hash(4)),
-    });
-
-    // Mark root_1 as having received its execution payload so that
-    // its FULL virtual node exists in the Gloas fork choice tree.
-    ops.push(Operation::ProcessExecutionPayloadEnvelope {
-        block_root: get_root(1),
-    });
-
-    // Parent prefers Full on equal branch weights (tiebreaker).
-    ops.push(Operation::SetPayloadTiebreak {
-        block_root: get_root(0),
-        is_timely: true,
-        is_data_available: true,
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1],
-        expected_head: get_root(3),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Two CL attestations to the Empty branch make it strictly heavier,
-    // overriding the Full tiebreaker.
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(4),
-        attestation_slot: Slot::new(3),
-    });
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(4),
-        attestation_slot: Slot::new(3),
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1, 1],
-        expected_head: get_root(4),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
+    let ops = vec![
+        // Build two branches where one child extends payload (Full) and the other doesn't (Empty).
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(0)),
+            execution_payload_block_hash: Some(get_hash(1)),
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(2),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(99)),
+            execution_payload_block_hash: Some(get_hash(2)),
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(3),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(1)),
+            execution_payload_block_hash: Some(get_hash(3)),
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(4),
+            parent_root: get_root(2),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(100)),
+            execution_payload_block_hash: Some(get_hash(4)),
+        },
+        // Mark root_1 as having received its execution payload so that
+        // its FULL virtual node exists in the Gloas fork choice tree.
+        Operation::ProcessExecutionPayloadEnvelope {
+            block_root: get_root(1),
+        },
+        // Parent prefers Full on equal branch weights (tiebreaker).
+        Operation::SetPayloadTiebreak {
+            block_root: get_root(0),
+            is_timely: true,
+            is_data_available: true,
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1],
+            expected_head: get_root(3),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Two CL attestations to the Empty branch make it strictly heavier,
+        // overriding the Full tiebreaker.
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(4),
+            attestation_slot: Slot::new(3),
+        },
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(4),
+            attestation_slot: Slot::new(3),
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1, 1],
+            expected_head: get_root(4),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),
@@ -493,47 +475,44 @@ pub fn get_gloas_weight_priority_over_payload_preference_test_definition()
 
 pub fn get_gloas_parent_empty_when_child_points_to_grandparent_test_definition()
 -> ForkChoiceTestDefinition {
-    let mut ops = vec![];
-
-    // Build a three-block chain A -> B -> C (CL parent links).
-    // A: EL parent = genesis hash(0), EL hash = hash(1).
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(0)),
-        execution_payload_block_hash: Some(get_hash(1)),
-    });
-
-    // B: EL parent = hash(1), EL hash = hash(2).
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(2),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(1)),
-        execution_payload_block_hash: Some(get_hash(2)),
-    });
-
-    // C: CL parent is B, but EL parent points to A (hash 1), not B (hash 2).
-    // This models B's payload not arriving in time, so C records parent status as Empty.
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(3),
-        root: get_root(3),
-        parent_root: get_root(2),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(1)),
-        execution_payload_block_hash: Some(get_hash(3)),
-    });
-
-    ops.push(Operation::AssertParentPayloadStatus {
-        block_root: get_root(3),
-        expected_status: PayloadStatus::Empty,
-    });
+    let ops = vec![
+        // Build a three-block chain A -> B -> C (CL parent links).
+        // A: EL parent = genesis hash(0), EL hash = hash(1).
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(0)),
+            execution_payload_block_hash: Some(get_hash(1)),
+        },
+        // B: EL parent = hash(1), EL hash = hash(2).
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(2),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(1)),
+            execution_payload_block_hash: Some(get_hash(2)),
+        },
+        // C: CL parent is B, but EL parent points to A (hash 1), not B (hash 2).
+        // This models B's payload not arriving in time, so C records parent status as Empty.
+        Operation::ProcessBlock {
+            slot: Slot::new(3),
+            root: get_root(3),
+            parent_root: get_root(2),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(1)),
+            execution_payload_block_hash: Some(get_hash(3)),
+        },
+        Operation::AssertParentPayloadStatus {
+            block_root: get_root(3),
+            expected_status: PayloadStatus::Empty,
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),
@@ -554,124 +533,118 @@ pub fn get_gloas_parent_empty_when_child_points_to_grandparent_test_definition()
 /// With equal CL weight, tiebreaker determines which branch wins.
 /// An extra CL attestation can override the tiebreaker.
 pub fn get_gloas_interleaved_attestations_test_definition() -> ForkChoiceTestDefinition {
-    let mut ops = vec![];
-
-    // Step 1: Two competing blocks at slot 1.
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(0)),
-        execution_payload_block_hash: Some(get_hash(1)),
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(2),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(99)),
-        execution_payload_block_hash: Some(get_hash(2)),
-    });
-
-    // Step 2: Regular attestations arrive, one per branch (equal CL weight).
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(1),
-    });
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(2),
-        attestation_slot: Slot::new(1),
-    });
-
-    // Step 3: Child blocks at slot 2.
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(3),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(1)),
-        execution_payload_block_hash: Some(get_hash(3)),
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(4),
-        parent_root: get_root(2),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(100)),
-        execution_payload_block_hash: Some(get_hash(4)),
-    });
-
-    // Mark root_1 as having received its execution payload so that
-    // its FULL virtual node exists in the Gloas fork choice tree.
-    ops.push(Operation::ProcessExecutionPayloadEnvelope {
-        block_root: get_root(1),
-    });
-
-    // Step 4: Set tiebreaker to Empty on genesis so the Empty branch wins.
-    ops.push(Operation::SetPayloadTiebreak {
-        block_root: get_root(0),
-        is_timely: false,
-        is_data_available: false,
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1, 1],
-        expected_head: get_root(4),
-        current_slot: Slot::new(1),
-        expected_payload_status: None,
-    });
-    // Weights are tied (1 vote each branch), tiebreaker is Empty.
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(0),
-        expected_status: PayloadStatus::Empty,
-        current_slot: None,
-        proposer_boost_root: None,
-    });
-
-    // Step 5: Flip tiebreaker to Full so the Full branch wins.
-    ops.push(Operation::SetPayloadTiebreak {
-        block_root: get_root(0),
-        is_timely: true,
-        is_data_available: true,
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1, 1],
-        expected_head: get_root(3),
-        current_slot: Slot::new(100),
-        expected_payload_status: None,
-    });
-    // Weights still tied, tiebreaker flipped to Full.
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(0),
-        expected_status: PayloadStatus::Full,
-        current_slot: None,
-        proposer_boost_root: None,
-    });
-
-    // Step 6: Add extra CL weight to the Empty branch; this overrides the Full tiebreaker.
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 2,
-        block_root: get_root(4),
-        attestation_slot: Slot::new(3),
-    });
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1, 1, 1],
-        expected_head: get_root(4),
-        current_slot: Slot::new(100),
-        expected_payload_status: None,
-    });
+    let ops = vec![
+        // Step 1: Two competing blocks at slot 1.
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(0)),
+            execution_payload_block_hash: Some(get_hash(1)),
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(2),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(99)),
+            execution_payload_block_hash: Some(get_hash(2)),
+        },
+        // Step 2: Regular attestations arrive, one per branch (equal CL weight).
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(1),
+        },
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(2),
+            attestation_slot: Slot::new(1),
+        },
+        // Step 3: Child blocks at slot 2.
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(3),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(1)),
+            execution_payload_block_hash: Some(get_hash(3)),
+        },
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(4),
+            parent_root: get_root(2),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(100)),
+            execution_payload_block_hash: Some(get_hash(4)),
+        },
+        // Mark root_1 as having received its execution payload so that
+        // its FULL virtual node exists in the Gloas fork choice tree.
+        Operation::ProcessExecutionPayloadEnvelope {
+            block_root: get_root(1),
+        },
+        // Step 4: Set tiebreaker to Empty on genesis so the Empty branch wins.
+        Operation::SetPayloadTiebreak {
+            block_root: get_root(0),
+            is_timely: false,
+            is_data_available: false,
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1, 1],
+            expected_head: get_root(4),
+            current_slot: Slot::new(1),
+            expected_payload_status: None,
+        },
+        // Weights are tied (1 vote each branch), tiebreaker is Empty.
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(0),
+            expected_status: PayloadStatus::Empty,
+            current_slot: None,
+            proposer_boost_root: None,
+        },
+        // Step 5: Flip tiebreaker to Full so the Full branch wins.
+        Operation::SetPayloadTiebreak {
+            block_root: get_root(0),
+            is_timely: true,
+            is_data_available: true,
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1, 1],
+            expected_head: get_root(3),
+            current_slot: Slot::new(100),
+            expected_payload_status: None,
+        },
+        // Weights still tied, tiebreaker flipped to Full.
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(0),
+            expected_status: PayloadStatus::Full,
+            current_slot: None,
+            proposer_boost_root: None,
+        },
+        // Step 6: Add extra CL weight to the Empty branch; this overrides the Full tiebreaker.
+        Operation::ProcessAttestation {
+            validator_index: 2,
+            block_root: get_root(4),
+            attestation_slot: Slot::new(3),
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1, 1, 1],
+            expected_head: get_root(4),
+            current_slot: Slot::new(100),
+            expected_payload_status: None,
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),
@@ -696,111 +669,101 @@ pub fn get_gloas_interleaved_attestations_test_definition() -> ForkChoiceTestDef
 ///   - Both Full and Empty directions from block 1 become available
 ///   - With equal weight, tiebreaker prefers Full → Block 2 wins
 pub fn get_gloas_payload_received_interleaving_test_definition() -> ForkChoiceTestDefinition {
-    let mut ops = vec![];
-
-    // Block 1 at slot 1: child of genesis. Genesis has zero block hash, so
-    // parent_payload_status = Empty regardless of block 1's execution_payload_parent_hash.
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(0)),
-        execution_payload_block_hash: Some(get_hash(1)),
-    });
-
-    // Block 2 at slot 2: Full child of block 1 (parent_hash matches block 1's block_hash).
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(2),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(1)),
-        execution_payload_block_hash: Some(get_hash(2)),
-    });
-
-    // Block 3 at slot 2: Empty child of block 1 (parent_hash doesn't match block 1's block_hash).
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(3),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(99)),
-        execution_payload_block_hash: Some(get_hash(3)),
-    });
-
-    // Verify parent_payload_status is set correctly.
-    ops.push(Operation::AssertParentPayloadStatus {
-        block_root: get_root(1),
-        expected_status: PayloadStatus::Empty,
-    });
-    ops.push(Operation::AssertParentPayloadStatus {
-        block_root: get_root(2),
-        expected_status: PayloadStatus::Full,
-    });
-    ops.push(Operation::AssertParentPayloadStatus {
-        block_root: get_root(3),
-        expected_status: PayloadStatus::Empty,
-    });
-
-    // Genesis does NOT have payload_received (no payload at genesis).
-    ops.push(Operation::AssertPayloadReceived {
-        block_root: get_root(0),
-        expected: false,
-    });
-
-    // Block 1 does not have payload_received yet.
-    ops.push(Operation::AssertPayloadReceived {
-        block_root: get_root(1),
-        expected: false,
-    });
-
-    // Give one vote to each competing child so they have equal weight.
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(2),
-        attestation_slot: Slot::new(2),
-    });
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(3),
-        attestation_slot: Slot::new(2),
-    });
-
-    // Before payload_received on block 1: only Empty direction available.
-    // Block 3 (Empty child) is reachable, Block 2 (Full child) is not.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1, 1],
-        expected_head: get_root(3),
-        current_slot: Slot::new(100),
-        expected_payload_status: None,
-    });
-
-    // Process execution payload envelope for block 1 → payload_received becomes true.
-    ops.push(Operation::ProcessExecutionPayloadEnvelope {
-        block_root: get_root(1),
-    });
-
-    ops.push(Operation::AssertPayloadReceived {
-        block_root: get_root(1),
-        expected: true,
-    });
-
-    // After payload_received on block 1: both Full and Empty directions available.
-    // Equal weight, tiebreaker prefers Full → Block 2 (Full child) wins.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1, 1],
-        expected_head: get_root(2),
-        current_slot: Slot::new(100),
-        expected_payload_status: None,
-    });
+    let ops = vec![
+        // Block 1 at slot 1: child of genesis. Genesis has zero block hash, so
+        // parent_payload_status = Empty regardless of block 1's execution_payload_parent_hash.
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(0)),
+            execution_payload_block_hash: Some(get_hash(1)),
+        },
+        // Block 2 at slot 2: Full child of block 1 (parent_hash matches block 1's block_hash).
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(2),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(1)),
+            execution_payload_block_hash: Some(get_hash(2)),
+        },
+        // Block 3 at slot 2: Empty child of block 1 (parent_hash doesn't match block 1's block_hash).
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(3),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(99)),
+            execution_payload_block_hash: Some(get_hash(3)),
+        },
+        // Verify parent_payload_status is set correctly.
+        Operation::AssertParentPayloadStatus {
+            block_root: get_root(1),
+            expected_status: PayloadStatus::Empty,
+        },
+        Operation::AssertParentPayloadStatus {
+            block_root: get_root(2),
+            expected_status: PayloadStatus::Full,
+        },
+        Operation::AssertParentPayloadStatus {
+            block_root: get_root(3),
+            expected_status: PayloadStatus::Empty,
+        },
+        // Genesis does NOT have payload_received (no payload at genesis).
+        Operation::AssertPayloadReceived {
+            block_root: get_root(0),
+            expected: false,
+        },
+        // Block 1 does not have payload_received yet.
+        Operation::AssertPayloadReceived {
+            block_root: get_root(1),
+            expected: false,
+        },
+        // Give one vote to each competing child so they have equal weight.
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(2),
+            attestation_slot: Slot::new(2),
+        },
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(3),
+            attestation_slot: Slot::new(2),
+        },
+        // Before payload_received on block 1: only Empty direction available.
+        // Block 3 (Empty child) is reachable, Block 2 (Full child) is not.
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1, 1],
+            expected_head: get_root(3),
+            current_slot: Slot::new(100),
+            expected_payload_status: None,
+        },
+        // Process execution payload envelope for block 1 → payload_received becomes true.
+        Operation::ProcessExecutionPayloadEnvelope {
+            block_root: get_root(1),
+        },
+        Operation::AssertPayloadReceived {
+            block_root: get_root(1),
+            expected: true,
+        },
+        // After payload_received on block 1: both Full and Empty directions available.
+        // Equal weight, tiebreaker prefers Full → Block 2 (Full child) wins.
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1, 1],
+            expected_head: get_root(2),
+            current_slot: Slot::new(100),
+            expected_payload_status: None,
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),
@@ -818,70 +781,65 @@ pub fn get_gloas_payload_received_interleaving_test_definition() -> ForkChoiceTe
 /// weights so the tiebreaker decides. Tests that the zero-out is applied and
 /// doesn't just compare raw payload weights.
 pub fn get_gloas_previous_slot_tiebreaker_test_definition() -> ForkChoiceTestDefinition {
-    let mut ops = vec![];
-
-    // Block 1 at slot 1 with its payload received.
-    // Genesis has zero block hash so all its children are Empty (genesis never has
-    // payload_received). Block 1's parent_hash doesn't match zero → Empty child.
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(0)),
-        execution_payload_block_hash: Some(get_hash(1)),
-    });
-    ops.push(Operation::ProcessExecutionPayloadEnvelope {
-        block_root: get_root(1),
-    });
-
-    // Block 2 at slot 2 with a mismatched EL parent hash, giving it an Empty parent payload status.
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(2),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(99)),
-        execution_payload_block_hash: Some(get_hash(2)),
-    });
-
-    // More Full weight than Empty on block 1.
-    ops.push(Operation::ProcessGloasAttestation {
-        validator_index: 0,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(2),
-        payload_present: true,
-    });
-
-    // Materialize the attestation into `full_payload_weight`.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![1],
-        expected_head: get_root(1),
-        current_slot: Slot::new(1),
-        expected_payload_status: Some(PayloadStatus::Full),
-    });
-
-    // Before zero-out (current_slot == block 1's slot), raw weights decide payload status (Full)
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(1),
-        expected_status: PayloadStatus::Full,
-        current_slot: Some(Slot::new(1)),
-        proposer_boost_root: None,
-    });
-
-    // At current_slot == block 1's slot + 1, both weights zero out and the
-    // tiebreaker picks Empty (block 2 extends block 1 with an Empty parent
-    // payload status).
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(1),
-        expected_status: PayloadStatus::Empty,
-        current_slot: Some(Slot::new(2)),
-        proposer_boost_root: Some(get_root(2)),
-    });
+    let ops = vec![
+        // Block 1 at slot 1 with its payload received.
+        // Genesis has zero block hash so all its children are Empty (genesis never has
+        // payload_received). Block 1's parent_hash doesn't match zero → Empty child.
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(0)),
+            execution_payload_block_hash: Some(get_hash(1)),
+        },
+        Operation::ProcessExecutionPayloadEnvelope {
+            block_root: get_root(1),
+        },
+        // Block 2 at slot 2 with a mismatched EL parent hash, giving it an Empty parent payload status.
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(2),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(99)),
+            execution_payload_block_hash: Some(get_hash(2)),
+        },
+        // More Full weight than Empty on block 1.
+        Operation::ProcessGloasAttestation {
+            validator_index: 0,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(2),
+            payload_present: true,
+        },
+        // Materialize the attestation into `full_payload_weight`.
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![1],
+            expected_head: get_root(1),
+            current_slot: Slot::new(1),
+            expected_payload_status: Some(PayloadStatus::Full),
+        },
+        // Before zero-out (current_slot == block 1's slot), raw weights decide payload status (Full)
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(1),
+            expected_status: PayloadStatus::Full,
+            current_slot: Some(Slot::new(1)),
+            proposer_boost_root: None,
+        },
+        // At current_slot == block 1's slot + 1, both weights zero out and the
+        // tiebreaker picks Empty (block 2 extends block 1 with an Empty parent
+        // payload status).
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(1),
+            expected_status: PayloadStatus::Empty,
+            current_slot: Some(Slot::new(2)),
+            proposer_boost_root: Some(get_root(2)),
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),
@@ -898,67 +856,62 @@ pub fn get_gloas_previous_slot_tiebreaker_test_definition() -> ForkChoiceTestDef
 /// Boost supports the ancestor's Full variant (via the descendant's Full parent
 /// payload status) but not Empty, so a large enough boost overrides raw Empty weight.
 pub fn get_gloas_proposer_boost_flips_ancestor_test_definition() -> ForkChoiceTestDefinition {
-    let mut ops = vec![];
-
-    // Block 1 at slot 1 with payload received.
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(0)),
-        execution_payload_block_hash: Some(get_hash(1)),
-    });
-    ops.push(Operation::ProcessExecutionPayloadEnvelope {
-        block_root: get_root(1),
-    });
-
-    // Block 2 at slot 3 with a Full parent payload status (skip slot 2 so
-    // block 1's previous-slot zero-out doesn't fire at current_slot 3).
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(3),
-        root: get_root(2),
-        parent_root: get_root(1),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(1)),
-        execution_payload_block_hash: Some(get_hash(2)),
-    });
-
-    // One Empty vote on block 1. Balance totals are chosen so the proposer
-    // boost score exceeds the single Empty voter's balance.
-    ops.push(Operation::ProcessGloasAttestation {
-        validator_index: 0,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(2),
-        payload_present: false,
-    });
-
-    ops.push(Operation::FindHead {
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        justified_state_balances: vec![100, 10000],
-        expected_head: get_root(1),
-        current_slot: Slot::new(3),
-        expected_payload_status: Some(PayloadStatus::Empty),
-    });
-
-    // Without boost the raw weights decide and Empty wins.
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(1),
-        expected_status: PayloadStatus::Empty,
-        current_slot: Some(Slot::new(3)),
-        proposer_boost_root: None,
-    });
-
-    // With boost on block 2 the boost supports block 1's Full variant, so Full wins.
-    ops.push(Operation::AssertPayloadStatusByWeight {
-        block_root: get_root(1),
-        expected_status: PayloadStatus::Full,
-        current_slot: Some(Slot::new(3)),
-        proposer_boost_root: Some(get_root(2)),
-    });
+    let ops = vec![
+        // Block 1 at slot 1 with payload received.
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(0)),
+            execution_payload_block_hash: Some(get_hash(1)),
+        },
+        Operation::ProcessExecutionPayloadEnvelope {
+            block_root: get_root(1),
+        },
+        // Block 2 at slot 3 with a Full parent payload status (skip slot 2 so
+        // block 1's previous-slot zero-out doesn't fire at current_slot 3).
+        Operation::ProcessBlock {
+            slot: Slot::new(3),
+            root: get_root(2),
+            parent_root: get_root(1),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(1)),
+            execution_payload_block_hash: Some(get_hash(2)),
+        },
+        // One Empty vote on block 1. Balance totals are chosen so the proposer
+        // boost score exceeds the single Empty voter's balance.
+        Operation::ProcessGloasAttestation {
+            validator_index: 0,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(2),
+            payload_present: false,
+        },
+        Operation::FindHead {
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            justified_state_balances: vec![100, 10000],
+            expected_head: get_root(1),
+            current_slot: Slot::new(3),
+            expected_payload_status: Some(PayloadStatus::Empty),
+        },
+        // Without boost the raw weights decide and Empty wins.
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(1),
+            expected_status: PayloadStatus::Empty,
+            current_slot: Some(Slot::new(3)),
+            proposer_boost_root: None,
+        },
+        // With boost on block 2 the boost supports block 1's Full variant, so Full wins.
+        Operation::AssertPayloadStatusByWeight {
+            block_root: get_root(1),
+            expected_status: PayloadStatus::Full,
+            current_slot: Some(Slot::new(3)),
+            proposer_boost_root: Some(get_root(2)),
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),
@@ -975,74 +928,69 @@ pub fn get_gloas_proposer_boost_flips_ancestor_test_definition() -> ForkChoiceTe
 /// function returns `true` and ignores PTC data-availability votes. It only checks those votes
 /// when the parent is from the immediately preceding slot.
 pub fn get_gloas_should_build_on_full_test_definition() -> ForkChoiceTestDefinition {
-    let mut ops = vec![];
-
-    // Block 1 at slot 1, child of genesis.
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: get_checkpoint(0),
-        finalized_checkpoint: get_checkpoint(0),
-        execution_payload_parent_hash: Some(get_hash(0)),
-        execution_payload_block_hash: Some(get_hash(1)),
-    });
-
-    // PTC has voted the payload data unavailable. `is_timely` sets `payload_received` so the votes
-    // are consulted, and clearing the data-availability bits gives the "false" votes a majority.
-    ops.push(Operation::SetPayloadTiebreak {
-        block_root: get_root(1),
-        is_timely: true,
-        is_data_available: false,
-    });
-
-    // When the parent is `Empty` `should_build_on_full` returns `false`. This check runs before
-    // the slot check, so the result is `false` for both the previous-slot case (block slot 1, proposal slot 2)
-    // and an earlier-slot case (proposal slot 3).
-    ops.push(Operation::AssertShouldBuildOnFull {
-        block_root: get_root(1),
-        parent_payload_status: PayloadStatus::Empty,
-        proposal_slot: Slot::new(2),
-        expected: false,
-    });
-    ops.push(Operation::AssertShouldBuildOnFull {
-        block_root: get_root(1),
-        parent_payload_status: PayloadStatus::Empty,
-        proposal_slot: Slot::new(3),
-        expected: false,
-    });
-
-    // `Full` parent from the immediately preceding slot (block slot 1, proposal slot 2). The PTC
-    // votes are consulted, and since data is unavailable the proposer does not build on full.
-    ops.push(Operation::AssertShouldBuildOnFull {
-        block_root: get_root(1),
-        parent_payload_status: PayloadStatus::Full,
-        proposal_slot: Slot::new(2),
-        expected: false,
-    });
-
-    // `Full` parent from an *earlier* slot (block slot 1, proposal slot 3). The slot check
-    // short-circuits to `true` without consulting the (unavailable) PTC votes.
-    ops.push(Operation::AssertShouldBuildOnFull {
-        block_root: get_root(1),
-        parent_payload_status: PayloadStatus::Full,
-        proposal_slot: Slot::new(3),
-        expected: true,
-    });
-
-    // Flip the PTC view to *available* and re-check the previous-slot case. The votes now permit
-    // building on full.
-    ops.push(Operation::SetPayloadTiebreak {
-        block_root: get_root(1),
-        is_timely: true,
-        is_data_available: true,
-    });
-    ops.push(Operation::AssertShouldBuildOnFull {
-        block_root: get_root(1),
-        parent_payload_status: PayloadStatus::Full,
-        proposal_slot: Slot::new(2),
-        expected: true,
-    });
+    let ops = vec![
+        // Block 1 at slot 1, child of genesis.
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: get_checkpoint(0),
+            finalized_checkpoint: get_checkpoint(0),
+            execution_payload_parent_hash: Some(get_hash(0)),
+            execution_payload_block_hash: Some(get_hash(1)),
+        },
+        // PTC has voted the payload data unavailable. `is_timely` sets `payload_received` so the votes
+        // are consulted, and clearing the data-availability bits gives the "false" votes a majority.
+        Operation::SetPayloadTiebreak {
+            block_root: get_root(1),
+            is_timely: true,
+            is_data_available: false,
+        },
+        // When the parent is `Empty` `should_build_on_full` returns `false`. This check runs before
+        // the slot check, so the result is `false` for both the previous-slot case (block slot 1, proposal slot 2)
+        // and an earlier-slot case (proposal slot 3).
+        Operation::AssertShouldBuildOnFull {
+            block_root: get_root(1),
+            parent_payload_status: PayloadStatus::Empty,
+            proposal_slot: Slot::new(2),
+            expected: false,
+        },
+        Operation::AssertShouldBuildOnFull {
+            block_root: get_root(1),
+            parent_payload_status: PayloadStatus::Empty,
+            proposal_slot: Slot::new(3),
+            expected: false,
+        },
+        // `Full` parent from the immediately preceding slot (block slot 1, proposal slot 2). The PTC
+        // votes are consulted, and since data is unavailable the proposer does not build on full.
+        Operation::AssertShouldBuildOnFull {
+            block_root: get_root(1),
+            parent_payload_status: PayloadStatus::Full,
+            proposal_slot: Slot::new(2),
+            expected: false,
+        },
+        // `Full` parent from an *earlier* slot (block slot 1, proposal slot 3). The slot check
+        // short-circuits to `true` without consulting the (unavailable) PTC votes.
+        Operation::AssertShouldBuildOnFull {
+            block_root: get_root(1),
+            parent_payload_status: PayloadStatus::Full,
+            proposal_slot: Slot::new(3),
+            expected: true,
+        },
+        // Flip the PTC view to *available* and re-check the previous-slot case. The votes now permit
+        // building on full.
+        Operation::SetPayloadTiebreak {
+            block_root: get_root(1),
+            is_timely: true,
+            is_data_available: true,
+        },
+        Operation::AssertShouldBuildOnFull {
+            block_root: get_root(1),
+            parent_payload_status: PayloadStatus::Full,
+            proposal_slot: Slot::new(2),
+            expected: true,
+        },
+    ];
 
     ForkChoiceTestDefinition {
         finalized_block_slot: Slot::new(0),

--- a/consensus/proto_array/src/fork_choice_test_definition/votes.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition/votes.rs
@@ -2,648 +2,622 @@ use super::*;
 
 pub fn get_votes_test_definition() -> ForkChoiceTestDefinition {
     let mut balances = vec![1; 2];
-    let mut ops = vec![];
-
-    // Ensure that the head starts at the finalized block.
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+    let mut ops = vec![
+        // Ensure that the head starts at the finalized block.
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(0),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a block with a hash of 2.
+        //
+        //          0
+        //         /
+        //        2
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
+            root: get_root(2),
+            parent_root: get_root(0),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(0),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a block with a hash of 2.
-    //
-    //          0
-    //         /
-    //        2
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(2),
-        parent_root: get_root(0),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is 2
+        //
+        //          0
+        //         /
+        // head-> 2
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is 2
-    //
-    //          0
-    //         /
-    // head-> 2
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a block with a hash of 1 that comes off the genesis block (this is a fork compared
-    // to the previous block).
-    //
-    //          0
-    //         / \
-    //        2   1
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(1),
-        root: get_root(1),
-        parent_root: get_root(0),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is still 2
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a vote to block 1
-    //
-    //          0
-    //         / \
-    //        2   1 <- +vote
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(2),
-    });
-
-    // Ensure that the head is now 1, because 1 has a vote.
-    //
-    //          0
-    //         / \
-    //        2   1 <- head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(1),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add a vote to block 2
-    //
-    //           0
-    //          / \
-    // +vote-> 2   1
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(2),
-        attestation_slot: Slot::new(2),
-    });
-
-    // Ensure that the head is 2 since 1 and 2 both have a vote
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add block 3.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(2),
-        root: get_root(3),
-        parent_root: get_root(1),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is still 2
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    //            |
-    //            3
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Move validator #0 vote from 1 to 3
-    //
-    //          0
-    //         / \
-    //        2   1 <- -vote
-    //            |
-    //            3 <- +vote
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(3),
-        attestation_slot: Slot::new(3),
-    });
-
-    // Ensure that the head is still 2
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    //            |
-    //            3
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Move validator #1 vote from 2 to 1 (this is an equivocation, but fork choice doesn't
-    // care)
-    //
-    //           0
-    //          / \
-    // -vote-> 2   1 <- +vote
-    //             |
-    //             3
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(1),
-        attestation_slot: Slot::new(3),
-    });
-
-    // Ensure that the head is now 3
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3 <- head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(3),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add block 4.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    //            |
-    //            4
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(3),
-        root: get_root(4),
-        parent_root: get_root(3),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that the head is now 4
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    //            |
-    //            4 <- head
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
-        },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(4),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add block 5, which has a justified epoch of 2.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    //            |
-    //            4
-    //           /
-    //          5 <- justified epoch = 2
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(4),
-        root: get_root(5),
-        parent_root: get_root(4),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
+        // Add a block with a hash of 1 that comes off the genesis block (this is a fork compared
+        // to the previous block).
+        //
+        //          0
+        //         / \
+        //        2   1
+        Operation::ProcessBlock {
+            slot: Slot::new(1),
             root: get_root(1),
+            parent_root: get_root(0),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(1),
+        // Ensure that the head is still 2
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Block 5 has incompatible finalized checkpoint, so `get_filtered_block_tree`
-    // excludes the entire 1->3->4->5 branch (no viable leaf). Head moves to 2.
-    //
-    //          0
-    //         / \
-    // head-> 2   1
-    //            |
-    //            3
-    //            |
-    //            4
-    //           /
-    //          5 <- incompatible finalized checkpoint
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a vote to block 1
+        //
+        //          0
+        //         / \
+        //        2   1 <- +vote
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(2),
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is now 1, because 1 has a vote.
+        //
+        //          0
+        //         / \
+        //        2   1 <- head
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(1),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(2),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Add block 6, which has a justified epoch of 0.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    //            |
-    //            4
-    //           / \
-    //          5   6 <- justified epoch = 0
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(0),
-        root: get_root(6),
-        parent_root: get_root(4),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Add a vote to block 2
+        //
+        //           0
+        //          / \
+        // +vote-> 2   1
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(2),
+            attestation_slot: Slot::new(2),
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        // Ensure that the head is 2 since 1 and 2 both have a vote
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Move both votes to 5.
-    //
-    //           0
-    //          / \
-    //         2   1
-    //             |
-    //             3
-    //             |
-    //             4
-    //            / \
-    // +2 vote-> 5   6
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(5),
-        attestation_slot: Slot::new(4),
-    });
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(5),
-        attestation_slot: Slot::new(4),
-    });
-
-    // Add blocks 7, 8 and 9. Adding these blocks helps test the `best_descendant`
-    // functionality.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    //            |
-    //            4
-    //           / \
-    //          5   6
-    //          |
-    //          7
-    //          |
-    //          8
-    //         /
-    //         9
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(0),
-        root: get_root(7),
-        parent_root: get_root(5),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
+        // Add block 3.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        Operation::ProcessBlock {
+            slot: Slot::new(2),
+            root: get_root(3),
+            parent_root: get_root(1),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
+        },
+        // Ensure that the head is still 2
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        //            |
+        //            3
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Move validator #0 vote from 1 to 3
+        //
+        //          0
+        //         / \
+        //        2   1 <- -vote
+        //            |
+        //            3 <- +vote
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(3),
+            attestation_slot: Slot::new(3),
+        },
+        // Ensure that the head is still 2
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        //            |
+        //            3
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Move validator #1 vote from 2 to 1 (this is an equivocation, but fork choice doesn't
+        // care)
+        //
+        //           0
+        //          / \
+        // -vote-> 2   1 <- +vote
+        //             |
+        //             3
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(1),
+            attestation_slot: Slot::new(3),
+        },
+        // Ensure that the head is now 3
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3 <- head
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(3),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Add block 4.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        //            |
+        //            4
+        Operation::ProcessBlock {
+            slot: Slot::new(3),
+            root: get_root(4),
+            parent_root: get_root(3),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
+        },
+        // Ensure that the head is now 4
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        //            |
+        //            4 <- head
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(4),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
+        },
+        // Add block 5, which has a justified epoch of 2.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        //            |
+        //            4
+        //           /
+        //          5 <- justified epoch = 2
+        Operation::ProcessBlock {
+            slot: Slot::new(4),
             root: get_root(5),
+            parent_root: get_root(4),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(1),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(1),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(5),
+        // Block 5 has incompatible finalized checkpoint, so `get_filtered_block_tree`
+        // excludes the entire 1->3->4->5 branch (no viable leaf). Head moves to 2.
+        //
+        //          0
+        //         / \
+        // head-> 2   1
+        //            |
+        //            3
+        //            |
+        //            4
+        //           /
+        //          5 <- incompatible finalized checkpoint
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(2),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(0),
-        root: get_root(8),
-        parent_root: get_root(7),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(5),
+        // Add block 6, which has a justified epoch of 0.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        //            |
+        //            4
+        //           / \
+        //          5   6 <- justified epoch = 0
+        Operation::ProcessBlock {
+            slot: Slot::new(0),
+            root: get_root(6),
+            parent_root: get_root(4),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(5),
+        // Move both votes to 5.
+        //
+        //           0
+        //          / \
+        //         2   1
+        //             |
+        //             3
+        //             |
+        //             4
+        //            / \
+        // +2 vote-> 5   6
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(5),
+            attestation_slot: Slot::new(4),
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(0),
-        root: get_root(9),
-        parent_root: get_root(8),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(5),
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(5),
+            attestation_slot: Slot::new(4),
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(5),
+        // Add blocks 7, 8 and 9. Adding these blocks helps test the `best_descendant`
+        // functionality.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        //            |
+        //            4
+        //           / \
+        //          5   6
+        //          |
+        //          7
+        //          |
+        //          8
+        //         /
+        //         9
+        Operation::ProcessBlock {
+            slot: Slot::new(0),
+            root: get_root(7),
+            parent_root: get_root(5),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Ensure that 6 is the head, even though 5 has all the votes. This is testing to ensure
-    // that 5 is filtered out due to a differing justified epoch.
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    //            |
-    //            4
-    //           / \
-    //          5   6 <- head
-    //          |
-    //          7
-    //          |
-    //          8
-    //         /
-    //         9
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::ProcessBlock {
+            slot: Slot::new(0),
+            root: get_root(8),
+            parent_root: get_root(7),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(1),
-            root: get_root(0),
+        Operation::ProcessBlock {
+            slot: Slot::new(0),
+            root: get_root(9),
+            parent_root: get_root(8),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(6),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Change fork-choice justified epoch to 1, and the start block to 5 and ensure that 9 is
-    // the head.
-    //
-    // << Change justified epoch to 1 >>
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    //            |
-    //            4
-    //           / \
-    //          5   6
-    //          |
-    //          7
-    //          |
-    //          8
-    //         /
-    // head-> 9
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(5),
+        // Ensure that 6 is the head, even though 5 has all the votes. This is testing to ensure
+        // that 5 is filtered out due to a differing justified epoch.
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        //            |
+        //            4
+        //           / \
+        //          5   6 <- head
+        //          |
+        //          7
+        //          |
+        //          8
+        //         /
+        //         9
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(1),
+                root: get_root(0),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(6),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(5),
+        // Change fork-choice justified epoch to 1, and the start block to 5 and ensure that 9 is
+        // the head.
+        //
+        // << Change justified epoch to 1 >>
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        //            |
+        //            4
+        //           / \
+        //          5   6
+        //          |
+        //          7
+        //          |
+        //          8
+        //         /
+        // head-> 9
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(9),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(9),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
-
-    // Change fork-choice justified epoch to 1, and the start block to 5 and ensure that 9 is
-    // the head.
-    //
-    // << Change justified epoch to 1 >>
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    //            |
-    //            4
-    //           / \
-    //          5   6
-    //          |
-    //          7
-    //          |
-    //          8
-    //         /
-    //        9 <- +2 votes
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 0,
-        block_root: get_root(9),
-        attestation_slot: Slot::new(5),
-    });
-    ops.push(Operation::ProcessAttestation {
-        validator_index: 1,
-        block_root: get_root(9),
-        attestation_slot: Slot::new(5),
-    });
-
-    // Add block 10
-    //
-    //          0
-    //         / \
-    //        2   1
-    //            |
-    //            3
-    //            |
-    //            4
-    //           / \
-    //          5   6
-    //          |
-    //          7
-    //          |
-    //          8
-    //         / \
-    //        9  10
-    ops.push(Operation::ProcessBlock {
-        slot: Slot::new(0),
-        root: get_root(10),
-        parent_root: get_root(8),
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(5),
+        // Change fork-choice justified epoch to 1, and the start block to 5 and ensure that 9 is
+        // the head.
+        //
+        // << Change justified epoch to 1 >>
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        //            |
+        //            4
+        //           / \
+        //          5   6
+        //          |
+        //          7
+        //          |
+        //          8
+        //         /
+        //        9 <- +2 votes
+        Operation::ProcessAttestation {
+            validator_index: 0,
+            block_root: get_root(9),
+            attestation_slot: Slot::new(5),
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(5),
+        Operation::ProcessAttestation {
+            validator_index: 1,
+            block_root: get_root(9),
+            attestation_slot: Slot::new(5),
         },
-        execution_payload_parent_hash: None,
-        execution_payload_block_hash: None,
-    });
-
-    // Double-check the head is still 9 (no diagram this time)
-    ops.push(Operation::FindHead {
-        justified_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(5),
+        // Add block 10
+        //
+        //          0
+        //         / \
+        //        2   1
+        //            |
+        //            3
+        //            |
+        //            4
+        //           / \
+        //          5   6
+        //          |
+        //          7
+        //          |
+        //          8
+        //         / \
+        //        9  10
+        Operation::ProcessBlock {
+            slot: Slot::new(0),
+            root: get_root(10),
+            parent_root: get_root(8),
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            execution_payload_parent_hash: None,
+            execution_payload_block_hash: None,
         },
-        finalized_checkpoint: Checkpoint {
-            epoch: Epoch::new(2),
-            root: get_root(5),
+        // Double-check the head is still 9 (no diagram this time)
+        Operation::FindHead {
+            justified_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            finalized_checkpoint: Checkpoint {
+                epoch: Epoch::new(2),
+                root: get_root(5),
+            },
+            justified_state_balances: balances.clone(),
+            expected_head: get_root(9),
+            current_slot: Slot::new(0),
+            expected_payload_status: None,
         },
-        justified_state_balances: balances.clone(),
-        expected_head: get_root(9),
-        current_slot: Slot::new(0),
-        expected_payload_status: None,
-    });
+    ];
 
     // Introduce 2 more validators into the system
     balances = vec![1; 4];

--- a/validator_client/http_api/src/lib.rs
+++ b/validator_client/http_api/src/lib.rs
@@ -857,19 +857,23 @@ pub async fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .then(
             move |request: UpdateCandidatesRequest,
                   block_service: BlockService<LighthouseValidatorStore<T, E>, T>| async move {
-                async fn parse_urls(urls: &[String]) -> Result<Vec<SensitiveUrl>, Response> {
+                // The error is the fully built HTTP response, which is large; box it to keep
+                // the `Result` small (`clippy::result_large_err`).
+                async fn parse_urls(urls: &[String]) -> Result<Vec<SensitiveUrl>, Box<Response>> {
                     match urls
                         .iter()
                         .map(|url| SensitiveUrl::parse(url).map_err(|e| e.to_string()))
                         .collect()
                     {
                         Ok(sensitive_urls) => Ok(sensitive_urls),
-                        Err(_) => Err(convert_rejection::<Infallible>(Err(
-                            warp_utils::reject::custom_bad_request(
-                                "one or more urls could not be parsed".to_string(),
-                            ),
-                        ))
-                        .await),
+                        Err(_) => Err(Box::new(
+                            convert_rejection::<Infallible>(Err(
+                                warp_utils::reject::custom_bad_request(
+                                    "one or more urls could not be parsed".to_string(),
+                                ),
+                            ))
+                            .await,
+                        )),
                     }
                 }
 
@@ -889,7 +893,7 @@ pub async fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                             }
                         }
                     }
-                    Err(e) => return e,
+                    Err(e) => return *e,
                 };
 
                 let response: UpdateCandidatesResponse = UpdateCandidatesResponse {


### PR DESCRIPTION
## Issue Addressed

Rust 1.98 (released 2026-08-18) is rolling out across the CI runner fleet, so `check-code` currently fails or passes depending on which runner a job lands on — e.g. [this failing run](https://github.com/sigp/lighthouse/actions/runs/32399814521/job/96525032659) vs runs ~100 minutes earlier that passed on old-toolchain runners. `unstable` itself trips the new lints, so every open PR is exposed to the lottery until this lands.

## Proposed Changes

Make `unstable` pass clippy 1.98:

- **`vec_init_then_push` (16 sites)** — rewrite the `Vec::new()` + `push` chains in `proto_array`'s fork-choice test definitions as `vec![…]` literals, dropping `mut` where nothing pushes afterwards. The fork-choice definition tests still pass (35/35), so the vectors are unchanged.
- **`result_large_err` in `validator_client/http_api`** — box the fully built HTTP `Response` used as `parse_urls`'s `Err`.
- **`result_large_err` in `fork_choice`'s test harness** — `#[allow]`ed with a comment: `apply_blocks_while` returns `Result<Self, Self>` deliberately (continue vs stop-with-state), so both variants are equally large and boxing only the error would shrink nothing.

## Review hint

The `proto_array` diff is best viewed with **whitespace hidden**: the struct fields and comments inside each rewritten block changed only in indentation, so hiding whitespace shrinks the diff from ~6,100 changed lines to ~1,300 — just the `ops.push(…{` → `…{` / `});` → `},` wrapper pairs.

Caveat: GitHub's "Load diff" for collapsed files drops the hide-whitespace setting (the lazy-load fragment request doesn't carry it), and these files are big enough to be collapsed — so for the large files the clean view needs a local diff:

```
git fetch upstream pull/9897/head
git diff -w --color-moved=dimmed-zebra upstream/unstable FETCH_HEAD -- consensus/proto_array
```

Equivalence was also verified directly: a temp harness dumped the full `Debug` output of all 17 test-definition functions (20k lines) on both the old and new code — the dumps are byte-for-byte identical.

Verified locally with `make lint-full` (exit 0) under rustc/clippy 1.98.0, plus `cargo fmt --check` and `cargo test -p proto_array`.
