### PR TITLE
Gloas gossip handlers

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -332,6 +332,15 @@ pub enum BlockError {
         bid_parent_root: Hash256,
         block_parent_root: Hash256,
     },
+    /// The bid does not build on the parent's execution head when the parent is empty.
+    ///
+    /// ## Peer scoring
+    ///
+    /// The block is invalid and the peer should be penalized.
+    BidParentBlockHashMismatch {
+        bid_parent_block_hash: ExecutionBlockHash,
+        parent_execution_head: ExecutionBlockHash,
+    },
     EnvelopeError(Box<EnvelopeError>),
 }
 
@@ -957,6 +966,23 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
                 bid_parent_root: bid.message.parent_block_root,
                 block_parent_root: block.message().parent_root(),
             });
+        }
+
+        // [New in Gloas]: If the child does not build on the parent's full payload, its bid must
+        // build on the execution head that the parent itself used.
+        if let Ok(bid) = block.message().body().signed_execution_payload_bid() {
+            let parent_is_full =
+                parent_block.execution_payload_block_hash == Some(bid.message.parent_block_hash);
+            let parent_execution_head = parent_block
+                .execution_payload_parent_hash
+                .or_else(|| parent_block.execution_status.block_hash())
+                .unwrap_or_default();
+            if !parent_is_full && bid.message.parent_block_hash != parent_execution_head {
+                return Err(BlockError::BidParentBlockHashMismatch {
+                    bid_parent_block_hash: bid.message.parent_block_hash,
+                    parent_execution_head,
+                });
+            }
         }
 
         drop(fork_choice_read_lock);

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -651,6 +651,18 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         self.cached_head_read_lock().clone()
     }
 
+    /// Apply a synthetic finalized checkpoint to the cached head state for EF test fixtures.
+    ///
+    /// Some gossip fixtures override finalization after producing their block and state files, so
+    /// replaying those files cannot reproduce the state used by the reference implementation.
+    #[cfg(feature = "ef_tests")]
+    pub fn testing_set_cached_head_state_finalized_checkpoint(&self, checkpoint: Checkpoint) {
+        let mut cached_head = self.cached_head_write_lock();
+        *Arc::make_mut(&mut cached_head.snapshot)
+            .beacon_state
+            .finalized_checkpoint_mut() = checkpoint;
+    }
+
     /// Access a read-lock for the cached head.
     ///
     /// This function is **not safe** to be public. See the module-level documentation for more

