### PR TITLE
Round floating-point values before logging

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -289,14 +289,15 @@ pub fn prometheus_metrics() -> warp::filters::log::Log<impl Fn(warp::filters::lo
 pub fn tracing_logging() -> warp::filters::log::Log<impl Fn(warp::filters::log::Info) + Clone> {
     warp::log::custom(move |info| {
         let status = info.status();
-        // Ensure elapsed time is in milliseconds.
-        let elapsed = info.elapsed().as_secs_f64() * 1000.0;
+        // Round to 3 decimal places (microsecond resolution) so the logged value doesn't carry
+        // binary floating-point noise (e.g. `5.601420999999999`).
+        let elapsed_ms = format!("{:.3}", info.elapsed().as_secs_f64() * 1000.0);
         let path = info.path();
         let method = info.method().to_string();
 
         if status.is_success() {
             debug!(
-                elapsed_ms = %elapsed,
+                elapsed_ms = %elapsed_ms,
                 status = %status,
                 path = %path,
                 method = %method,
@@ -304,7 +305,7 @@ pub fn tracing_logging() -> warp::filters::log::Log<impl Fn(warp::filters::log::
             );
         } else {
             warn!(
-                elapsed_ms = %elapsed,
+                elapsed_ms = %elapsed_ms,
                 status = %status,
                 path = %path,
                 method = %method,

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -537,7 +537,7 @@ impl<E: EthSpec> PeerManager<E> {
         direction: ConnectionDirection,
     ) {
         let client = self.network_globals.client(peer_id);
-        let score = self.network_globals.peers.read().score(peer_id);
+        let score = format!("{:.2}", self.network_globals.peers.read().score(peer_id));
         debug!(%protocol, %err, %client, %peer_id, %score, ?direction, "RPC Error");
         metrics::inc_counter_vec(
             &metrics::TOTAL_RPC_ERRORS_PER_CLIENT,

--- a/testing/simulator/src/checks.rs
+++ b/testing/simulator/src/checks.rs
@@ -537,9 +537,9 @@ pub async fn check_attestation_correctness<E: EthSpec>(
     let source_percent = source_successes / total * 100.0;
 
     eprintln!("Total Attestations: {}", total);
-    eprintln!("Head: {}: {}%", head_successes, head_percent);
-    eprintln!("Target: {}: {}%", target_successes, target_percent);
-    eprintln!("Source: {}: {}%", source_successes, source_percent);
+    eprintln!("Head: {}: {:.2}%", head_successes, head_percent);
+    eprintln!("Target: {}: {:.2}%", target_successes, target_percent);
+    eprintln!("Source: {}: {:.2}%", source_successes, source_percent);
 
     if head_percent < acceptable_attestation_performance {
         return Err("Head percent was below required level".to_string());


### PR DESCRIPTION
## Description

Several human-facing log lines print raw `f64` values with full binary-floating-point precision instead of a rounded value, e.g. `elapsed_ms: 5.601420999999999` and peer `score: 0.00010441950170731398`. This fixes the three spots found:

- `http_api`'s `tracing_logging` filter logged `info.elapsed().as_secs_f64() * 1000.0` directly as `elapsed_ms` with no rounding.
- `PeerManager::handle_rpc_error`'s "RPC Error" log read the score via `PeerDB::score() -> f64`, bypassing `Score`'s own `{:.2}` `Display` impl that every other score-logging call site already uses.
- `testing/simulator`'s attestation reward check printed head/target/source percentages with the default `{}` formatter.

All three now format to a fixed precision (`{:.3}` for sub-ms request timings, `{:.2}` elsewhere, matching existing sibling log lines).

## Additional Info

Log-output only; no behavioural change. Verified with `cargo check -p http_api`, `cargo check -p lighthouse_network`, and `cargo check -p simulator`.