### PR TITLE
Improve Gloas sync notifier logs

### DIFF
--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -367,43 +367,60 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                     head_root.short().to_string()
                 };
 
-                let block_hash = match beacon_chain.canonical_head.head_execution_status() {
-                    Ok(ExecutionStatus::Irrelevant(_)) => "n/a".to_string(),
-                    Ok(ExecutionStatus::Valid(hash)) => {
-                        metrics::set_gauge(&metrics::IS_OPTIMISTIC_SYNC, 0);
-                        format!("{} (verified)", hash)
-                    }
-                    Ok(ExecutionStatus::Optimistic(hash)) => {
-                        metrics::set_gauge(&metrics::IS_OPTIMISTIC_SYNC, 1);
-                        warn!(
-                            info = "chain not fully verified, \
-                            block and attestation production disabled until execution engine syncs",
-                            execution_block_hash = ?hash,
-                            "Head is optimistic"
-                        );
-                        format!("{} (unverified)", hash)
-                    }
-                    Ok(ExecutionStatus::Invalid(hash)) => {
-                        crit!(
-                            msg = "this scenario may be unrecoverable",
-                            execution_block_hash = ?hash,
-                            "Head execution payload is invalid"
-                        );
-                        format!("{} (invalid)", hash)
-                    }
-                    Err(_) => "unknown".to_string(),
-                };
+                if beacon_chain
+                    .spec
+                    .fork_name_at_slot::<T::EthSpec>(head_slot)
+                    .gloas_enabled()
+                {
+                    info!(
+                        peers = peer_count_pretty(connected_peer_count),
+                        payload_envelope_status = ?cached_head.head_payload_status(),
+                        finalized_root = %finalized_checkpoint.root.short(),
+                        finalized_epoch = %finalized_checkpoint.epoch,
+                        epoch = %current_epoch,
+                        block = block_info,
+                        slot = %current_slot,
+                        "Synced"
+                    );
+                } else {
+                    let block_hash = match beacon_chain.canonical_head.head_execution_status() {
+                        Ok(ExecutionStatus::Irrelevant(_)) => "n/a".to_string(),
+                        Ok(ExecutionStatus::Valid(hash)) => {
+                            metrics::set_gauge(&metrics::IS_OPTIMISTIC_SYNC, 0);
+                            format!("{} (verified)", hash)
+                        }
+                        Ok(ExecutionStatus::Optimistic(hash)) => {
+                            metrics::set_gauge(&metrics::IS_OPTIMISTIC_SYNC, 1);
+                            warn!(
+                                info = "chain not fully verified, \
+                                block and attestation production disabled until execution engine syncs",
+                                execution_block_hash = ?hash,
+                                "Head is optimistic"
+                            );
+                            format!("{} (unverified)", hash)
+                        }
+                        Ok(ExecutionStatus::Invalid(hash)) => {
+                            crit!(
+                                msg = "this scenario may be unrecoverable",
+                                execution_block_hash = ?hash,
+                                "Head execution payload is invalid"
+                            );
+                            format!("{} (invalid)", hash)
+                        }
+                        Err(_) => "unknown".to_string(),
+                    };
 
-                info!(
-                    peers = peer_count_pretty(connected_peer_count),
-                    exec_hash = block_hash,
-                    finalized_root = %finalized_checkpoint.root.short(),
-                    finalized_epoch = %finalized_checkpoint.epoch,
-                    epoch = %current_epoch,
-                    block = block_info,
-                    slot = %current_slot,
-                    "Synced"
-                );
+                    info!(
+                        peers = peer_count_pretty(connected_peer_count),
+                        exec_hash = block_hash,
+                        finalized_root = %finalized_checkpoint.root.short(),
+                        finalized_epoch = %finalized_checkpoint.epoch,
+                        epoch = %current_epoch,
+                        block = block_info,
+                        slot = %current_slot,
+                        "Synced"
+                    );
+                }
             } else {
                 metrics::set_gauge(&metrics::IS_SYNCED, 0);
                 info!(


### PR DESCRIPTION
## Issue Addressed

#9099

## Proposed Changes

- Log `payload_envelope_status` for canonical heads at and after the Gloas fork.
- Read the existing `Pending`, `Empty`, or `Full` status from the canonical fork-choice head.
- Preserve the existing execution hash, optimistic sync warning, and metric behavior before Gloas.

## Additional Info

#9101 previously attempted to address this issue but was closed for staleness after changes to the ePBS specification. This implementation uses the payload status maintained by the current canonical fork-choice head instead of deriving it from the beacon state.

Validation performed:

- `cargo check -p client --locked`
- `cargo test -p client --lib --locked`
- `cargo clippy -p client --all-targets --locked`
- `cargo fmt --all -- --check`