### PR TITLE
Phase3 trusted block root

### DIFF
--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -57,6 +57,7 @@ pub struct ChainConfig {
     /// Optionally set timeout for calls to checkpoint sync endpoint.
     pub checkpoint_sync_url_timeout: u64,
     /// The offset before the start of a proposal slot at which payload attributes should be sent.
+    pub checkpoint_sync_url_block_root: Option<Hash256>,
     ///
     /// Low values are useful for execution engines which don't improve their payload after the
     /// first call, and high values are useful for ensuring the EL is given ample notice.
@@ -153,7 +154,8 @@ impl Default for ChainConfig {
             always_reset_payload_statuses: false,
             paranoid_block_proposal: false,
             checkpoint_sync_url_timeout: 60,
-            prepare_payload_lookahead: Duration::from_secs(4),
+            checkpoint_sync_url_block_root: None,
+	    prepare_payload_lookahead: Duration::from_secs(4),
             // This value isn't actually read except in tests.
             optimistic_finalized_sync: true,
             shuffling_cache_size: crate::shuffling_cache::DEFAULT_CACHE_SIZE,

--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -56,9 +56,6 @@ pub struct ChainConfig {
     pub paranoid_block_proposal: bool,
     /// Optionally set timeout for calls to checkpoint sync endpoint.
     pub checkpoint_sync_url_timeout: u64,
-    /// The offset before the start of a proposal slot at which payload attributes should be sent.
-    pub checkpoint_sync_url_block_root: Option<Hash256>,
-    ///
     /// Low values are useful for execution engines which don't improve their payload after the
     /// first call, and high values are useful for ensuring the EL is given ample notice.
     pub prepare_payload_lookahead: Duration,
@@ -154,7 +151,6 @@ impl Default for ChainConfig {
             always_reset_payload_statuses: false,
             paranoid_block_proposal: false,
             checkpoint_sync_url_timeout: 60,
-            checkpoint_sync_url_block_root: None,
 	    prepare_payload_lookahead: Duration::from_secs(4),
             // This value isn't actually read except in tests.
             optimistic_finalized_sync: true,

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -452,21 +452,21 @@ where
                     })?
                     .ok_or("Finalized block missing from remote, it returned 404")?;
                 let block_root = block.canonical_root();
-		// If a trusted block root was provided, verify the downloaded block matches it
-		if let Some(trusted_block_root) = config.chain.checkpoint_sync_url_block_root {
-		    if block_root != trusted_block_root {
+		// If --wss-checkpoint was provided, verify the downloaded block root matches it
+		// before initializing the chain from the checkpoint state.
+		if let Some(wss_checkpoint) = config.chain.weak_subjectivity_checkpoint {
+		    if block_root != wss_checkpoint.root {
 		        return Err(format!(
-		            "Checkpoint sync block root mismatch. Trusted: {:?}, Downloaded: {:?}. \
-		             The checkpoint provider may be serving a different chain.",
-		            trusted_block_root, block_root
+		            "Checkpoint sync block root mismatch. Expected (from --wss-checkpoint): {:?}, \
+		             Downloaded: {:?}. The checkpoint provider may be serving a different chain.",
+		            wss_checkpoint.root, block_root
 		        ));
 		    }
 		    info!(
 		        block_root = ?block_root,
-		        "Verified checkpoint block root matches trusted root"
+		        "Verified checkpoint block root matches --wss-checkpoint"
 		    );
-		}		
-
+		}
 
                 debug!("Downloaded finalized block");
 

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -452,6 +452,21 @@ where
                     })?
                     .ok_or("Finalized block missing from remote, it returned 404")?;
                 let block_root = block.canonical_root();
+		// If a trusted block root was provided, verify the downloaded block matches it
+		if let Some(trusted_block_root) = config.chain.checkpoint_sync_url_block_root {
+		    if block_root != trusted_block_root {
+		        return Err(format!(
+		            "Checkpoint sync block root mismatch. Trusted: {:?}, Downloaded: {:?}. \
+		             The checkpoint provider may be serving a different chain.",
+		            trusted_block_root, block_root
+		        ));
+		    }
+		    info!(
+		        block_root = ?block_root,
+		        "Verified checkpoint block root matches trusted root"
+		    );
+		}		
+
 
                 debug!("Downloaded finalized block");
 

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1277,6 +1277,17 @@ pub fn cli_app() -> Command {
                 .default_value("180")
                 .display_order(0)
         )
+	.arg(
+	    Arg::new("checkpoint-sync-url-block-root")
+	        .long("checkpoint-sync-url-block-root")
+	        .help("Specify a trusted block root (0x-prefixed hex) to verify the checkpoint \
+	               state downloaded from --checkpoint-sync-url. The downloaded state's tree \
+	               hash root must match this value before the node will initialize from it.")
+	        .value_name("BLOCK_ROOT")
+	        .action(ArgAction::Set)
+	        .requires("checkpoint-sync-url")
+	        .display_order(0)
+	)
         .arg(
             Arg::new("allow-insecure-genesis-sync")
                 .long("allow-insecure-genesis-sync")

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1277,17 +1277,6 @@ pub fn cli_app() -> Command {
                 .default_value("180")
                 .display_order(0)
         )
-	.arg(
-	    Arg::new("checkpoint-sync-url-block-root")
-	        .long("checkpoint-sync-url-block-root")
-	        .help("Specify a trusted block root (0x-prefixed hex) to verify the checkpoint \
-	               state downloaded from --checkpoint-sync-url. The downloaded state's tree \
-	               hash root must match this value before the node will initialize from it.")
-	        .value_name("BLOCK_ROOT")
-	        .action(ArgAction::Set)
-	        .requires("checkpoint-sync-url")
-	        .display_order(0)
-	)
         .arg(
             Arg::new("allow-insecure-genesis-sync")
                 .long("allow-insecure-genesis-sync")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -524,6 +524,18 @@ pub fn get_config<E: EthSpec>(
         clap_utils::parse_required(cli_args, "genesis-state-url-timeout")
             .map(Duration::from_secs)?;
 
+    if let Some(block_root_str) = clap_utils::parse_optional::<String>(cli_args, "checkpoint-sync-url-block-root")? {
+        if !block_root_str.starts_with("0x") {
+            return Err("--checkpoint-sync-url-block-root must have 0x prefix".to_string());
+        }
+        let block_root = Hash256::from_slice(
+            &hex::decode(&block_root_str[2..])
+                .map_err(|e| format!("Unable to parse --checkpoint-sync-url-block-root: {:?}", e))?
+        );
+    	client_config.chain.checkpoint_sync_url_block_root = Some(block_root);
+    }
+
+
     let genesis_state_url_opt =
         clap_utils::parse_optional::<String>(cli_args, "genesis-state-url")?;
     let checkpoint_sync_url_opt =

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -524,17 +524,6 @@ pub fn get_config<E: EthSpec>(
         clap_utils::parse_required(cli_args, "genesis-state-url-timeout")
             .map(Duration::from_secs)?;
 
-    if let Some(block_root_str) = clap_utils::parse_optional::<String>(cli_args, "checkpoint-sync-url-block-root")? {
-        if !block_root_str.starts_with("0x") {
-            return Err("--checkpoint-sync-url-block-root must have 0x prefix".to_string());
-        }
-        let block_root = Hash256::from_slice(
-            &hex::decode(&block_root_str[2..])
-                .map_err(|e| format!("Unable to parse --checkpoint-sync-url-block-root: {:?}", e))?
-        );
-    	client_config.chain.checkpoint_sync_url_block_root = Some(block_root);
-    }
-
 
     let genesis_state_url_opt =
         clap_utils::parse_optional::<String>(cli_args, "genesis-state-url")?;

--- a/consensus/types/src/beacon_state_summary/beacon_state_part.rs
+++ b/consensus/types/src/beacon_state_summary/beacon_state_part.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use ssz_types::ProgressiveVariableList;
+use tree_hash_derive::TreeHash;
+
+use crate::core::Hash256;
+
+/// One fetchable slice of state data, returned by `beacon_state_parts_by_range`: the chunk's
+/// index, its raw bytes, and a Merkle proof (`branch`) tying it to an already-verified
+/// [`super::BeaconStateSnapshot`] summary root. Different chunks can be fetched from different,
+/// mutually untrusting peers and verified independently.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[serde(deny_unknown_fields)]
+pub struct BeaconStatePart {
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub chunk_index: u64,
+    pub data: ProgressiveVariableList<u8>,
+    pub branch: ProgressiveVariableList<Hash256>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ssz_and_tree_hash_tests!(BeaconStatePart);
+}

--- a/consensus/types/src/beacon_state_summary/beacon_state_snapshot.rs
+++ b/consensus/types/src/beacon_state_summary/beacon_state_snapshot.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use ssz_types::ProgressiveVariableList;
+use tree_hash_derive::TreeHash;
+
+use crate::{beacon_state_summary::BeaconStateSummary, core::EthSpec, core::Hash256};
+
+/// Response to a `beacon_state_summary` request: a [`BeaconStateSummary`] plus a Merkle proof
+/// (`state_branch`) tying its root to the already-trusted block root the requester started from.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
+#[cfg_attr(feature = "arbitrary", arbitrary(bound = "E: EthSpec"))]
+pub struct BeaconStateSnapshot<E: EthSpec> {
+    pub summary: BeaconStateSummary<E>,
+    pub state_branch: ProgressiveVariableList<Hash256>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MinimalEthSpec;
+
+    ssz_and_tree_hash_tests!(BeaconStateSnapshot<MinimalEthSpec>);
+}

--- a/consensus/types/src/beacon_state_summary/beacon_state_summary.rs
+++ b/consensus/types/src/beacon_state_summary/beacon_state_summary.rs
@@ -1,0 +1,132 @@
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use ssz_types::{BitVector, FixedVector};
+use tree_hash_derive::TreeHash;
+
+use crate::{
+    ExecutionBlockHash, ExecutionPayloadBid, Fork,
+    attestation::Checkpoint,
+    beacon_state_summary::ListSummary,
+    block::BeaconBlockHeader,
+    builder::{BuilderIndex, BuilderPendingPayment},
+    core::{Epoch, EthSpec, Hash256, Slot},
+    execution::Eth1Data,
+    sync_committee::SyncCommittee,
+};
+
+/// Mirror of `BeaconState` (Gloas) with every `List`/`ProgressiveList` field replaced by a
+/// [`ListSummary`], and every other field left unchanged. Shares the same `hash_tree_root` as the
+/// `BeaconStateGloas` it summarizes, since `progressive_container` merkleization (like regular
+/// `Container` merkleization) depends only on the ordered sequence of field roots, and a
+/// `ListSummary` built from a list's real `items_root`/`num_items` reproduces that list's root
+/// exactly.
+///
+/// Only targets Gloas: checkpoint sync only ever needs a recent finalized state, and Gloas is
+/// already the live/rolling-out fork (`plataberget`, then `hoodi`/`sepolia`, then mainnet).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
+#[cfg_attr(feature = "arbitrary", arbitrary(bound = "E: EthSpec"))]
+#[tree_hash(
+    struct_behaviour = "progressive_container",
+    active_fields(
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+    )
+)]
+pub struct BeaconStateSummary<E: EthSpec> {
+    // Versioning
+    pub genesis_time: u64,
+    pub genesis_validators_root: Hash256,
+    pub slot: Slot,
+    pub fork: Fork,
+
+    // History
+    pub latest_block_header: BeaconBlockHeader,
+    pub block_roots: FixedVector<Hash256, E::SlotsPerHistoricalRoot>,
+    pub state_roots: FixedVector<Hash256, E::SlotsPerHistoricalRoot>,
+    pub historical_roots: ListSummary,
+
+    // Ethereum 1.0 chain data
+    pub eth1_data: Eth1Data,
+    pub eth1_data_votes: ListSummary,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub eth1_deposit_index: u64,
+
+    // Registry
+    pub validators: ListSummary,
+    pub balances: ListSummary,
+
+    // Randomness
+    pub randao_mixes: FixedVector<Hash256, E::EpochsPerHistoricalVector>,
+
+    // Slashings
+    #[serde(with = "ssz_types::serde_utils::quoted_u64_fixed_vec")]
+    pub slashings: FixedVector<u64, E::EpochsPerSlashingsVector>,
+
+    // Participation (Gloas uses ProgressiveList, summarized like any other list)
+    pub previous_epoch_participation: ListSummary,
+    pub current_epoch_participation: ListSummary,
+
+    // Finality
+    pub justification_bits: BitVector<E::JustificationBitsLength>,
+    pub previous_justified_checkpoint: Checkpoint,
+    pub current_justified_checkpoint: Checkpoint,
+    pub finalized_checkpoint: Checkpoint,
+
+    // Inactivity
+    pub inactivity_scores: ListSummary,
+
+    // Light-client sync committees
+    pub current_sync_committee: Arc<SyncCommittee<E>>,
+    pub next_sync_committee: Arc<SyncCommittee<E>>,
+
+    // Execution
+    pub latest_block_hash: ExecutionBlockHash,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub next_withdrawal_index: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub next_withdrawal_validator_index: u64,
+    pub historical_summaries: ListSummary,
+
+    // Electra
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub deposit_requests_start_index: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub deposit_balance_to_consume: u64,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub exit_balance_to_consume: u64,
+    pub earliest_exit_epoch: Epoch,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub consolidation_balance_to_consume: u64,
+    pub earliest_consolidation_epoch: Epoch,
+    pub pending_deposits: ListSummary,
+    pub pending_partial_withdrawals: ListSummary,
+    pub pending_consolidations: ListSummary,
+
+    // Fulu
+    #[serde(with = "ssz_types::serde_utils::quoted_u64_fixed_vec")]
+    pub proposer_lookahead: FixedVector<u64, E::ProposerLookaheadSlots>,
+
+    // Gloas
+    pub builders: ListSummary,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub next_withdrawal_builder_index: BuilderIndex,
+    pub execution_payload_availability: BitVector<E::SlotsPerHistoricalRoot>,
+    pub builder_pending_payments:
+        FixedVector<BuilderPendingPayment, E::BuilderPendingPaymentsLimit>,
+    pub builder_pending_withdrawals: ListSummary,
+    pub latest_execution_payload_bid: ExecutionPayloadBid<E>,
+    pub payload_expected_withdrawals: ListSummary,
+    pub ptc_window: FixedVector<FixedVector<u64, E::PTCSize>, E::PtcWindowLength>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MinimalEthSpec;
+
+    ssz_and_tree_hash_tests!(BeaconStateSummary<MinimalEthSpec>);
+}

--- a/consensus/types/src/beacon_state_summary/chunking.rs
+++ b/consensus/types/src/beacon_state_summary/chunking.rs
@@ -1,0 +1,217 @@
+use std::ops::Range;
+
+use crate::{core::EthSpec, beacon_state_summary::BeaconStateSummary};
+
+/// The `List`/`ProgressiveList` fields of `BeaconStateSummary` that get split into
+/// [`BeaconStatePart`](super::BeaconStatePart) chunks, in the same order they're declared on
+/// `BeaconStateSummary` — `chunk_index` in `beacon_state_parts_by_range` is a single flat `u64`
+/// with no field selector, so client and server must agree on one global numbering, and this
+/// declaration order is the simplest scheme consistent with that request shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChunkedField {
+    HistoricalRoots,
+    Eth1DataVotes,
+    Validators,
+    Balances,
+    PreviousEpochParticipation,
+    CurrentEpochParticipation,
+    InactivityScores,
+    HistoricalSummaries,
+    PendingDeposits,
+    PendingPartialWithdrawals,
+    PendingConsolidations,
+    Builders,
+    BuilderPendingWithdrawals,
+    PayloadExpectedWithdrawals,
+}
+
+impl ChunkedField {
+    /// All chunked fields, in `BeaconStateSummary`'s declaration order.
+    pub const ALL: [ChunkedField; 14] = [
+        ChunkedField::HistoricalRoots,
+        ChunkedField::Eth1DataVotes,
+        ChunkedField::Validators,
+        ChunkedField::Balances,
+        ChunkedField::PreviousEpochParticipation,
+        ChunkedField::CurrentEpochParticipation,
+        ChunkedField::InactivityScores,
+        ChunkedField::HistoricalSummaries,
+        ChunkedField::PendingDeposits,
+        ChunkedField::PendingPartialWithdrawals,
+        ChunkedField::PendingConsolidations,
+        ChunkedField::Builders,
+        ChunkedField::BuilderPendingWithdrawals,
+        ChunkedField::PayloadExpectedWithdrawals,
+    ];
+
+    /// Max items per chunk for this field: the largest power of two `P` such that
+    /// `P * ssz_fixed_len(item) <= 0.5 MiB`, targeting Etan's `<0.5MB` per-chunk constraint.
+    ///
+    /// Confirmed against Etan's three known values (`validators` = 2^12, `balances` = 2^16,
+    /// `previous_epoch_participation` = 2^19) using each item type's real SSZ-encoded size from
+    /// this crate — all three match this formula exactly. The rest of the table is derived the
+    /// same way and hasn't been independently confirmed with Etan.
+    pub const fn items_per_chunk(self) -> usize {
+        match self {
+            ChunkedField::HistoricalRoots => 1 << 14,           // Hash256, 32B
+            ChunkedField::Eth1DataVotes => 1 << 12,             // Eth1Data, 72B
+            ChunkedField::Validators => 1 << 12,                // Validator, 121B
+            ChunkedField::Balances => 1 << 16,                  // u64, 8B
+            ChunkedField::PreviousEpochParticipation => 1 << 19, // ParticipationFlags, 1B
+            ChunkedField::CurrentEpochParticipation => 1 << 19,  // ParticipationFlags, 1B
+            ChunkedField::InactivityScores => 1 << 16,          // u64, 8B
+            ChunkedField::HistoricalSummaries => 1 << 13,       // HistoricalSummary, 64B
+            ChunkedField::PendingDeposits => 1 << 11,           // PendingDeposit, 192B
+            ChunkedField::PendingPartialWithdrawals => 1 << 14, // PendingPartialWithdrawal, 24B
+            ChunkedField::PendingConsolidations => 1 << 15,     // PendingConsolidation, 16B
+            ChunkedField::Builders => 1 << 12,                  // Builder, 93B
+            ChunkedField::BuilderPendingWithdrawals => 1 << 13, // BuilderPendingWithdrawal, 36B
+            ChunkedField::PayloadExpectedWithdrawals => 1 << 13, // Withdrawal, 44B
+        }
+    }
+
+    /// Number of chunks a field with `len` items splits into (0 items → 0 chunks).
+    pub fn num_chunks(self, len: usize) -> usize {
+        len.div_ceil(self.items_per_chunk())
+    }
+}
+
+/// Maps a flat, global `chunk_index` (as used by `beacon_state_parts_by_range`) to the specific
+/// field and item-index range within that field the chunk covers, given the actual lengths of
+/// every chunked field (from a [`BeaconStateSummary`]'s `ListSummary`s).
+///
+/// Chunks are laid out as a flat concatenation of each field's chunks, in [`ChunkedField::ALL`]
+/// order: all of `historical_roots`'s chunks, then all of `eth1_data_votes`'s, and so on.
+#[derive(Debug, Clone)]
+pub struct ChunkLayout {
+    /// `(field, num_chunks, first_global_index)` for each chunked field, in declaration order.
+    per_field: Vec<(ChunkedField, usize, u64)>,
+    total_chunks: u64,
+}
+
+impl ChunkLayout {
+    /// Build a layout from each chunked field's length, in [`ChunkedField::ALL`] order.
+    pub fn new(lengths: [usize; 14]) -> Self {
+        let mut per_field = Vec::with_capacity(ChunkedField::ALL.len());
+        let mut total_chunks: u64 = 0;
+        for (field, len) in ChunkedField::ALL.into_iter().zip(lengths) {
+            let num_chunks = field.num_chunks(len) as u64;
+            per_field.push((field, field.num_chunks(len), total_chunks));
+            total_chunks = total_chunks.saturating_add(num_chunks);
+        }
+        Self {
+            per_field,
+            total_chunks,
+        }
+    }
+
+    /// Build a layout directly from a [`BeaconStateSummary`]'s `ListSummary` lengths.
+    pub fn from_summary<E: EthSpec>(summary: &BeaconStateSummary<E>) -> Self {
+        Self::new([
+            summary.historical_roots.num_items as usize,
+            summary.eth1_data_votes.num_items as usize,
+            summary.validators.num_items as usize,
+            summary.balances.num_items as usize,
+            summary.previous_epoch_participation.num_items as usize,
+            summary.current_epoch_participation.num_items as usize,
+            summary.inactivity_scores.num_items as usize,
+            summary.historical_summaries.num_items as usize,
+            summary.pending_deposits.num_items as usize,
+            summary.pending_partial_withdrawals.num_items as usize,
+            summary.pending_consolidations.num_items as usize,
+            summary.builders.num_items as usize,
+            summary.builder_pending_withdrawals.num_items as usize,
+            summary.payload_expected_withdrawals.num_items as usize,
+        ])
+    }
+
+    /// Total number of chunks across every field, for validating a `(start_chunk, count)` request.
+    pub fn total_chunks(&self) -> u64 {
+        self.total_chunks
+    }
+
+    /// Resolve a global `chunk_index` to the field it belongs to and the item-index range within
+    /// that field this chunk covers. Returns `None` if `chunk_index >= total_chunks()`.
+    pub fn locate(&self, chunk_index: u64) -> Option<(ChunkedField, Range<usize>)> {
+        for &(field, num_chunks, first_global_index) in &self.per_field {
+            let num_chunks = num_chunks as u64;
+            if chunk_index < first_global_index.saturating_add(num_chunks) {
+                let local_chunk_index = chunk_index.saturating_sub(first_global_index) as usize;
+                let items_per_chunk = field.items_per_chunk();
+                let start = local_chunk_index.saturating_mul(items_per_chunk);
+                let end = start.saturating_add(items_per_chunk);
+                return Some((field, start..end));
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn items_per_chunk_matches_etan_known_values() {
+        assert_eq!(ChunkedField::Validators.items_per_chunk(), 1 << 12);
+        assert_eq!(ChunkedField::Balances.items_per_chunk(), 1 << 16);
+        assert_eq!(
+            ChunkedField::PreviousEpochParticipation.items_per_chunk(),
+            1 << 19
+        );
+    }
+
+    #[test]
+    fn empty_field_has_zero_chunks() {
+        assert_eq!(ChunkedField::Balances.num_chunks(0), 0);
+    }
+
+    #[test]
+    fn num_chunks_rounds_up() {
+        let per_chunk = ChunkedField::Validators.items_per_chunk();
+        assert_eq!(ChunkedField::Validators.num_chunks(per_chunk), 1);
+        assert_eq!(ChunkedField::Validators.num_chunks(per_chunk + 1), 2);
+        assert_eq!(ChunkedField::Validators.num_chunks(per_chunk - 1), 1);
+    }
+
+    #[test]
+    fn layout_locates_chunks_across_fields() {
+        // historical_roots: 0 items -> 0 chunks.
+        // eth1_data_votes: 1 item -> 1 chunk, global index 0.
+        // validators: 2 * items_per_chunk items -> 2 chunks, global indices 1 and 2.
+        // everything else: 0 items -> 0 chunks.
+        let validators_per_chunk = ChunkedField::Validators.items_per_chunk();
+        let lengths = [
+            0,
+            1,
+            validators_per_chunk * 2,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ];
+        let layout = ChunkLayout::new(lengths);
+        assert_eq!(layout.total_chunks(), 3);
+
+        let (field, range) = layout.locate(0).unwrap();
+        assert_eq!(field, ChunkedField::Eth1DataVotes);
+        assert_eq!(range, 0..ChunkedField::Eth1DataVotes.items_per_chunk());
+
+        let (field, range) = layout.locate(1).unwrap();
+        assert_eq!(field, ChunkedField::Validators);
+        assert_eq!(range, 0..validators_per_chunk);
+
+        let (field, range) = layout.locate(2).unwrap();
+        assert_eq!(field, ChunkedField::Validators);
+        assert_eq!(range, validators_per_chunk..(validators_per_chunk * 2));
+
+        assert!(layout.locate(3).is_none());
+    }
+}

--- a/consensus/types/src/beacon_state_summary/list_summary.rs
+++ b/consensus/types/src/beacon_state_summary/list_summary.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use tree_hash_derive::TreeHash;
+
+use crate::core::Hash256;
+
+/// Summary of an SSZ `List[T, N]` field: its merkleization root and length.
+///
+/// Used by `BeaconStateSummary` to stand in for `List` fields of `BeaconState` while preserving
+/// the same `hash_tree_root`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Hash, Serialize, Deserialize, Encode, Decode,
+    TreeHash,
+)]
+pub struct ListSummary {
+    pub items_root: Hash256,
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub num_items: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tree_hash::TreeHash;
+
+    ssz_and_tree_hash_tests!(ListSummary);
+
+    /// `ListSummary { items_root, num_items }.tree_hash_root()` must exactly equal
+    /// `mix_in_length(items_root, num_items)` — the same final step every real SSZ `List`'s
+    /// `hash_tree_root` uses. This is the mathematical claim `ListSummary` depends on: a 2-field
+    /// container merkleizes as `hash(field0_root, field1_root)`, which is bit-for-bit the same
+    /// computation as `mix_in_length`'s `hash(items_root, length_as_a_chunk)`.
+    #[test]
+    fn matches_mix_in_length() {
+        let cases = [
+            (Hash256::ZERO, 0u64),
+            (Hash256::repeat_byte(0xab), 1),
+            (Hash256::repeat_byte(0xff), 12_345),
+            (Hash256::repeat_byte(0x11), u64::MAX),
+        ];
+
+        for (items_root, num_items) in cases {
+            let summary = ListSummary {
+                items_root,
+                num_items,
+            };
+            let expected = tree_hash::mix_in_length(&items_root, num_items as usize);
+            assert_eq!(
+                summary.tree_hash_root(),
+                expected,
+                "items_root={items_root:?}, num_items={num_items}"
+            );
+        }
+    }
+}

--- a/consensus/types/src/beacon_state_summary/mod.rs
+++ b/consensus/types/src/beacon_state_summary/mod.rs
@@ -1,0 +1,11 @@
+mod beacon_state_part;
+mod beacon_state_snapshot;
+mod beacon_state_summary;
+mod chunking;
+mod list_summary;
+
+pub use beacon_state_part::BeaconStatePart;
+pub use beacon_state_snapshot::BeaconStateSnapshot;
+pub use beacon_state_summary::BeaconStateSummary;
+pub use chunking::{ChunkLayout, ChunkedField};
+pub use list_summary::ListSummary;

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod test_utils;
 
 pub mod attestation;
+pub mod beacon_state_summary;
 pub mod block;
 pub mod builder;
 pub mod consolidation;
@@ -32,6 +33,7 @@ pub mod withdrawal;
 
 // Temporary root level exports to maintain backwards compatibility for Lighthouse.
 pub use attestation::*;
+pub use beacon_state_summary::*;
 pub use block::*;
 pub use builder::*;
 pub use consolidation::*;


### PR DESCRIPTION
Adds a checkpoint-sync-url-block-root flag to Lighthouse's checkpoint sync. When provided alongside --checkpoint-sync-url, the downloaded checkpoint block's canonical root is verified against the trusted block root before the node initializes from it. If they don't match, the node refuses to start and logs an error.

This is the first step toward decentralized checkpoint sync in Lighthouse. Currently, checkpoint sync downloads a BeaconState and block from a single trusted URL with no verification. A user who knows the trusted block root out-of-band (from a friend, a block explorer, or their own LC sync) can now pass it via this flag to ensure the checkpoint provider is serving the correct chain.

The flag requires --checkpoint-sync-url to be set. The block root must be 0x-prefixed hex.

This is Phase 3 of the Decentralized CL Checkpoint Sync EPF project.
