### PR TITLE
Respect explicit --log-color and auto-detect from stdout

### DIFF
--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -531,8 +531,9 @@ Flags:
           already-subscribed subnets, use with --subscribe-all-subnets to ensure
           all attestations are received for import.
       --log-color [<log-color>]
-          Enables/Disables colors for logs in terminal. Set it to false to
-          disable colors. [default: true] [possible values: true, false]
+          Enables/Disables colors for logs in terminal. If not specified, colors
+          are enabled only when stdout is a terminal. [possible values: true,
+          false]
       --log-extra-info
           If present, show module,file,line in logs
       --logfile-color

--- a/book/src/help_general.md
+++ b/book/src/help_general.md
@@ -96,8 +96,9 @@ Flags:
   -h, --help
           Prints help information
       --log-color [<log-color>]
-          Enables/Disables colors for logs in terminal. Set it to false to
-          disable colors. [default: true] [possible values: true, false]
+          Enables/Disables colors for logs in terminal. If not specified, colors
+          are enabled only when stdout is a terminal. [possible values: true,
+          false]
       --log-extra-info
           If present, show module,file,line in logs
       --logfile-color

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -258,8 +258,9 @@ Flags:
           keys. If you misplace your database and then run with this flag you
           risk being slashed.
       --log-color [<log-color>]
-          Enables/Disables colors for logs in terminal. Set it to false to
-          disable colors. [default: true] [possible values: true, false]
+          Enables/Disables colors for logs in terminal. If not specified, colors
+          are enabled only when stdout is a terminal. [possible values: true,
+          false]
       --log-extra-info
           If present, show module,file,line in logs
       --logfile-color

--- a/book/src/help_vm.md
+++ b/book/src/help_vm.md
@@ -95,8 +95,9 @@ Flags:
   -h, --help
           Prints help information
       --log-color [<log-color>]
-          Enables/Disables colors for logs in terminal. Set it to false to
-          disable colors. [default: true] [possible values: true, false]
+          Enables/Disables colors for logs in terminal. If not specified, colors
+          are enabled only when stdout is a terminal. [possible values: true,
+          false]
       --log-extra-info
           If present, show module,file,line in logs
       --logfile-color

--- a/book/src/help_vm_create.md
+++ b/book/src/help_vm_create.md
@@ -121,8 +121,9 @@ Flags:
   -h, --help
           Prints help information
       --log-color [<log-color>]
-          Enables/Disables colors for logs in terminal. Set it to false to
-          disable colors. [default: true] [possible values: true, false]
+          Enables/Disables colors for logs in terminal. If not specified, colors
+          are enabled only when stdout is a terminal. [possible values: true,
+          false]
       --log-extra-info
           If present, show module,file,line in logs
       --logfile-color

--- a/book/src/help_vm_import.md
+++ b/book/src/help_vm_import.md
@@ -109,8 +109,9 @@ Flags:
           something is amiss. Users should also be careful to avoid submitting
           duplicate deposits for validators that already exist on the VC.
       --log-color [<log-color>]
-          Enables/Disables colors for logs in terminal. Set it to false to
-          disable colors. [default: true] [possible values: true, false]
+          Enables/Disables colors for logs in terminal. If not specified, colors
+          are enabled only when stdout is a terminal. [possible values: true,
+          false]
       --log-extra-info
           If present, show module,file,line in logs
       --logfile-color

--- a/book/src/help_vm_move.md
+++ b/book/src/help_vm_move.md
@@ -103,8 +103,9 @@ Flags:
   -h, --help
           Prints help information
       --log-color [<log-color>]
-          Enables/Disables colors for logs in terminal. Set it to false to
-          disable colors. [default: true] [possible values: true, false]
+          Enables/Disables colors for logs in terminal. If not specified, colors
+          are enabled only when stdout is a terminal. [possible values: true,
+          false]
       --log-extra-info
           If present, show module,file,line in logs
       --logfile-color

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -221,10 +221,9 @@ fn main() {
                 .long("log-color")
                 .alias("log-color")
                 .help("Enables/Disables colors for logs in terminal. \
-                    Set it to false to disable colors.")
+                    If not specified, colors are enabled only when stdout is a terminal.")
                 .num_args(0..=1)
                 .default_missing_value("true")
-                .default_value("true")
                 .value_parser(clap::value_parser!(bool))
                 .help_heading(FLAG_HEADER)
                 .global(true)
@@ -511,14 +510,11 @@ fn run<E: EthSpec>(
 
     let log_format = matches.get_one::<String>("log-format");
 
-    let log_color = if std::io::stdin().is_terminal() {
-        matches
-            .get_one::<bool>("log-color")
-            .copied()
-            .unwrap_or(true)
-    } else {
-        // Disable color when in non-interactive mode.
-        false
+    let log_color = match matches.get_one::<bool>("log-color") {
+        // User specified whether logs should be colored.
+        Some(v) => *v,
+        // Otherwise, only use color if stdout is a terminal (i.e. not redirected to a file or piped)
+        None => std::io::stdout().is_terminal(),
     };
 
     let logfile_color = matches.get_flag("logfile-color");


### PR DESCRIPTION
## Issue Addressed

Closes #8122 

`--log-color` was ignored whenever stdin was not a terminal, so users running Lighthouse in Docker could not enable colored logs at all, even with `--log-color true`.

## Proposed Changes

This PR makes `--log-color` first-class:

- If the user passes `--log-color[=<bool>]`, always honor it
- Otherwise, fall back to auto-detection

## Additional Info

The auto-detection now inspects `stdout` rather than `stdin`. `log_color` only feeds the stdout `LoggingLayer` — file output has its own `--logfile-color` —, so what matters is whether the sink interprets ANSI escapes, not whether the session is interactive.
