### PR TITLE
Enable Gloas FCR ef-tests and use parent-first safe hash

### DIFF
--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -62,8 +62,6 @@ excluded_paths = [
     "tests/.*/gloas/ssz_static/ExecutionPayloadHeader/.*",
     # ForkChoiceNode is internal to fork choice and probably doesn't need SSZ tests.
     "tests/.*/gloas/ssz_static/ForkChoiceNode/.*",
-    # TODO(gloas): the FCR handler disables Gloas until Gloas fast confirmation is supported.
-    "tests/.*/gloas/fast_confirmation/.*",
     # TODO(gloas): new in v1.7.0-alpha.13. Needs a handler and support for the
     # `viable_for_head_roots_and_weights` check, which requires proto array internals.
     "tests/.*/gloas/fork_choice/should_apply_proposer_boost/.*",

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -794,8 +794,7 @@ impl<E: EthSpec + TypeName> Handler for FastConfirmationHandler<E> {
     }
 
     fn disabled_forks(&self) -> Vec<ForkName> {
-        // TODO(gloas): remove once we have Gloas fast confirmation tests
-        vec![ForkName::Gloas]
+        vec![]
     }
 }
 


### PR DESCRIPTION
## Description

Enable Gloas Fast Confirmation Rule ef-tests and align safe-hash selection with the Gloas FCR spec.

Closes #9771

## Proposed Changes

- Enable Gloas in `FastConfirmationHandler` and stop ignoring `gloas/fast_confirmation` fixtures
- Add `Block::safe_execution_block_hash` (prefer bid parent hash; else payload hash) and use it in `run_fcr` and the ef-test check

## Test plan

- [x] `cargo check`
- [x] `cargo nextest run -p ef_tests --features "ef_tests,fake_crypto" fast_confirmation`