### PR TITLE
fix lc_is_latest

### DIFF
--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -132,9 +132,12 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
 
         // Spec: Full nodes SHOULD provide the LightClientOptimisticUpdate with the highest
         // attested_header.beacon.slot (if multiple, highest signature_slot) as selected by fork choice
+	let max_participants = sync_aggregate.sync_committee_bits.len();
+	let new_participants = sync_aggregate.sync_committee_bits.num_set_bits();
+	let new_has_supermajority = new_participants.saturating_mul(3) >= max_participants.saturating_mul(2);
         let is_latest_optimistic = match &self.latest_optimistic_update.read().clone() {
             Some(latest_optimistic_update) => {
-                latest_optimistic_update.is_latest(attested_slot, signature_slot)
+                latest_optimistic_update.is_latest(attested_slot, new_has_supermajority, new_participants, signature_slot)
             }
             None => true,
         };
@@ -152,7 +155,8 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
         // attested_header.beacon.slot (if multiple, highest signature_slot) as selected by fork choice
         let is_latest_finality = match &self.latest_finality_update.read().clone() {
             Some(latest_finality_update) => {
-                latest_finality_update.is_latest(attested_slot, signature_slot)
+	        let finalized_slot = cached_parts.finalized_checkpoint.epoch.start_slot(T::EthSpec::slots_per_epoch());
+                latest_finality_update.is_latest(finalized_slot, new_has_supermajority, new_participants, signature_slot)
             }
             None => true,
         };

--- a/consensus/types/src/light_client/light_client_finality_update.rs
+++ b/consensus/types/src/light_client/light_client_finality_update.rs
@@ -207,6 +207,13 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
         })
     }
 
+    pub fn get_finalized_header_slot<'a>(&'a self) -> Slot {
+        map_light_client_finality_update_ref!(&'a _, self.to_ref(), |inner, cons| {
+            cons(inner);
+            inner.finalized_header.beacon.slot
+        })
+    }
+
     pub fn from_ssz_bytes(bytes: &[u8], fork_name: ForkName) -> Result<Self, ssz::DecodeError> {
         let finality_update = match fork_name {
             ForkName::Altair | ForkName::Bellatrix => {
@@ -250,18 +257,25 @@ impl<E: EthSpec> LightClientFinalityUpdate<E> {
     }
 
     // Implements spec prioritization rules:
-    // > Full nodes SHOULD provide the LightClientFinalityUpdate with the highest attested_header.beacon.slot (if multiple, highest signature_slot)
-    //
+    // > Full nodes SHOULD provide the LightClientFinalityUpdate with the highest finalized_header.beacon.slot
     // ref: https://github.com/ethereum/consensus-specs/blob/113c58f9bf9c08867f6f5f633c4d98e0364d612a/specs/altair/light-client/full-node.md#create_light_client_finality_update
-    pub fn is_latest(&self, attested_slot: Slot, signature_slot: Slot) -> bool {
-        let prev_slot = self.get_attested_header_slot();
-        if attested_slot > prev_slot {
-            true
-        } else {
-            attested_slot == prev_slot && signature_slot > self.signature_slot()
+    pub fn is_latest(&self, new_finalized_slot: Slot, new_has_supermajority: bool, new_participants: usize, signature_slot: Slot) -> bool {
+        let prev_finalized_slot = self.get_finalized_header_slot();
+        if new_finalized_slot != prev_finalized_slot {
+            return new_finalized_slot > prev_finalized_slot;
         }
+        let max_participants = self.sync_aggregate().sync_committee_bits.len();
+        let prev_participants = self.sync_aggregate().sync_committee_bits.num_set_bits();
+        let prev_has_supermajority = prev_participants.saturating_mul(3) >= max_participants.saturating_mul(2);
+        if new_has_supermajority != prev_has_supermajority {
+            return new_has_supermajority;
+        }
+        if !new_has_supermajority && new_participants != prev_participants {
+            return new_participants > prev_participants;
+        }
+        signature_slot > self.signature_slot()
+    	}
     }
-}
 
 impl<'de, E: EthSpec> ContextDeserialize<'de, ForkName> for LightClientFinalityUpdate<E> {
     fn context_deserialize<D>(deserializer: D, context: ForkName) -> Result<Self, D::Error>

--- a/consensus/types/src/light_client/light_client_optimistic_update.rs
+++ b/consensus/types/src/light_client/light_client_optimistic_update.rs
@@ -197,16 +197,23 @@ impl<E: EthSpec> LightClientOptimisticUpdate<E> {
     }
 
     // Implements spec prioritization rules:
-    // > Full nodes SHOULD provide the LightClientOptimisticUpdate with the highest attested_header.beacon.slot (if multiple, highest signature_slot)
-    //
-    // ref: https://github.com/ethereum/consensus-specs/blob/113c58f9bf9c08867f6f5f633c4d98e0364d612a/specs/altair/light-client/full-node.md#create_light_client_optimistic_update
-    pub fn is_latest(&self, attested_slot: Slot, signature_slot: Slot) -> bool {
-        let prev_slot = self.get_slot();
-        if attested_slot > prev_slot {
-            true
-        } else {
-            attested_slot == prev_slot && signature_slot > self.signature_slot()
+    // > Full nodes SHOULD provide the LightClientFinalityUpdate with the highest finalized_header.beacon.slot
+    // ref: https://github.com/ethereum/consensus-specs/blob/113c58f9bf9c08867f6f5f633c4d98e0364d612a/specs/altair/light-client/full-node.md#create_light_client_finality_update
+    pub fn is_latest(&self, new_finalized_slot: Slot, new_has_supermajority: bool, new_participants: usize, signature_slot: Slot) -> bool {
+        let prev_finalized_slot = self.get_slot();
+        if new_finalized_slot != prev_finalized_slot {
+            return new_finalized_slot > prev_finalized_slot;
         }
+        let max_participants = self.sync_aggregate().sync_committee_bits.len();
+        let prev_participants = self.sync_aggregate().sync_committee_bits.num_set_bits();
+        let prev_has_supermajority = prev_participants.saturating_mul(3) >= max_participants.saturating_mul(2);
+        if new_has_supermajority != prev_has_supermajority {
+            return new_has_supermajority;
+        }
+        if !new_has_supermajority && new_participants != prev_participants {
+            return new_participants > prev_participants;
+        }
+        signature_slot > self.signature_slot()
     }
 }
 


### PR DESCRIPTION
LightClientFinalityUpdate::is_latest was comparing attested_header.beacon.slot when it should compare finalized_header.beacon.slot. The finality update should only be replaced when finalization actually advances, not just when the attested slot increases.
LightClientOptimisticUpdate::is_latest was not considering sync committee participation at all. Updates with higher participation should be preferred over those with lower participation, even if the attested slot is lower.

Both bugs were discovered while implementing the light_client_data_collection ef_test handler in #9666. The tests revealed that both updates were being replaced incorrectly during reorg scenarios.

The fix updates is_latest in both types to use the correct prioritization: finalized slot first for finality updates, participation first for optimistic updates, with attested slot and signature slot as tiebreakers. A new get_finalized_header_slot method is added to LightClientFinalityUpdate to support this.