### PR TITLE
Attempt to fix flaky fallback simulator test

### DIFF
--- a/testing/simulator/src/cli.rs
+++ b/testing/simulator/src/cli.rs
@@ -44,7 +44,7 @@ pub fn cli_app() -> Command {
                         .short('s')
                         .long("speed-up-factor")
                         .action(ArgAction::Set)
-                        .default_value("3")
+                        .default_value("2")
                         .help("Speed up factor. Please use a divisor of 6."),
                 )
                 .arg(

--- a/testing/simulator/src/cli.rs
+++ b/testing/simulator/src/cli.rs
@@ -44,8 +44,8 @@ pub fn cli_app() -> Command {
                         .short('s')
                         .long("speed-up-factor")
                         .action(ArgAction::Set)
-                        .default_value("3")
-                        .help("Speed up factor. Please use a divisor of 12."),
+                        .default_value("2")
+                        .help("Speed up factor. Please use a divisor of 6."),
                 )
                 .arg(
                     Arg::new("debug-level")

--- a/testing/simulator/src/cli.rs
+++ b/testing/simulator/src/cli.rs
@@ -44,7 +44,7 @@ pub fn cli_app() -> Command {
                         .short('s')
                         .long("speed-up-factor")
                         .action(ArgAction::Set)
-                        .default_value("2")
+                        .default_value("3")
                         .help("Speed up factor. Please use a divisor of 6."),
                 )
                 .arg(
@@ -115,8 +115,8 @@ pub fn cli_app() -> Command {
                         .short('s')
                         .long("speed-up-factor")
                         .action(ArgAction::Set)
-                        .default_value("3")
-                        .help("Speed up factor. Please use a divisor of 12."),
+                        .default_value("2")
+                        .help("Speed up factor. Please use a divisor of 6."),
                 )
                 .arg(
                     Arg::new("debug-level")

--- a/testing/simulator/src/main.rs
+++ b/testing/simulator/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! This crate provides various simulations that create both beacon nodes and validator clients,
 //! each with `v` validators.
 //!

--- a/testing/simulator/src/main.rs
+++ b/testing/simulator/src/main.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"]
-
 //! This crate provides various simulations that create both beacon nodes and validator clients,
 //! each with `v` validators.
 //!


### PR DESCRIPTION
The fallback simulator is flaky: https://github.com/sigp/lighthouse/actions/runs/32495923675/job/96814181569?pr=9864. The error is::

`called `Result::unwrap()` on an `Err` value: "There wasn't a block produced at every slot, got: 127, expected: 129, missed: [66, 125]"`


One of the possible reason is that the slot time used is currently 2s, which is probably too short (Minimal spec slot time is 6s, and speed-up-factor defaults to 3, which makes the slot time 2s):

https://github.com/sigp/lighthouse/blob/e423a66763bb1bd780492d635123f208d80c3538/testing/simulator/src/cli.rs#L42-L49

The Kurtosis testnet uses 3s slot time. 

With 2s slot time, attestation deadline is 1/3 of it, which is 667ms into the slot, which is probably too short. If the signing is a little bit slow:

`INFO  Publishing signed block                       slot: 66, signing_time_ms: 798`

It is already over the attestation deadline, and the slot got re-orged:
```
Aug 21 15:20:52.009 INFO  Attempting re-org due to weak head            head_weight: 0, threshold_weight: 48000000000
```

head_weight is 0 because the attestations arrived late. 

This PR attempts to fix it by increasing the slot time to 3s, not sure if it will help 100%, but happy to get feedback about this.

The downside of this is a slightly longer test time, but I think it's still acceptable. Currently, with Minimal spec and running for 16 epochs, time taken is:

16 epochs * 8 slots/epoch * 2 s/slot = 256s which is less than 5 mins

With the change, the slot time becomes 3s, so the time taken is 1.5x longer, which is ~7.5 mins.

Also did the same to basic simulator test.

Diagnosed with the help of Claude Code
