### PR TITLE
Fix slot lookup immediately after a head event

### DIFF
--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -72,14 +72,13 @@ impl BlockId {
                 Ok((justified_checkpoint.root, execution_optimistic, false))
             }
             CoreBlockId::Slot(slot) => {
-                let fallback_requires_fork_choice_check = if let Some((cached_slot, cached_root)) =
-                    chain
-                        .early_attester_cache
-                        .get_head_block_root()
-                        .filter(|(cached_slot, _)| cached_slot == slot)
+                if let Some((cached_slot, cached_root)) = chain
+                    .early_attester_cache
+                    .get_head_block_root()
+                    .filter(|(cached_slot, _)| cached_slot == slot)
                 {
-                    // Read the cache again before checking persistence. If the block is not
-                    // persisted, this read occurs while its importer holds the fork choice write lock.
+                    // An unpersisted cache entry is only visible while its importer holds the fork
+                    // choice write lock, so an unchanged entry cannot be replaced concurrently.
                     let cache_unchanged = chain.early_attester_cache.get_head_block_root()
                         == Some((cached_slot, cached_root));
 
@@ -109,15 +108,9 @@ impl BlockId {
                             return Ok((root, false, false));
                         }
                     }
+                }
 
-                    true
-                } else {
-                    false
-                };
-
-                let execution_optimistic = chain
-                    .is_optimistic_or_invalid_head()
-                    .map_err(warp_utils::reject::unhandled_error)?;
+                let cached_head_root = chain.canonical_head.cached_head().head_block_root();
                 let root = chain
                     .block_root_at_slot(*slot, WhenSlotSkipped::None)
                     .map_err(warp_utils::reject::unhandled_error)
@@ -129,16 +122,30 @@ impl BlockId {
                             ))
                         })
                     })?;
-                if fallback_requires_fork_choice_check {
-                    let fork_choice = chain.canonical_head.fork_choice_read_lock();
-                    let current_head_root = fork_choice.cached_fork_choice_view().head_block_root;
-                    if !fork_choice.is_descendant(root, current_head_root) {
-                        return Err(warp_utils::reject::custom_not_found(format!(
-                            "beacon block at slot {}",
-                            slot
-                        )));
-                    }
+
+                let fork_choice = chain.canonical_head.fork_choice_read_lock();
+                let execution_optimistic = fork_choice
+                    .get_block_execution_status(&cached_head_root)
+                    .ok_or(BeaconChainError::HeadMissingFromForkChoice(
+                        cached_head_root,
+                    ))
+                    .map_err(warp_utils::reject::unhandled_error)?
+                    .is_optimistic_or_invalid();
+                let current_head_root = fork_choice.cached_fork_choice_view().head_block_root;
+
+                // The cached head can change after the slot lookup. Reject a recent block that is
+                // no longer on the fork choice head chain. Historical roots can be pruned from
+                // fork choice and retain the existing slot lookup behaviour.
+                if fork_choice.contains_block(&root)
+                    && !fork_choice.is_descendant(root, current_head_root)
+                {
+                    return Err(warp_utils::reject::custom_not_found(format!(
+                        "beacon block at slot {}",
+                        slot
+                    )));
                 }
+                drop(fork_choice);
+
                 let finalized = *slot
                     <= chain
                         .canonical_head
@@ -195,26 +202,6 @@ impl BlockId {
                 }
             }
         }
-    }
-
-    pub(crate) fn is_canonical<T: BeaconChainTypes>(
-        &self,
-        root: Hash256,
-        slot: Slot,
-        chain: &BeaconChain<T>,
-    ) -> Result<bool, warp::Rejection> {
-        // A successful slot lookup only returns the canonical block at that slot.
-        if matches!(
-            &self.0,
-            CoreBlockId::Slot(requested_slot) if *requested_slot == slot
-        ) {
-            return Ok(true);
-        }
-
-        chain
-            .block_root_at_slot(slot, WhenSlotSkipped::None)
-            .map_err(warp_utils::reject::unhandled_error)
-            .map(|canonical| canonical.is_some_and(|canonical| root == canonical))
     }
 
     pub fn blinded_block_by_root<T: BeaconChainTypes>(
@@ -721,22 +708,22 @@ mod tests {
         );
     }
 
