### PR TITLE
Add check for `--disable-proposer-reorg` flag

### DIFF
--- a/beacon_node/beacon_chain/src/block_production/mod.rs
+++ b/beacon_node/beacon_chain/src/block_production/mod.rs
@@ -175,6 +175,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         head_slot: Slot,
         canonical_head: Hash256,
     ) -> Option<ReOrgInputs<T::EthSpec>> {
+        if self.config.disable_proposer_reorg {
+            return None;
+        }
+
         let re_org_head_threshold = ReOrgThreshold(self.spec.reorg_head_weight_threshold);
         let re_org_parent_threshold = ReOrgThreshold(self.spec.reorg_parent_weight_threshold);
         let re_org_max_epochs_since_finalization =


### PR DESCRIPTION
Follow up from a comment here:

https://github.com/sigp/lighthouse/pull/9177#discussion_r3868932242

Add a check to return early if the flag `--disable-proposal-reorg` is used (i.e., do not reorg).