--- a/beacon_node/beacon_chain/src/payload_attestation_verification/gossip_verified_payload_attestation.rs
+++ b/beacon_node/beacon_chain/src/payload_attestation_verification/gossip_verified_payload_attestation.rs
@@ -222,20 +222,33 @@ fn verify_propagation_slot_range<S: SlotClock>(
     message_slot: Slot,
     spec: &ChainSpec,
 ) -> Result<(), Error> {
-    let latest_permissible_slot = slot_clock
-        .now_with_future_tolerance(spec.maximum_gossip_clock_disparity())
+    let current_time = slot_clock
+        .now_duration()
         .ok_or(BeaconChainError::UnableToReadSlot)?;
-    if message_slot > latest_permissible_slot {
+    let disparity = spec.maximum_gossip_clock_disparity();
+    let earliest_permissible_time = slot_clock
+        .start_of(message_slot)
+        .ok_or(BeaconChainError::UnableToReadSlot)?
+        .saturating_sub(disparity);
+    let latest_permissible_time = slot_clock
+        .start_of(message_slot.saturating_add(1u64))
+        .ok_or(BeaconChainError::UnableToReadSlot)?
+        .saturating_add(disparity);
+
+    if current_time < earliest_permissible_time {
+        let latest_permissible_slot = slot_clock
+            .now_with_future_tolerance(disparity)
+            .ok_or(BeaconChainError::UnableToReadSlot)?;
         return Err(Error::FutureSlot {
             message_slot,
             latest_permissible_slot,
         });
     }
 
-    let earliest_permissible_slot = slot_clock
-        .now_with_past_tolerance(spec.maximum_gossip_clock_disparity())
-        .ok_or(BeaconChainError::UnableToReadSlot)?;
-    if message_slot < earliest_permissible_slot {
+    if current_time > latest_permissible_time {
+        let earliest_permissible_slot = slot_clock
+            .now_with_past_tolerance(disparity)
+            .ok_or(BeaconChainError::UnableToReadSlot)?;
         return Err(Error::PastSlot {
             message_slot,
             earliest_permissible_slot,

--- a/beacon_node/beacon_chain/src/payload_attestation_verification/gossip_verified_payload_attestation.rs
+++ b/beacon_node/beacon_chain/src/payload_attestation_verification/gossip_verified_payload_attestation.rs
@@ -225,34 +225,21 @@ fn verify_propagation_slot_range<S: SlotClock>(
     let current_time = slot_clock
         .now_duration()
         .ok_or(BeaconChainError::UnableToReadSlot)?;
-    let disparity = spec.maximum_gossip_clock_disparity();
     let earliest_permissible_time = slot_clock
         .start_of(message_slot)
         .ok_or(BeaconChainError::UnableToReadSlot)?
-        .saturating_sub(disparity);
+        .saturating_sub(spec.maximum_gossip_clock_disparity());
     let latest_permissible_time = slot_clock
         .start_of(message_slot.saturating_add(1u64))
         .ok_or(BeaconChainError::UnableToReadSlot)?
-        .saturating_add(disparity);
+        .saturating_add(spec.maximum_gossip_clock_disparity());
 
     if current_time < earliest_permissible_time {
-        let latest_permissible_slot = slot_clock
-            .now_with_future_tolerance(disparity)
-            .ok_or(BeaconChainError::UnableToReadSlot)?;
-        return Err(Error::FutureSlot {
-            message_slot,
-            latest_permissible_slot,
-        });
+        return Err(Error::FutureSlot { message_slot });
     }
 
     if current_time > latest_permissible_time {
-        let earliest_permissible_slot = slot_clock
-            .now_with_past_tolerance(disparity)
-            .ok_or(BeaconChainError::UnableToReadSlot)?;
-        return Err(Error::PastSlot {
-            message_slot,
-            earliest_permissible_slot,
-        });
+        return Err(Error::PastSlot { message_slot });
     }
 
     Ok(())

--- a/beacon_node/beacon_chain/src/payload_attestation_verification/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_attestation_verification/mod.rs
@@ -32,20 +32,14 @@ pub enum Error {
     /// ## Peer scoring
     ///
     /// Assuming the local clock is correct, the peer has sent an invalid message.
-    FutureSlot {
-        message_slot: Slot,
-        latest_permissible_slot: Slot,
-    },
+    FutureSlot { message_slot: Slot },
     /// The payload attestation message is from a slot that is prior to the earliest
     /// permissible slot (with respect to the gossip clock disparity).
     ///
     /// ## Peer scoring
     ///
     /// Assuming the local clock is correct, the peer has sent an invalid message.
-    PastSlot {
-        message_slot: Slot,
-        earliest_permissible_slot: Slot,
-    },
+    PastSlot { message_slot: Slot },
     /// We have already observed a valid payload attestation message from this validator
     /// for this slot.
     ///

--- a/beacon_node/beacon_chain/src/payload_bid_verification/gossip_verified_bid.rs
+++ b/beacon_node/beacon_chain/src/payload_bid_verification/gossip_verified_bid.rs
@@ -90,17 +90,20 @@ fn verify_bid_slot_range<S: SlotClock>(
     let current_time = slot_clock
         .now_duration()
         .ok_or(PayloadBidError::UnableToReadSlot)?;
-    let disparity = spec.maximum_gossip_clock_disparity();
     let earliest_permissible_time = slot_clock
         .start_of(bid_slot.saturating_sub(1u64))
         .ok_or(PayloadBidError::UnableToReadSlot)?
-        .saturating_sub(disparity);
+        .saturating_sub(spec.maximum_gossip_clock_disparity());
     let latest_permissible_time = slot_clock
         .start_of(bid_slot.saturating_add(1u64))
         .ok_or(PayloadBidError::UnableToReadSlot)?
-        .saturating_add(disparity);
+        .saturating_add(spec.maximum_gossip_clock_disparity());
 
-    if current_time < earliest_permissible_time || current_time > latest_permissible_time {
+    if current_time < earliest_permissible_time {
+        return Err(PayloadBidError::InvalidBidSlot { bid_slot });
+    }
+
+    if current_time > latest_permissible_time {
         return Err(PayloadBidError::InvalidBidSlot { bid_slot });
     }
 
@@ -448,10 +451,11 @@ pub fn is_gas_limit_target_compatible(
 
 #[cfg(test)]
 mod tests {
-    use super::is_gas_limit_target_compatible;
+    use super::{is_gas_limit_target_compatible, verify_bid_slot_range};
     use bls::Signature;
     use kzg::KzgCommitment;
     use ssz_types::ProgressiveVariableList;
+    use std::time::Duration;
     use types::{
         Address, BeaconState, ChainSpec, EthSpec, ExecutionPayloadBid, MinimalEthSpec,
         ProposerPreferences, SignedProposerPreferences, Slot,
@@ -459,6 +463,7 @@ mod tests {
 
     use super::verify_bid_consistency;
     use crate::payload_bid_verification::PayloadBidError;
+    use crate::slot_clock::{SlotClock, TestingSlotClock};
 
     type E = MinimalEthSpec;
 
@@ -490,6 +495,27 @@ mod tests {
         let spec = E::default_spec();
         let state = BeaconState::new(0, <_>::default(), &spec);
         (state, spec)
+    }
+
+    #[test]
+    fn test_bid_slot_upper_disparity_boundary() {
+        let spec = E::default_spec();
+        let slot_clock =
+            TestingSlotClock::new(Slot::new(0), Duration::ZERO, spec.get_slot_duration());
+        let bid_slot = Slot::new(100);
+        let upper_boundary = slot_clock
+            .start_of(bid_slot.saturating_add(1u64))
+            .unwrap()
+            .saturating_add(spec.maximum_gossip_clock_disparity());
+
+        slot_clock.set_current_time(upper_boundary);
+        assert!(verify_bid_slot_range(&slot_clock, bid_slot, &spec).is_ok());
+
+        slot_clock.set_current_time(upper_boundary.saturating_add(Duration::from_millis(1)));
+        assert!(matches!(
+            verify_bid_slot_range(&slot_clock, bid_slot, &spec),
+            Err(PayloadBidError::InvalidBidSlot { .. })
+        ));
     }
 
     #[test]

--- a/beacon_node/beacon_chain/src/payload_bid_verification/gossip_verified_bid.rs
+++ b/beacon_node/beacon_chain/src/payload_bid_verification/gossip_verified_bid.rs
@@ -26,16 +26,11 @@ use types::{
 /// and proposer preferences.
 pub(crate) fn verify_bid_consistency<E: EthSpec>(
     bid: &ExecutionPayloadBid<E>,
-    current_slot: Slot,
     proposer_preferences: &SignedProposerPreferences,
     head_state: &BeaconState<E>,
     spec: &ChainSpec,
 ) -> Result<(), PayloadBidError> {
     let bid_slot = bid.slot;
-
-    if bid_slot != current_slot && bid_slot != current_slot.saturating_add(1u64) {
-        return Err(PayloadBidError::InvalidBidSlot { bid_slot });
-    }
 
     // Execution payments are used by off protocol builders. In protocol bids
     // should always have this value set to zero.
@@ -82,6 +77,31 @@ pub(crate) fn verify_bid_consistency<E: EthSpec>(
             builder_index,
             builder_bid: bid.value,
         });
+    }
+
+    Ok(())
+}
+
+fn verify_bid_slot_range<S: SlotClock>(
+    slot_clock: &S,
+    bid_slot: Slot,
+    spec: &ChainSpec,
+) -> Result<(), PayloadBidError> {
+    let current_time = slot_clock
+        .now_duration()
+        .ok_or(PayloadBidError::UnableToReadSlot)?;
+    let disparity = spec.maximum_gossip_clock_disparity();
+    let earliest_permissible_time = slot_clock
+        .start_of(bid_slot.saturating_sub(1u64))
+        .ok_or(PayloadBidError::UnableToReadSlot)?
+        .saturating_sub(disparity);
+    let latest_permissible_time = slot_clock
+        .start_of(bid_slot.saturating_add(1u64))
+        .ok_or(PayloadBidError::UnableToReadSlot)?
+        .saturating_add(disparity);
+
+    if current_time < earliest_permissible_time || current_time > latest_permissible_time {
+        return Err(PayloadBidError::InvalidBidSlot { bid_slot });
     }
 
     Ok(())
@@ -187,6 +207,8 @@ impl<E: EthSpec> GossipVerifiedPayloadBid<E> {
         let bid_parent_block_root = signed_bid.message.parent_block_root;
         let bid_value = signed_bid.message.value;
 
+        verify_bid_slot_range(ctx.slot_clock, bid_slot, ctx.spec)?;
+
         if ctx
             .gossip_verified_payload_bid_cache
             .seen_builder_bid_for_parent(&bid_slot, bid_parent, signed_bid.message.builder_index)
@@ -211,10 +233,6 @@ impl<E: EthSpec> GossipVerifiedPayloadBid<E> {
         }
 
         let cached_head = ctx.canonical_head.cached_head();
-        let current_slot = ctx
-            .slot_clock
-            .now()
-            .ok_or(PayloadBidError::UnableToReadSlot)?;
         let parent_state = &cached_head.snapshot.beacon_state;
 
         // Look up the preferences keyed by the dependent root that is canonical from our head's
@@ -306,7 +324,6 @@ impl<E: EthSpec> GossipVerifiedPayloadBid<E> {
 
         verify_bid_consistency(
             &signed_bid.message,
-            current_slot,
             &proposer_preferences,
             &bid_state,
             ctx.spec,
@@ -476,34 +493,6 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_bid_slot_too_old() {
-        let (state, spec) = state_and_spec();
-        let current_slot = Slot::new(10);
-        let bid = make_bid(Slot::new(5), Address::ZERO, 30_000_000);
-        let prefs = make_preferences(Address::ZERO, 30_000_000);
-
-        let result = verify_bid_consistency::<E>(&bid, current_slot, &prefs, &state, &spec);
-        assert!(matches!(
-            result,
-            Err(PayloadBidError::InvalidBidSlot { .. })
-        ));
-    }
-
-    #[test]
-    fn test_invalid_bid_slot_too_far_ahead() {
-        let (state, spec) = state_and_spec();
-        let current_slot = Slot::new(10);
-        let bid = make_bid(Slot::new(12), Address::ZERO, 30_000_000);
-        let prefs = make_preferences(Address::ZERO, 30_000_000);
-
-        let result = verify_bid_consistency::<E>(&bid, current_slot, &prefs, &state, &spec);
-        assert!(matches!(
-            result,
-            Err(PayloadBidError::InvalidBidSlot { .. })
-        ));
-    }
-
-    #[test]
     fn test_execution_payment_nonzero() {
         let (state, spec) = state_and_spec();
         let current_slot = Slot::new(10);
@@ -511,7 +500,7 @@ mod tests {
         bid.execution_payment = 42;
         let prefs = make_preferences(Address::ZERO, 30_000_000);
 
-        let result = verify_bid_consistency::<E>(&bid, current_slot, &prefs, &state, &spec);
+        let result = verify_bid_consistency::<E>(&bid, &prefs, &state, &spec);
         assert!(matches!(
             result,
             Err(PayloadBidError::ExecutionPaymentNonZero {
@@ -527,7 +516,7 @@ mod tests {
         let bid = make_bid(current_slot, Address::ZERO, 30_000_000);
         let prefs = make_preferences(Address::repeat_byte(0xaa), 30_000_000);
 
-        let result = verify_bid_consistency::<E>(&bid, current_slot, &prefs, &state, &spec);
+        let result = verify_bid_consistency::<E>(&bid, &prefs, &state, &spec);
         assert!(matches!(result, Err(PayloadBidError::InvalidFeeRecipient)));
     }
 
@@ -544,7 +533,7 @@ mod tests {
             .collect();
         bid.blob_kzg_commitments = ProgressiveVariableList::new(commitments);
 
-        let result = verify_bid_consistency::<E>(&bid, current_slot, &prefs, &state, &spec);
+        let result = verify_bid_consistency::<E>(&bid, &prefs, &state, &spec);
         assert!(matches!(
             result,
             Err(PayloadBidError::InvalidBlobKzgCommitments { .. })

--- a/beacon_node/beacon_chain/src/payload_bid_verification/gossip_verified_bid.rs
+++ b/beacon_node/beacon_chain/src/payload_bid_verification/gossip_verified_bid.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    BeaconChain, BeaconChainTypes, BeaconStore, CachedHead, CanonicalHead,
+    BeaconChain, BeaconChainTypes, CachedHead, CanonicalHead,
     canonical_head::ForkChoiceReadGuard,
     payload_bid_verification::{
         PayloadBidError,
@@ -12,8 +12,9 @@ use crate::{
 use educe::Educe;
 use eth2::types::{EventKind, ForkVersionedResponse};
 use slot_clock::SlotClock;
-use state_processing::signature_sets::{
-    execution_payload_bid_signature_set, get_builder_pubkey_from_state,
+use state_processing::{
+    signature_sets::{execution_payload_bid_signature_set, get_builder_pubkey_from_state},
+    state_advance::complete_state_advance,
 };
 use tracing::debug;
 use types::{
@@ -163,7 +164,6 @@ pub struct GossipVerificationContext<'a, T: BeaconChainTypes> {
     pub gossip_verified_proposer_preferences_cache: &'a GossipVerifiedProposerPreferenceCache,
     pub slot_clock: &'a T::SlotClock,
     pub spec: &'a ChainSpec,
-    pub store: &'a BeaconStore<T>,
 }
 
 /// A wrapper around a `SignedExecutionPayloadBid` that indicates it has been approved for re-gossiping on
@@ -215,48 +215,12 @@ impl<E: EthSpec> GossipVerifiedPayloadBid<E> {
             .slot_clock
             .now()
             .ok_or(PayloadBidError::UnableToReadSlot)?;
-        let snapshot_state = &cached_head.snapshot.beacon_state;
-
-        // At the Gloas fork boundary the head snapshot is still a pre-Gloas state, so we must
-        // use the advanced state instead.
-        // TODO(post-gloas) this can be removed after the gloas fork
-        let advanced_state;
-        let head_state = if ctx
-            .spec
-            .fork_name_at_slot::<T::EthSpec>(bid_slot)
-            .gloas_enabled()
-            && !snapshot_state.fork_name_unchecked().gloas_enabled()
-        {
-            let (_, state) = ctx
-                .store
-                .get_advanced_hot_state(
-                    cached_head.head_block_root(),
-                    bid_slot,
-                    cached_head.head_state_root(),
-                )
-                .map_err(|e| {
-                    PayloadBidError::InternalError(format!(
-                        "failed to load advanced head state: {e:?}"
-                    ))
-                })?
-                .ok_or_else(|| {
-                    PayloadBidError::InternalError("advanced head state unavailable".to_string())
-                })?;
-            if !state.fork_name_unchecked().gloas_enabled() {
-                return Err(PayloadBidError::InternalError(
-                    "head state not yet advanced to Gloas".to_string(),
-                ));
-            }
-            advanced_state = state;
-            &advanced_state
-        } else {
-            snapshot_state
-        };
+        let parent_state = &cached_head.snapshot.beacon_state;
 
         // Look up the preferences keyed by the dependent root that is canonical from our head's
         // perspective, so we don't pick up preferences cached for a competing branch's proposer.
         let proposal_epoch = bid_slot.epoch(T::EthSpec::slots_per_epoch());
-        let dependent_root = head_state.proposer_shuffling_decision_root_at_epoch(
+        let dependent_root = parent_state.proposer_shuffling_decision_root_at_epoch(
             proposal_epoch,
             cached_head.head_block_root(),
             ctx.spec,
@@ -289,7 +253,7 @@ impl<E: EthSpec> GossipVerifiedPayloadBid<E> {
         // [REJECT] `bid.prev_randao` is the correct RANDAO mix -- i.e. validate that
         // `bid.prev_randao == get_randao_mix(parent_state, get_current_epoch(parent_state))`
         if signed_bid.message.prev_randao
-            != *head_state.get_randao_mix(current_slot.epoch(E::slots_per_epoch()))?
+            != *parent_state.get_randao_mix(parent_state.current_epoch())?
         {
             return Err(PayloadBidError::InvalidPrevRandao { slot: bid_slot });
         }
@@ -310,7 +274,7 @@ impl<E: EthSpec> GossipVerifiedPayloadBid<E> {
         // this check may be inaccurate. Fixing this requires storing
         // gas_limit in fork choice or looking it up from the store by parent_block_hash. Taking the above
         // TODO into consideration maybe should persist parent block hash and gas limit in fork choice?
-        if let Ok(parent_bid) = head_state.latest_execution_payload_bid()
+        if let Ok(parent_bid) = parent_state.latest_execution_payload_bid()
             && !is_gas_limit_target_compatible(
                 parent_bid.gas_limit,
                 signed_bid.message.gas_limit,
@@ -322,18 +286,36 @@ impl<E: EthSpec> GossipVerifiedPayloadBid<E> {
 
         drop(fork_choice);
 
+        // Builder validity and balance are evaluated at the bid's slot, after applying any skipped
+        // slot and epoch processing to the parent block post-state.
+        let mut bid_state = parent_state.clone();
+        complete_state_advance(
+            &mut bid_state,
+            Some(cached_head.head_state_root()),
+            bid_slot,
+            ctx.spec,
+        )
+        .map_err(|e| {
+            PayloadBidError::InternalError(format!("failed to advance state to bid slot: {e:?}"))
+        })?;
+        if !bid_state.fork_name_unchecked().gloas_enabled() {
+            return Err(PayloadBidError::InternalError(
+                "bid state not yet advanced to Gloas".to_string(),
+            ));
+        }
+
         verify_bid_consistency(
             &signed_bid.message,
             current_slot,
             &proposer_preferences,
-            head_state,
+            &bid_state,
             ctx.spec,
         )?;
 
         // Verify signature
         execution_payload_bid_signature_set(
-            head_state,
-            |i| get_builder_pubkey_from_state(head_state, i),
+            &bid_state,
+            |i| get_builder_pubkey_from_state(&bid_state, i),
             &signed_bid,
             ctx.spec,
         )
@@ -365,7 +347,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .gossip_verified_proposer_preferences_cache,
             slot_clock: &self.slot_clock,
             spec: &self.spec,
-            store: &self.store,
         }
     }
 

--- a/beacon_node/beacon_chain/src/payload_bid_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/payload_bid_verification/tests.rs
@@ -57,7 +57,6 @@ struct TestContext {
     spec: ChainSpec,
     genesis_block_root: Hash256,
     inactive_builder_index: u64,
-    store: crate::BeaconStore<T>,
 }
 
 fn builder_withdrawal_credentials(pubkey: &bls::PublicKey, spec: &ChainSpec) -> Hash256 {
@@ -177,7 +176,6 @@ impl TestContext {
             spec,
             genesis_block_root: block_root,
             inactive_builder_index,
-            store,
         }
     }
 
@@ -205,7 +203,6 @@ impl TestContext {
             gossip_verified_proposer_preferences_cache: &self.preferences_cache,
             slot_clock: &self.slot_clock,
             spec: &self.spec,
-            store: &self.store,
         }
     }
 

--- a/beacon_node/beacon_chain/src/payload_bid_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/payload_bid_verification/tests.rs
@@ -645,6 +645,7 @@ fn parent_block_root_not_canonical() {
     // The non-canonical fork block is at slot 1, so use slot 2 to satisfy the `bid.slot > parent
     // block slot` rule and exercise the  bid descendant from parent check specifically.
     let slot = Slot::new(2);
+    ctx.slot_clock.set_slot(1);
     seed_preferences(&ctx, slot, Address::ZERO, 30_000_000);
 
     let fork_root = ctx.insert_non_canonical_block();

--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/gossip_verified_proposer_preferences.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/gossip_verified_proposer_preferences.rs
@@ -18,6 +18,7 @@ use types::{ChainSpec, EthSpec, Hash256, ProposerPreferences, SignedProposerPref
 pub(crate) fn verify_preferences_consistency<E: EthSpec>(
     preferences: &ProposerPreferences,
     current_slot: Slot,
+    latest_permissible_slot: Slot,
     spec: &ChainSpec,
 ) -> Result<(), ProposerPreferencesError> {
     let proposal_slot = preferences.proposal_slot;
@@ -25,16 +26,12 @@ pub(crate) fn verify_preferences_consistency<E: EthSpec>(
     let proposal_epoch = proposal_slot.epoch(E::slots_per_epoch());
 
     if proposal_epoch < current_epoch
-        || proposal_epoch > current_epoch.saturating_add(spec.min_seed_lookahead)
+        || proposal_epoch
+            > latest_permissible_slot
+                .epoch(E::slots_per_epoch())
+                .saturating_add(spec.min_seed_lookahead)
     {
         return Err(ProposerPreferencesError::InvalidProposalEpoch { proposal_epoch });
-    }
-
-    if proposal_slot <= current_slot {
-        return Err(ProposerPreferencesError::ProposalSlotAlreadyPassed {
-            proposal_slot,
-            current_slot,
-        });
     }
 
     Ok(())
@@ -69,6 +66,18 @@ impl GossipVerifiedProposerPreferences {
             .slot_clock
             .now()
             .ok_or(ProposerPreferencesError::UnableToReadSlot)?;
+        let latest_permissible_slot = ctx
+            .slot_clock
+            .now_with_future_tolerance(ctx.spec.maximum_gossip_clock_disparity())
+            .ok_or(ProposerPreferencesError::UnableToReadSlot)?;
+        let current_time = ctx
+            .slot_clock
+            .now_duration()
+            .ok_or(ProposerPreferencesError::UnableToReadSlot)?;
+        let proposal_slot_start = ctx
+            .slot_clock
+            .start_of(proposal_slot)
+            .ok_or(ProposerPreferencesError::UnableToReadSlot)?;
 
         if ctx
             .gossip_verified_proposer_preferences_cache
@@ -83,8 +92,18 @@ impl GossipVerifiedProposerPreferences {
         verify_preferences_consistency::<T::EthSpec>(
             &signed_preferences.message,
             current_slot,
+            latest_permissible_slot,
             ctx.spec,
         )?;
+
+        if current_time
+            > proposal_slot_start.saturating_add(ctx.spec.maximum_gossip_clock_disparity())
+        {
+            return Err(ProposerPreferencesError::ProposalSlotAlreadyPassed {
+                proposal_slot,
+                current_slot,
+            });
+        }
 
         let proposal_epoch = proposal_slot.epoch(T::EthSpec::slots_per_epoch());
 
@@ -288,7 +307,8 @@ mod tests {
         let current_slot = Slot::new(2 * E::slots_per_epoch());
         let prefs = make_preferences(Slot::new(3), 0);
 
-        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &spec());
+        let result =
+            verify_preferences_consistency::<E>(&prefs, current_slot, current_slot, &spec());
         assert!(matches!(
             result,
             Err(ProposerPreferencesError::InvalidProposalEpoch { .. })
@@ -303,40 +323,11 @@ mod tests {
         let current_slot = Slot::new(E::slots_per_epoch());
         let prefs = make_preferences(Slot::new(3 * E::slots_per_epoch() + 1), 0);
 
-        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &spec());
+        let result =
+            verify_preferences_consistency::<E>(&prefs, current_slot, current_slot, &spec());
         assert!(matches!(
             result,
             Err(ProposerPreferencesError::InvalidProposalEpoch { .. })
-        ));
-    }
-
-    #[test]
-    fn test_proposal_slot_already_passed() {
-        if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
-            return;
-        }
-        let current_slot = Slot::new(10);
-        let prefs = make_preferences(Slot::new(9), 0);
-
-        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &spec());
-        assert!(matches!(
-            result,
-            Err(ProposerPreferencesError::ProposalSlotAlreadyPassed { .. })
-        ));
-    }
-
-    #[test]
-    fn test_proposal_slot_equal_to_current() {
-        if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
-            return;
-        }
-        let current_slot = Slot::new(10);
-        let prefs = make_preferences(Slot::new(10), 0);
-
-        let result = verify_preferences_consistency::<E>(&prefs, current_slot, &spec());
-        assert!(matches!(
-            result,
-            Err(ProposerPreferencesError::ProposalSlotAlreadyPassed { .. })
         ));
     }
 }

--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/gossip_verified_proposer_preferences.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/gossip_verified_proposer_preferences.rs
@@ -37,6 +37,32 @@ pub(crate) fn verify_preferences_consistency<E: EthSpec>(
     Ok(())
 }
 
+/// Verify that the proposal slot has not passed, accounting for
+/// `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
+fn verify_proposal_slot_range<S: SlotClock>(
+    slot_clock: &S,
+    proposal_slot: Slot,
+    current_slot: Slot,
+    spec: &ChainSpec,
+) -> Result<(), ProposerPreferencesError> {
+    let current_time = slot_clock
+        .now_duration()
+        .ok_or(ProposerPreferencesError::UnableToReadSlot)?;
+    let latest_permissible_time = slot_clock
+        .start_of(proposal_slot)
+        .ok_or(ProposerPreferencesError::UnableToReadSlot)?
+        .saturating_add(spec.maximum_gossip_clock_disparity());
+
+    if current_time > latest_permissible_time {
+        return Err(ProposerPreferencesError::ProposalSlotAlreadyPassed {
+            proposal_slot,
+            current_slot,
+        });
+    }
+
+    Ok(())
+}
+
 pub struct GossipVerificationContext<'a, T: BeaconChainTypes> {
     pub canonical_head: &'a CanonicalHead<T>,
     pub gossip_verified_proposer_preferences_cache: &'a GossipVerifiedProposerPreferenceCache,
@@ -70,14 +96,6 @@ impl GossipVerifiedProposerPreferences {
             .slot_clock
             .now_with_future_tolerance(ctx.spec.maximum_gossip_clock_disparity())
             .ok_or(ProposerPreferencesError::UnableToReadSlot)?;
-        let current_time = ctx
-            .slot_clock
-            .now_duration()
-            .ok_or(ProposerPreferencesError::UnableToReadSlot)?;
-        let proposal_slot_start = ctx
-            .slot_clock
-            .start_of(proposal_slot)
-            .ok_or(ProposerPreferencesError::UnableToReadSlot)?;
 
         if ctx
             .gossip_verified_proposer_preferences_cache
@@ -96,14 +114,7 @@ impl GossipVerifiedProposerPreferences {
             ctx.spec,
         )?;
 
-        if current_time
-            > proposal_slot_start.saturating_add(ctx.spec.maximum_gossip_clock_disparity())
-        {
-            return Err(ProposerPreferencesError::ProposalSlotAlreadyPassed {
-                proposal_slot,
-                current_slot,
-            });
-        }
+        verify_proposal_slot_range(ctx.slot_clock, proposal_slot, current_slot, ctx.spec)?;
 
         let proposal_epoch = proposal_slot.epoch(T::EthSpec::slots_per_epoch());
 

--- a/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
+++ b/beacon_node/beacon_chain/src/proposer_preferences_verification/tests.rs
@@ -244,6 +244,8 @@ fn proposal_slot_already_passed() {
         return;
     }
     let ctx = TestContext::new();
+    // Move beyond slot 0's gossip disparity window so the proposal slot has actually passed.
+    ctx.slot_clock.set_slot(1);
     let gossip = ctx.gossip_ctx();
 
     let prefs = make_signed_preferences(Slot::new(0), 0, Hash256::ZERO);

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1763,7 +1763,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             | Err(e @ BlockError::KnownInvalidExecutionPayload(_))
             | Err(e @ BlockError::GenesisBlock)
             | Err(e @ BlockError::InvalidBlobCount { .. })
-            | Err(e @ BlockError::BidParentRootMismatch { .. }) => {
+            | Err(e @ BlockError::BidParentRootMismatch { .. })
+            | Err(e @ BlockError::BidParentBlockHashMismatch { .. }) => {
                 warn!(error = %e, "Could not verify block for gossip. Rejecting the block");
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Reject);
                 self.gossip_penalize_peer(

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -1058,7 +1058,8 @@ impl From<Result<AvailabilityProcessingStatus, BlockError>> for BlockProcessingR
                     | BlockError::KnownInvalidExecutionPayload(_)
                     | BlockError::Slashable
                     | BlockError::InvalidBlobCount { .. }
-                    | BlockError::BidParentRootMismatch { .. } => block_peer_penalty(&e),
+                    | BlockError::BidParentRootMismatch { .. }
+                    | BlockError::BidParentBlockHashMismatch { .. } => block_peer_penalty(&e),
                 };
                 Self::Error {
                     penalty,

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -74,13 +74,13 @@ excluded_paths = [
     "tests/.*/.*/networking/gossip_beacon_block/.*/gossip_beacon_block__ignore_parent_consensus_failed_execution_known/.*",
     "tests/.*/.*/networking/gossip_beacon_block/.*/gossip_beacon_block__reject_parent_consensus_failed_execution_not_verified/.*",
     "tests/.*/.*/networking/gossip_beacon_block/.*/gossip_beacon_block__reject_parent_failed_validation/.*",
-    # Gossip validation tests target the latest stable fork.
+    # Gossip validation tests target the latest stable fork and Gloas.
     "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra)/networking/gossip_beacon_attestation/.*",
     "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra)/networking/gossip_beacon_aggregate_and_proof/.*",
-    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra|gloas)/networking/gossip_voluntary_exit/.*",
-    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra|gloas)/networking/gossip_bls_to_execution_change/.*",
-    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra|gloas)/networking/gossip_sync_committee_message/.*",
-    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra|gloas)/networking/gossip_sync_committee_contribution_and_proof/.*",
+    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra)/networking/gossip_voluntary_exit/.*",
+    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra)/networking/gossip_bls_to_execution_change/.*",
+    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra)/networking/gossip_sync_committee_message/.*",
+    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra)/networking/gossip_sync_committee_contribution_and_proof/.*",
     # The production-backed harness cannot construct these synthetic fixture histories.
     # Keep these patterns synchronized with GossipValidation::has_known_harness_limitation.
     "tests/.*/fulu/networking/gossip_(beacon_attestation|beacon_aggregate_and_proof)/.*/gossip_.*__accepts_.*/.*",

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -47,8 +47,6 @@ excluded_paths = [
     "bls12-381-tests/hash_to_G2",
     "tests/.*/eip7732",
     "tests/.*/eip7805",
-    # TODO(gloas): Add production-backed handlers for the new Gloas gossip test suites.
-    "tests/.*/gloas/networking/gossip_.*",
     # Heze fork is not implemented
     "tests/.*/heze/.*",
     # Ignore MatrixEntry SSZ tests for now.

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -75,8 +75,8 @@ excluded_paths = [
     "tests/.*/.*/networking/gossip_beacon_block/.*/gossip_beacon_block__reject_parent_consensus_failed_execution_not_verified/.*",
     "tests/.*/.*/networking/gossip_beacon_block/.*/gossip_beacon_block__reject_parent_failed_validation/.*",
     # Gossip validation tests target the latest stable fork.
-    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra|gloas)/networking/gossip_beacon_attestation/.*",
-    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra|gloas)/networking/gossip_beacon_aggregate_and_proof/.*",
+    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra)/networking/gossip_beacon_attestation/.*",
+    "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra)/networking/gossip_beacon_aggregate_and_proof/.*",
     "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra|gloas)/networking/gossip_voluntary_exit/.*",
     "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra|gloas)/networking/gossip_bls_to_execution_change/.*",
     "tests/.*/(phase0|altair|bellatrix|capella|deneb|electra|gloas)/networking/gossip_sync_committee_message/.*",
@@ -86,6 +86,19 @@ excluded_paths = [
     "tests/.*/fulu/networking/gossip_(beacon_attestation|beacon_aggregate_and_proof)/.*/gossip_.*__accepts_.*/.*",
     "tests/.*/fulu/networking/gossip_(beacon_attestation|beacon_aggregate_and_proof)/.*/gossip_.*__reject_block_failed_validation/.*",
     "tests/.*/fulu/networking/gossip_(beacon_attestation|beacon_aggregate_and_proof)/.*/gossip_.*__ignore_finalized_not_ancestor/.*",
+    # Lighthouse does not support optimistic Gloas payload imports. Keep these synchronized with
+    # IGNORED_GLOAS_PAYLOAD_STATUS_CASES in gossip_validation.rs.
+    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_beacon_attestation__ignore_payload_pending_el_validation/.*",
+    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_beacon_attestation__reject_payload_failed_el_validation/.*",
+    "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_beacon_aggregate_and_proof__ignore_payload_pending_el_validation/.*",
+    "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_beacon_aggregate_and_proof__reject_payload_failed_el_validation/.*",
+    # Gloas attestation cases with production-harness limitations.
+    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_.*__accepts_.*/.*",
+    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_.*__reject_block_failed_validation/.*",
+    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_.*__ignore_finalized_not_ancestor/.*",
+    "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_.*__accepts_.*/.*",
+    "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_.*__reject_block_failed_validation/.*",
+    "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_.*__ignore_finalized_not_ancestor/.*",
     "tests/.*/.*/networking/gossip_blob_sidecar/.*",
     "tests/.*/.*/networking/gossip_data_column_sidecar/.*",
     "tests/.*/.*/networking/gossip_partial_data_column_sidecar/.*",

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -99,6 +99,11 @@ excluded_paths = [
     "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_.*__accepts_.*/.*",
     "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_.*__reject_block_failed_validation/.*",
     "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_.*__ignore_finalized_not_ancestor/.*",
+    # Gloas execution payload envelope cases with production-harness limitations.
+    # Keep these synchronized with IGNORED_EXECUTION_PAYLOAD_ENVELOPE_CASES.
+    "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__reject_block_failed_validation/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__ignore_duplicate/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__ignore_pre_finalized/.*",
     "tests/.*/.*/networking/gossip_blob_sidecar/.*",
     "tests/.*/.*/networking/gossip_data_column_sidecar/.*",
     "tests/.*/.*/networking/gossip_partial_data_column_sidecar/.*",

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -104,6 +104,10 @@ excluded_paths = [
     "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__reject_block_failed_validation/.*",
     "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__ignore_duplicate/.*",
     "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__ignore_pre_finalized/.*",
+    # Lighthouse cannot distinguish a consensus-invalid block from an unseen block when
+    # validating payload attestations. Keep this synchronized with
+    # IGNORED_PAYLOAD_ATTESTATION_CASES.
+    "tests/.*/gloas/networking/gossip_payload_attestation_message/.*/gossip_payload_attestation_message__reject_block_failed_validation/.*",
     # Bid gas-limit validation currently uses the committed bid rather than the parent payload.
     # Keep these synchronized with IGNORED_EXECUTION_PAYLOAD_BID_GAS_LIMIT_CASES.
     "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_decrease_exceeding_limit/.*",

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -86,36 +86,38 @@ excluded_paths = [
     "tests/.*/fulu/networking/gossip_(beacon_attestation|beacon_aggregate_and_proof)/.*/gossip_.*__accepts_.*/.*",
     "tests/.*/fulu/networking/gossip_(beacon_attestation|beacon_aggregate_and_proof)/.*/gossip_.*__reject_block_failed_validation/.*",
     "tests/.*/fulu/networking/gossip_(beacon_attestation|beacon_aggregate_and_proof)/.*/gossip_.*__ignore_finalized_not_ancestor/.*",
-    # Lighthouse does not support optimistic Gloas payload imports. Keep these synchronized with
-    # IGNORED_GLOAS_PAYLOAD_STATUS_CASES in gossip_validation.rs.
-    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_beacon_attestation__ignore_payload_pending_el_validation/.*",
-    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_beacon_attestation__reject_payload_failed_el_validation/.*",
-    "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_beacon_aggregate_and_proof__ignore_payload_pending_el_validation/.*",
-    "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_beacon_aggregate_and_proof__reject_payload_failed_el_validation/.*",
-    # Gloas attestation cases with production-harness limitations.
-    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_.*__accepts_.*/.*",
-    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_.*__reject_block_failed_validation/.*",
-    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_.*__ignore_finalized_not_ancestor/.*",
+    # Gloas aggregate cases with production-harness limitations. Lighthouse also does not support
+    # optimistic Gloas payload imports. Keep these synchronized with
+    # GossipValidation::has_known_harness_limitation.
     "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_.*__accepts_.*/.*",
-    "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_.*__reject_block_failed_validation/.*",
     "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_.*__ignore_finalized_not_ancestor/.*",
-    # Gloas execution payload envelope cases with production-harness limitations.
-    # Keep these synchronized with IGNORED_EXECUTION_PAYLOAD_ENVELOPE_CASES.
-    "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__reject_block_failed_validation/.*",
+    "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_beacon_aggregate_and_proof__ignore_payload_pending_el_validation/.*",
+    "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_.*__reject_block_failed_validation/.*",
+    "tests/.*/gloas/networking/gossip_beacon_aggregate_and_proof/.*/gossip_beacon_aggregate_and_proof__reject_payload_failed_el_validation/.*",
+    # Gloas attestation cases with the same production-harness limitations.
+    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_.*__accepts_.*/.*",
+    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_.*__ignore_finalized_not_ancestor/.*",
+    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_beacon_attestation__ignore_payload_pending_el_validation/.*",
+    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_.*__reject_block_failed_validation/.*",
+    "tests/.*/gloas/networking/gossip_beacon_attestation/.*/gossip_beacon_attestation__reject_payload_failed_el_validation/.*",
+    # Gloas bid gas-limit validation currently uses the committed bid rather than the parent
+    # payload. Keep these synchronized with IGNORED_EXECUTION_PAYLOAD_BID_GAS_LIMIT_CASES.
+    # TODO(gloas): should be enabled after https://github.com/sigp/lighthouse/pull/9905
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_decrease_exceeding_limit/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_decrease_within_limit/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_increase_exceeding_limit/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_increase_within_limit/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_parent_under_step/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_target_equals_parent/.*",
+    # Gloas execution payload envelope cases with production-harness limitations. Keep these
+    # synchronized with IGNORED_EXECUTION_PAYLOAD_ENVELOPE_CASES.
     "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__ignore_duplicate/.*",
     "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__ignore_pre_finalized/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__reject_block_failed_validation/.*",
     # Lighthouse cannot distinguish a consensus-invalid block from an unseen block when
     # validating payload attestations. Keep this synchronized with
     # IGNORED_PAYLOAD_ATTESTATION_CASES.
     "tests/.*/gloas/networking/gossip_payload_attestation_message/.*/gossip_payload_attestation_message__reject_block_failed_validation/.*",
-    # Bid gas-limit validation currently uses the committed bid rather than the parent payload.
-    # Keep these synchronized with IGNORED_EXECUTION_PAYLOAD_BID_GAS_LIMIT_CASES.
-    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_decrease_exceeding_limit/.*",
-    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_parent_under_step/.*",
-    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_target_equals_parent/.*",
-    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_increase_within_limit/.*",
-    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_decrease_within_limit/.*",
-    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_increase_exceeding_limit/.*",
     "tests/.*/.*/networking/gossip_blob_sidecar/.*",
     "tests/.*/.*/networking/gossip_data_column_sidecar/.*",
     "tests/.*/.*/networking/gossip_partial_data_column_sidecar/.*",

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -104,6 +104,14 @@ excluded_paths = [
     "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__reject_block_failed_validation/.*",
     "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__ignore_duplicate/.*",
     "tests/.*/gloas/networking/gossip_execution_payload_envelope/.*/gossip_execution_payload_envelope__ignore_pre_finalized/.*",
+    # Bid gas-limit validation currently uses the committed bid rather than the parent payload.
+    # Keep these synchronized with IGNORED_EXECUTION_PAYLOAD_BID_GAS_LIMIT_CASES.
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_decrease_exceeding_limit/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_parent_under_step/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_target_equals_parent/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_increase_within_limit/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_decrease_within_limit/.*",
+    "tests/.*/gloas/networking/gossip_execution_payload_bid/.*/gossip_execution_payload_bid__valid_gas_limit_increase_exceeding_limit/.*",
     "tests/.*/.*/networking/gossip_blob_sidecar/.*",
     "tests/.*/.*/networking/gossip_data_column_sidecar/.*",
     "tests/.*/.*/networking/gossip_partial_data_column_sidecar/.*",

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -409,13 +409,18 @@ impl<E: EthSpec> GossipTester<E> {
                 )?,
             Topic::DataColumnSidecar
             | Topic::ExecutionPayloadBid
-            | Topic::ExecutionPayload
             | Topic::PartialDataColumnSidecar
             | Topic::PayloadAttestationMessage => {
                 return Err(Error::InternalError(format!(
                     "Gloas gossip topic {topic:?} is enabled but not implemented by the EF harness"
                 )));
             }
+            Topic::ExecutionPayload => self.process_execution_payload_envelope(
+                path,
+                message_meta,
+                message_id.clone(),
+                peer_id,
+            )?,
             Topic::ProposerPreferences => {
                 self.process_proposer_preferences(path, message_meta, message_id.clone(), peer_id)?
             }
@@ -483,6 +488,30 @@ impl<E: EthSpec> GossipTester<E> {
         ));
 
         self.block_on_dangerous(process_fn)?;
+        Ok(())
+    }
+
+    fn process_execution_payload_envelope(
+        &self,
+        path: &Path,
+        message_meta: &MessageMeta,
+        message_id: MessageId,
+        peer_id: PeerId,
+    ) -> Result<(), Error> {
+        let envelope: SignedExecutionPayloadEnvelope<E> =
+            ssz_decode_file(&path.join(format!("{}.ssz_snappy", message_meta.message)))?;
+        let seen_duration = self.set_message_time(message_meta)?;
+
+        self.block_on_dangerous(
+            self.network_beacon_processor
+                .clone()
+                .process_gossip_execution_payload_envelope(
+                    message_id,
+                    peer_id,
+                    Arc::new(envelope),
+                    seen_duration,
+                ),
+        )?;
         Ok(())
     }
 
@@ -916,6 +945,17 @@ impl<E: EthSpec> GossipValidation<E> {
             "gossip_beacon_attestation__reject_payload_failed_el_validation",
             "gossip_beacon_aggregate_and_proof__reject_payload_failed_el_validation",
         ];
+        const IGNORED_EXECUTION_PAYLOAD_ENVELOPE_CASES: &[&str] = &[
+            // Lighthouse does not retain consensus-invalid blocks, so the harness cannot construct
+            // the known-invalid block status required by this vector.
+            "gossip_execution_payload_envelope__reject_block_failed_validation",
+            // Lighthouse does not yet track gossip-valid envelopes independently of payload
+            // execution and availability.
+            "gossip_execution_payload_envelope__ignore_duplicate",
+            // The fixture overrides fork choice finalization, while production envelope validation
+            // reads the finalized checkpoint from the canonical head.
+            "gossip_execution_payload_envelope__ignore_pre_finalized",
+        ];
         let Some(case_name) = self.path.file_name().and_then(|name| name.to_str()) else {
             return false;
         };
@@ -935,6 +975,9 @@ impl<E: EthSpec> GossipValidation<E> {
                     || UNSUPPORTED_TIMING_BOUNDARY_CASES
                         .iter()
                         .any(|suffix| case_name.ends_with(suffix))
+            }
+            Topic::ExecutionPayload => {
+                IGNORED_EXECUTION_PAYLOAD_ENVELOPE_CASES.contains(&case_name)
             }
             _ => false,
         }

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -322,14 +322,14 @@ impl<E: EthSpec> GossipTester<E> {
             if setup_block.failed {
                 continue;
             }
+            let block = blocks.get(&setup_block.block).ok_or_else(|| {
+                Error::FailedToParseTest(format!("unknown block file {}", setup_block.block))
+            })?;
             if initial_block_index != Some(index) {
-                let block = blocks.get(&setup_block.block).ok_or_else(|| {
-                    Error::FailedToParseTest(format!("unknown block file {}", setup_block.block))
-                })?;
                 self.import_setup_block(block.clone(), setup_block.payload_status)?;
             }
             if let Some(payload) = setup_block.payload.as_deref() {
-                self.import_setup_payload(&case.path, payload)?;
+                self.import_setup_payload(&case.path, block, payload)?;
             }
         }
 
@@ -691,10 +691,36 @@ impl<E: EthSpec> GossipTester<E> {
         }
     }
 
-    fn import_setup_payload(&self, path: &Path, payload: &str) -> Result<(), Error> {
+    fn import_setup_payload(
+        &self,
+        path: &Path,
+        block: &SignedBeaconBlock<E>,
+        payload: &str,
+    ) -> Result<(), Error> {
         let envelope: SignedExecutionPayloadEnvelope<E> =
             ssz_decode_file(&path.join(format!("{payload}.ssz_snappy")))?;
         let block_root = envelope.beacon_block_root();
+        if block.canonical_root() != block_root {
+            return Err(Error::FailedToParseTest(format!(
+                "setup payload references block {block_root:?}, expected {:?}",
+                block.canonical_root()
+            )));
+        }
+
+        let bid = block
+            .message()
+            .body()
+            .signed_execution_payload_bid()
+            .map_err(|e| {
+                Error::InternalError(format!(
+                    "setup payload block {block_root:?} is missing its bid: {e:?}"
+                ))
+            })?;
+        self.harness
+            .chain
+            .pending_payload_cache
+            .insert_bid(block_root, Arc::new(bid.clone()));
+
         let verified_envelope = self
             .block_on_dangerous(
                 self.harness

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -70,6 +70,10 @@ struct CaseConfig {
 #[serde(deny_unknown_fields)]
 struct SetupBlock {
     block: String,
+    #[serde(default, rename = "payload")]
+    _payload: Option<String>,
+    #[serde(default, rename = "pending")]
+    _pending: bool,
     #[serde(default)]
     failed: bool,
     #[serde(default)]
@@ -104,6 +108,10 @@ struct MessageMeta {
     offset_ms: Option<u64>,
     #[serde(default)]
     current_time_ms: Option<u64>,
+    #[serde(default, rename = "group_id")]
+    _group_id: Option<String>,
+    #[serde(default, rename = "column_index")]
+    _column_index: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -118,6 +126,12 @@ enum Topic {
     BlsToExecutionChange,
     SyncCommittee,
     SyncCommitteeContributionAndProof,
+    DataColumnSidecar,
+    ExecutionPayloadBid,
+    ExecutionPayload,
+    PartialDataColumnSidecar,
+    PayloadAttestationMessage,
+    ProposerPreferences,
 }
 
 #[derive(Debug)]
@@ -383,6 +397,16 @@ impl<E: EthSpec> GossipTester<E> {
                     message_id.clone(),
                     peer_id,
                 )?,
+            Topic::DataColumnSidecar
+            | Topic::ExecutionPayloadBid
+            | Topic::ExecutionPayload
+            | Topic::PartialDataColumnSidecar
+            | Topic::PayloadAttestationMessage
+            | Topic::ProposerPreferences => {
+                return Err(Error::InternalError(format!(
+                    "Gloas gossip topic {topic:?} is enabled but not implemented by the EF harness"
+                )));
+            }
         }
 
         self.validation_result(&message_id, &peer_id)

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -20,12 +20,12 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use types::{
     AttesterSlashing, BeaconBlock, BeaconState, BlobSchedule, BlockImportSource, ChainSpec,
-    Checkpoint, EthSpec, ExecPayload, ForkName, Hash256, PayloadAttestationMessage,
-    ProposerSlashing, SignedAggregateAndProof, SignedAggregateAndProofElectra,
-    SignedAggregateAndProofGloas, SignedBeaconBlock, SignedBlsToExecutionChange,
-    SignedContributionAndProof, SignedExecutionPayloadBid, SignedExecutionPayloadEnvelope,
-    SignedProposerPreferences, SignedVoluntaryExit, SingleAttestation, Slot, SubnetId,
-    SyncCommitteeMessage, SyncSubnetId,
+    Checkpoint, DataColumnSidecar, DataColumnSubnetId, EthSpec, ExecPayload, ForkName, Hash256,
+    PayloadAttestationMessage, ProposerSlashing, SignedAggregateAndProof,
+    SignedAggregateAndProofElectra, SignedAggregateAndProofGloas, SignedBeaconBlock,
+    SignedBlsToExecutionChange, SignedContributionAndProof, SignedExecutionPayloadBid,
+    SignedExecutionPayloadEnvelope, SignedProposerPreferences, SignedVoluntaryExit,
+    SingleAttestation, Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -427,7 +427,14 @@ impl<E: EthSpec> GossipTester<E> {
                     message_id.clone(),
                     peer_id,
                 )?,
-            Topic::DataColumnSidecar | Topic::PartialDataColumnSidecar => {
+            Topic::DataColumnSidecar => self.process_data_column_sidecar(
+                path,
+                message_meta,
+                fork_name,
+                message_id.clone(),
+                peer_id,
+            )?,
+            Topic::PartialDataColumnSidecar => {
                 return Err(Error::InternalError(format!(
                     "Gloas gossip topic {topic:?} is enabled but not implemented by the EF harness"
                 )));
@@ -543,6 +550,38 @@ impl<E: EthSpec> GossipTester<E> {
                     peer_id,
                     Arc::new(envelope),
                     seen_duration,
+                ),
+        )?;
+        Ok(())
+    }
+
+    fn process_data_column_sidecar(
+        &self,
+        path: &Path,
+        message_meta: &MessageMeta,
+        fork_name: ForkName,
+        message_id: MessageId,
+        peer_id: PeerId,
+    ) -> Result<(), Error> {
+        let column_sidecar = ssz_decode_file_with(
+            &path.join(format!("{}.ssz_snappy", message_meta.message)),
+            |bytes| DataColumnSidecar::<E>::from_ssz_bytes_for_fork(bytes, fork_name),
+        )?;
+        let subnet_id = DataColumnSubnetId::new(message_meta.subnet_id.ok_or_else(|| {
+            Error::FailedToParseTest("missing data_column_sidecar subnet_id".into())
+        })?);
+        let seen_duration = self.set_message_time(message_meta)?;
+
+        self.block_on_dangerous(
+            self.network_beacon_processor
+                .clone()
+                .process_gossip_data_column_sidecar(
+                    message_id,
+                    peer_id,
+                    subnet_id,
+                    Arc::new(column_sidecar),
+                    seen_duration,
+                    false,
                 ),
         )?;
         Ok(())
@@ -1112,6 +1151,11 @@ impl<E: EthSpec> GossipValidation<E> {
             // from an unseen block, so both cases are ignored as an unknown head block.
             "gossip_payload_attestation_message__reject_block_failed_validation",
         ];
+        const IGNORED_DATA_COLUMN_CASES: &[&str] = &[
+            // Lighthouse does not retain a status that distinguishes a consensus-invalid block
+            // from an unseen block, so both cases are ignored as an unknown block root.
+            "gossip_data_column_sidecar__reject_block_failed_validation",
+        ];
         let Some(case_name) = self.path.file_name().and_then(|name| name.to_str()) else {
             return false;
         };
@@ -1141,6 +1185,7 @@ impl<E: EthSpec> GossipValidation<E> {
             Topic::PayloadAttestationMessage => {
                 IGNORED_PAYLOAD_ATTESTATION_CASES.contains(&case_name)
             }
+            Topic::DataColumnSidecar => IGNORED_DATA_COLUMN_CASES.contains(&case_name),
             _ => false,
         }
     }

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -4,6 +4,7 @@ use crate::decode::{ssz_decode_file, ssz_decode_file_with, ssz_decode_state, yam
 use crate::type_name::TypeName;
 use ::fork_choice::InvalidationOperation;
 use beacon_chain::block_verification_types::LookupBlock;
+use beacon_chain::proposer_preferences_verification::gossip_verified_proposer_preferences::GossipVerifiedProposerPreferences;
 use beacon_chain::slot_clock::{SlotClock, TestingSlotClock};
 use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType};
 use beacon_chain::{BlockError, NotifyExecutionLayer};
@@ -21,9 +22,9 @@ use types::{
     AttesterSlashing, BeaconBlock, BeaconState, BlobSchedule, BlockImportSource, ChainSpec,
     Checkpoint, EthSpec, ExecPayload, ForkName, Hash256, ProposerSlashing, SignedAggregateAndProof,
     SignedAggregateAndProofElectra, SignedAggregateAndProofGloas, SignedBeaconBlock,
-    SignedBlsToExecutionChange, SignedContributionAndProof, SignedExecutionPayloadEnvelope,
-    SignedProposerPreferences, SignedVoluntaryExit, SingleAttestation, Slot, SubnetId,
-    SyncCommitteeMessage, SyncSubnetId,
+    SignedBlsToExecutionChange, SignedContributionAndProof, SignedExecutionPayloadBid,
+    SignedExecutionPayloadEnvelope, SignedProposerPreferences, SignedVoluntaryExit,
+    SingleAttestation, Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -233,6 +234,9 @@ impl<E: EthSpec> GossipTester<E> {
         tester.set_time_ms(current_time_ms)?;
         tester.import_setup_blocks(case, &blocks, initial_block_index)?;
         tester.set_finalized_checkpoint(case.finalized_checkpoint(&blocks)?);
+        if case.meta.topic == Topic::ExecutionPayloadBid {
+            tester.block_on_dangerous(tester.harness.chain.recompute_head_at_current_slot())?;
+        }
 
         Ok(tester)
     }
@@ -334,7 +338,14 @@ impl<E: EthSpec> GossipTester<E> {
                 self.import_setup_block(block.clone(), setup_block.payload_status)?;
             }
             if let Some(payload) = setup_block.payload.as_deref() {
-                self.import_setup_payload(&case.path, block, payload)?;
+                let payload_path = case.path.join(format!("{payload}.ssz_snappy"));
+                if payload_path.exists() {
+                    if case.meta.topic == Topic::ExecutionPayloadBid {
+                        self.import_setup_payload_for_bid(&case.path, block, payload)?;
+                    } else {
+                        self.import_setup_payload(&case.path, block, payload)?;
+                    }
+                }
             }
         }
 
@@ -408,7 +419,6 @@ impl<E: EthSpec> GossipTester<E> {
                     peer_id,
                 )?,
             Topic::DataColumnSidecar
-            | Topic::ExecutionPayloadBid
             | Topic::PartialDataColumnSidecar
             | Topic::PayloadAttestationMessage => {
                 return Err(Error::InternalError(format!(
@@ -421,6 +431,16 @@ impl<E: EthSpec> GossipTester<E> {
                 message_id.clone(),
                 peer_id,
             )?,
+            Topic::ExecutionPayloadBid => {
+                if let Some(acceptance) = self.process_execution_payload_bid_message(
+                    path,
+                    message_meta,
+                    message_id.clone(),
+                    peer_id,
+                )? {
+                    return Ok(acceptance);
+                }
+            }
             Topic::ProposerPreferences => {
                 self.process_proposer_preferences(path, message_meta, message_id.clone(), peer_id)?
             }
@@ -513,6 +533,54 @@ impl<E: EthSpec> GossipTester<E> {
                 ),
         )?;
         Ok(())
+    }
+
+    fn process_execution_payload_bid_message(
+        &self,
+        path: &Path,
+        message_meta: &MessageMeta,
+        message_id: MessageId,
+        peer_id: PeerId,
+    ) -> Result<Option<MessageAcceptance>, Error> {
+        if message_meta.message.starts_with("proposer_preferences_") {
+            let preferences: SignedProposerPreferences =
+                ssz_decode_file(&path.join(format!("{}.ssz_snappy", message_meta.message)))?;
+            self.set_message_time(message_meta)?;
+            let verified_preferences = GossipVerifiedProposerPreferences {
+                signed_preferences: Arc::new(preferences),
+            };
+            self.harness
+                .chain
+                .gossip_verified_proposer_preferences_cache
+                .insert_seen_validator(&verified_preferences);
+            self.harness
+                .chain
+                .gossip_verified_proposer_preferences_cache
+                .insert_preferences(verified_preferences);
+            return Ok(Some(MessageAcceptance::Accept));
+        }
+        if message_meta
+            .message
+            .starts_with("execution_payload_envelope_")
+        {
+            let _: SignedExecutionPayloadEnvelope<E> =
+                ssz_decode_file(&path.join(format!("{}.ssz_snappy", message_meta.message)))?;
+            self.set_message_time(message_meta)?;
+            return Ok(Some(MessageAcceptance::Accept));
+        }
+        if !message_meta.message.starts_with("execution_payload_bid_") {
+            return Err(Error::FailedToParseTest(format!(
+                "unsupported execution payload bid fixture message {}",
+                message_meta.message
+            )));
+        }
+
+        let bid: SignedExecutionPayloadBid<E> =
+            ssz_decode_file(&path.join(format!("{}.ssz_snappy", message_meta.message)))?;
+        self.set_message_time(message_meta)?;
+        self.network_beacon_processor
+            .process_gossip_execution_payload_bid(message_id, peer_id, Arc::new(bid));
+        Ok(None)
     }
 
     fn process_voluntary_exit(
@@ -756,6 +824,44 @@ impl<E: EthSpec> GossipTester<E> {
         }
     }
 
+    fn import_setup_payload_for_bid(
+        &self,
+        path: &Path,
+        block: &SignedBeaconBlock<E>,
+        payload: &str,
+    ) -> Result<(), Error> {
+        let envelope: SignedExecutionPayloadEnvelope<E> =
+            ssz_decode_file(&path.join(format!("{payload}.ssz_snappy")))?;
+        let block_root = envelope.beacon_block_root();
+        if block.canonical_root() != block_root {
+            return Err(Error::FailedToParseTest(format!(
+                "setup payload references block {block_root:?}, expected {:?}",
+                block.canonical_root()
+            )));
+        }
+
+        self.harness
+            .chain
+            .store
+            .put_payload_envelope(&block_root, &envelope)
+            .map_err(|e| {
+                Error::InternalError(format!(
+                    "failed to store setup payload for block {block_root:?}: {e:?}"
+                ))
+            })?;
+        self.harness
+            .chain
+            .canonical_head
+            .fork_choice_write_lock()
+            .on_valid_payload_envelope_received(block_root)
+            .map_err(|e| {
+                Error::InternalError(format!(
+                    "failed to mark setup payload for block {block_root:?} as received: {e:?}"
+                ))
+            })?;
+        Ok(())
+    }
+
     fn import_setup_payload(
         &self,
         path: &Path,
@@ -956,6 +1062,16 @@ impl<E: EthSpec> GossipValidation<E> {
             // reads the finalized checkpoint from the canonical head.
             "gossip_execution_payload_envelope__ignore_pre_finalized",
         ];
+        const IGNORED_EXECUTION_PAYLOAD_BID_GAS_LIMIT_CASES: &[&str] = &[
+            // Known limitation: bid gossip validation uses the head state's committed bid gas
+            // limit instead of the parent executed payload's gas limit.
+            "gossip_execution_payload_bid__valid_gas_limit_decrease_exceeding_limit",
+            "gossip_execution_payload_bid__valid_gas_limit_parent_under_step",
+            "gossip_execution_payload_bid__valid_gas_limit_target_equals_parent",
+            "gossip_execution_payload_bid__valid_gas_limit_increase_within_limit",
+            "gossip_execution_payload_bid__valid_gas_limit_decrease_within_limit",
+            "gossip_execution_payload_bid__valid_gas_limit_increase_exceeding_limit",
+        ];
         let Some(case_name) = self.path.file_name().and_then(|name| name.to_str()) else {
             return false;
         };
@@ -978,6 +1094,9 @@ impl<E: EthSpec> GossipValidation<E> {
             }
             Topic::ExecutionPayload => {
                 IGNORED_EXECUTION_PAYLOAD_ENVELOPE_CASES.contains(&case_name)
+            }
+            Topic::ExecutionPayloadBid => {
+                IGNORED_EXECUTION_PAYLOAD_BID_GAS_LIMIT_CASES.contains(&case_name)
             }
             _ => false,
         }

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -4,6 +4,7 @@ use crate::decode::{ssz_decode_file, ssz_decode_file_with, ssz_decode_state, yam
 use crate::type_name::TypeName;
 use ::fork_choice::InvalidationOperation;
 use beacon_chain::block_verification_types::LookupBlock;
+use beacon_chain::payload_envelope_verification::EnvelopeSource;
 use beacon_chain::proposer_preferences_verification::gossip_verified_proposer_preferences::GossipVerifiedProposerPreferences;
 use beacon_chain::slot_clock::{SlotClock, TestingSlotClock};
 use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType};
@@ -984,7 +985,7 @@ impl<E: EthSpec> GossipTester<E> {
                 self.harness
                     .chain
                     .clone()
-                    .verify_envelope_for_gossip(Arc::new(envelope)),
+                    .verify_envelope_for_gossip(Arc::new(envelope), EnvelopeSource::Gossip),
             )?
             .map_err(|e| {
                 Error::InternalError(format!(

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -20,11 +20,12 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use types::{
     AttesterSlashing, BeaconBlock, BeaconState, BlobSchedule, BlockImportSource, ChainSpec,
-    Checkpoint, EthSpec, ExecPayload, ForkName, Hash256, ProposerSlashing, SignedAggregateAndProof,
-    SignedAggregateAndProofElectra, SignedAggregateAndProofGloas, SignedBeaconBlock,
-    SignedBlsToExecutionChange, SignedContributionAndProof, SignedExecutionPayloadBid,
-    SignedExecutionPayloadEnvelope, SignedProposerPreferences, SignedVoluntaryExit,
-    SingleAttestation, Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId,
+    Checkpoint, EthSpec, ExecPayload, ForkName, Hash256, PayloadAttestationMessage,
+    ProposerSlashing, SignedAggregateAndProof, SignedAggregateAndProofElectra,
+    SignedAggregateAndProofGloas, SignedBeaconBlock, SignedBlsToExecutionChange,
+    SignedContributionAndProof, SignedExecutionPayloadBid, SignedExecutionPayloadEnvelope,
+    SignedProposerPreferences, SignedVoluntaryExit, SingleAttestation, Slot, SubnetId,
+    SyncCommitteeMessage, SyncSubnetId,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -426,13 +427,17 @@ impl<E: EthSpec> GossipTester<E> {
                     message_id.clone(),
                     peer_id,
                 )?,
-            Topic::DataColumnSidecar
-            | Topic::PartialDataColumnSidecar
-            | Topic::PayloadAttestationMessage => {
+            Topic::DataColumnSidecar | Topic::PartialDataColumnSidecar => {
                 return Err(Error::InternalError(format!(
                     "Gloas gossip topic {topic:?} is enabled but not implemented by the EF harness"
                 )));
             }
+            Topic::PayloadAttestationMessage => self.process_payload_attestation_message(
+                path,
+                message_meta,
+                message_id.clone(),
+                peer_id,
+            )?,
             Topic::ExecutionPayload => self.process_execution_payload_envelope(
                 path,
                 message_meta,
@@ -727,6 +732,28 @@ impl<E: EthSpec> GossipTester<E> {
                 message_id,
                 peer_id,
                 Arc::new(proposer_preferences),
+            );
+        Ok(())
+    }
+
+    fn process_payload_attestation_message(
+        &self,
+        path: &Path,
+        message_meta: &MessageMeta,
+        message_id: MessageId,
+        peer_id: PeerId,
+    ) -> Result<(), Error> {
+        let payload_attestation_message: PayloadAttestationMessage =
+            ssz_decode_file(&path.join(format!("{}.ssz_snappy", message_meta.message)))?;
+        self.set_message_time(message_meta)?;
+
+        self.network_beacon_processor
+            .clone()
+            .process_gossip_payload_attestation(
+                message_id,
+                peer_id,
+                Box::new(payload_attestation_message),
+                ReprocessAllowance::None,
             );
         Ok(())
     }
@@ -1080,6 +1107,11 @@ impl<E: EthSpec> GossipValidation<E> {
             "gossip_execution_payload_bid__valid_gas_limit_decrease_within_limit",
             "gossip_execution_payload_bid__valid_gas_limit_increase_exceeding_limit",
         ];
+        const IGNORED_PAYLOAD_ATTESTATION_CASES: &[&str] = &[
+            // Lighthouse does not retain a status that distinguishes a consensus-invalid block
+            // from an unseen block, so both cases are ignored as an unknown head block.
+            "gossip_payload_attestation_message__reject_block_failed_validation",
+        ];
         let Some(case_name) = self.path.file_name().and_then(|name| name.to_str()) else {
             return false;
         };
@@ -1105,6 +1137,9 @@ impl<E: EthSpec> GossipValidation<E> {
             }
             Topic::ExecutionPayloadBid => {
                 IGNORED_EXECUTION_PAYLOAD_BID_GAS_LIMIT_CASES.contains(&case_name)
+            }
+            Topic::PayloadAttestationMessage => {
+                IGNORED_PAYLOAD_ATTESTATION_CASES.contains(&case_name)
             }
             _ => false,
         }

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -22,7 +22,8 @@ use types::{
     Checkpoint, EthSpec, ExecPayload, ForkName, Hash256, ProposerSlashing, SignedAggregateAndProof,
     SignedAggregateAndProofElectra, SignedAggregateAndProofGloas, SignedBeaconBlock,
     SignedBlsToExecutionChange, SignedContributionAndProof, SignedExecutionPayloadEnvelope,
-    SignedVoluntaryExit, SingleAttestation, Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId,
+    SignedProposerPreferences, SignedVoluntaryExit, SingleAttestation, Slot, SubnetId,
+    SyncCommitteeMessage, SyncSubnetId,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -73,7 +74,7 @@ struct SetupBlock {
     #[serde(default)]
     payload: Option<String>,
     #[serde(default, rename = "pending")]
-    _pending: bool,
+    pending: bool,
     #[serde(default)]
     failed: bool,
     #[serde(default)]
@@ -319,19 +320,25 @@ impl<E: EthSpec> GossipTester<E> {
         initial_block_index: Option<usize>,
     ) -> Result<(), Error> {
         for (index, setup_block) in case.meta.blocks.iter().enumerate() {
-            if setup_block.failed {
+            if setup_block.failed || setup_block.pending {
                 continue;
             }
             let block = blocks.get(&setup_block.block).ok_or_else(|| {
                 Error::FailedToParseTest(format!("unknown block file {}", setup_block.block))
             })?;
             if initial_block_index != Some(index) {
+                let block_time_ms = slot_time_ms(block.slot(), &self.spec)?;
+                if block_time_ms > self.current_time_ms {
+                    self.set_time_ms(block_time_ms)?;
+                }
                 self.import_setup_block(block.clone(), setup_block.payload_status)?;
             }
             if let Some(payload) = setup_block.payload.as_deref() {
                 self.import_setup_payload(&case.path, block, payload)?;
             }
         }
+
+        self.set_time_ms(self.current_time_ms)?;
 
         Ok(())
     }
@@ -404,11 +411,13 @@ impl<E: EthSpec> GossipTester<E> {
             | Topic::ExecutionPayloadBid
             | Topic::ExecutionPayload
             | Topic::PartialDataColumnSidecar
-            | Topic::PayloadAttestationMessage
-            | Topic::ProposerPreferences => {
+            | Topic::PayloadAttestationMessage => {
                 return Err(Error::InternalError(format!(
                     "Gloas gossip topic {topic:?} is enabled but not implemented by the EF harness"
                 )));
+            }
+            Topic::ProposerPreferences => {
+                self.process_proposer_preferences(path, message_meta, message_id.clone(), peer_id)?
             }
         }
 
@@ -592,6 +601,27 @@ impl<E: EthSpec> GossipTester<E> {
                 sync_message,
                 subnet_id,
                 seen_timestamp,
+            );
+        Ok(())
+    }
+
+    fn process_proposer_preferences(
+        &self,
+        path: &Path,
+        message_meta: &MessageMeta,
+        message_id: MessageId,
+        peer_id: PeerId,
+    ) -> Result<(), Error> {
+        let proposer_preferences: SignedProposerPreferences =
+            ssz_decode_file(&path.join(format!("{}.ssz_snappy", message_meta.message)))?;
+        self.set_message_time(message_meta)?;
+
+        self.network_beacon_processor
+            .clone()
+            .process_gossip_proposer_preferences(
+                message_id,
+                peer_id,
+                Arc::new(proposer_preferences),
             );
         Ok(())
     }

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -21,8 +21,8 @@ use types::{
     AttesterSlashing, BeaconBlock, BeaconState, BlobSchedule, BlockImportSource, ChainSpec,
     Checkpoint, EthSpec, ExecPayload, ForkName, Hash256, ProposerSlashing, SignedAggregateAndProof,
     SignedAggregateAndProofElectra, SignedBeaconBlock, SignedBlsToExecutionChange,
-    SignedContributionAndProof, SignedVoluntaryExit, SingleAttestation, Slot, SubnetId,
-    SyncCommitteeMessage, SyncSubnetId,
+    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedVoluntaryExit,
+    SingleAttestation, Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -70,8 +70,8 @@ struct CaseConfig {
 #[serde(deny_unknown_fields)]
 struct SetupBlock {
     block: String,
-    #[serde(default, rename = "payload")]
-    _payload: Option<String>,
+    #[serde(default)]
+    payload: Option<String>,
     #[serde(default, rename = "pending")]
     _pending: bool,
     #[serde(default)]
@@ -322,13 +322,15 @@ impl<E: EthSpec> GossipTester<E> {
             if setup_block.failed {
                 continue;
             }
-            if initial_block_index == Some(index) {
-                continue;
+            if initial_block_index != Some(index) {
+                let block = blocks.get(&setup_block.block).ok_or_else(|| {
+                    Error::FailedToParseTest(format!("unknown block file {}", setup_block.block))
+                })?;
+                self.import_setup_block(block.clone(), setup_block.payload_status)?;
             }
-            let block = blocks.get(&setup_block.block).ok_or_else(|| {
-                Error::FailedToParseTest(format!("unknown block file {}", setup_block.block))
-            })?;
-            self.import_setup_block(block.clone(), setup_block.payload_status)?;
+            if let Some(payload) = setup_block.payload.as_deref() {
+                self.import_setup_payload(&case.path, payload)?;
+            }
         }
 
         Ok(())
@@ -687,6 +689,39 @@ impl<E: EthSpec> GossipTester<E> {
                 "setup block {block_root:?} import failed: {e:?}"
             ))),
         }
+    }
+
+    fn import_setup_payload(&self, path: &Path, payload: &str) -> Result<(), Error> {
+        let envelope: SignedExecutionPayloadEnvelope<E> =
+            ssz_decode_file(&path.join(format!("{payload}.ssz_snappy")))?;
+        let block_root = envelope.beacon_block_root();
+        let verified_envelope = self
+            .block_on_dangerous(
+                self.harness
+                    .chain
+                    .clone()
+                    .verify_envelope_for_gossip(Arc::new(envelope)),
+            )?
+            .map_err(|e| {
+                Error::InternalError(format!(
+                    "setup payload for block {block_root:?} failed gossip verification: {e:?}"
+                ))
+            })?;
+
+        self.block_on_dangerous(self.harness.chain.process_execution_payload_envelope(
+            block_root,
+            verified_envelope,
+            NotifyExecutionLayer::Yes,
+            BlockImportSource::Lookup,
+            || Ok(()),
+        ))?
+        .map_err(|e| {
+            Error::InternalError(format!(
+                "setup payload for block {block_root:?} failed import: {e:?}"
+            ))
+        })?;
+
+        Ok(())
     }
 
     fn configure_payload_status(

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -172,9 +172,22 @@ impl<E: EthSpec + TypeName> Case for GossipValidation<E> {
             return Err(Error::SkippedKnownFailure);
         }
 
-        if let Some(bls_setting) = self.meta.bls_setting {
-            bls_setting.check()?;
-        }
+        let bls_setting = self.meta.bls_setting.unwrap_or_else(|| {
+            if self.meta.messages.iter().any(|message| {
+                message.expected == ExpectedOutcome::Reject
+                    && message.reason.as_ref().is_some_and(|reason| {
+                        let reason = reason.to_ascii_lowercase();
+                        reason.contains("invalid") && reason.contains("signature")
+                    })
+            }) {
+                // Some Gloas gossip vectors omit `bls_setting: required` even though their
+                // expected rejection depends on real signature verification.
+                BlsSetting::Required
+            } else {
+                BlsSetting::Flexible
+            }
+        });
+        bls_setting.check()?;
 
         let spec = Self::testing_spec(&self.path, fork_name)?;
         let tester = GossipTester::new(self, spec)?;

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -20,9 +20,9 @@ use std::time::Duration;
 use types::{
     AttesterSlashing, BeaconBlock, BeaconState, BlobSchedule, BlockImportSource, ChainSpec,
     Checkpoint, EthSpec, ExecPayload, ForkName, Hash256, ProposerSlashing, SignedAggregateAndProof,
-    SignedAggregateAndProofElectra, SignedBeaconBlock, SignedBlsToExecutionChange,
-    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedVoluntaryExit,
-    SingleAttestation, Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId,
+    SignedAggregateAndProofElectra, SignedAggregateAndProofGloas, SignedBeaconBlock,
+    SignedBlsToExecutionChange, SignedContributionAndProof, SignedExecutionPayloadEnvelope,
+    SignedVoluntaryExit, SingleAttestation, Slot, SubnetId, SyncCommitteeMessage, SyncSubnetId,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -369,6 +369,7 @@ impl<E: EthSpec> GossipTester<E> {
             Topic::BeaconAggregateAndProof => self.process_beacon_aggregate_and_proof(
                 path,
                 message_meta,
+                fork_name,
                 message_id.clone(),
                 peer_id,
             )?,
@@ -527,13 +528,18 @@ impl<E: EthSpec> GossipTester<E> {
         &self,
         path: &Path,
         message_meta: &MessageMeta,
+        fork_name: ForkName,
         message_id: MessageId,
         peer_id: PeerId,
     ) -> Result<(), Error> {
-        let aggregate = ssz_decode_file::<SignedAggregateAndProofElectra<E>>(
-            &path.join(format!("{}.ssz_snappy", message_meta.message)),
-        )
-        .map(SignedAggregateAndProof::Electra)?;
+        let ssz_path = path.join(format!("{}.ssz_snappy", message_meta.message));
+        let aggregate = if fork_name.gloas_enabled() {
+            ssz_decode_file::<SignedAggregateAndProofGloas<E>>(&ssz_path)
+                .map(SignedAggregateAndProof::Gloas)?
+        } else {
+            ssz_decode_file::<SignedAggregateAndProofElectra<E>>(&ssz_path)
+                .map(SignedAggregateAndProof::Electra)?
+        };
         let seen_timestamp = self.set_message_time(message_meta)?;
 
         self.network_beacon_processor
@@ -869,6 +875,17 @@ impl<E: EthSpec> GossipValidation<E> {
             "accepts_last_slot_when_epoch_window_closes",
             "accepts_one_millisecond_before_slot_start",
         ];
+        const IGNORED_GLOAS_PAYLOAD_STATUS_CASES: &[&str] = &[
+            // Lighthouse does not support optimistic Gloas payload imports, so these fixtures
+            // cannot construct the optimistic payload status required by the gossip condition.
+            "gossip_beacon_attestation__ignore_payload_pending_el_validation",
+            "gossip_beacon_aggregate_and_proof__ignore_payload_pending_el_validation",
+            // Lighthouse does not support optimistic Gloas payload imports, so it cannot construct
+            // the fixture's precondition: a payload that was accepted and subsequently invalidated
+            // by the execution layer. This status only changes gossip peer scoring.
+            "gossip_beacon_attestation__reject_payload_failed_el_validation",
+            "gossip_beacon_aggregate_and_proof__reject_payload_failed_el_validation",
+        ];
         let Some(case_name) = self.path.file_name().and_then(|name| name.to_str()) else {
             return false;
         };
@@ -879,7 +896,8 @@ impl<E: EthSpec> GossipValidation<E> {
                 // These vectors require fixture history that the production-backed harness cannot
                 // construct: a retained consensus-invalid block, an unknown finalized root, or a
                 // known but unfinalized slot-zero block.
-                self.meta.blocks.iter().any(|block| block.failed)
+                IGNORED_GLOAS_PAYLOAD_STATUS_CASES.contains(&case_name)
+                    || self.meta.blocks.iter().any(|block| block.failed)
                     || matches!(
                         self.meta.finalized_checkpoint,
                         Some(FinalizedCheckpoint::Root { .. })

--- a/testing/ef_tests/src/cases/gossip_validation.rs
+++ b/testing/ef_tests/src/cases/gossip_validation.rs
@@ -233,9 +233,17 @@ impl<E: EthSpec> GossipTester<E> {
 
         tester.set_time_ms(current_time_ms)?;
         tester.import_setup_blocks(case, &blocks, initial_block_index)?;
-        tester.set_finalized_checkpoint(case.finalized_checkpoint(&blocks)?);
+        let finalized_checkpoint = case.finalized_checkpoint(&blocks)?;
+        tester.set_finalized_checkpoint(finalized_checkpoint);
         if case.meta.topic == Topic::ExecutionPayloadBid {
             tester.block_on_dangerous(tester.harness.chain.recompute_head_at_current_slot())?;
+            if let Some(checkpoint) = finalized_checkpoint {
+                tester
+                    .harness
+                    .chain
+                    .canonical_head
+                    .testing_set_cached_head_state_finalized_checkpoint(checkpoint);
+            }
         }
 
         Ok(tester)

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -1054,6 +1054,17 @@ impl<E> GossipValidationHandler<E> {
     pub fn latest_stable(handler_name: &'static str) -> Self {
         Self::for_forks(handler_name, vec![ForkName::latest_stable()])
     }
+
+    pub fn latest_stable_and_gloas(handler_name: &'static str) -> Self {
+        Self::for_forks(
+            handler_name,
+            vec![ForkName::latest_stable(), ForkName::Gloas],
+        )
+    }
+
+    pub fn gloas_only(handler_name: &'static str) -> Self {
+        Self::for_forks(handler_name, vec![ForkName::Gloas])
+    }
 }
 
 impl<E: EthSpec + TypeName> Handler for GossipValidationHandler<E> {
@@ -1079,10 +1090,6 @@ impl<E: EthSpec + TypeName> Handler for GossipValidationHandler<E> {
     fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
         let fork_name_str = fork_name.to_string();
         self.supported_forks.contains(&fork_name) && self.handler_path(&fork_name_str).exists()
-    }
-
-    fn disabled_forks(&self) -> Vec<ForkName> {
-        vec![ForkName::Gloas]
     }
 }
 

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -1342,14 +1342,6 @@ fn gossip_execution_payload_envelope() {
 }
 
 #[test]
-fn gossip_partial_data_column_sidecar() {
-    GossipValidationHandler::<MinimalEthSpec>::gloas_only("gossip_partial_data_column_sidecar")
-        .run();
-    GossipValidationHandler::<MainnetEthSpec>::gloas_only("gossip_partial_data_column_sidecar")
-        .run();
-}
-
-#[test]
 fn gossip_payload_attestation_message() {
     GossipValidationHandler::<MinimalEthSpec>::gloas_only("gossip_payload_attestation_message")
         .run();

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -1259,46 +1259,106 @@ fn gossip_attester_slashing() {
 
 #[test]
 fn gossip_voluntary_exit() {
-    GossipValidationHandler::<MinimalEthSpec>::latest_stable("gossip_voluntary_exit").run();
-    GossipValidationHandler::<MainnetEthSpec>::latest_stable("gossip_voluntary_exit").run();
+    GossipValidationHandler::<MinimalEthSpec>::latest_stable_and_gloas("gossip_voluntary_exit")
+        .run();
+    GossipValidationHandler::<MainnetEthSpec>::latest_stable_and_gloas("gossip_voluntary_exit")
+        .run();
 }
 
 #[test]
 fn gossip_beacon_attestation() {
-    GossipValidationHandler::<MinimalEthSpec>::latest_stable("gossip_beacon_attestation").run();
-    GossipValidationHandler::<MainnetEthSpec>::latest_stable("gossip_beacon_attestation").run();
+    GossipValidationHandler::<MinimalEthSpec>::latest_stable_and_gloas("gossip_beacon_attestation")
+        .run();
+    GossipValidationHandler::<MainnetEthSpec>::latest_stable_and_gloas("gossip_beacon_attestation")
+        .run();
 }
 
 #[test]
 fn gossip_beacon_aggregate_and_proof() {
-    GossipValidationHandler::<MinimalEthSpec>::latest_stable("gossip_beacon_aggregate_and_proof")
-        .run();
-    GossipValidationHandler::<MainnetEthSpec>::latest_stable("gossip_beacon_aggregate_and_proof")
-        .run();
+    GossipValidationHandler::<MinimalEthSpec>::latest_stable_and_gloas(
+        "gossip_beacon_aggregate_and_proof",
+    )
+    .run();
+    GossipValidationHandler::<MainnetEthSpec>::latest_stable_and_gloas(
+        "gossip_beacon_aggregate_and_proof",
+    )
+    .run();
 }
 
 #[test]
 fn gossip_bls_to_execution_change() {
-    GossipValidationHandler::<MinimalEthSpec>::latest_stable("gossip_bls_to_execution_change")
-        .run();
-    GossipValidationHandler::<MainnetEthSpec>::latest_stable("gossip_bls_to_execution_change")
-        .run();
+    GossipValidationHandler::<MinimalEthSpec>::latest_stable_and_gloas(
+        "gossip_bls_to_execution_change",
+    )
+    .run();
+    GossipValidationHandler::<MainnetEthSpec>::latest_stable_and_gloas(
+        "gossip_bls_to_execution_change",
+    )
+    .run();
 }
 
 #[test]
 fn gossip_sync_committee_message() {
-    GossipValidationHandler::<MinimalEthSpec>::latest_stable("gossip_sync_committee_message").run();
-    GossipValidationHandler::<MainnetEthSpec>::latest_stable("gossip_sync_committee_message").run();
+    GossipValidationHandler::<MinimalEthSpec>::latest_stable_and_gloas(
+        "gossip_sync_committee_message",
+    )
+    .run();
+    GossipValidationHandler::<MainnetEthSpec>::latest_stable_and_gloas(
+        "gossip_sync_committee_message",
+    )
+    .run();
 }
 
 #[test]
 fn gossip_sync_committee_contribution_and_proof() {
-    GossipValidationHandler::<MinimalEthSpec>::latest_stable(
+    GossipValidationHandler::<MinimalEthSpec>::latest_stable_and_gloas(
         "gossip_sync_committee_contribution_and_proof",
     )
     .run();
-    GossipValidationHandler::<MainnetEthSpec>::latest_stable(
+    GossipValidationHandler::<MainnetEthSpec>::latest_stable_and_gloas(
         "gossip_sync_committee_contribution_and_proof",
     )
     .run();
+}
+
+#[test]
+fn gossip_data_column_sidecar() {
+    GossipValidationHandler::<MinimalEthSpec>::gloas_only("gossip_data_column_sidecar").run();
+    GossipValidationHandler::<MainnetEthSpec>::gloas_only("gossip_data_column_sidecar").run();
+}
+
+#[test]
+fn gossip_execution_payload_bid() {
+    GossipValidationHandler::<MinimalEthSpec>::gloas_only("gossip_execution_payload_bid").run();
+    GossipValidationHandler::<MainnetEthSpec>::gloas_only("gossip_execution_payload_bid").run();
+}
+
+#[test]
+fn gossip_execution_payload_envelope() {
+    GossipValidationHandler::<MinimalEthSpec>::gloas_only("gossip_execution_payload_envelope")
+        .run();
+    GossipValidationHandler::<MainnetEthSpec>::gloas_only("gossip_execution_payload_envelope")
+        .run();
+}
+
+#[test]
+fn gossip_partial_data_column_sidecar() {
+    GossipValidationHandler::<MinimalEthSpec>::gloas_only("gossip_partial_data_column_sidecar")
+        .run();
+    GossipValidationHandler::<MainnetEthSpec>::gloas_only("gossip_partial_data_column_sidecar")
+        .run();
+}
+
+#[test]
+fn gossip_payload_attestation_message() {
+    GossipValidationHandler::<MinimalEthSpec>::gloas_only("gossip_payload_attestation_message")
+        .run();
+    GossipValidationHandler::<MainnetEthSpec>::gloas_only("gossip_payload_attestation_message")
+        .run();
+}
+
+#[test]
+fn gossip_proposer_preferences() {
+    GossipValidationHandler::<MinimalEthSpec>::gloas_only("gossip_proposer_preferences").run();
+    GossipValidationHandler::<MainnetEthSpec>::gloas_only("gossip_proposer_preferences").run();
 }


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Enable all gloas gossip test handlers. Have intentionally skipped quite a few test vectors where the tests expects us to store invalid blocks or construct a history of invalid blocks. 

Must re-enable gas limit tests after https://github.com/sigp/lighthouse/pull/9905
Must re-enable partial data column tests in #9325 

Note to reviewer: better to review commit wise.
Used codex assistance for the harness building.