-    struct UnpersistedBlock {
+    struct AvailableBlockWithPostState {
         available_block: AvailableBlock<MinimalEthSpec>,
         post_state: BeaconState<MinimalEthSpec>,
     }
 
-    impl UnpersistedBlock {
+    impl AvailableBlockWithPostState {
         fn root(&self) -> Hash256 {
             self.available_block.block_root()
         }
     }
 
-    async fn make_unpersisted_block(
+    async fn make_available_block_with_post_state(
         harness: &TestHarness,
         state: BeaconState<MinimalEthSpec>,
         slot: Slot,
-    ) -> UnpersistedBlock {
+    ) -> AvailableBlockWithPostState {
         let (block_contents, post_state) = harness.make_block(state, slot).await;
         let (block, _) = block_contents;
         let available_block = AvailableBlock::new(
@@ -745,7 +732,7 @@ mod tests {
             &harness.chain.custody_context,
         )
         .unwrap();
-        UnpersistedBlock {
+        AvailableBlockWithPostState {
             available_block,
             post_state,
         }
@@ -753,7 +740,7 @@ mod tests {
 
     fn add_block_to_fork_choice(
         harness: &TestHarness,
-        block: &UnpersistedBlock,
+        block: &AvailableBlockWithPostState,
         block_delay: Duration,
     ) -> ProtoBlock {
         let block_root = block.root();
@@ -772,7 +759,11 @@ mod tests {
         fork_choice.get_block(&block_root).unwrap()
     }
 
-    fn cache_block(harness: &TestHarness, block: &UnpersistedBlock, proto_block: ProtoBlock) {
+    fn cache_block(
+        harness: &TestHarness,
+        block: &AvailableBlockWithPostState,
+        proto_block: ProtoBlock,
+    ) {
         harness
             .chain
             .early_attester_cache
@@ -785,10 +776,7 @@ mod tests {
             .unwrap();
     }
 
-    fn spawn_slot_header_lookup(
-        chain: Arc<TestChain>,
-        slot: Slot,
-    ) -> (JoinHandle<()>, Receiver<Hash256>) {
+    fn spawn_slot_lookup(chain: Arc<TestChain>, slot: Slot) -> (JoinHandle<()>, Receiver<Hash256>) {
         let (started_tx, started_rx) = std::sync::mpsc::channel();
         let (result_tx, result_rx) = std::sync::mpsc::channel();
         let request = std::thread::spawn(move || {
@@ -799,11 +787,6 @@ mod tests {
             assert!(!result.2);
             let (block, _, _) = BlockId::from_root(result.0).blinded_block(&chain).unwrap();
             assert_eq!(block.canonical_root(), result.0);
-            assert!(
-                block_id
-                    .is_canonical(result.0, block.slot(), &chain)
-                    .unwrap()
-            );
             result_tx.send(result.0).unwrap();
         });
         started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
@@ -820,7 +803,8 @@ mod tests {
         harness.advance_slot();
 
         let slot = harness.get_current_slot();
-        let block = make_unpersisted_block(&harness, harness.get_current_state(), slot).await;
+        let block =
+            make_available_block_with_post_state(&harness, harness.get_current_state(), slot).await;
         let block_root = block.root();
         let proto_block = add_block_to_fork_choice(&harness, &block, Duration::ZERO);
         let mut fork_choice = chain.canonical_head.fork_choice_write_lock();
@@ -840,7 +824,7 @@ mod tests {
             "precondition: persisted slot lookup must not resolve the new head"
         );
 
-        let (request, result_rx) = spawn_slot_header_lookup(chain.clone(), slot);
+        let (request, result_rx) = spawn_slot_lookup(chain.clone(), slot);
         assert_eq!(
             result_rx
                 .recv_timeout(Duration::from_secs(2))
@@ -848,12 +832,6 @@ mod tests {
             block_root
         );
         chain.early_attester_cache.clear();
-        assert!(
-            BlockId(CoreBlockId::Slot(slot))
-                .is_canonical(block_root, slot, chain)
-                .unwrap(),
-            "slot lookup result must remain canonical after the cache is cleared"
-        );
         drop(fork_choice);
         request.join().unwrap();
     }
@@ -869,8 +847,8 @@ mod tests {
 
         let slot = harness.get_current_slot();
         let state = harness.get_current_state();
-        let block_a = make_unpersisted_block(&harness, state.clone(), slot).await;
-        let block_b = make_unpersisted_block(&harness, state, slot).await;
+        let block_a = make_available_block_with_post_state(&harness, state.clone(), slot).await;
+        let block_b = make_available_block_with_post_state(&harness, state, slot).await;
         let block_root_a = block_a.root();
         let block_root_b = block_b.root();
         assert_ne!(
@@ -878,7 +856,8 @@ mod tests {
             "precondition: blocks must compete at the same slot"
         );
 
-        // Import both blocks too late for proposer boost. Fork choice then selects the higher root.
+        // Add both blocks to fork choice too late for proposer boost. Fork choice then selects the
+        // higher root.
         let (stale_block, replacement_block) = if block_root_a < block_root_b {
             (&block_a, &block_b)
         } else {
@@ -942,6 +921,68 @@ mod tests {
             BlockId(CoreBlockId::Slot(slot)).root(chain).unwrap(),
             (replacement_block.root(), false, false),
             "same-slot replacement must be served"
+        );
+    }
+
+    #[tokio::test]
+    async fn slot_rejects_cached_head_after_fork_choice_changes() {
+        let harness = harness();
+        let chain = &harness.chain;
+        harness
+            .execution_block_generator()
+            .set_generate_blobs(false);
+        harness.advance_slot();
+
+        let slot = harness.get_current_slot();
+        let state = harness.get_current_state();
+        let block_a = make_available_block_with_post_state(&harness, state.clone(), slot).await;
+        let block_b = make_available_block_with_post_state(&harness, state, slot).await;
+        let (stale_block, replacement_block) = if block_a.root() < block_b.root() {
+            (&block_a, &block_b)
+        } else {
+            (&block_b, &block_a)
+        };
+
+        harness
+            .process_block(
+                slot,
+                stale_block.root(),
+                (stale_block.available_block.block().clone().into(), None),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            chain.canonical_head.cached_head().head_block_root(),
+            stale_block.root(),
+            "precondition: first block must be the cached head"
+        );
+        assert_eq!(
+            chain.early_attester_cache.get_head_block_root(),
+            None,
+            "precondition: early attester cache must be empty"
+        );
+
+        harness.advance_slot();
+        add_block_to_fork_choice(&harness, replacement_block, Duration::MAX);
+        let current_head_root = {
+            let mut fork_choice = chain.canonical_head.fork_choice_write_lock();
+            fork_choice
+                .get_head(harness.get_current_slot(), &chain.spec)
+                .unwrap()
+                .0
+        };
+        assert_eq!(
+            current_head_root,
+            replacement_block.root(),
+            "precondition: replacement block must be the fork choice head"
+        );
+
+        let rejection = BlockId(CoreBlockId::Slot(slot)).root(chain).unwrap_err();
+        assert!(
+            rejection
+                .find::<warp_utils::reject::CustomNotFound>()
+                .is_some(),
+            "cached head must be rejected after fork choice selects a same-slot replacement"
         );
     }
 
@@ -1061,11 +1102,12 @@ mod tests {
             BlockId(CoreBlockId::Root(block_root)).root(chain).unwrap(),
             (block_root, false, false)
         );
-        assert!(
-            !BlockId(CoreBlockId::Root(block_root))
-                .is_canonical(block_root, block.slot(), chain)
+        assert_ne!(
+            chain
+                .block_root_at_slot(block.slot(), WhenSlotSkipped::None)
                 .unwrap(),
-            "unpersisted root lookup must not be marked canonical"
+            Some(block_root),
+            "precondition: cached block must not be in the canonical snapshot"
         );
 
         let (blinded_block, execution_optimistic, finalized) =

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -608,11 +608,10 @@ mod tests {
         custody_context::NodeCustodyType,
         data_availability_checker::AvailableBlock,
         test_utils::{
-            AttestationStrategy, BeaconChainHarness, EphemeralHarnessType, fork_name_from_env,
+            BeaconChainHarness, EphemeralHarnessType, fork_name_from_env,
             generate_data_column_sidecars_from_block,
         },
     };
-    use fork_choice::AttestationFromBlock;
     use proto_array::Block as ProtoBlock;
     use std::sync::mpsc::Receiver;
     use std::thread::JoinHandle;
@@ -711,7 +710,6 @@ mod tests {
     struct UnpersistedBlock {
         available_block: AvailableBlock<MinimalEthSpec>,
         post_state: BeaconState<MinimalEthSpec>,
-        proto_block: ProtoBlock,
     }
 
     impl UnpersistedBlock {
@@ -733,37 +731,41 @@ mod tests {
             &harness.chain.custody_context,
         )
         .unwrap();
-        let block_root = available_block.block_root();
-        let proto_block = {
-            let mut fork_choice = harness.chain.canonical_head.fork_choice_write_lock();
-            fork_choice
-                .on_block(
-                    slot,
-                    available_block.block().message(),
-                    block_root,
-                    Duration::ZERO,
-                    &post_state,
-                    PayloadVerificationStatus::Verified,
-                    &harness.chain.spec,
-                )
-                .unwrap();
-            fork_choice.get_block(&block_root).unwrap()
-        };
         UnpersistedBlock {
             available_block,
             post_state,
-            proto_block,
         }
     }
 
-    fn cache_block(harness: &TestHarness, block: &UnpersistedBlock) {
+    fn add_block_to_fork_choice(
+        harness: &TestHarness,
+        block: &UnpersistedBlock,
+        block_delay: Duration,
+    ) -> ProtoBlock {
+        let block_root = block.root();
+        let mut fork_choice = harness.chain.canonical_head.fork_choice_write_lock();
+        fork_choice
+            .on_block(
+                block.available_block.block().slot(),
+                block.available_block.block().message(),
+                block_root,
+                block_delay,
+                &block.post_state,
+                PayloadVerificationStatus::Verified,
+                &harness.chain.spec,
+            )
+            .unwrap();
+        fork_choice.get_block(&block_root).unwrap()
+    }
+
+    fn cache_block(harness: &TestHarness, block: &UnpersistedBlock, proto_block: ProtoBlock) {
         harness
             .chain
             .early_attester_cache
             .add_head_block(
                 block.root(),
                 &block.available_block,
-                block.proto_block.clone(),
+                proto_block,
                 &block.post_state,
             )
             .unwrap();
@@ -804,10 +806,11 @@ mod tests {
         let slot = harness.get_current_slot();
         let block = make_unpersisted_block(&harness, harness.get_current_state(), slot).await;
         let block_root = block.root();
+        let proto_block = add_block_to_fork_choice(&harness, &block, Duration::ZERO);
         let mut fork_choice = chain.canonical_head.fork_choice_write_lock();
         let (head_root, _) = fork_choice.get_head(slot, &chain.spec).unwrap();
         assert_eq!(head_root, block_root, "precondition: block must be head");
-        cache_block(&harness, &block);
+        cache_block(&harness, &block, proto_block);
 
         assert!(
             !chain.store.block_exists(&block_root).unwrap(),
@@ -859,18 +862,25 @@ mod tests {
             "precondition: blocks must compete at the same slot"
         );
 
-        let old_head_root = {
-            let mut fork_choice = chain.canonical_head.fork_choice_write_lock();
-            let (head_root, _) = fork_choice.get_head(slot, &chain.spec).unwrap();
-            head_root
-        };
-        let (stale_block, replacement_block) = if old_head_root == block_root_a {
+        let (stale_block, replacement_block) = if block_root_a < block_root_b {
             (&block_a, &block_b)
         } else {
             (&block_b, &block_a)
         };
 
-        cache_block(&harness, stale_block);
+        let stale_proto_block = add_block_to_fork_choice(&harness, stale_block, Duration::MAX);
+        let old_head_root = {
+            let mut fork_choice = chain.canonical_head.fork_choice_write_lock();
+            let (head_root, _) = fork_choice.get_head(slot, &chain.spec).unwrap();
+            head_root
+        };
+        assert_eq!(
+            old_head_root,
+            stale_block.root(),
+            "precondition: first block must become head"
+        );
+
+        cache_block(&harness, stale_block, stale_proto_block);
         chain
             .store
             .put_block(
@@ -884,30 +894,10 @@ mod tests {
             "persisted cache entry must cover the gap before the canonical head is updated"
         );
 
-        let fork_name = chain.spec.fork_name_at_slot::<MinimalEthSpec>(slot);
-        let attestations = harness.get_single_attestations(
-            &AttestationStrategy::AllValidators,
-            &replacement_block.post_state,
-            replacement_block.available_block.block().state_root(),
-            replacement_block.root(),
-            slot,
-        );
-        harness.advance_slot();
+        let replacement_proto_block =
+            add_block_to_fork_choice(&harness, replacement_block, Duration::MAX);
         let mut fork_choice = chain.canonical_head.fork_choice_write_lock();
-        for (attestation, _) in attestations.into_iter().flatten() {
-            let indexed_attestation = attestation.to_indexed::<MinimalEthSpec>(fork_name).unwrap();
-            fork_choice
-                .on_attestation(
-                    chain.slot().unwrap(),
-                    indexed_attestation.to_ref(),
-                    AttestationFromBlock::False,
-                    &chain.spec,
-                )
-                .unwrap();
-        }
-        let (new_head_root, _) = fork_choice
-            .get_head(chain.slot().unwrap(), &chain.spec)
-            .unwrap();
+        let (new_head_root, _) = fork_choice.get_head(slot, &chain.spec).unwrap();
         assert_eq!(
             new_head_root,
             replacement_block.root(),
@@ -923,7 +913,7 @@ mod tests {
             "stale same-slot cache entry must produce the existing not-found rejection"
         );
 
-        cache_block(&harness, replacement_block);
+        cache_block(&harness, replacement_block, replacement_proto_block);
         chain
             .store
             .put_block(

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -94,7 +94,7 @@ impl BlockId {
                         )
                     } else {
                         // Block import holds the fork choice write lock from cache insertion until
-                        // persistence. Re-read the cache so a concurrent clear is not accepted.
+                        // persistence. Re-read the cache to reject an entry cleared during lookup.
                         chain
                             .early_attester_cache
                             .get_head_block_root()
@@ -821,7 +821,7 @@ mod tests {
                 .block_root_at_slot(slot, WhenSlotSkipped::None)
                 .unwrap(),
             None,
-            "precondition: persisted lookup must not know the new head"
+            "precondition: persisted slot lookup must not resolve the new head"
         );
 
         let (request, result_rx) = spawn_slot_header_lookup(chain.clone(), slot);
@@ -836,7 +836,7 @@ mod tests {
             BlockId(CoreBlockId::Slot(slot))
                 .is_canonical(block_root, slot, chain)
                 .unwrap(),
-            "resolved slot must remain canonical across the cache handoff"
+            "slot lookup result must remain canonical after the cache is cleared"
         );
         drop(fork_choice);
         request.join().unwrap();
@@ -862,6 +862,7 @@ mod tests {
             "precondition: blocks must compete at the same slot"
         );
 
+        // Import both blocks too late for proposer boost. Fork choice then selects the higher root.
         let (stale_block, replacement_block) = if block_root_a < block_root_b {
             (&block_a, &block_b)
         } else {
@@ -891,7 +892,7 @@ mod tests {
         assert_eq!(
             BlockId(CoreBlockId::Slot(slot)).root(chain).unwrap(),
             (stale_block.root(), false, false),
-            "persisted cache entry must cover the gap before the canonical head is updated"
+            "persisted cached head must resolve before the canonical snapshot is updated"
         );
 
         let replacement_proto_block =
@@ -901,7 +902,7 @@ mod tests {
         assert_eq!(
             new_head_root,
             replacement_block.root(),
-            "precondition: new votes must replace the same-slot head"
+            "precondition: higher-root block must become head"
         );
         drop(fork_choice);
 
@@ -910,7 +911,7 @@ mod tests {
             rejection
                 .find::<warp_utils::reject::CustomNotFound>()
                 .is_some(),
-            "stale same-slot cache entry must produce the existing not-found rejection"
+            "stale same-slot cache entry must produce a not-found rejection"
         );
 
         cache_block(&harness, replacement_block, replacement_proto_block);
@@ -1048,7 +1049,7 @@ mod tests {
             !BlockId(CoreBlockId::Root(block_root))
                 .is_canonical(block_root, block.slot(), chain)
                 .unwrap(),
-            "root lookup must preserve persisted canonical metadata"
+            "unpersisted root lookup must not be marked canonical"
         );
 
         let (blinded_block, execution_optimistic, finalized) =

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -72,44 +72,48 @@ impl BlockId {
                 Ok((justified_checkpoint.root, execution_optimistic, false))
             }
             CoreBlockId::Slot(slot) => {
-                if let Some((cached_slot, cached_root)) = chain
-                    .early_attester_cache
-                    .get_head_block_root()
-                    .filter(|(cached_slot, _)| cached_slot == slot)
+                let fallback_requires_fork_choice_check = if let Some((cached_slot, cached_root)) =
+                    chain
+                        .early_attester_cache
+                        .get_head_block_root()
+                        .filter(|(cached_slot, _)| cached_slot == slot)
                 {
-                    let cached_root_is_persisted = chain
-                        .store
-                        .block_exists(&cached_root)
-                        .map_err(BeaconChainError::DBError)
-                        .map_err(warp_utils::reject::unhandled_error)?;
+                    // Read the cache again before checking persistence. If the block is not
+                    // persisted, this read occurs while its importer holds the fork choice write lock.
+                    let cache_unchanged = chain.early_attester_cache.get_head_block_root()
+                        == Some((cached_slot, cached_root));
 
-                    let cached_head = if cached_root_is_persisted {
+                    if cache_unchanged {
+                        let cached_root_is_persisted = chain
+                            .store
+                            .block_exists(&cached_root)
+                            .map_err(BeaconChainError::DBError)
+                            .map_err(warp_utils::reject::unhandled_error)?;
+
+                        if !cached_root_is_persisted {
+                            return Ok((cached_root, false, false));
+                        }
+
+                        // Block import locks fork choice before it locks the early attester cache.
+                        // Use the same order to confirm the persisted cached head.
                         let fork_choice = chain.canonical_head.fork_choice_read_lock();
-                        chain.early_attester_cache.get_head_block_root().filter(
+                        let cached_head = chain.early_attester_cache.get_head_block_root().filter(
                             |(current_slot, current_root)| {
                                 current_slot == slot
                                     && *current_root
                                         == fork_choice.cached_fork_choice_view().head_block_root
                             },
-                        )
-                    } else {
-                        // Block import holds the fork choice write lock from cache insertion until
-                        // persistence. Re-read the cache to reject an entry cleared during lookup.
-                        chain
-                            .early_attester_cache
-                            .get_head_block_root()
-                            .filter(|cached_head| *cached_head == (cached_slot, cached_root))
-                    };
+                        );
 
-                    return cached_head
-                        .map(|(_, root)| (root, false, false))
-                        .ok_or_else(|| {
-                            warp_utils::reject::custom_not_found(format!(
-                                "beacon block at slot {}",
-                                slot
-                            ))
-                        });
-                }
+                        if let Some((_, root)) = cached_head {
+                            return Ok((root, false, false));
+                        }
+                    }
+
+                    true
+                } else {
+                    false
+                };
 
                 let execution_optimistic = chain
                     .is_optimistic_or_invalid_head()
@@ -125,6 +129,16 @@ impl BlockId {
                             ))
                         })
                     })?;
+                if fallback_requires_fork_choice_check {
+                    let fork_choice = chain.canonical_head.fork_choice_read_lock();
+                    let current_head_root = fork_choice.cached_fork_choice_view().head_block_root;
+                    if !fork_choice.is_descendant(root, current_head_root) {
+                        return Err(warp_utils::reject::custom_not_found(format!(
+                            "beacon block at slot {}",
+                            slot
+                        )));
+                    }
+                }
                 let finalized = *slot
                     <= chain
                         .canonical_head
@@ -774,21 +788,23 @@ mod tests {
     fn spawn_slot_header_lookup(
         chain: Arc<TestChain>,
         slot: Slot,
-    ) -> (JoinHandle<()>, Receiver<(Hash256, bool, bool, bool)>) {
+    ) -> (JoinHandle<()>, Receiver<Hash256>) {
         let (started_tx, started_rx) = std::sync::mpsc::channel();
         let (result_tx, result_rx) = std::sync::mpsc::channel();
         let request = std::thread::spawn(move || {
             started_tx.send(()).unwrap();
             let block_id = BlockId(CoreBlockId::Slot(slot));
             let result = block_id.root(&chain).unwrap();
+            assert!(!result.1);
+            assert!(!result.2);
             let (block, _, _) = BlockId::from_root(result.0).blinded_block(&chain).unwrap();
             assert_eq!(block.canonical_root(), result.0);
-            let canonical = block_id
-                .is_canonical(result.0, block.slot(), &chain)
-                .unwrap();
-            result_tx
-                .send((result.0, result.1, result.2, canonical))
-                .unwrap();
+            assert!(
+                block_id
+                    .is_canonical(result.0, block.slot(), &chain)
+                    .unwrap()
+            );
+            result_tx.send(result.0).unwrap();
         });
         started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
         (request, result_rx)
@@ -829,7 +845,7 @@ mod tests {
             result_rx
                 .recv_timeout(Duration::from_secs(2))
                 .expect("unpersisted lookup must not wait for the fork choice write lock"),
-            (block_root, false, false, true)
+            block_root
         );
         chain.early_attester_cache.clear();
         assert!(

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -72,6 +72,45 @@ impl BlockId {
                 Ok((justified_checkpoint.root, execution_optimistic, false))
             }
             CoreBlockId::Slot(slot) => {
+                if let Some((cached_slot, cached_root)) = chain
+                    .early_attester_cache
+                    .get_head_block_root()
+                    .filter(|(cached_slot, _)| cached_slot == slot)
+                {
+                    let cached_root_is_persisted = chain
+                        .store
+                        .block_exists(&cached_root)
+                        .map_err(BeaconChainError::DBError)
+                        .map_err(warp_utils::reject::unhandled_error)?;
+
+                    let cached_head = if cached_root_is_persisted {
+                        let fork_choice = chain.canonical_head.fork_choice_read_lock();
+                        chain.early_attester_cache.get_head_block_root().filter(
+                            |(current_slot, current_root)| {
+                                current_slot == slot
+                                    && *current_root
+                                        == fork_choice.cached_fork_choice_view().head_block_root
+                            },
+                        )
+                    } else {
+                        // Block import holds the fork choice write lock from cache insertion until
+                        // persistence. Re-read the cache so a concurrent clear is not accepted.
+                        chain
+                            .early_attester_cache
+                            .get_head_block_root()
+                            .filter(|cached_head| *cached_head == (cached_slot, cached_root))
+                    };
+
+                    return cached_head
+                        .map(|(_, root)| (root, false, false))
+                        .ok_or_else(|| {
+                            warp_utils::reject::custom_not_found(format!(
+                                "beacon block at slot {}",
+                                slot
+                            ))
+                        });
+                }
+
                 let execution_optimistic = chain
                     .is_optimistic_or_invalid_head()
                     .map_err(warp_utils::reject::unhandled_error)?;
@@ -132,12 +171,8 @@ impl BlockId {
                 } else if chain.early_attester_cache.get_block(*root).is_some() {
                     // Fall back to the early attester cache for blocks that are in fork choice
                     // but haven't been written to disk yet.
-                    let execution_optimistic = chain
-                        .canonical_head
-                        .fork_choice_read_lock()
-                        .is_optimistic_or_invalid_block(root)
-                        .unwrap_or(false);
-                    Ok((*root, execution_optimistic, false))
+                    // Blocks in this cache are execution validated and not finalized.
+                    Ok((*root, false, false))
                 } else {
                     Err(warp_utils::reject::custom_not_found(format!(
                         "beacon block with root {}",
@@ -146,6 +181,26 @@ impl BlockId {
                 }
             }
         }
+    }
+
+    pub(crate) fn is_canonical<T: BeaconChainTypes>(
+        &self,
+        root: Hash256,
+        slot: Slot,
+        chain: &BeaconChain<T>,
+    ) -> Result<bool, warp::Rejection> {
+        // A successful slot lookup only returns the canonical block at that slot.
+        if matches!(
+            &self.0,
+            CoreBlockId::Slot(requested_slot) if *requested_slot == slot
+        ) {
+            return Ok(true);
+        }
+
+        chain
+            .block_root_at_slot(slot, WhenSlotSkipped::None)
+            .map_err(warp_utils::reject::unhandled_error)
+            .map(|canonical| canonical.is_some_and(|canonical| root == canonical))
     }
 
     pub fn blinded_block_by_root<T: BeaconChainTypes>(
@@ -553,14 +608,19 @@ mod tests {
         custody_context::NodeCustodyType,
         data_availability_checker::AvailableBlock,
         test_utils::{
-            BeaconChainHarness, EphemeralHarnessType, fork_name_from_env,
+            AttestationStrategy, BeaconChainHarness, EphemeralHarnessType, fork_name_from_env,
             generate_data_column_sidecars_from_block,
         },
     };
+    use fork_choice::AttestationFromBlock;
+    use proto_array::Block as ProtoBlock;
+    use std::sync::mpsc::Receiver;
+    use std::thread::JoinHandle;
     use std::time::Duration;
-    use types::MinimalEthSpec;
+    use types::{BeaconState, MinimalEthSpec};
 
     type TestHarness = BeaconChainHarness<EphemeralHarnessType<MinimalEthSpec>>;
+    type TestChain = BeaconChain<EphemeralHarnessType<MinimalEthSpec>>;
 
     fn harness() -> TestHarness {
         BeaconChainHarness::builder(MinimalEthSpec)
@@ -645,6 +705,236 @@ mod tests {
         assert_eq!(
             BlockId(CoreBlockId::Head).root(&harness.chain).unwrap().0,
             block_root
+        );
+    }
+
+    struct UnpersistedBlock {
+        available_block: AvailableBlock<MinimalEthSpec>,
+        post_state: BeaconState<MinimalEthSpec>,
+        proto_block: ProtoBlock,
+    }
+
+    impl UnpersistedBlock {
+        fn root(&self) -> Hash256 {
+            self.available_block.block_root()
+        }
+    }
+
+    async fn make_unpersisted_block(
+        harness: &TestHarness,
+        state: BeaconState<MinimalEthSpec>,
+        slot: Slot,
+    ) -> UnpersistedBlock {
+        let (block_contents, post_state) = harness.make_block(state, slot).await;
+        let (block, _) = block_contents;
+        let available_block = AvailableBlock::new(
+            block,
+            AvailableBlockData::NoData,
+            &harness.chain.custody_context,
+        )
+        .unwrap();
+        let block_root = available_block.block_root();
+        let proto_block = {
+            let mut fork_choice = harness.chain.canonical_head.fork_choice_write_lock();
+            fork_choice
+                .on_block(
+                    slot,
+                    available_block.block().message(),
+                    block_root,
+                    Duration::ZERO,
+                    &post_state,
+                    PayloadVerificationStatus::Verified,
+                    &harness.chain.spec,
+                )
+                .unwrap();
+            fork_choice.get_block(&block_root).unwrap()
+        };
+        UnpersistedBlock {
+            available_block,
+            post_state,
+            proto_block,
+        }
+    }
+
+    fn cache_block(harness: &TestHarness, block: &UnpersistedBlock) {
+        harness
+            .chain
+            .early_attester_cache
+            .add_head_block(
+                block.root(),
+                &block.available_block,
+                block.proto_block.clone(),
+                &block.post_state,
+            )
+            .unwrap();
+    }
+
+    fn spawn_slot_header_lookup(
+        chain: Arc<TestChain>,
+        slot: Slot,
+    ) -> (JoinHandle<()>, Receiver<(Hash256, bool, bool, bool)>) {
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
+        let request = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let block_id = BlockId(CoreBlockId::Slot(slot));
+            let result = block_id.root(&chain).unwrap();
+            let (block, _, _) = BlockId::from_root(result.0).blinded_block(&chain).unwrap();
+            assert_eq!(block.canonical_root(), result.0);
+            let canonical = block_id
+                .is_canonical(result.0, block.slot(), &chain)
+                .unwrap();
+            result_tx
+                .send((result.0, result.1, result.2, canonical))
+                .unwrap();
+        });
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        (request, result_rx)
+    }
+
+    #[tokio::test]
+    async fn slot_uses_early_attester_cache_for_unpersisted_head() {
+        let harness = harness();
+        let chain = &harness.chain;
+        harness
+            .execution_block_generator()
+            .set_generate_blobs(false);
+        harness.advance_slot();
+
+        let slot = harness.get_current_slot();
+        let block = make_unpersisted_block(&harness, harness.get_current_state(), slot).await;
+        let block_root = block.root();
+        let mut fork_choice = chain.canonical_head.fork_choice_write_lock();
+        let (head_root, _) = fork_choice.get_head(slot, &chain.spec).unwrap();
+        assert_eq!(head_root, block_root, "precondition: block must be head");
+        cache_block(&harness, &block);
+
+        assert!(
+            !chain.store.block_exists(&block_root).unwrap(),
+            "precondition: head block must not be persisted"
+        );
+        assert_eq!(
+            chain
+                .block_root_at_slot(slot, WhenSlotSkipped::None)
+                .unwrap(),
+            None,
+            "precondition: persisted lookup must not know the new head"
+        );
+
+        let (request, result_rx) = spawn_slot_header_lookup(chain.clone(), slot);
+        assert_eq!(
+            result_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("unpersisted lookup must not wait for the fork choice write lock"),
+            (block_root, false, false, true)
+        );
+        chain.early_attester_cache.clear();
+        assert!(
+            BlockId(CoreBlockId::Slot(slot))
+                .is_canonical(block_root, slot, chain)
+                .unwrap(),
+            "resolved slot must remain canonical across the cache handoff"
+        );
+        drop(fork_choice);
+        request.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn slot_rejects_stale_cache_and_accepts_same_slot_replacement() {
+        let harness = harness();
+        let chain = &harness.chain;
+        harness
+            .execution_block_generator()
+            .set_generate_blobs(false);
+        harness.advance_slot();
+
+        let slot = harness.get_current_slot();
+        let state = harness.get_current_state();
+        let block_a = make_unpersisted_block(&harness, state.clone(), slot).await;
+        let block_b = make_unpersisted_block(&harness, state, slot).await;
+        let block_root_a = block_a.root();
+        let block_root_b = block_b.root();
+        assert_ne!(
+            block_root_a, block_root_b,
+            "precondition: blocks must compete at the same slot"
+        );
+
+        let old_head_root = {
+            let mut fork_choice = chain.canonical_head.fork_choice_write_lock();
+            let (head_root, _) = fork_choice.get_head(slot, &chain.spec).unwrap();
+            head_root
+        };
+        let (stale_block, replacement_block) = if old_head_root == block_root_a {
+            (&block_a, &block_b)
+        } else {
+            (&block_b, &block_a)
+        };
+
+        cache_block(&harness, stale_block);
+        chain
+            .store
+            .put_block(
+                &stale_block.root(),
+                stale_block.available_block.block().clone(),
+            )
+            .unwrap();
+        assert_eq!(
+            BlockId(CoreBlockId::Slot(slot)).root(chain).unwrap(),
+            (stale_block.root(), false, false),
+            "persisted cache entry must cover the gap before the canonical head is updated"
+        );
+
+        let fork_name = chain.spec.fork_name_at_slot::<MinimalEthSpec>(slot);
+        let attestations = harness.get_single_attestations(
+            &AttestationStrategy::AllValidators,
+            &replacement_block.post_state,
+            replacement_block.available_block.block().state_root(),
+            replacement_block.root(),
+            slot,
+        );
+        harness.advance_slot();
+        let mut fork_choice = chain.canonical_head.fork_choice_write_lock();
+        for (attestation, _) in attestations.into_iter().flatten() {
+            let indexed_attestation = attestation.to_indexed::<MinimalEthSpec>(fork_name).unwrap();
+            fork_choice
+                .on_attestation(
+                    chain.slot().unwrap(),
+                    indexed_attestation.to_ref(),
+                    AttestationFromBlock::False,
+                    &chain.spec,
+                )
+                .unwrap();
+        }
+        let (new_head_root, _) = fork_choice
+            .get_head(chain.slot().unwrap(), &chain.spec)
+            .unwrap();
+        assert_eq!(
+            new_head_root,
+            replacement_block.root(),
+            "precondition: new votes must replace the same-slot head"
+        );
+        drop(fork_choice);
+
+        let rejection = BlockId(CoreBlockId::Slot(slot)).root(chain).unwrap_err();
+        assert!(
+            rejection
+                .find::<warp_utils::reject::CustomNotFound>()
+                .is_some(),
+            "stale same-slot cache entry must produce the existing not-found rejection"
+        );
+
+        cache_block(&harness, replacement_block);
+        chain
+            .store
+            .put_block(
+                &replacement_block.root(),
+                replacement_block.available_block.block().clone(),
+            )
+            .unwrap();
+        assert_eq!(
+            BlockId(CoreBlockId::Slot(slot)).root(chain).unwrap(),
+            (replacement_block.root(), false, false),
+            "same-slot replacement must be served"
         );
     }
 
@@ -763,6 +1053,12 @@ mod tests {
         assert_eq!(
             BlockId(CoreBlockId::Root(block_root)).root(chain).unwrap(),
             (block_root, false, false)
+        );
+        assert!(
+            !BlockId(CoreBlockId::Root(block_root))
+                .is_canonical(block_root, block.slot(), chain)
+                .unwrap(),
+            "root lookup must preserve persisted canonical metadata"
         );
 
         let (blinded_block, execution_optimistic, finalized) =

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -56,7 +56,7 @@ use axum::Router;
 use axum_utils::server::Server;
 use axum_utils::tls::TlsConfig;
 use beacon::states;
-use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
+use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes, WhenSlotSkipped};
 use beacon_processor::BeaconProcessorSend;
 pub use block_id::BlockId;
 use builder_states::get_next_withdrawals;
@@ -65,8 +65,8 @@ use context_deserialize::ContextDeserialize;
 use directory::DEFAULT_ROOT_DIR;
 use eth2::lighthouse::sync_state::SyncState;
 use eth2::types::{
-    self as api_types, BroadcastValidation, EndpointVersion, ForkChoice, ForkChoiceExtraData,
-    ForkChoiceNode, LightClientUpdatesQuery, PublishBlockRequest, ValidatorId,
+    self as api_types, BlockId as CoreBlockId, BroadcastValidation, EndpointVersion, ForkChoice,
+    ForkChoiceExtraData, ForkChoiceNode, LightClientUpdatesQuery, PublishBlockRequest, ValidatorId,
 };
 use eth2::{CONSENSUS_VERSION_HEADER, CONTENT_TYPE_HEADER, SSZ_CONTENT_TYPE_HEADER};
 use health_metrics::observe::Observe;
@@ -791,7 +791,15 @@ pub async fn serve<T: BeaconChainTypes>(
                     let (block, _execution_optimistic, _finalized) =
                         BlockId::from_root(root).blinded_block(&chain)?;
 
-                    let canonical = block_id.is_canonical(root, block.slot(), &chain)?;
+                    // A successful slot lookup has already selected the canonical block at that
+                    // slot.
+                    let canonical = match &block_id.0 {
+                        CoreBlockId::Slot(requested_slot) => *requested_slot == block.slot(),
+                        _ => chain
+                            .block_root_at_slot(block.slot(), WhenSlotSkipped::None)
+                            .map_err(warp_utils::reject::unhandled_error)?
+                            .is_some_and(|canonical| root == canonical),
+                    };
 
                     let data = api_types::BlockHeaderData {
                         root,

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -56,7 +56,7 @@ use axum::Router;
 use axum_utils::server::Server;
 use axum_utils::tls::TlsConfig;
 use beacon::states;
-use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes, WhenSlotSkipped};
+use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
 use beacon_processor::BeaconProcessorSend;
 pub use block_id::BlockId;
 use builder_states::get_next_withdrawals;
@@ -791,10 +791,7 @@ pub async fn serve<T: BeaconChainTypes>(
                     let (block, _execution_optimistic, _finalized) =
                         BlockId::from_root(root).blinded_block(&chain)?;
 
-                    let canonical = chain
-                        .block_root_at_slot(block.slot(), WhenSlotSkipped::None)
-                        .map_err(warp_utils::reject::unhandled_error)?
-                        .is_some_and(|canonical| root == canonical);
+                    let canonical = block_id.is_canonical(root, block.slot(), &chain)?;
 
                     let data = api_types::BlockHeaderData {
                         root,


### PR DESCRIPTION
## Issue Addressed

`GET /eth/v1/beacon/headers/{slot}` can return 404 immediately after Lighthouse emits a `head` event because slot lookup only checks persisted state.

Since #8718, Lighthouse emits the head event before block persistence. The early-cache lookups added in #8729 and #9338 do not cover slot IDs.

## Proposed Changes

For a slot matching the early attester cache, return the cached root before persistence. After the cached block is persisted, compare its root with the last computed fork-choice head. If the cache changes during the lookup, use the persisted slot result only when it remains an ancestor of the current fork-choice head. This prevents a same-slot replacement from returning the old root.

The slot header remains canonical while the block moves from the early cache to persisted state.

## Additional Info

The pre-persistence path does not take the fork-choice lock or recompute the head. Blocks served from the early attester cache are execution validated and not finalized.