### PR TITLE
Re-enable optimistic sync for Gloas payload envelopes

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4436,10 +4436,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let fork_choice_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_FORK_CHOICE);
             match fork_choice.get_head(current_slot, &self.spec) {
                 // This block became the head, add it to the early attester cache.
-                Ok((new_head_root, _)) if new_head_root == block_root => {
+                Ok((new_head_root, head_payload_status)) if new_head_root == block_root => {
+                    // Ask about the node that the head is on. The status of the block can let an
+                    // empty head claim a validity that its branch never established.
                     if let Some(proto_block) = fork_choice.get_block(&block_root) {
-                        let new_head_is_optimistic =
-                            proto_block.execution_status.is_optimistic_or_invalid();
+                        let new_head_is_optimistic = fork_choice
+                            .get_node_execution_status(&block_root, head_payload_status)
+                            .is_some_and(|status| status.is_optimistic_or_invalid());
 
                         if let Err(e) = self.early_attester_cache.add_head_block(
                             block_root,
@@ -5503,12 +5506,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Err(Box::new(DoNotReOrg::NotProposing.into()));
         }
 
-        // This only works pre-Gloas, but we don't run this code for Gloas anyway.
+        // This only works pre-Gloas, so a Gloas node reports no head hash here.
         let parent_head_hash = info
             .parent_node
-            .execution_status()
+            .as_v17()
             .ok()
-            .and_then(|execution_status| execution_status.block_hash());
+            .and_then(|node| node.execution_status.block_hash());
         let forkchoice_update_params = ForkchoiceUpdateParameters {
             head_root: info.parent_node.root(),
             head_hash: parent_head_hash,

--- a/beacon_node/beacon_chain/src/block_production/mod.rs
+++ b/beacon_node/beacon_chain/src/block_production/mod.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use fork_choice::PayloadStatus;
-use proto_array::{ProposerHeadError, ReOrgThreshold};
+use proto_array::{ParentPayloadStatus, ProposerHeadError, ReOrgThreshold};
 use slot_clock::SlotClock;
 use tracing::{debug, error, info, instrument, warn};
 use types::{BeaconState, Epoch, EthSpec, Hash256, SignedExecutionPayloadEnvelope, Slot};
@@ -245,7 +245,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // The head uniquely determines the parent payload status for the re-org block, whichever
         // variant (full or empty) it builds on must have more weight, or else we would have already
         // re-orged away from this block naturally, and it would not be the head, by definition.
-        let parent_payload_status = proposer_head.head_node.get_parent_payload_status();
+        // Resolved to a `PayloadStatus` here because `produce_block_on_state_gloas` is shared
+        // with the head-based path, whose value is the head's own side and can be `Pending`. A
+        // pre-Gloas parent has no separate payload to extend: build on the empty node.
+        let parent_payload_status = match proposer_head.head_node.get_parent_payload_status() {
+            ParentPayloadStatus::Full => PayloadStatus::Full,
+            ParentPayloadStatus::Empty | ParentPayloadStatus::PreGloas => PayloadStatus::Empty,
+        };
 
         let (state_root, state) = self
             .store

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -597,9 +597,10 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
     /// significantly past the cached `head_snapshot`. In such a scenario it is likely prudent to
     /// run `BeaconChain::recompute_head` to update the cached values.
     pub fn head_execution_status(&self) -> Result<ExecutionStatus, Error> {
-        let head_block_root = self.cached_head().head_block_root();
+        let head = self.cached_head();
+        let head_block_root = head.head_block_root();
         self.fork_choice_read_lock()
-            .get_block_execution_status(&head_block_root)
+            .get_node_execution_status(&head_block_root, head.head_payload_status())
             .ok_or(Error::HeadMissingFromForkChoice(head_block_root))
     }
 
@@ -615,7 +616,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         let head_block_root = head.head_block_root();
         let execution_status = self
             .fork_choice_read_lock()
-            .get_block_execution_status(&head_block_root)
+            .get_node_execution_status(&head_block_root, head.head_payload_status())
             .ok_or(Error::HeadMissingFromForkChoice(head_block_root))?;
         Ok((head, execution_status))
     }

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -238,7 +238,8 @@ pub fn validate_execution_payload_for_gossip<T: BeaconChainTypes>(
             // Parent has valid or optimistic execution status.
             ExecutionStatus::Valid(_) | ExecutionStatus::Optimistic(_) => true,
             // Pre-merge blocks have irrelevant execution status.
-            ExecutionStatus::Irrelevant(_) => false,
+            // A pre-Gloas block cannot have a Gloas parent, so `NotYetRevealed` is unreachable.
+            ExecutionStatus::Irrelevant(_) | ExecutionStatus::NotYetRevealed(_) => false,
             // If the parent has an invalid payload then it's impossible to build a valid block upon
             // it. Reject the block.
             ExecutionStatus::Invalid(_) => {

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -133,7 +133,7 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
 pub async fn notify_new_payload<T: BeaconChainTypes>(
     chain: &Arc<BeaconChain<T>>,
     slot: Slot,
-    parent_beacon_block_root: Hash256,
+    invalidation_head_block_root: Hash256,
     new_payload_request: NewPayloadRequest<'_, T::EthSpec>,
 ) -> Result<PayloadVerificationStatus, PayloadVerificationError> {
     let execution_layer = chain
@@ -181,11 +181,9 @@ pub async fn notify_new_payload<T: BeaconChainTypes>(
                 if let Some(latest_valid_hash) =
                     latest_valid_hash.filter(|hash| *hash != ExecutionBlockHash::zero())
                 {
-                    // This block has not yet been applied to fork choice, so the latest block that was
-                    // imported to fork choice was the parent.
                     chain
                         .process_invalid_execution_payload(&InvalidationOperation::InvalidateMany {
-                            head_block_root: parent_beacon_block_root,
+                            head_block_root: invalidation_head_block_root,
                             always_invalidate_head: false,
                             latest_valid_ancestor: latest_valid_hash,
                         })

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -170,14 +170,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .map_err(BeaconChainError::TokioJoin)?
             .ok_or(BeaconChainError::RuntimeShutdown)??;
 
-        // TODO(gloas): optimistic sync is not supported for Gloas, maybe we could re-add it
-        if payload_verification_outcome
-            .payload_verification_status
-            .is_optimistic()
-        {
-            return Err(EnvelopeError::OptimisticSyncNotSupported { block_root });
-        }
-
         Ok(AvailabilityPendingExecutedEnvelope::new(
             signed_envelope,
             block_root,
@@ -247,7 +239,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // Update the block's payload to received in fork choice, which creates the `Full` virtual
         // node which can be eligible for head.
         fork_choice
-            .on_valid_payload_envelope_received(block_root)
+            .on_payload_envelope_received(
+                block_root,
+                payload_verification_status,
+                signed_envelope.message().payload.block_hash,
+            )
             .map_err(|e| EnvelopeError::InternalError(format!("{e:?}")))?;
 
         // It is important NOT to return errors here before the database commit, because the envelope

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/payload_notifier.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/payload_notifier.rs
@@ -63,9 +63,10 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
         if let Some(precomputed_status) = self.payload_verification_status {
             Ok(precomputed_status)
         } else {
-            let parent_root = self.block.message().parent_root();
+            // The EE judged this block's own payload, so invalidate the block, not its parent.
+            let block_root = self.block.canonical_root();
             let request = Self::build_new_payload_request(&self.envelope, &self.block)?;
-            notify_new_payload(&self.chain, self.envelope.slot(), parent_root, request).await
+            notify_new_payload(&self.chain, self.envelope.slot(), block_root, request).await
         }
     }
 

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -34,6 +34,7 @@ use execution_layer::{
     test_utils::{DEFAULT_JWT_SECRET, ExecutionBlockGenerator, MockBuilder, MockExecutionLayer},
 };
 use fixed_bytes::FixedBytesExtended;
+use fork_choice::PayloadVerificationStatus;
 use futures::channel::mpsc::Receiver;
 pub use genesis::{DEFAULT_ETH1_BLOCK_HASH, InteropGenesisBuilder};
 use int_to_bytes::int_to_bytes32;
@@ -3089,6 +3090,7 @@ where
             slot = %signed_envelope.slot(),
             "Processing execution payload envelope"
         );
+        let payload_block_hash = signed_envelope.message.payload.block_hash;
 
         state_processing::envelope_processing::verify_execution_payload_envelope(
             state,
@@ -3176,7 +3178,11 @@ where
         self.chain
             .canonical_head
             .fork_choice_write_lock()
-            .on_valid_payload_envelope_received(block_root)
+            .on_payload_envelope_received(
+                block_root,
+                PayloadVerificationStatus::Verified,
+                payload_block_hash,
+            )
             .expect("should update fork choice with envelope");
 
         // Run fork choice because the envelope could become the head.

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -21,6 +21,7 @@ use beacon_chain::{
 use bls::{AggregateSignature, Keypair, Signature};
 use fixed_bytes::FixedBytesExtended;
 use fork_choice::PayloadStatus;
+use fork_choice::PayloadVerificationStatus;
 use logging::create_test_tracing_subscriber;
 use slasher::{Config as SlasherConfig, Slasher};
 use state_processing::{
@@ -31,6 +32,7 @@ use state_processing::{
 use std::marker::PhantomData;
 use std::sync::{Arc, LazyLock};
 use tempfile::tempdir;
+use types::ExecutionBlockHash;
 use types::{test_utils::generate_deterministic_keypair, *};
 
 type E = MainnetEthSpec;
@@ -277,7 +279,11 @@ fn update_fork_choice_with_envelopes(
                 .chain
                 .canonical_head
                 .fork_choice_write_lock()
-                .on_valid_payload_envelope_received(snapshot.beacon_block_root);
+                .on_payload_envelope_received(
+                    snapshot.beacon_block_root,
+                    PayloadVerificationStatus::Verified,
+                    ExecutionBlockHash::zero(),
+                );
         }
     }
 }
@@ -1284,7 +1290,11 @@ async fn block_gossip_verification() {
                 .chain
                 .canonical_head
                 .fork_choice_write_lock()
-                .on_valid_payload_envelope_received(snapshot.beacon_block_root)
+                .on_payload_envelope_received(
+                    snapshot.beacon_block_root,
+                    PayloadVerificationStatus::Verified,
+                    ExecutionBlockHash::zero(),
+                )
                 .expect("should update fork choice with envelope");
         }
     }
@@ -2620,7 +2630,11 @@ async fn process_chain_segment_ignores_duplicate_gloas_block_when_payload_receiv
         .chain
         .canonical_head
         .fork_choice_write_lock()
-        .on_valid_payload_envelope_received(block_root)
+        .on_payload_envelope_received(
+            block_root,
+            PayloadVerificationStatus::Verified,
+            ExecutionBlockHash::zero(),
+        )
         .expect("payload should be marked received");
 
     let data_sidecars = Some(DataSidecars::DataColumns(

--- a/beacon_node/beacon_chain/tests/envelope_verification.rs
+++ b/beacon_node/beacon_chain/tests/envelope_verification.rs
@@ -3,8 +3,9 @@ use beacon_chain::payload_envelope_verification::EnvelopeSource;
 use beacon_chain::test_utils::{BeaconChainHarness, fork_name_from_env};
 use bls::PublicKeyBytes;
 use eth2::types::EventKind;
+use proto_array::ExecutionStatus;
 use std::sync::Arc;
-use types::{Address, MinimalEthSpec, Slot, WithdrawalRequest};
+use types::{Address, Hash256, MinimalEthSpec, Slot, WithdrawalRequest};
 
 type E = MinimalEthSpec;
 
@@ -333,5 +334,152 @@ async fn gossip_seen_envelope_can_be_reverified_via_non_gossip() {
     assert!(
         gossip_receiver.try_recv().is_err(),
         "an envelope re-verified over HTTP must not re-emit execution_payload_gossip"
+    );
+}
+
+/// Helper: build a Gloas harness with a mock execution layer.
+fn gloas_harness() -> BeaconChainHarness<beacon_chain::test_utils::EphemeralHarnessType<E>> {
+    BeaconChainHarness::builder(E::default())
+        .default_spec()
+        .deterministic_keypairs(64)
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build()
+}
+
+/// Helper: produce the block and envelope for `slot`, import both, and return the block root.
+async fn import_block_and_envelope(
+    harness: &BeaconChainHarness<beacon_chain::test_utils::EphemeralHarnessType<E>>,
+    slot: Slot,
+) -> Hash256 {
+    let state = harness.get_current_state();
+    harness.advance_slot();
+    let (block_contents, opt_envelope, _) = harness.make_block_with_envelope(state, slot).await;
+    let block_root = block_contents.0.canonical_root();
+
+    let block = block_contents.0.clone();
+    harness
+        .process_block(slot, block_root, block_contents)
+        .await
+        .expect("block should be processed");
+
+    // Without its custody columns the envelope never reaches fork choice.
+    harness.process_gossip_columns(&block, None).await;
+
+    let signed_envelope = opt_envelope.expect("Gloas block should produce an envelope");
+    let gossip_verified = harness
+        .chain
+        .verify_envelope_for_gossip(Arc::new(signed_envelope), EnvelopeSource::Gossip)
+        .await
+        .expect("envelope gossip verification should succeed");
+
+    let status = harness
+        .chain
+        .process_execution_payload_envelope(
+            block_root,
+            gossip_verified,
+            beacon_chain::NotifyExecutionLayer::Yes,
+            types::BlockImportSource::Gossip,
+            #[allow(clippy::result_large_err)]
+            || Ok(()),
+        )
+        .await
+        .expect("envelope import should succeed even when the execution layer is syncing");
+
+    assert!(
+        matches!(
+            status,
+            beacon_chain::AvailabilityProcessingStatus::Imported(..)
+        ),
+        "envelope for slot {slot} should import, got {status:?}",
+    );
+
+    // The next block builds on the payload status of the head. If the head does not catch up
+    // here, every block extends the `EMPTY` variant of its parent.
+    harness.chain.recompute_head_at_current_slot().await;
+
+    block_root
+}
+
+/// Helper: the execution status that fork choice holds for the payload of a block.
+fn execution_status(
+    harness: &BeaconChainHarness<beacon_chain::test_utils::EphemeralHarnessType<E>>,
+    block_root: Hash256,
+) -> ExecutionStatus {
+    harness
+        .chain
+        .canonical_head
+        .fork_choice_read_lock()
+        .get_block(&block_root)
+        .expect("block should be in fork choice")
+        .execution_status
+}
+
+/// An execution layer that answers `SYNCING` must not stop the import of an envelope. The
+/// node holds the payload as `Optimistic`. It does not refuse the payload with
+/// `OptimisticSyncNotSupported`.
+#[tokio::test]
+async fn syncing_execution_layer_imports_payload_optimistically() {
+    if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
+
+    let harness = gloas_harness();
+    harness.extend_to_slot(Slot::new(1)).await;
+
+    harness
+        .mock_execution_layer
+        .as_ref()
+        .expect("mock execution layer")
+        .server
+        .all_payloads_syncing(true);
+
+    let block_root = import_block_and_envelope(&harness, Slot::new(2)).await;
+
+    assert!(
+        execution_status(&harness, block_root).is_strictly_optimistic(),
+        "a payload the execution layer could not validate must be held as optimistic",
+    );
+}
+
+/// A later valid payload promotes every optimistic payload below it. The node does not fetch
+/// an old payload again.
+#[tokio::test]
+async fn a_later_valid_payload_promotes_its_optimistic_ancestors() {
+    if !fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+        return;
+    }
+
+    let harness = gloas_harness();
+    harness.extend_to_slot(Slot::new(1)).await;
+
+    let mock = harness
+        .mock_execution_layer
+        .as_ref()
+        .expect("mock execution layer");
+
+    // The node imports two slots while the execution layer answers `SYNCING`.
+    mock.server.all_payloads_syncing(true);
+    let first_root = import_block_and_envelope(&harness, Slot::new(2)).await;
+    let second_root = import_block_and_envelope(&harness, Slot::new(3)).await;
+
+    assert!(execution_status(&harness, first_root).is_strictly_optimistic());
+    assert!(execution_status(&harness, second_root).is_strictly_optimistic());
+
+    // The execution layer catches up and validates the next payload.
+    mock.server.all_payloads_valid();
+    let third_root = import_block_and_envelope(&harness, Slot::new(4)).await;
+
+    assert!(
+        execution_status(&harness, third_root).is_valid_and_post_bellatrix(),
+        "the payload the execution layer validated must be valid",
+    );
+    assert!(
+        execution_status(&harness, second_root).is_valid_and_post_bellatrix(),
+        "its parent's payload is vouched for by the valid descendant",
+    );
+    assert!(
+        execution_status(&harness, first_root).is_valid_and_post_bellatrix(),
+        "promotion must walk the whole ancestry, not just one step",
     );
 }

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::result_large_err)]
 
 use beacon_chain::block_verification_types::LookupBlock;
+use beacon_chain::payload_envelope_verification::{EnvelopeError, EnvelopeSource};
 use beacon_chain::{
     BeaconChainError, BlockError, ChainConfig, ExecutionPayloadError,
     INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON, NotifyExecutionLayer, StateSkipConfig,
@@ -78,16 +79,25 @@ impl InvalidPayloadRig {
     }
 
     fn block_hash(&self, block_root: Hash256) -> ExecutionBlockHash {
-        self.harness
+        let block = self
+            .harness
             .chain
             .get_blinded_block(&block_root)
             .unwrap()
+            .unwrap();
+        // Pre-Gloas the block contains the payload. In Gloas the block commits only to a bid, so
+        // fork choice holds the hash.
+        if let Ok(payload) = block.message().body().execution_payload() {
+            return payload.block_hash();
+        }
+        self.harness
+            .chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .get_block(&block_root)
             .unwrap()
-            .message()
-            .body()
-            .execution_payload()
+            .execution_payload_block_hash
             .unwrap()
-            .block_hash()
     }
 
     fn execution_status(&self, block_root: Hash256) -> ExecutionStatus {
@@ -192,7 +202,8 @@ impl InvalidPayloadRig {
         let head = self.harness.chain.head_snapshot();
         let state = head.beacon_state.clone();
         let slot = slot_override.unwrap_or(state.slot() + 1);
-        let ((block, blobs), post_state) = self.harness.make_block(state, slot).await;
+        let ((block, blobs), opt_envelope, post_state) =
+            self.harness.make_block_with_envelope(state, slot).await;
         let block_root = block.canonical_root();
 
         let set_new_payload = |payload: Payload| match payload {
@@ -260,6 +271,10 @@ impl InvalidPayloadRig {
                     .await
                     .unwrap();
 
+                self.import_envelope(&block, opt_envelope.clone())
+                    .await
+                    .expect("envelope import should succeed");
+
                 if self.enable_attestations {
                     let all_validators: Vec<usize> = (0..VALIDATOR_COUNT).collect();
                     self.harness.attest_block(
@@ -295,11 +310,17 @@ impl InvalidPayloadRig {
                 set_new_payload(new_payload_response);
                 set_forkchoice_updated(forkchoice_response);
 
-                match self
+                let is_gloas = opt_envelope.is_some();
+                let outcome = match self
                     .harness
-                    .process_block(slot, block.canonical_root(), (block, blobs))
+                    .process_block(slot, block.canonical_root(), (block.clone(), blobs))
                     .await
                 {
+                    Ok(_) => self.import_envelope(&block, opt_envelope.clone()).await,
+                    Err(error) => Err(error),
+                };
+
+                match outcome {
                     Err(error) if evaluate_error(&error) => (),
                     Err(other) => {
                         panic!("evaluate_error returned false with {:?}", other)
@@ -321,6 +342,20 @@ impl InvalidPayloadRig {
                     .fork_choice_read_lock()
                     .get_block(&block_root);
                 if let Payload::Invalid { .. } = new_payload_response {
+                    if is_gloas {
+                        // In Gloas the block is still valid. Only its payload was rejected, so
+                        // the block stays in fork choice on its `EMPTY` node. The payload is
+                        // `Irrelevant` when the envelope never reached fork choice. It is
+                        // `Invalid` when invalidation ran. It is never valid.
+                        assert!(
+                            !block_in_forkchoice
+                                .unwrap()
+                                .execution_status
+                                .is_valid_and_post_bellatrix(),
+                            "a rejected payload must never be recorded as valid"
+                        );
+                        return block_root;
+                    }
                     // A block found to be immediately invalid should not end up in fork choice.
                     assert_eq!(block_in_forkchoice, None);
 
@@ -342,6 +377,59 @@ impl InvalidPayloadRig {
         block_root
     }
 
+    /// Pre-Gloas the block contains the payload and there is no envelope to import. In Gloas the
+    /// execution layer sees the payload only when the envelope arrives. A block on its own
+    /// leaves the node `Irrelevant`.
+    async fn import_envelope(
+        &self,
+        block: &Arc<SignedBeaconBlock<E>>,
+        opt_envelope: Option<SignedExecutionPayloadEnvelope<E>>,
+    ) -> Result<(), BlockError> {
+        let Some(signed_envelope) = opt_envelope else {
+            return Ok(());
+        };
+        let block_root = block.canonical_root();
+
+        // Without its custody columns the envelope never reaches fork choice.
+        self.harness.process_gossip_columns(block, None).await;
+
+        let gossip_verified = self
+            .harness
+            .chain
+            .verify_envelope_for_gossip(Arc::new(signed_envelope), EnvelopeSource::Gossip)
+            .await
+            .expect("envelope gossip verification should succeed");
+
+        let result = self
+            .harness
+            .chain
+            .process_execution_payload_envelope(
+                block_root,
+                gossip_verified,
+                NotifyExecutionLayer::Yes,
+                BlockImportSource::Gossip,
+                #[allow(clippy::result_large_err)]
+                || Ok(()),
+            )
+            .await;
+
+        // The next block builds on the head's payload status, so the head has to catch up here.
+        self.harness.chain.recompute_head_at_current_slot().await;
+
+        // In Gloas the status from the execution layer arrives through the envelope, so the
+        // same rejection is wrapped one level deeper. This unwraps it, so the error
+        // predicates of the tests, which are written for the pre-Gloas shape, still apply.
+        result.map(|_| ()).map_err(|e| match e {
+            BlockError::EnvelopeError(envelope_error) => match *envelope_error {
+                EnvelopeError::ExecutionPayloadError(inner) => {
+                    BlockError::ExecutionPayloadError(inner)
+                }
+                other => BlockError::EnvelopeError(Box::new(other)),
+            },
+            other => other,
+        })
+    }
+
     async fn invalidate_manually(&self, block_root: Hash256) {
         self.harness
             .chain
@@ -354,7 +442,7 @@ impl InvalidPayloadRig {
 /// Simple test of the different import types.
 #[tokio::test]
 async fn valid_invalid_syncing() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     let mut rig = InvalidPayloadRig::new();
@@ -371,7 +459,7 @@ async fn valid_invalid_syncing() {
 /// `latest_valid_hash`.
 #[tokio::test]
 async fn invalid_payload_invalidates_parent() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     let mut rig = InvalidPayloadRig::new().enable_attestations();
@@ -428,7 +516,7 @@ async fn immediate_forkchoice_update_invalid_test(
 
 #[tokio::test]
 async fn immediate_forkchoice_update_payload_invalid() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     immediate_forkchoice_update_invalid_test(|latest_valid_hash| Payload::Invalid {
@@ -439,7 +527,7 @@ async fn immediate_forkchoice_update_payload_invalid() {
 
 #[tokio::test]
 async fn immediate_forkchoice_update_payload_invalid_block_hash() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     immediate_forkchoice_update_invalid_test(|_| Payload::InvalidBlockHash).await
@@ -447,7 +535,7 @@ async fn immediate_forkchoice_update_payload_invalid_block_hash() {
 
 #[tokio::test]
 async fn immediate_forkchoice_update_payload_invalid_terminal_block() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     immediate_forkchoice_update_invalid_test(|_| Payload::Invalid {
@@ -459,6 +547,8 @@ async fn immediate_forkchoice_update_payload_invalid_terminal_block() {
 /// Ensure the client tries to exit when the justified checkpoint is invalidated.
 #[tokio::test]
 async fn justified_checkpoint_becomes_invalid() {
+    // Pre-Gloas only. In Gloas the error arrives as `EnvelopeError(BeaconChainError(..))`,
+    // which the error predicate of this test does not match.
     if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
         return;
     }
@@ -503,6 +593,7 @@ async fn justified_checkpoint_becomes_invalid() {
 /// Ensure that a `latest_valid_hash` for a pre-finality block only reverts a single block.
 #[tokio::test]
 async fn pre_finalized_latest_valid_hash() {
+    // Pre-Gloas only. The block is absent from fork choice in Gloas. Not yet diagnosed.
     if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
         return;
     }
@@ -552,7 +643,7 @@ async fn pre_finalized_latest_valid_hash() {
 /// - Will not validate `latest_valid_root` and its ancestors.
 #[tokio::test]
 async fn latest_valid_hash_will_not_validate() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     const LATEST_VALID_SLOT: u64 = 3;
@@ -601,6 +692,7 @@ async fn latest_valid_hash_will_not_validate() {
 /// Check behaviour when the `latest_valid_hash` is a junk value.
 #[tokio::test]
 async fn latest_valid_hash_is_junk() {
+    // Pre-Gloas only. Head selection gives a different root in Gloas. Not yet diagnosed.
     if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
         return;
     }
@@ -644,7 +736,7 @@ async fn latest_valid_hash_is_junk() {
 /// Check that descendants of invalid blocks are also invalidated.
 #[tokio::test]
 async fn invalidates_all_descendants() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     let num_blocks = E::slots_per_epoch() * 4 + E::slots_per_epoch() / 2;
@@ -747,6 +839,8 @@ async fn invalidates_all_descendants() {
 /// Check that the head will switch after the canonical branch is invalidated.
 #[tokio::test]
 async fn switches_heads() {
+    // Pre-Gloas only. This test builds its fork block with `make_block`, so no envelope is
+    // imported and the block has no `FULL` node.
     if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
         return;
     }
@@ -846,6 +940,8 @@ async fn switches_heads() {
 
 #[tokio::test]
 async fn invalid_during_processing() {
+    // Pre-Gloas only. In Gloas the block is valid when only its payload is rejected, so the
+    // block stays in the database.
     if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
         return;
     }
@@ -880,7 +976,7 @@ async fn invalid_during_processing() {
 
 #[tokio::test]
 async fn invalid_after_optimistic_sync() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     let mut rig = InvalidPayloadRig::new().enable_attestations();
@@ -920,7 +1016,7 @@ async fn invalid_after_optimistic_sync() {
 
 #[tokio::test]
 async fn manually_validate_child() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     let mut rig = InvalidPayloadRig::new().enable_attestations();
@@ -940,7 +1036,7 @@ async fn manually_validate_child() {
 
 #[tokio::test]
 async fn manually_validate_parent() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     let mut rig = InvalidPayloadRig::new().enable_attestations();
@@ -960,7 +1056,7 @@ async fn manually_validate_parent() {
 
 #[tokio::test]
 async fn payload_preparation() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     let mut rig = InvalidPayloadRig::new();
@@ -1025,6 +1121,8 @@ async fn payload_preparation() {
 
 #[tokio::test]
 async fn invalid_parent() {
+    // Pre-Gloas only. In Gloas a rejected payload leaves the parent `Irrelevant`, not
+    // `Invalid`, and a child can build on the `EMPTY` node of the parent.
     if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
         return;
     }
@@ -1092,7 +1190,7 @@ async fn invalid_parent() {
 
 #[tokio::test]
 async fn attesting_to_optimistic_head() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     let mut rig = InvalidPayloadRig::new();
@@ -1291,7 +1389,7 @@ impl InvalidHeadSetup {
 
 #[tokio::test]
 async fn recover_from_invalid_head_by_importing_blocks() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     let InvalidHeadSetup {
@@ -1333,7 +1431,7 @@ async fn recover_from_invalid_head_by_importing_blocks() {
 
 #[tokio::test]
 async fn recover_from_invalid_head_after_persist_and_reboot() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     let InvalidHeadSetup {
@@ -1378,7 +1476,7 @@ async fn recover_from_invalid_head_after_persist_and_reboot() {
 
 #[tokio::test]
 async fn weights_after_resetting_optimistic_status() {
-    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled() || f.gloas_enabled()) {
+    if fork_name_from_env().is_some_and(|f| !f.bellatrix_enabled()) {
         return;
     }
     let mut rig = InvalidPayloadRig::new().enable_attestations();

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -680,7 +680,12 @@ async fn latest_valid_hash_will_not_validate() {
         if slot > LATEST_VALID_SLOT {
             assert!(execution_status.is_invalid())
         } else if slot == 0 {
-            assert!(execution_status.is_irrelevant())
+            // A Gloas genesis commits to a payload no envelope ever reveals.
+            if fork_name_from_env().is_some_and(|f| f.gloas_enabled()) {
+                assert!(execution_status.is_not_yet_revealed())
+            } else {
+                assert!(execution_status.is_irrelevant())
+            }
         } else if slot == 1 {
             assert!(execution_status.is_valid_and_post_bellatrix())
         } else {

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -29,6 +29,7 @@ use beacon_chain::{
 use bls::{Keypair, Signature, SignatureBytes};
 use fixed_bytes::FixedBytesExtended;
 use fork_choice::PayloadStatus;
+use fork_choice::PayloadVerificationStatus;
 use logging::create_test_tracing_subscriber;
 use maplit::hashset;
 use rand::Rng;
@@ -56,6 +57,7 @@ use store::{
 };
 use tempfile::{TempDir, tempdir};
 use tracing::info;
+use types::ExecutionBlockHash;
 use types::test_utils::test_arbitrary_instance;
 use types::*;
 
@@ -3439,7 +3441,11 @@ async fn weak_subjectivity_sync_test(
         beacon_chain
             .canonical_head
             .fork_choice_write_lock()
-            .on_valid_payload_envelope_received(wss_block_root)
+            .on_payload_envelope_received(
+                wss_block_root,
+                PayloadVerificationStatus::Verified,
+                ExecutionBlockHash::zero(),
+            )
             .unwrap();
     }
 
@@ -3519,7 +3525,11 @@ async fn weak_subjectivity_sync_test(
             beacon_chain
                 .canonical_head
                 .fork_choice_write_lock()
-                .on_valid_payload_envelope_received(block_root)
+                .on_payload_envelope_received(
+                    block_root,
+                    PayloadVerificationStatus::Verified,
+                    ExecutionBlockHash::zero(),
+                )
                 .unwrap();
         }
 

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -372,7 +372,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                     Ok(ExecutionStatus::NotYetRevealed(hash)) => {
                         debug!(
                             bid_block_hash = ?hash,
-                            "Head execution payload is not yet revealed"
+                            "Head excution payload is not yet revealed"
                         );
                         format!("{} (unrevealed)", hash)
                     }

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -369,6 +369,13 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
 
                 let block_hash = match beacon_chain.canonical_head.head_execution_status() {
                     Ok(ExecutionStatus::Irrelevant(_)) => "n/a".to_string(),
+                    Ok(ExecutionStatus::NotYetRevealed(hash)) => {
+                        debug!(
+                            bid_block_hash = ?hash,
+                            "Head execution payload is not yet revealed"
+                        );
+                        format!("{} (unrevealed)", hash)
+                    }
                     Ok(ExecutionStatus::Valid(hash)) => {
                         metrics::set_gauge(&metrics::IS_OPTIMISTIC_SYNC, 0);
                         format!("{} (verified)", hash)

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -372,7 +372,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                     Ok(ExecutionStatus::NotYetRevealed(hash)) => {
                         debug!(
                             bid_block_hash = ?hash,
-                            "Head excution payload is not yet revealed"
+                            "Head execution payload is not yet revealed"
                         );
                         format!("{} (unrevealed)", hash)
                     }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2156,20 +2156,12 @@ pub async fn serve<T: BeaconChainTypes>(
                         .nodes
                         .iter()
                         .map(|node| {
-                            let execution_status = if node
+                            let execution_status = node
                                 .execution_status()
-                                .is_ok_and(|status| status.is_execution_enabled())
-                            {
-                                node.execution_status()
-                                    .ok()
-                                    .map(|status| status.to_string())
-                            } else {
-                                None
-                            };
+                                .is_execution_enabled()
+                                .then(|| node.execution_status().to_string());
 
-                            let execution_status_string = node
-                                .execution_status()
-                                .map_or_else(|_| "irrelevant".to_string(), |s| s.to_string());
+                            let execution_status_string = node.execution_status().to_string();
 
                             ForkChoiceNode {
                                 slot: node.slot(),
@@ -2184,8 +2176,7 @@ pub async fn serve<T: BeaconChainTypes>(
                                 validity: execution_status,
                                 execution_block_hash: node
                                     .execution_status()
-                                    .ok()
-                                    .and_then(|status| status.block_hash())
+                                    .block_hash()
                                     .map(|block_hash| block_hash.into_root()),
                                 extra_data: ForkChoiceExtraData {
                                     target_root: node.target_root(),

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -3828,16 +3828,10 @@ impl ApiTester {
             .nodes
             .iter()
             .map(|node| {
-                let execution_status = if node
+                let execution_status = node
                     .execution_status()
-                    .is_ok_and(|status| status.is_execution_enabled())
-                {
-                    node.execution_status()
-                        .ok()
-                        .map(|status| status.to_string())
-                } else {
-                    None
-                };
+                    .is_execution_enabled()
+                    .then(|| node.execution_status().to_string());
                 ForkChoiceNode {
                     slot: node.slot(),
                     block_root: node.root(),
@@ -3851,8 +3845,7 @@ impl ApiTester {
                     validity: execution_status,
                     execution_block_hash: node
                         .execution_status()
-                        .ok()
-                        .and_then(|status| status.block_hash())
+                        .block_hash()
                         .map(|block_hash| block_hash.into_root()),
                     extra_data: ForkChoiceExtraData {
                         target_root: node.target_root(),
@@ -3870,11 +3863,7 @@ impl ApiTester {
                         unrealized_finalized_epoch: node
                             .unrealized_finalized_checkpoint()
                             .map(|checkpoint| checkpoint.epoch),
-                        execution_status: node
-                            .execution_status()
-                            .ok()
-                            .map(|status| status.to_string())
-                            .unwrap_or_else(|| "irrelevant".to_string()),
+                        execution_status: node.execution_status().to_string(),
                         best_child: node
                             .best_child()
                             .ok()

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -1230,11 +1230,22 @@ fn parent_node_of<'a>(
 /// Pre-bellatrix `Irrelevant` payloads and missing nodes are treated as not
 /// optimistic (the spec MUST applies post-merge). A missing node will be
 /// rejected later by `get_block_slot`, so this returning `false` here is safe.
+///
+/// A Gloas block has two fork choice nodes, so this checks both. The first is the payload of
+/// the block. The second is the payload that the empty node inherits. In Gloas the
+/// confirmation rule applies to the parent block, which adds one slot of delay.
 fn is_optimistic_or_invalid(root: Hash256, proto_array: &ProtoArray) -> Result<bool, Error> {
-    Ok(get_block(root, proto_array)?
+    if get_block(root, proto_array)?
         .execution_status()
-        .ok()
-        .is_some_and(|s| s.is_optimistic_or_invalid()))
+        .is_optimistic_or_invalid()
+    {
+        return Ok(true);
+    }
+
+    Ok(proto_array
+        .empty_node_execution_status(root)
+        .map(|status| status.is_optimistic_or_invalid())
+        .unwrap_or(false))
 }
 
 /// Spec: `is_ancestor`.

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -593,33 +593,31 @@ where
         )?;
 
         // Cache some values for the next forkchoiceUpdate call to the execution layer.
-        // For Gloas blocks, `execution_status` is Irrelevant (no embedded payload).
-        // If the payload envelope was received (Full), use the bid's block_hash as the
-        // execution chain head. Otherwise fall back to the parent hash (Pending) or None.
+        //
+        // A Gloas block keeps its payload outside the block, so the hash comes from the bid and
+        // depends on the node the head is on: the payload of the block when the head is `Full`,
+        // and the payload the block builds on otherwise. Pre-Gloas blocks carry no bid, so they
+        // fall back to the hash in their own execution status.
+        //
         // For justified/finalized hashes we always use the bid's parent_block_hash, since the
         // payload from the justified/finalized block is not itself justified/finalized due to
         // being applied immediately prior to the next block.
         let head_hash = self.get_block(&head_root).and_then(|b| {
-            b.execution_status
-                .block_hash()
-                .or(match head_payload_status {
-                    PayloadStatus::Full => b.execution_payload_block_hash,
-                    PayloadStatus::Pending | PayloadStatus::Empty => {
-                        b.execution_payload_parent_hash
-                    }
-                })
+            match head_payload_status {
+                PayloadStatus::Full => b.execution_payload_block_hash,
+                PayloadStatus::Pending | PayloadStatus::Empty => b.execution_payload_parent_hash,
+            }
+            .or_else(|| b.execution_status.block_hash())
         });
         let justified_root = self.justified_checkpoint().root;
         let finalized_root = self.finalized_checkpoint().root;
         let justified_hash = self.get_block(&justified_root).and_then(|b| {
-            b.execution_status
-                .block_hash()
-                .or(b.execution_payload_parent_hash)
+            b.execution_payload_parent_hash
+                .or_else(|| b.execution_status.block_hash())
         });
         let finalized_hash = self.get_block(&finalized_root).and_then(|b| {
-            b.execution_status
-                .block_hash()
-                .or(b.execution_payload_parent_hash)
+            b.execution_payload_parent_hash
+                .or_else(|| b.execution_status.block_hash())
         });
         self.forkchoice_update_parameters = ForkchoiceUpdateParameters {
             head_root,
@@ -722,13 +720,33 @@ where
     /// Mark a Gloas payload envelope as valid and received.
     ///
     /// This must only be called for valid Gloas payloads.
-    pub fn on_valid_payload_envelope_received(
+    pub fn on_payload_envelope_received(
         &mut self,
         block_root: Hash256,
+        payload_verification_status: PayloadVerificationStatus,
+        payload_block_hash: ExecutionBlockHash,
     ) -> Result<(), Error<T::Error>> {
+        let execution_status = match payload_verification_status {
+            PayloadVerificationStatus::Verified => ExecutionStatus::Valid(payload_block_hash),
+            PayloadVerificationStatus::Optimistic => {
+                ExecutionStatus::Optimistic(payload_block_hash)
+            }
+            // A revealed Gloas payload always has execution enabled, so this is a logic error.
+            PayloadVerificationStatus::Irrelevant => {
+                return Err(Error::InvalidPayloadStatus {
+                    block_slot: Slot::new(0),
+                    block_root,
+                    payload_verification_status,
+                });
+            }
+        };
+
+        // `on_payload_envelope_received` promotes the ancestry itself. It starts at the parent.
         self.proto_array
-            .on_valid_payload_envelope_received(block_root)
-            .map_err(Error::FailedToProcessValidExecutionPayload)
+            .on_payload_envelope_received(block_root, execution_status)
+            .map_err(Error::FailedToProcessValidExecutionPayload)?;
+
+        Ok(())
     }
 
     /// Pre-Gloas only.
@@ -1671,6 +1689,20 @@ where
     pub fn get_block_execution_status(&self, block_root: &Hash256) -> Option<ExecutionStatus> {
         if self.is_finalized_checkpoint_or_descendant(*block_root) {
             self.proto_array.get_block_execution_status(block_root)
+        } else {
+            None
+        }
+    }
+
+    /// See `ProtoArrayForkChoice::get_node_execution_status` for documentation.
+    pub fn get_node_execution_status(
+        &self,
+        block_root: &Hash256,
+        payload_status: PayloadStatus,
+    ) -> Option<ExecutionStatus> {
+        if self.is_finalized_checkpoint_or_descendant(*block_root) {
+            self.proto_array
+                .get_node_execution_status(block_root, payload_status)
         } else {
             None
         }

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1688,7 +1688,15 @@ where
     /// Returns an `ExecutionStatus` if the block is known **and** a descendant of the finalized root.
     pub fn get_block_execution_status(&self, block_root: &Hash256) -> Option<ExecutionStatus> {
         if self.is_finalized_checkpoint_or_descendant(*block_root) {
-            self.proto_array.get_block_execution_status(block_root)
+            match self.proto_array.get_block_execution_status(block_root) {
+                // The block's own payload has not arrived, so a chain ending here runs on an
+                // ancestor's payload. Report the status the chain actually executed, not the
+                // one no EL has judged.
+                Some(ExecutionStatus::NotYetRevealed(_)) => self
+                    .proto_array
+                    .get_node_execution_status(block_root, PayloadStatus::Empty),
+                other => other,
+            }
         } else {
             None
         }

--- a/consensus/proto_array/src/error.rs
+++ b/consensus/proto_array/src/error.rs
@@ -51,6 +51,7 @@ pub enum Error {
         parent_root: Hash256,
     },
     Arith(ArithError),
+    Unexpected(String),
     InvalidNodeVariant {
         block_root: Hash256,
     },

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -576,7 +576,10 @@ impl ForkChoiceTestDefinition {
                 }
                 Operation::ProcessExecutionPayloadEnvelope { block_root } => {
                     fork_choice
-                        .on_valid_payload_envelope_received(block_root)
+                        .on_payload_envelope_received(
+                            block_root,
+                            ExecutionStatus::Valid(ExecutionBlockHash::zero()),
+                        )
                         .unwrap_or_else(|e| {
                             panic!(
                                 "on_execution_payload op at index {} returned error: {}",

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -5,6 +5,7 @@ mod no_votes;
 mod votes;
 
 use crate::error::Error;
+use crate::proto_array::ParentPayloadStatus;
 use crate::proto_array_fork_choice::{Block, ExecutionStatus, PayloadStatus, ProtoArrayForkChoice};
 use crate::{InvalidationOperation, JustifiedBalances};
 use fixed_bytes::FixedBytesExtended;
@@ -98,7 +99,7 @@ pub enum Operation {
     },
     AssertParentPayloadStatus {
         block_root: Hash256,
-        expected_status: PayloadStatus,
+        expected_status: ParentPayloadStatus,
     },
     SetPayloadTiebreak {
         block_root: Hash256,

--- a/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition/gloas_payload.rs
@@ -55,11 +55,11 @@ pub fn get_gloas_chain_following_test_definition() -> ForkChoiceTestDefinition {
         },
         Operation::AssertParentPayloadStatus {
             block_root: get_root(1),
-            expected_status: PayloadStatus::Full,
+            expected_status: ParentPayloadStatus::Full,
         },
         Operation::AssertParentPayloadStatus {
             block_root: get_root(2),
-            expected_status: PayloadStatus::Empty,
+            expected_status: ParentPayloadStatus::Empty,
         },
         // With equal full/empty parent weights, tiebreak decides which chain to follow.
         Operation::SetPayloadTiebreak {
@@ -510,7 +510,7 @@ pub fn get_gloas_parent_empty_when_child_points_to_grandparent_test_definition()
         },
         Operation::AssertParentPayloadStatus {
             block_root: get_root(3),
-            expected_status: PayloadStatus::Empty,
+            expected_status: ParentPayloadStatus::Empty,
         },
     ];
 
@@ -704,15 +704,15 @@ pub fn get_gloas_payload_received_interleaving_test_definition() -> ForkChoiceTe
         // Verify parent_payload_status is set correctly.
         Operation::AssertParentPayloadStatus {
             block_root: get_root(1),
-            expected_status: PayloadStatus::Empty,
+            expected_status: ParentPayloadStatus::Empty,
         },
         Operation::AssertParentPayloadStatus {
             block_root: get_root(2),
-            expected_status: PayloadStatus::Full,
+            expected_status: ParentPayloadStatus::Full,
         },
         Operation::AssertParentPayloadStatus {
             block_root: get_root(3),
-            expected_status: PayloadStatus::Empty,
+            expected_status: ParentPayloadStatus::Empty,
         },
         // Genesis does NOT have payload_received (no payload at genesis).
         Operation::AssertPayloadReceived {
@@ -1058,11 +1058,10 @@ mod tests {
             execution_payload_block_hash: Some(get_hash(2)),
         });
 
-        // Parent payload status of fork boundary block should always be Empty.
-        let expected_parent_status = PayloadStatus::Empty;
+        // The fork boundary block extends a pre-Gloas parent, which has no separate payload.
         ops.push(Operation::AssertParentPayloadStatus {
             block_root: get_root(2),
-            expected_status: expected_parent_status,
+            expected_status: ParentPayloadStatus::PreGloas,
         });
 
         // Mark root 2's execution payload as received so the Full virtual child exists.
@@ -1100,9 +1099,9 @@ mod tests {
         ops.push(Operation::AssertParentPayloadStatus {
             block_root: get_root(3),
             expected_status: if first_gloas_block_full {
-                PayloadStatus::Full
+                ParentPayloadStatus::Full
             } else {
-                PayloadStatus::Empty
+                ParentPayloadStatus::Empty
             },
         });
 

--- a/consensus/proto_array/src/lib.rs
+++ b/consensus/proto_array/src/lib.rs
@@ -6,7 +6,9 @@ mod proto_array_fork_choice;
 mod ssz_container;
 
 pub use crate::justified_balances::JustifiedBalances;
-pub use crate::proto_array::{InvalidationOperation, calculate_committee_fraction};
+pub use crate::proto_array::{
+    InvalidationOperation, ParentPayloadStatus, calculate_committee_fraction,
+};
 pub use crate::proto_array_fork_choice::{
     Block, DoNotReOrg, ExecutionStatus, LatestMessage, PayloadStatus, ProposerHeadError,
     ProposerHeadInfo, ProtoArrayForkChoice, ReOrgThreshold,

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -114,9 +114,13 @@ pub struct ProtoNode {
     #[superstruct(only(V17), partial_getter(copy))]
     #[ssz(with = "four_byte_option_usize")]
     pub best_descendant: Option<usize>,
-    /// Indicates if an execution node has marked this block as valid. Also contains the execution
-    /// block hash. This is only used pre-Gloas.
-    #[superstruct(only(V17), partial_getter(copy))]
+    /// Validity of the payload that this block reveals, and its execution block hash. The status
+    /// is `Irrelevant` until a Gloas envelope reveals the payload.
+    ///
+    /// This is the status of one payload, not of the block. A head on `(root, EMPTY)` ran the
+    /// payload of an ancestor. Use `ProtoArrayForkChoice::get_node_execution_status` when the
+    /// node is not known.
+    #[superstruct(getter(copy))]
     pub execution_status: ExecutionStatus,
     #[superstruct(getter(copy))]
     #[ssz(with = "four_byte_option_checkpoint")]
@@ -441,13 +445,7 @@ impl ProtoArray {
                 continue;
             }
 
-            let execution_status_is_invalid = if let Ok(proto_node) = node.as_v17()
-                && proto_node.execution_status.is_invalid()
-            {
-                true
-            } else {
-                false
-            };
+            let execution_status_is_invalid = node.execution_status().is_invalid();
 
             let node_delta = deltas
                 .get(node_index)
@@ -643,6 +641,8 @@ impl ProtoArray {
                 full_payload_weight: 0,
                 execution_payload_block_hash,
                 execution_payload_parent_hash,
+                // The payload is revealed later, in an envelope.
+                execution_status: ExecutionStatus::Irrelevant(false),
                 payload_timeliness_votes: BitVector::default(),
                 payload_data_availability_votes: BitVector::default(),
                 ptc_participation: BitVector::default(),
@@ -694,7 +694,8 @@ impl ProtoArray {
         if let Some(parent_index) = node.parent()
             && matches!(block.execution_status, ExecutionStatus::Valid(_))
         {
-            self.propagate_execution_payload_validation_by_index(parent_index)?;
+            let parent_status = node.parent_payload_status().unwrap_or(PayloadStatus::Full);
+            self.propagate_execution_payload_validation_from(parent_index, parent_status)?;
         }
 
         Ok(())
@@ -797,7 +798,11 @@ impl ProtoArray {
     /// Process a valid execution payload envelope for a Gloas block.
     ///
     /// Sets `payload_received` to true.
-    pub fn on_valid_payload_envelope_received(&mut self, block_root: Hash256) -> Result<(), Error> {
+    pub fn on_payload_envelope_received(
+        &mut self,
+        block_root: Hash256,
+        execution_status: ExecutionStatus,
+    ) -> Result<(), Error> {
         let index = *self
             .indices
             .get(&block_root)
@@ -810,8 +815,62 @@ impl ProtoArray {
             .as_v29_mut()
             .map_err(|_| Error::InvalidNodeVariant { block_root })?;
         v29.payload_received = true;
+        // The envelope reveals the payload, so the node takes the status from the execution layer.
+        v29.execution_status = execution_status;
+        let parent = v29.parent;
+        let parent_status = v29.parent_payload_status;
+
+        // A valid payload also validates every payload that its branch executed, so promote the
+        // ancestry.
+        if execution_status.is_valid_and_post_bellatrix()
+            && let Some(parent_index) = parent
+        {
+            self.propagate_execution_payload_validation_from(parent_index, parent_status)?;
+        }
 
         Ok(())
+    }
+
+    /// Execution validity of `(block_root, EMPTY)`. This node runs no payload of its own. It
+    /// inherits from the nearest ancestor across a `FULL` edge. The result is not cached, so it
+    /// cannot become stale.
+    pub fn empty_node_execution_status(
+        &self,
+        block_root: Hash256,
+    ) -> Result<ExecutionStatus, Error> {
+        let mut index = *self
+            .indices
+            .get(&block_root)
+            .ok_or(Error::NodeUnknown(block_root))?;
+
+        loop {
+            let node = self
+                .nodes
+                .get(index)
+                .ok_or(Error::InvalidNodeIndex(index))?;
+
+            // Pre-Gloas there is no empty variant to resolve.
+            let ProtoNode::V29(gloas_node) = node else {
+                return Ok(node.execution_status());
+            };
+
+            // Reached an ancestor whose payload this branch executed.
+            if gloas_node.parent_payload_status == PayloadStatus::Full {
+                let Some(parent_index) = gloas_node.parent else {
+                    return Ok(ExecutionStatus::irrelevant());
+                };
+                let parent = self
+                    .nodes
+                    .get(parent_index)
+                    .ok_or(Error::InvalidNodeIndex(parent_index))?;
+                return Ok(parent.execution_status());
+            }
+
+            match gloas_node.parent {
+                Some(parent_index) => index = parent_index,
+                None => return Ok(ExecutionStatus::irrelevant()),
+            }
+        }
     }
 
     /// Updates the `block_root` and all ancestors to have validated execution payloads.
@@ -828,29 +887,34 @@ impl ProtoArray {
             .indices
             .get(&block_root)
             .ok_or(Error::NodeUnknown(block_root))?;
-        self.propagate_execution_payload_validation_by_index(index)
+        self.propagate_execution_payload_validation_from(index, PayloadStatus::Full)
     }
 
-    /// Updates the `verified_node_index` and all ancestors to have validated execution payloads.
+    /// Promotes `start_index` and every payload that its branch executed to `Valid`.
     ///
-    /// This function is a no-op if called for a Gloas block.
+    /// `start_status` is the node that the walk starts on. An `EMPTY` edge is a gap in the
+    /// execution chain, not the end of it. The walk steps over that node and continues.
     ///
     /// Returns an error if:
     ///
-    /// - The `verified_node_index` is unknown.
+    /// - The `start_index` is unknown.
     /// - Any of the to-be-validated payloads are already invalid.
-    fn propagate_execution_payload_validation_by_index(
+    fn propagate_execution_payload_validation_from(
         &mut self,
-        verified_node_index: usize,
+        start_index: usize,
+        start_status: PayloadStatus,
     ) -> Result<(), Error> {
-        let mut index = verified_node_index;
+        let mut index = start_index;
+        let mut status = start_status;
         loop {
             let node = self
                 .nodes
                 .get_mut(index)
                 .ok_or(Error::InvalidNodeIndex(index))?;
-            let parent_index = match node {
-                ProtoNode::V17(node) => match node.execution_status {
+
+            // Only a `FULL` node has a payload of its own in the execution ancestry of this branch.
+            if status == PayloadStatus::Full {
+                match node.execution_status() {
                     // We have reached a node that we already know is valid. No need to iterate further
                     // since we assume an ancestors have already been set to valid.
                     ExecutionStatus::Valid(_) => return Ok(()),
@@ -861,30 +925,26 @@ impl ProtoArray {
                     // The block has an unknown status, set it to valid since any ancestor of a valid
                     // payload can be considered valid.
                     ExecutionStatus::Optimistic(payload_block_hash) => {
-                        node.execution_status = ExecutionStatus::Valid(payload_block_hash);
-                        if let Some(parent_index) = node.parent {
-                            parent_index
-                        } else {
-                            // We have reached the root block, iteration complete.
-                            return Ok(());
-                        }
+                        *node.execution_status_mut() = ExecutionStatus::Valid(payload_block_hash);
                     }
                     // An ancestor of the valid payload was invalid. This is a serious error which
                     // indicates a consensus failure in the execution node. This is unrecoverable.
                     ExecutionStatus::Invalid(ancestor_payload_block_hash) => {
                         return Err(Error::InvalidAncestorOfValidPayload {
-                            ancestor_block_root: node.root,
+                            ancestor_block_root: node.root(),
                             ancestor_payload_block_hash,
                         });
                     }
-                },
-                // Gloas nodes should not be marked valid by this function, which exists only
-                // for pre-Gloas fork choice.
-                ProtoNode::V29(_) => {
-                    return Ok(());
                 }
-            };
+            }
 
+            let Some(parent_index) = node.parent() else {
+                // We have reached the root block, iteration complete.
+                return Ok(());
+            };
+            // Which of the two nodes of the parent this block extends. Pre-Gloas the chain
+            // is all `FULL`.
+            status = node.parent_payload_status().unwrap_or(PayloadStatus::Full);
             index = parent_index;
         }
     }
@@ -932,17 +992,29 @@ impl ProtoArray {
 
         // Collect all *ancestors* which were declared invalid since they reside between the
         // `head_block_root` and the `latest_valid_ancestor_root`.
+        let mut status = PayloadStatus::Full;
         loop {
             let node = self
                 .nodes
                 .get_mut(index)
                 .ok_or(Error::InvalidNodeIndex(index))?;
 
+            // An `EMPTY` edge is a gap in the execution ancestry of the branch, not the end of it.
+            // This branch never ran the payload of this block, so the walk steps over it.
+            if status != PayloadStatus::Full {
+                let Some(parent_index) = node.parent() else {
+                    break;
+                };
+                status = node.parent_payload_status().unwrap_or(PayloadStatus::Full);
+                index = parent_index;
+                continue;
+            }
+
             let node_execution_status = node.execution_status();
             match node_execution_status {
-                Ok(ExecutionStatus::Valid(hash))
-                | Ok(ExecutionStatus::Invalid(hash))
-                | Ok(ExecutionStatus::Optimistic(hash)) => {
+                ExecutionStatus::Valid(hash)
+                | ExecutionStatus::Invalid(hash)
+                | ExecutionStatus::Optimistic(hash) => {
                     // If we're no longer processing the `head_block_root` and the last valid
                     // ancestor is unknown, exit this loop and proceed to invalidate and
                     // descendants of `head_block_root`/`latest_valid_ancestor_root`.
@@ -958,8 +1030,7 @@ impl ProtoArray {
                         break;
                     }
                 }
-                Ok(ExecutionStatus::Irrelevant(_)) => break,
-                Err(_) => break,
+                ExecutionStatus::Irrelevant(_) => break,
             }
 
             // Only invalidate the head block if either:
@@ -973,29 +1044,27 @@ impl ProtoArray {
                 match node.execution_status() {
                     // It's illegal for an execution client to declare that some previously-valid block
                     // is now invalid. This is a consensus failure on their behalf.
-                    Ok(ExecutionStatus::Valid(hash)) => {
+                    ExecutionStatus::Valid(hash) => {
                         return Err(Error::ValidExecutionStatusBecameInvalid {
                             block_root: node.root(),
                             payload_block_hash: hash,
                         });
                     }
-                    Ok(ExecutionStatus::Optimistic(hash)) => {
+                    ExecutionStatus::Optimistic(hash) => {
                         invalidated_indices.insert(index);
-                        if let ProtoNode::V17(node) = node {
-                            node.execution_status = ExecutionStatus::Invalid(hash);
-                        }
+                        *node.execution_status_mut() = ExecutionStatus::Invalid(hash);
                     }
                     // The block is already invalid, but keep going backwards to ensure all ancestors
                     // are updated.
-                    Ok(ExecutionStatus::Invalid(_)) => (),
+                    ExecutionStatus::Invalid(_) => (),
                     // This block is pre-merge, therefore it has no execution status. Nor do its
                     // ancestors.
-                    Ok(ExecutionStatus::Irrelevant(_)) => break,
-                    Err(_) => break,
+                    ExecutionStatus::Irrelevant(_) => break,
                 }
             }
 
             if let Some(parent_index) = node.parent() {
+                status = node.parent_payload_status().unwrap_or(PayloadStatus::Full);
                 index = parent_index
             } else {
                 // The root of the block tree has been reached (aka the finalized block), without
@@ -1032,24 +1101,40 @@ impl ProtoArray {
             if let Some(parent_index) = node.parent()
                 && invalidated_indices.contains(&parent_index)
             {
+                // A Gloas descendant becomes invalid only when it built on the payload of the
+                // ancestor. A descendant that took the `EMPTY` edge stays viable.
+                if let ProtoNode::V29(gloas_node) = node
+                    && gloas_node.parent_payload_status != PayloadStatus::Full
+                {
+                    continue;
+                }
+
                 match node.execution_status() {
-                    Ok(ExecutionStatus::Valid(hash)) => {
+                    ExecutionStatus::Valid(hash) => {
                         return Err(Error::ValidExecutionStatusBecameInvalid {
                             block_root: node.root(),
                             payload_block_hash: hash,
                         });
                     }
-                    Ok(ExecutionStatus::Optimistic(hash)) | Ok(ExecutionStatus::Invalid(hash)) => {
-                        if let ProtoNode::V17(node) = node {
-                            node.execution_status = ExecutionStatus::Invalid(hash)
+                    ExecutionStatus::Optimistic(hash) | ExecutionStatus::Invalid(hash) => {
+                        *node.execution_status_mut() = ExecutionStatus::Invalid(hash);
+                    }
+                    ExecutionStatus::Irrelevant(_) => {
+                        // In Gloas this means only that the payload is not revealed yet. The block did
+                        // commit to the invalid ancestry. Pre-Gloas this state is a contradiction.
+                        match node {
+                            ProtoNode::V29(gloas_node) => {
+                                gloas_node.execution_status = ExecutionStatus::Invalid(
+                                    gloas_node.execution_payload_block_hash,
+                                );
+                            }
+                            ProtoNode::V17(_) => {
+                                return Err(Error::IrrelevantDescendant {
+                                    block_root: node.root(),
+                                });
+                            }
                         }
                     }
-                    Ok(ExecutionStatus::Irrelevant(_)) => {
-                        return Err(Error::IrrelevantDescendant {
-                            block_root: node.root(),
-                        });
-                    }
-                    Err(_) => (),
                 }
 
                 invalidated_indices.insert(index);
@@ -1160,9 +1245,11 @@ impl ProtoArray {
     ///
     /// The spec removes execution-invalid blocks (and their entire subtrees) from
     /// `store.blocks` before running. We replicate that here with a forward pass
-    /// propagating `excluded` from parent to child — V29 children of an invalidated
-    /// V17 ancestor are excluded transitively, since V29 nodes carry no
-    /// `execution_status` of their own.
+    /// propagating `excluded` from parent to child.
+    ///
+    /// This pass keeps one boolean for each block. It cannot express that only one of the two
+    /// nodes of a Gloas block is dead, so it excludes both. This costs liveness, not safety. A
+    /// correct version needs one result for each `(block, node)` pair.
     fn filter_block_tree<E: EthSpec>(
         &self,
         start_index: usize,
@@ -1180,7 +1267,7 @@ impl ProtoArray {
                 Some(p) => *excluded.get(p).ok_or(Error::InvalidNodeIndex(p))?,
                 None => false,
             };
-            let self_invalid = node.execution_status().is_ok_and(|s| s.is_invalid());
+            let self_invalid = node.execution_status().is_invalid();
             excluded[i] = parent_excluded || self_invalid;
         }
 
@@ -1920,8 +2007,7 @@ impl ProtoArray {
             .rev()
             .find(|node| {
                 node.execution_status()
-                    .ok()
-                    .and_then(|execution_status| execution_status.block_hash())
+                    .block_hash()
                     .is_some_and(|node_block_hash| node_block_hash == *block_hash)
             })
             .map(|node| node.root())

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -981,170 +981,193 @@ impl ProtoArray {
         }
     }
 
+    /// Find `Pn`, the deepest node an `InvalidationOperation` condemns.
+    ///
+    /// Spec — `H`: EL hash, `B`: beacon block root, `P`: proto node entry:
+    ///
+    /// On INVALID the EL invalidates a range of EL hashes `H0..=Hn`, head first: `Hn` is the
+    /// deepest and its parent is the latest valid hash. Assuming no equivocations the mapping
+    /// `H-B-P` is exactly one-to-one, so the range maps to proto nodes `P0..=Pn`, independent
+    /// of payload status. If `Hn` is INVALID, all children of `Hn` are INVALID, so all proto
+    /// node children of `Pn` must be marked INVALID regardless of payload status.
+    ///
+    /// The condemned set `Sb` is the path `P0..=Pn` extended past gaps down to the deepest
+    /// executed node. Marking `Pn` and sweeping descendants condemns all of it: the node above
+    /// `Pn` is a `FULL`-edge child of `Pn` (that is what makes `Pn` the deepest executed
+    /// node), so only `Pn` needs returning.
+    ///
+    /// The range always starts at the head; the latest-valid-ancestor rules only decide where
+    /// it ends (exclusive): at the vouched latest valid block, right after the head when only
+    /// the head itself was judged, or nowhere.
+    fn find_deepest_node_to_invalidate<E: EthSpec>(
+        &self,
+        op: &InvalidationOperation,
+        best_finalized_checkpoint: Checkpoint,
+    ) -> Result<Option<usize>, Error> {
+        let head_block_root = op.block_root();
+        let head_index = *self
+            .indices
+            .get(&head_block_root)
+            .ok_or(Error::NodeUnknown(head_block_root))?;
+
+        // Map the latest valid ancestor *hash* to a beacon block *root*, keeping it only if it
+        // is an ancestor of the head, at or above finalization.
+        let latest_valid_ancestor_root = op
+            .latest_valid_ancestor()
+            .and_then(|hash| self.execution_block_hash_to_beacon_block_root(&hash))
+            .filter(|&root| {
+                self.is_descendant(root, head_block_root)
+                    && self
+                        .is_finalized_checkpoint_or_descendant::<E>(root, best_finalized_checkpoint)
+            });
+
+        // The range starts at the head; the rules only decide where it ends (exclusive).
+        let range_end = if let Some(root) = latest_valid_ancestor_root {
+            // The chain down to the latest valid block is condemned.
+            Some(*self.indices.get(&root).ok_or(Error::NodeUnknown(root))?)
+        } else if op.invalidate_block_root() {
+            // The head was judged directly but the latest valid hash is unusable (junk or
+            // pre-finalization): condemn the head alone. Guessing at ancestors could reach the
+            // justified checkpoint and shut the client down.
+            self.nodes
+                .get(head_index)
+                .ok_or(Error::InvalidNodeIndex(head_index))?
+                .parent()
+        } else {
+            // The head was never judged and the latest valid hash is unusable: condemn nothing.
+            return Ok(None);
+        };
+
+        // Collect every node in the range, recording whether this branch executed its
+        // payload. The head is executed by definition; every other node takes it from its
+        // child's edge.
+        let mut path: Vec<(usize, bool)> = Vec::new();
+        let mut payload_executed = true;
+        let mut index = head_index;
+        loop {
+            if Some(index) == range_end {
+                break;
+            }
+            let node = self
+                .nodes
+                .get(index)
+                .ok_or(Error::InvalidNodeIndex(index))?;
+
+            path.push((index, payload_executed));
+
+            let Some(parent_index) = node.parent() else {
+                break;
+            };
+            // A `PreGloas` payload rides inside its block, so that edge is executed too.
+            payload_executed = match node.get_parent_payload_status() {
+                ParentPayloadStatus::Full | ParentPayloadStatus::PreGloas => true,
+                ParentPayloadStatus::Empty => false,
+            };
+            index = parent_index;
+        }
+
+        // `Pn` is the deepest executed entry; the gap tail below it sits on valid state.
+        Ok(path
+            .iter()
+            .rev()
+            .find(|&&(_, payload_executed)| payload_executed)
+            .map(|&(index, _)| index))
+    }
     /// Invalidate zero or more blocks, as specified by the `InvalidationOperation`.
     ///
-    /// See the documentation of `InvalidationOperation` for usage.
+    /// See `find_deepest_node_to_invalidate` for the model, and the documentation of
+    /// `InvalidationOperation` for usage.
     pub fn propagate_execution_payload_invalidation<E: EthSpec>(
         &mut self,
         op: &InvalidationOperation,
         best_finalized_checkpoint: Checkpoint,
     ) -> Result<(), Error> {
-        let mut invalidated_indices: HashSet<usize> = <_>::default();
-        let head_block_root = op.block_root();
-
         /*
          * Step 1:
          *
-         * Find the `head_block_root` and maybe iterate backwards and invalidate ancestors. Record
-         * all invalidated block indices in `invalidated_indices`.
+         * Find `Pn`, the deepest node to invalidate.
          */
 
-        let mut index = *self
-            .indices
-            .get(&head_block_root)
-            .ok_or(Error::NodeUnknown(head_block_root))?;
-
-        // Try to map the ancestor payload *hash* to an ancestor beacon block *root*.
-        let latest_valid_ancestor_root = op
-            .latest_valid_ancestor()
-            .and_then(|hash| self.execution_block_hash_to_beacon_block_root(&hash));
-
-        // Set to `true` if both conditions are satisfied:
-        //
-        // 1. The `head_block_root` is a descendant of `latest_valid_ancestor_hash`
-        // 2. The `latest_valid_ancestor_hash` is equal to or a descendant of the finalized block.
-        let latest_valid_ancestor_is_descendant =
-            latest_valid_ancestor_root.is_some_and(|ancestor_root| {
-                self.is_descendant(ancestor_root, head_block_root)
-                    && self.is_finalized_checkpoint_or_descendant::<E>(
-                        ancestor_root,
-                        best_finalized_checkpoint,
-                    )
-            });
-
-        // Collect all *ancestors* which were declared invalid since they reside between the
-        // `head_block_root` and the `latest_valid_ancestor_root`.
-        loop {
-            let node = self
-                .nodes
-                .get_mut(index)
-                .ok_or(Error::InvalidNodeIndex(index))?;
-
-            let node_execution_status = node.execution_status();
-            match node_execution_status {
-                Ok(ExecutionStatus::Valid(hash))
-                | Ok(ExecutionStatus::Invalid(hash))
-                | Ok(ExecutionStatus::Optimistic(hash)) => {
-                    // If we're no longer processing the `head_block_root` and the last valid
-                    // ancestor is unknown, exit this loop and proceed to invalidate and
-                    // descendants of `head_block_root`/`latest_valid_ancestor_root`.
-                    //
-                    // In effect, this means that if an unknown hash (junk or pre-finalization) is
-                    // supplied, don't validate any ancestors. The alternative is to invalidate
-                    // *all* ancestors, which would likely involve shutting down the client due to
-                    // an invalid justified checkpoint.
-                    if !latest_valid_ancestor_is_descendant && node.root() != head_block_root {
-                        break;
-                    } else if op.latest_valid_ancestor() == Some(hash) {
-                        // Reached latest valid block, stop invalidating further.
-                        break;
-                    }
-                }
-                Ok(ExecutionStatus::Irrelevant(_)) => break,
-                Err(_) => break,
-            }
-
-            // Only invalidate the head block if either:
-            //
-            // - The head block was specifically indicated to be invalidated.
-            // - The latest valid hash is a known ancestor.
-            if node.root() != head_block_root
-                || op.invalidate_block_root()
-                || latest_valid_ancestor_is_descendant
-            {
-                match node.execution_status() {
-                    // It's illegal for an execution client to declare that some previously-valid block
-                    // is now invalid. This is a consensus failure on their behalf.
-                    Ok(ExecutionStatus::Valid(hash)) => {
-                        return Err(Error::ValidExecutionStatusBecameInvalid {
-                            block_root: node.root(),
-                            payload_block_hash: hash,
-                        });
-                    }
-                    Ok(ExecutionStatus::Optimistic(hash)) => {
-                        invalidated_indices.insert(index);
-                        if let ProtoNode::V17(node) = node {
-                            node.execution_status = ExecutionStatus::Invalid(hash);
-                        }
-                    }
-                    // The block is already invalid, but keep going backwards to ensure all ancestors
-                    // are updated.
-                    Ok(ExecutionStatus::Invalid(_)) => (),
-                    // This block is pre-merge, therefore it has no execution status. Nor do its
-                    // ancestors.
-                    Ok(ExecutionStatus::Irrelevant(_)) => break,
-                    Err(_) => break,
-                }
-            }
-
-            if let Some(parent_index) = node.parent() {
-                index = parent_index
-            } else {
-                // The root of the block tree has been reached (aka the finalized block), without
-                // matching `latest_valid_ancestor_hash`. It's not possible or useful to go any
-                // further back: the finalized checkpoint is invalid so all is lost!
-                break;
-            }
-        }
+        let Some(deepest_executed_index) =
+            self.find_deepest_node_to_invalidate::<E>(op, best_finalized_checkpoint)?
+        else {
+            return Ok(());
+        };
 
         /*
          * Step 2:
          *
-         * Start at either the `latest_valid_ancestor` or the `head_block_root` and iterate
-         * *forwards* to invalidate all descendants of all blocks in `invalidated_indices`.
+         * Collect `Pn` and all its descendants, except those on `Pn`'s `EMPTY` edge: `Pn` is
+         * the one node invalid without an invalid payload in its own state lineage, so a
+         * descendant that skipped its payload stays viable. Every other collected parent
+         * poisons its descendants whichever edge they took, and a `PreGloas` edge never
+         * escapes: that parent carries its payload inside the block.
          */
 
-        let starting_block_root = latest_valid_ancestor_root
-            .filter(|_| latest_valid_ancestor_is_descendant)
-            .unwrap_or(head_block_root);
-        let latest_valid_ancestor_index = *self
-            .indices
-            .get(&starting_block_root)
-            .ok_or(Error::NodeUnknown(starting_block_root))?;
-        let first_potential_descendant = latest_valid_ancestor_index + 1;
+        let mut invalidated_indices: HashSet<usize> = <_>::default();
+        invalidated_indices.insert(deepest_executed_index);
+        let mut to_invalidate: Vec<usize> = vec![deepest_executed_index];
+        // Insertion order is parent-before-child, so one forward pass reaches every descendant.
+        for index in deepest_executed_index + 1..self.nodes.len() {
+            let node = self
+                .nodes
+                .get(index)
+                .ok_or(Error::InvalidNodeIndex(index))?;
+            let Some(parent_index) = node.parent() else {
+                continue;
+            };
+            if !invalidated_indices.contains(&parent_index) {
+                continue;
+            }
+            if parent_index == deepest_executed_index
+                && let ProtoNode::V29(gloas_node) = node
+                && gloas_node.parent_payload_status == ParentPayloadStatus::Empty
+            {
+                continue;
+            }
+            invalidated_indices.insert(index);
+            to_invalidate.push(index);
+        }
 
-        // Collect all *descendants* which have been declared invalid since they're the descendant of a block
-        // with an invalid execution payload.
-        for index in first_potential_descendant..self.nodes.len() {
+        /*
+         * Step 3:
+         *
+         * Invalidate all of them.
+         */
+
+        for index in to_invalidate {
             let node = self
                 .nodes
                 .get_mut(index)
                 .ok_or(Error::InvalidNodeIndex(index))?;
-
-            if let Some(parent_index) = node.parent()
-                && invalidated_indices.contains(&parent_index)
-            {
-                match node.execution_status() {
-                    Ok(ExecutionStatus::Valid(hash)) => {
-                        return Err(Error::ValidExecutionStatusBecameInvalid {
-                            block_root: node.root(),
-                            payload_block_hash: hash,
-                        });
-                    }
-                    Ok(ExecutionStatus::Optimistic(hash)) | Ok(ExecutionStatus::Invalid(hash)) => {
-                        if let ProtoNode::V17(node) = node {
-                            node.execution_status = ExecutionStatus::Invalid(hash)
+            match node.execution_status() {
+                // It's illegal for an execution client to declare that some previously-valid
+                // block is now invalid. This is a consensus failure on their behalf.
+                ExecutionStatus::Valid(hash) => {
+                    return Err(Error::ValidExecutionStatusBecameInvalid {
+                        block_root: node.root(),
+                        payload_block_hash: hash,
+                    });
+                }
+                ExecutionStatus::Optimistic(hash) | ExecutionStatus::Invalid(hash) => {
+                    *node.execution_status_mut() = ExecutionStatus::Invalid(hash);
+                }
+                ExecutionStatus::Irrelevant(_) => {
+                    // In Gloas this means only that the payload is not revealed yet. The block
+                    // did commit to the invalid ancestry. Pre-Gloas this state is a
+                    // contradiction.
+                    match node {
+                        ProtoNode::V29(gloas_node) => {
+                            gloas_node.execution_status =
+                                ExecutionStatus::Invalid(gloas_node.execution_payload_block_hash);
+                        }
+                        ProtoNode::V17(_) => {
+                            return Err(Error::IrrelevantDescendant {
+                                block_root: node.root(),
+                            });
                         }
                     }
-                    Ok(ExecutionStatus::Irrelevant(_)) => {
-                        return Err(Error::IrrelevantDescendant {
-                            block_root: node.root(),
-                        });
-                    }
-                    Err(_) => (),
                 }
-
-                invalidated_indices.insert(index);
             }
         }
 

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -472,49 +472,54 @@ impl ProtoArray {
             // during the virtual tree walk in `get_weight`, matching the spec's
             // `get_weight` which adds boost separately from `get_attestation_score`.
 
-            // Apply the delta to the node and return the mass to back-propagate to its parent.
-            // A pre-Gloas invalid block loses all of its weight; a Gloas invalid payload kills
-            // only its `FULL` virtual node, so only its viable (`empty + pending`) mass propagates.
+            // Apply this round's delta and return the mass to back-propagate. An invalid node's
+            // dead weight was removed when it was invalidated, so move only its viable mass;
+            // deltas aimed at the dead part are absorbed (they'd otherwise underflow it).
             let backprop_delta = match node {
                 ProtoNode::V17(node) => {
-                    node.weight = apply_delta(node.weight, node_delta.delta, node_index)?;
-
                     if execution_status_is_invalid {
-                        // An invalid pre-Gloas node is entirely dead: remove its whole weight.
+                        // Whole node is dead: pin to zero, absorb the delta.
                         let removed = node.weight;
                         node.weight = 0;
-                        node_delta
-                            .delta
-                            .checked_sub(removed as i64)
+                        0i64.checked_sub(removed as i64)
                             .ok_or(Error::InvalidExecutionDeltaOverflow(node_index))?
                     } else {
+                        node.weight = apply_delta(node.weight, node_delta.delta, node_index)?;
                         node_delta.delta
                     }
                 }
                 ProtoNode::V29(node) => {
-                    node.weight = apply_delta(node.weight, node_delta.delta, node_index)?;
+                    // The empty side and equivocation score stay live whatever the verdict.
+                    node.equivocating_attestation_score = node
+                        .equivocating_attestation_score
+                        .saturating_add(node_delta.equivocating_attestation_delta);
                     node.empty_payload_weight = apply_delta(
                         node.empty_payload_weight,
                         node_delta.empty_delta,
                         node_index,
                     )?;
-                    node.full_payload_weight =
-                        apply_delta(node.full_payload_weight, node_delta.full_delta, node_index)?;
-                    node.equivocating_attestation_score = node
-                        .equivocating_attestation_score
-                        .saturating_add(node_delta.equivocating_attestation_delta);
 
                     if execution_status_is_invalid {
-                        // An invalid payload kills only the `FULL` virtual node. Drop its mass
-                        // from the aggregate (leaving `empty + pending`) and zero the full bucket.
+                        // Only the full side is dead: move the viable `delta - full_delta`, zero
+                        // the full bucket, and drop its accumulated mass.
                         let full_removed = node.full_payload_weight;
-                        node.weight = node.weight.saturating_sub(full_removed);
                         node.full_payload_weight = 0;
-                        node_delta
+                        let viable_delta = node_delta
                             .delta
+                            .checked_sub(node_delta.full_delta)
+                            .ok_or(Error::InvalidExecutionDeltaOverflow(node_index))?;
+                        node.weight = apply_delta(node.weight, viable_delta, node_index)?
+                            .saturating_sub(full_removed);
+                        viable_delta
                             .checked_sub(full_removed as i64)
                             .ok_or(Error::InvalidExecutionDeltaOverflow(node_index))?
                     } else {
+                        node.weight = apply_delta(node.weight, node_delta.delta, node_index)?;
+                        node.full_payload_weight = apply_delta(
+                            node.full_payload_weight,
+                            node_delta.full_delta,
+                            node_index,
+                        )?;
                         node_delta.delta
                     }
                 }

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -468,43 +468,57 @@ impl ProtoArray {
                 .copied()
                 .ok_or(Error::InvalidNodeDelta(node_index))?;
 
-            let delta = if execution_status_is_invalid {
-                // If the node has an invalid execution payload, reduce its weight to zero.
-                0_i64
-                    .checked_sub(node.weight() as i64)
-                    .ok_or(Error::InvalidExecutionDeltaOverflow(node_index))?
-            } else {
-                node_delta.delta
-            };
-
-            let (node_empty_delta, node_full_delta) = if node.as_v29().is_ok() {
-                (node_delta.empty_delta, node_delta.full_delta)
-            } else {
-                (0, 0)
-            };
-
             // Proposer boost is NOT applied here. It is computed on-the-fly
             // during the virtual tree walk in `get_weight`, matching the spec's
             // `get_weight` which adds boost separately from `get_attestation_score`.
 
-            // Apply the delta to the node.
-            if execution_status_is_invalid {
-                // Invalid nodes always have a weight of 0.
-                *node.weight_mut() = 0;
-            } else {
-                *node.weight_mut() = apply_delta(node.weight(), delta, node_index)?;
-            }
+            // Apply the delta to the node and return the mass to back-propagate to its parent.
+            // A pre-Gloas invalid block loses all of its weight; a Gloas invalid payload kills
+            // only its `FULL` virtual node, so only its viable (`empty + pending`) mass propagates.
+            let backprop_delta = match node {
+                ProtoNode::V17(node) => {
+                    node.weight = apply_delta(node.weight, node_delta.delta, node_index)?;
 
-            // Apply post-Gloas score deltas.
-            if let Ok(node) = node.as_v29_mut() {
-                node.empty_payload_weight =
-                    apply_delta(node.empty_payload_weight, node_empty_delta, node_index)?;
-                node.full_payload_weight =
-                    apply_delta(node.full_payload_weight, node_full_delta, node_index)?;
-                node.equivocating_attestation_score = node
-                    .equivocating_attestation_score
-                    .saturating_add(node_delta.equivocating_attestation_delta);
-            }
+                    if execution_status_is_invalid {
+                        // An invalid pre-Gloas node is entirely dead: remove its whole weight.
+                        let removed = node.weight;
+                        node.weight = 0;
+                        node_delta
+                            .delta
+                            .checked_sub(removed as i64)
+                            .ok_or(Error::InvalidExecutionDeltaOverflow(node_index))?
+                    } else {
+                        node_delta.delta
+                    }
+                }
+                ProtoNode::V29(node) => {
+                    node.weight = apply_delta(node.weight, node_delta.delta, node_index)?;
+                    node.empty_payload_weight = apply_delta(
+                        node.empty_payload_weight,
+                        node_delta.empty_delta,
+                        node_index,
+                    )?;
+                    node.full_payload_weight =
+                        apply_delta(node.full_payload_weight, node_delta.full_delta, node_index)?;
+                    node.equivocating_attestation_score = node
+                        .equivocating_attestation_score
+                        .saturating_add(node_delta.equivocating_attestation_delta);
+
+                    if execution_status_is_invalid {
+                        // An invalid payload kills only the `FULL` virtual node. Drop its mass
+                        // from the aggregate (leaving `empty + pending`) and zero the full bucket.
+                        let full_removed = node.full_payload_weight;
+                        node.weight = node.weight.saturating_sub(full_removed);
+                        node.full_payload_weight = 0;
+                        node_delta
+                            .delta
+                            .checked_sub(full_removed as i64)
+                            .ok_or(Error::InvalidExecutionDeltaOverflow(node_index))?
+                    } else {
+                        node_delta.delta
+                    }
+                }
+            };
 
             // Update the parent delta (if any).
             if let Some(parent_index) = node.parent() {
@@ -515,7 +529,7 @@ impl ProtoArray {
                 // Back-propagate the node's delta to its parent.
                 parent_delta.delta = parent_delta
                     .delta
-                    .checked_add(delta)
+                    .checked_add(backprop_delta)
                     .ok_or(Error::DeltaOverflow(parent_index))?;
 
                 // Route ALL child weight into the parent's FULL or EMPTY bucket
@@ -527,13 +541,13 @@ impl ProtoArray {
                         ParentPayloadStatus::Full => {
                             parent_delta.full_delta = parent_delta
                                 .full_delta
-                                .checked_add(delta)
+                                .checked_add(backprop_delta)
                                 .ok_or(Error::DeltaOverflow(parent_index))?;
                         }
                         ParentPayloadStatus::Empty => {
                             parent_delta.empty_delta = parent_delta
                                 .empty_delta
-                                .checked_add(delta)
+                                .checked_add(backprop_delta)
                                 .ok_or(Error::DeltaOverflow(parent_index))?;
                         }
                         // A pre-Gloas parent has no payload buckets.

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -662,8 +662,7 @@ impl ProtoArray {
                 full_payload_weight: 0,
                 execution_payload_block_hash,
                 execution_payload_parent_hash,
-                // The payload is revealed later, in an envelope.
-                execution_status: ExecutionStatus::Irrelevant(false),
+                execution_status: ExecutionStatus::NotYetRevealed(execution_payload_block_hash),
                 payload_timeliness_votes: BitVector::default(),
                 payload_data_availability_votes: BitVector::default(),
                 ptc_participation: BitVector::default(),
@@ -1121,24 +1120,19 @@ impl ProtoArray {
                         payload_block_hash: hash,
                     });
                 }
-                ExecutionStatus::Optimistic(hash) | ExecutionStatus::Invalid(hash) => {
+                // A `NotYetRevealed` payload never arrived, but the block committed to the
+                // invalid ancestry: no reveal can rescue a payload whose parent chain is
+                // condemned.
+                ExecutionStatus::Optimistic(hash)
+                | ExecutionStatus::Invalid(hash)
+                | ExecutionStatus::NotYetRevealed(hash) => {
                     *node.execution_status_mut() = ExecutionStatus::Invalid(hash);
                 }
+                // A pre-merge descendant of an executed block is a contradiction.
                 ExecutionStatus::Irrelevant(_) => {
-                    // In Gloas this means only that the payload is not revealed yet. The block
-                    // did commit to the invalid ancestry. Pre-Gloas this state is a
-                    // contradiction.
-                    match node {
-                        ProtoNode::V29(gloas_node) => {
-                            gloas_node.execution_status =
-                                ExecutionStatus::Invalid(gloas_node.execution_payload_block_hash);
-                        }
-                        ProtoNode::V17(_) => {
-                            return Err(Error::IrrelevantDescendant {
-                                block_root: node.root(),
-                            });
-                        }
-                    }
+                    return Err(Error::IrrelevantDescendant {
+                        block_root: node.root(),
+                    });
                 }
             }
 

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -1097,45 +1097,17 @@ impl ProtoArray {
         /*
          * Step 2:
          *
-         * Collect `Pn` and all its descendants, except those on `Pn`'s `EMPTY` edge: `Pn` is
-         * the one node invalid without an invalid payload in its own state lineage, so a
-         * descendant that skipped its payload stays viable. Every other collected parent
+         * Invalidate `Pn` and all its descendants, walking the children index. The only
+         * exception: descendants on `Pn`'s `EMPTY` edge stay viable — `Pn` is the one node
+         * invalid without an invalid payload in its own state lineage. Every deeper parent
          * poisons its descendants whichever edge they took, and a `PreGloas` edge never
          * escapes: that parent carries its payload inside the block.
          */
 
-        let mut invalidated_indices: HashSet<usize> = <_>::default();
-        invalidated_indices.insert(deepest_executed_index);
+        // Each node has one parent, so it sits in exactly one children list: the walk visits
+        // every condemned node exactly once with no bookkeeping.
         let mut to_invalidate: Vec<usize> = vec![deepest_executed_index];
-        // Insertion order is parent-before-child, so one forward pass reaches every descendant.
-        for index in deepest_executed_index + 1..self.nodes.len() {
-            let node = self
-                .nodes
-                .get(index)
-                .ok_or(Error::InvalidNodeIndex(index))?;
-            let Some(parent_index) = node.parent() else {
-                continue;
-            };
-            if !invalidated_indices.contains(&parent_index) {
-                continue;
-            }
-            if parent_index == deepest_executed_index
-                && let ProtoNode::V29(gloas_node) = node
-                && gloas_node.parent_payload_status == ParentPayloadStatus::Empty
-            {
-                continue;
-            }
-            invalidated_indices.insert(index);
-            to_invalidate.push(index);
-        }
-
-        /*
-         * Step 3:
-         *
-         * Invalidate all of them.
-         */
-
-        for index in to_invalidate {
+        while let Some(index) = to_invalidate.pop() {
             let node = self
                 .nodes
                 .get_mut(index)
@@ -1168,6 +1140,30 @@ impl ProtoArray {
                         }
                     }
                 }
+            }
+
+            for &child_index in self
+                .children
+                .get(index)
+                .ok_or(Error::InvalidNodeIndex(index))?
+            {
+                let child = self
+                    .nodes
+                    .get(child_index)
+                    .ok_or(Error::InvalidNodeIndex(child_index))?;
+
+                // deepest_executed_index is the oldest ancestor INVALID. We know
+                // parent(deepest_executed_index) is VALID. So EMPTY childs of
+                // deepest_executed_index are descendant of the VALID parent.
+                if index == deepest_executed_index {
+                    match child.get_parent_payload_status() {
+                        ParentPayloadStatus::Empty => continue,
+                        // `Full` executed the invalid payload; a `PreGloas` edge carries the
+                        // parent's payload inside the block.
+                        ParentPayloadStatus::Full | ParentPayloadStatus::PreGloas => {}
+                    }
+                }
+                to_invalidate.push(child_index);
             }
         }
 

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -131,7 +131,7 @@ pub struct ProtoNode {
 
     /// We track the parent payload status from which the current node was extended.
     #[superstruct(only(V29), partial_getter(copy))]
-    pub parent_payload_status: PayloadStatus,
+    pub parent_payload_status: ParentPayloadStatus,
     #[superstruct(only(V29), partial_getter(copy))]
     pub empty_payload_weight: u64,
     #[superstruct(only(V29), partial_getter(copy))]
@@ -177,19 +177,35 @@ pub struct ProtoNode {
     pub equivocating_attestation_score: u64,
 }
 
+/// The stored edge to the parent: which node of the parent this block extends. `PreGloas` is
+/// the fork-boundary edge to a V17 parent, whose payload rides inside the block itself. Each
+/// consumer decides what that means for its own question. Never `Pending`.
+///
+/// `Empty` and `Full` keep the tag values this field stored before `PreGloas` existed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[ssz(enum_behaviour = "tag")]
+#[repr(u8)]
+pub enum ParentPayloadStatus {
+    Empty = 0,
+    Full = 1,
+    PreGloas = 2,
+}
+
 impl ProtoNode {
     pub fn is_gloas(&self) -> bool {
         self.as_v29().is_ok()
     }
 
-    /// Generic version of spec's `parent_payload_status` that works for pre-Gloas nodes by
-    /// considering their parents Empty.
-    pub fn get_parent_payload_status(&self) -> PayloadStatus {
-        self.parent_payload_status().unwrap_or(PayloadStatus::Empty)
+    /// The stored edge to the parent. A V17 node has no edge of its own; its parent, one fork
+    /// deeper still, carried its payload inside the block just the same.
+    pub fn get_parent_payload_status(&self) -> ParentPayloadStatus {
+        self.parent_payload_status()
+            .unwrap_or(ParentPayloadStatus::PreGloas)
     }
 
     pub fn is_parent_node_full(&self) -> bool {
-        self.get_parent_payload_status() == PayloadStatus::Full
+        self.get_parent_payload_status() == ParentPayloadStatus::Full
     }
 
     pub fn attestation_score(&self, payload_status: PayloadStatus) -> u64 {
@@ -507,16 +523,21 @@ impl ProtoArray {
                 // direction). If this child is on the FULL path from the parent,
                 // all weight supports the parent's FULL virtual node, and vice versa.
                 if let Ok(child_v29) = node.as_v29() {
-                    if child_v29.parent_payload_status == PayloadStatus::Full {
-                        parent_delta.full_delta = parent_delta
-                            .full_delta
-                            .checked_add(delta)
-                            .ok_or(Error::DeltaOverflow(parent_index))?;
-                    } else {
-                        parent_delta.empty_delta = parent_delta
-                            .empty_delta
-                            .checked_add(delta)
-                            .ok_or(Error::DeltaOverflow(parent_index))?;
+                    match child_v29.parent_payload_status {
+                        ParentPayloadStatus::Full => {
+                            parent_delta.full_delta = parent_delta
+                                .full_delta
+                                .checked_add(delta)
+                                .ok_or(Error::DeltaOverflow(parent_index))?;
+                        }
+                        ParentPayloadStatus::Empty => {
+                            parent_delta.empty_delta = parent_delta
+                                .empty_delta
+                                .checked_add(delta)
+                                .ok_or(Error::DeltaOverflow(parent_index))?;
+                        }
+                        // A pre-Gloas parent has no payload buckets.
+                        ParentPayloadStatus::PreGloas => {}
                     }
                 } else {
                     // This is a v17 node with a v17 parent.
@@ -592,7 +613,7 @@ impl ProtoArray {
                         block_root: block.root,
                     })?;
 
-            let parent_payload_status: PayloadStatus =
+            let parent_payload_status: ParentPayloadStatus =
                 if let Some(parent_node) = parent_index.and_then(|idx| self.nodes.get(idx)) {
                     match parent_node {
                         ProtoNode::V29(v29) => {
@@ -600,22 +621,22 @@ impl ProtoArray {
                             // block hash in the parent node matches the parent block hash in the
                             // child bid.
                             if execution_payload_parent_hash == v29.execution_payload_block_hash {
-                                PayloadStatus::Full
+                                ParentPayloadStatus::Full
                             } else {
-                                PayloadStatus::Empty
+                                ParentPayloadStatus::Empty
                             }
                         }
                         ProtoNode::V17(_) => {
-                            // Parent is pre-Gloas, pre-Gloas blocks are treated as having Empty
-                            // payload status. This case is reached during the fork transition.
-                            PayloadStatus::Empty
+                            // Parent is pre-Gloas: its payload rides inside the block, so there
+                            // is no node to pick. Reached during the fork transition.
+                            ParentPayloadStatus::PreGloas
                         }
                     }
                 } else {
                     // Parent is missing (genesis or pruned due to finalization). This code path
                     // should only be hit at Gloas genesis. Default to empty, the genesis block
                     // has no payload enevelope.
-                    PayloadStatus::Empty
+                    ParentPayloadStatus::Empty
                 };
 
             // The spec does something slightly strange where it initialises the payload timeliness
@@ -694,8 +715,10 @@ impl ProtoArray {
         if let Some(parent_index) = node.parent()
             && matches!(block.execution_status, ExecutionStatus::Valid(_))
         {
-            let parent_status = node.parent_payload_status().unwrap_or(PayloadStatus::Full);
-            self.propagate_execution_payload_validation_from(parent_index, parent_status)?;
+            self.propagate_execution_payload_validation_from(
+                parent_index,
+                node.get_parent_payload_status(),
+            )?;
         }
 
         Ok(())
@@ -854,16 +877,20 @@ impl ProtoArray {
                 return Ok(node.execution_status());
             };
 
-            // Reached an ancestor whose payload this branch executed.
-            if gloas_node.parent_payload_status == PayloadStatus::Full {
-                let Some(parent_index) = gloas_node.parent else {
-                    return Ok(ExecutionStatus::irrelevant());
-                };
-                let parent = self
-                    .nodes
-                    .get(parent_index)
-                    .ok_or(Error::InvalidNodeIndex(parent_index))?;
-                return Ok(parent.execution_status());
+            // Reached an ancestor whose payload this branch executed. A pre-Gloas parent
+            // carries its payload inside the block, so it counts as executed too.
+            match gloas_node.parent_payload_status {
+                ParentPayloadStatus::Full | ParentPayloadStatus::PreGloas => {
+                    let Some(parent_index) = gloas_node.parent else {
+                        return Ok(ExecutionStatus::irrelevant());
+                    };
+                    let parent = self
+                        .nodes
+                        .get(parent_index)
+                        .ok_or(Error::InvalidNodeIndex(parent_index))?;
+                    return Ok(parent.execution_status());
+                }
+                ParentPayloadStatus::Empty => {}
             }
 
             match gloas_node.parent {
@@ -887,7 +914,8 @@ impl ProtoArray {
             .indices
             .get(&block_root)
             .ok_or(Error::NodeUnknown(block_root))?;
-        self.propagate_execution_payload_validation_from(index, PayloadStatus::Full)
+        // Pre-Gloas only entry: the verified node carries its payload inside itself.
+        self.propagate_execution_payload_validation_from(index, ParentPayloadStatus::PreGloas)
     }
 
     /// Promotes `start_index` and every payload that its branch executed to `Valid`.
@@ -902,7 +930,7 @@ impl ProtoArray {
     fn propagate_execution_payload_validation_from(
         &mut self,
         start_index: usize,
-        start_status: PayloadStatus,
+        start_status: ParentPayloadStatus,
     ) -> Result<(), Error> {
         let mut index = start_index;
         let mut status = start_status;
@@ -912,39 +940,43 @@ impl ProtoArray {
                 .get_mut(index)
                 .ok_or(Error::InvalidNodeIndex(index))?;
 
-            // Only a `FULL` node has a payload of its own in the execution ancestry of this branch.
-            if status == PayloadStatus::Full {
-                match node.execution_status() {
-                    // We have reached a node that we already know is valid. No need to iterate further
-                    // since we assume an ancestors have already been set to valid.
-                    ExecutionStatus::Valid(_) => return Ok(()),
-                    // We have reached an irrelevant node, this node is prior to a terminal execution
-                    // block. There's no need to iterate further, it's impossible for this block to have
-                    // any relevant ancestors.
-                    ExecutionStatus::Irrelevant(_) => return Ok(()),
-                    // The block has an unknown status, set it to valid since any ancestor of a valid
-                    // payload can be considered valid.
-                    ExecutionStatus::Optimistic(payload_block_hash) => {
-                        *node.execution_status_mut() = ExecutionStatus::Valid(payload_block_hash);
-                    }
-                    // An ancestor of the valid payload was invalid. This is a serious error which
-                    // indicates a consensus failure in the execution node. This is unrecoverable.
-                    ExecutionStatus::Invalid(ancestor_payload_block_hash) => {
-                        return Err(Error::InvalidAncestorOfValidPayload {
-                            ancestor_block_root: node.root(),
-                            ancestor_payload_block_hash,
-                        });
+            // Only a `FULL` node has a payload of its own in the execution ancestry of this
+            // branch. A pre-Gloas block carries its payload inside itself, so it is executed.
+            match status {
+                ParentPayloadStatus::Full | ParentPayloadStatus::PreGloas => {
+                    match node.execution_status() {
+                        // We have reached a node that we already know is valid. No need to iterate further
+                        // since we assume an ancestors have already been set to valid.
+                        ExecutionStatus::Valid(_) => return Ok(()),
+                        // We have reached an irrelevant node, this node is prior to a terminal execution
+                        // block. There's no need to iterate further, it's impossible for this block to have
+                        // any relevant ancestors.
+                        ExecutionStatus::Irrelevant(_) => return Ok(()),
+                        // The block has an unknown status, set it to valid since any ancestor of a valid
+                        // payload can be considered valid.
+                        ExecutionStatus::Optimistic(payload_block_hash) => {
+                            *node.execution_status_mut() =
+                                ExecutionStatus::Valid(payload_block_hash);
+                        }
+                        // An ancestor of the valid payload was invalid. This is a serious error which
+                        // indicates a consensus failure in the execution node. This is unrecoverable.
+                        ExecutionStatus::Invalid(ancestor_payload_block_hash) => {
+                            return Err(Error::InvalidAncestorOfValidPayload {
+                                ancestor_block_root: node.root(),
+                                ancestor_payload_block_hash,
+                            });
+                        }
                     }
                 }
+                ParentPayloadStatus::Empty => {}
             }
 
             let Some(parent_index) = node.parent() else {
                 // We have reached the root block, iteration complete.
                 return Ok(());
             };
-            // Which of the two nodes of the parent this block extends. Pre-Gloas the chain
-            // is all `FULL`.
-            status = node.parent_payload_status().unwrap_or(PayloadStatus::Full);
+            // Which of the two nodes of the parent this block extends.
+            status = node.get_parent_payload_status();
             index = parent_index;
         }
     }
@@ -992,29 +1024,17 @@ impl ProtoArray {
 
         // Collect all *ancestors* which were declared invalid since they reside between the
         // `head_block_root` and the `latest_valid_ancestor_root`.
-        let mut status = PayloadStatus::Full;
         loop {
             let node = self
                 .nodes
                 .get_mut(index)
                 .ok_or(Error::InvalidNodeIndex(index))?;
 
-            // An `EMPTY` edge is a gap in the execution ancestry of the branch, not the end of it.
-            // This branch never ran the payload of this block, so the walk steps over it.
-            if status != PayloadStatus::Full {
-                let Some(parent_index) = node.parent() else {
-                    break;
-                };
-                status = node.parent_payload_status().unwrap_or(PayloadStatus::Full);
-                index = parent_index;
-                continue;
-            }
-
             let node_execution_status = node.execution_status();
             match node_execution_status {
-                ExecutionStatus::Valid(hash)
-                | ExecutionStatus::Invalid(hash)
-                | ExecutionStatus::Optimistic(hash) => {
+                Ok(ExecutionStatus::Valid(hash))
+                | Ok(ExecutionStatus::Invalid(hash))
+                | Ok(ExecutionStatus::Optimistic(hash)) => {
                     // If we're no longer processing the `head_block_root` and the last valid
                     // ancestor is unknown, exit this loop and proceed to invalidate and
                     // descendants of `head_block_root`/`latest_valid_ancestor_root`.
@@ -1030,7 +1050,8 @@ impl ProtoArray {
                         break;
                     }
                 }
-                ExecutionStatus::Irrelevant(_) => break,
+                Ok(ExecutionStatus::Irrelevant(_)) => break,
+                Err(_) => break,
             }
 
             // Only invalidate the head block if either:
@@ -1044,27 +1065,29 @@ impl ProtoArray {
                 match node.execution_status() {
                     // It's illegal for an execution client to declare that some previously-valid block
                     // is now invalid. This is a consensus failure on their behalf.
-                    ExecutionStatus::Valid(hash) => {
+                    Ok(ExecutionStatus::Valid(hash)) => {
                         return Err(Error::ValidExecutionStatusBecameInvalid {
                             block_root: node.root(),
                             payload_block_hash: hash,
                         });
                     }
-                    ExecutionStatus::Optimistic(hash) => {
+                    Ok(ExecutionStatus::Optimistic(hash)) => {
                         invalidated_indices.insert(index);
-                        *node.execution_status_mut() = ExecutionStatus::Invalid(hash);
+                        if let ProtoNode::V17(node) = node {
+                            node.execution_status = ExecutionStatus::Invalid(hash);
+                        }
                     }
                     // The block is already invalid, but keep going backwards to ensure all ancestors
                     // are updated.
-                    ExecutionStatus::Invalid(_) => (),
+                    Ok(ExecutionStatus::Invalid(_)) => (),
                     // This block is pre-merge, therefore it has no execution status. Nor do its
                     // ancestors.
-                    ExecutionStatus::Irrelevant(_) => break,
+                    Ok(ExecutionStatus::Irrelevant(_)) => break,
+                    Err(_) => break,
                 }
             }
 
             if let Some(parent_index) = node.parent() {
-                status = node.parent_payload_status().unwrap_or(PayloadStatus::Full);
                 index = parent_index
             } else {
                 // The root of the block tree has been reached (aka the finalized block), without
@@ -1101,40 +1124,24 @@ impl ProtoArray {
             if let Some(parent_index) = node.parent()
                 && invalidated_indices.contains(&parent_index)
             {
-                // A Gloas descendant becomes invalid only when it built on the payload of the
-                // ancestor. A descendant that took the `EMPTY` edge stays viable.
-                if let ProtoNode::V29(gloas_node) = node
-                    && gloas_node.parent_payload_status != PayloadStatus::Full
-                {
-                    continue;
-                }
-
                 match node.execution_status() {
-                    ExecutionStatus::Valid(hash) => {
+                    Ok(ExecutionStatus::Valid(hash)) => {
                         return Err(Error::ValidExecutionStatusBecameInvalid {
                             block_root: node.root(),
                             payload_block_hash: hash,
                         });
                     }
-                    ExecutionStatus::Optimistic(hash) | ExecutionStatus::Invalid(hash) => {
-                        *node.execution_status_mut() = ExecutionStatus::Invalid(hash);
-                    }
-                    ExecutionStatus::Irrelevant(_) => {
-                        // In Gloas this means only that the payload is not revealed yet. The block did
-                        // commit to the invalid ancestry. Pre-Gloas this state is a contradiction.
-                        match node {
-                            ProtoNode::V29(gloas_node) => {
-                                gloas_node.execution_status = ExecutionStatus::Invalid(
-                                    gloas_node.execution_payload_block_hash,
-                                );
-                            }
-                            ProtoNode::V17(_) => {
-                                return Err(Error::IrrelevantDescendant {
-                                    block_root: node.root(),
-                                });
-                            }
+                    Ok(ExecutionStatus::Optimistic(hash)) | Ok(ExecutionStatus::Invalid(hash)) => {
+                        if let ProtoNode::V17(node) = node {
+                            node.execution_status = ExecutionStatus::Invalid(hash)
                         }
                     }
+                    Ok(ExecutionStatus::Irrelevant(_)) => {
+                        return Err(Error::IrrelevantDescendant {
+                            block_root: node.root(),
+                        });
+                    }
+                    Err(_) => (),
                 }
 
                 invalidated_indices.insert(index);
@@ -1580,7 +1587,13 @@ impl ProtoArray {
                 return Ok(IndexedForkChoiceNode {
                     root: current.root(),
                     proto_node_index: current_index,
-                    payload_status: child.get_parent_payload_status(),
+                    payload_status: match child.get_parent_payload_status() {
+                        ParentPayloadStatus::Full => PayloadStatus::Full,
+                        // A pre-Gloas parent has a single virtual node, conventionally `EMPTY`.
+                        ParentPayloadStatus::Empty | ParentPayloadStatus::PreGloas => {
+                            PayloadStatus::Empty
+                        }
+                    },
                 });
             }
 
@@ -1621,7 +1634,14 @@ impl ProtoArray {
                         .ok_or(Error::InvalidNodeIndex(i))
                         .map(|child| {
                             // Spec: node.payload_status == get_parent_payload_status(store, blocks[root])
-                            (child.get_parent_payload_status() == node.payload_status).then(|| {
+                            let child_side = match child.get_parent_payload_status() {
+                                ParentPayloadStatus::Full => PayloadStatus::Full,
+                                ParentPayloadStatus::Empty => PayloadStatus::Empty,
+                                // A pre-Gloas parent has a single virtual node - set to EMPTY to
+                                // match the unconditional children push at the top of this function
+                                ParentPayloadStatus::PreGloas => PayloadStatus::Empty,
+                            };
+                            (child_side == node.payload_status).then(|| {
                                 (
                                     IndexedForkChoiceNode {
                                         root: child.root(),

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -836,21 +836,39 @@ impl ProtoArray {
         let v29 = node
             .as_v29_mut()
             .map_err(|_| Error::InvalidNodeVariant { block_root })?;
+        // The envelope arrived: record it so sync stops fetching, whatever the verdict.
         v29.payload_received = true;
-        // The envelope reveals the payload, so the node takes the status from the execution layer.
-        v29.execution_status = execution_status;
-        let parent = v29.parent;
-        let parent_status = v29.parent_payload_status;
 
-        // A valid payload also validates every payload that its branch executed, so promote the
-        // ancestry.
-        if execution_status.is_valid_and_post_bellatrix()
-            && let Some(parent_index) = parent
-        {
-            self.propagate_execution_payload_validation_from(parent_index, parent_status)?;
+        // A settled verdict is never revisited: a duplicate `Valid`, or an `Invalid` the
+        // invalidation sweep already set from this payload's condemned ancestry.
+        match v29.execution_status {
+            ExecutionStatus::NotYetRevealed(_) | ExecutionStatus::Optimistic(_) => {}
+            ExecutionStatus::Valid(_) | ExecutionStatus::Invalid(_) => return Ok(()),
+            ExecutionStatus::Irrelevant(_) => {
+                return Err(Error::Unexpected(format!(
+                    "pre-merge status on a Gloas node: {block_root:?}"
+                )));
+            }
         }
 
-        Ok(())
+        // Store the EL's verdict; only `Valid` also validates the branch this payload executed.
+        match execution_status {
+            ExecutionStatus::Optimistic(_) => {
+                v29.execution_status = execution_status;
+                Ok(())
+            }
+            ExecutionStatus::Valid(_) => {
+                // The walk validates this node on its own `FULL` side and every payload above it that
+                // its branch executed.
+                self.propagate_execution_payload_validation_from(index, ParentPayloadStatus::Full)
+            }
+            // The fork choice wrapper only maps envelope verdicts to `Valid` or `Optimistic`.
+            ExecutionStatus::Invalid(_)
+            | ExecutionStatus::Irrelevant(_)
+            | ExecutionStatus::NotYetRevealed(_) => Err(Error::Unexpected(format!(
+                "envelope carries no EL verdict: {execution_status:?}"
+            ))),
+        }
     }
 
     /// Execution validity of `(block_root, EMPTY)`. This node runs no payload of its own. It
@@ -953,9 +971,9 @@ impl ProtoArray {
                         ExecutionStatus::Irrelevant(_) => return Ok(()),
                         // The block has an unknown status, set it to valid since any ancestor of a valid
                         // payload can be considered valid.
-                        ExecutionStatus::Optimistic(payload_block_hash) => {
-                            *node.execution_status_mut() =
-                                ExecutionStatus::Valid(payload_block_hash);
+                        ExecutionStatus::Optimistic(hash)
+                        | ExecutionStatus::NotYetRevealed(hash) => {
+                            *node.execution_status_mut() = ExecutionStatus::Valid(hash);
                         }
                         // An ancestor of the valid payload was invalid. This is a serious error which
                         // indicates a consensus failure in the execution node. This is unrecoverable.

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -959,33 +959,33 @@ impl ProtoArray {
 
             // Only a `FULL` node has a payload of its own in the execution ancestry of this
             // branch. A pre-Gloas block carries its payload inside itself, so it is executed.
-            match status {
-                ParentPayloadStatus::Full | ParentPayloadStatus::PreGloas => {
-                    match node.execution_status() {
-                        // We have reached a node that we already know is valid. No need to iterate further
-                        // since we assume an ancestors have already been set to valid.
-                        ExecutionStatus::Valid(_) => return Ok(()),
-                        // We have reached an irrelevant node, this node is prior to a terminal execution
-                        // block. There's no need to iterate further, it's impossible for this block to have
-                        // any relevant ancestors.
-                        ExecutionStatus::Irrelevant(_) => return Ok(()),
-                        // The block has an unknown status, set it to valid since any ancestor of a valid
-                        // payload can be considered valid.
-                        ExecutionStatus::Optimistic(hash)
-                        | ExecutionStatus::NotYetRevealed(hash) => {
-                            *node.execution_status_mut() = ExecutionStatus::Valid(hash);
-                        }
-                        // An ancestor of the valid payload was invalid. This is a serious error which
-                        // indicates a consensus failure in the execution node. This is unrecoverable.
-                        ExecutionStatus::Invalid(ancestor_payload_block_hash) => {
-                            return Err(Error::InvalidAncestorOfValidPayload {
-                                ancestor_block_root: node.root(),
-                                ancestor_payload_block_hash,
-                            });
-                        }
+            let executed = match status {
+                ParentPayloadStatus::Full | ParentPayloadStatus::PreGloas => true,
+                ParentPayloadStatus::Empty => false,
+            };
+            if executed {
+                match node.execution_status() {
+                    // We have reached a node that we already know is valid. No need to iterate further
+                    // since we assume an ancestors have already been set to valid.
+                    ExecutionStatus::Valid(_) => return Ok(()),
+                    // We have reached an irrelevant node, this node is prior to a terminal execution
+                    // block. There's no need to iterate further, it's impossible for this block to have
+                    // any relevant ancestors.
+                    ExecutionStatus::Irrelevant(_) => return Ok(()),
+                    // The block has an unknown status, set it to valid since any ancestor of a valid
+                    // payload can be considered valid.
+                    ExecutionStatus::Optimistic(hash) | ExecutionStatus::NotYetRevealed(hash) => {
+                        *node.execution_status_mut() = ExecutionStatus::Valid(hash);
+                    }
+                    // An ancestor of the valid payload was invalid. This is a serious error which
+                    // indicates a consensus failure in the execution node. This is unrecoverable.
+                    ExecutionStatus::Invalid(ancestor_payload_block_hash) => {
+                        return Err(Error::InvalidAncestorOfValidPayload {
+                            ancestor_block_root: node.root(),
+                            ancestor_payload_block_hash,
+                        });
                     }
                 }
-                ParentPayloadStatus::Empty => {}
             }
 
             let Some(parent_index) = node.parent() else {

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -542,12 +542,13 @@ impl ProtoArrayForkChoice {
     /// Mark a Gloas payload envelope as valid and received.
     ///
     /// This must only be called for valid Gloas payloads.
-    pub fn on_valid_payload_envelope_received(
+    pub fn on_payload_envelope_received(
         &mut self,
         block_root: Hash256,
+        execution_status: ExecutionStatus,
     ) -> Result<(), String> {
         self.proto_array
-            .on_valid_payload_envelope_received(block_root)
+            .on_payload_envelope_received(block_root, execution_status)
             .map_err(|e| format!("Failed to process execution payload: {:?}", e))
     }
 
@@ -834,10 +835,10 @@ impl ProtoArrayForkChoice {
     /// This will operate on *all* blocks, even those that do not descend from the finalized
     /// ancestor.
     pub fn contains_invalid_payloads(&mut self) -> bool {
-        self.proto_array.nodes.iter().any(|node| {
-            node.execution_status()
-                .is_ok_and(|status| status.is_invalid())
-        })
+        self.proto_array
+            .nodes
+            .iter()
+            .any(|node| node.execution_status().is_invalid())
     }
 
     /// For all nodes, regardless of their relationship to the finalized block, set their execution
@@ -860,10 +861,8 @@ impl ProtoArrayForkChoice {
                 .ok_or("unreachable index out of bounds in proto_array nodes")?;
 
             match node.execution_status() {
-                Ok(ExecutionStatus::Invalid(block_hash)) => {
-                    if let ProtoNode::V17(node) = node {
-                        node.execution_status = ExecutionStatus::Optimistic(block_hash);
-                    }
+                ExecutionStatus::Invalid(block_hash) => {
+                    *node.execution_status_mut() = ExecutionStatus::Optimistic(block_hash);
 
                     // Restore the weight of the node, it would have been set to `0` in
                     // `apply_score_changes` when it was invalidated.
@@ -908,14 +907,11 @@ impl ProtoArrayForkChoice {
                 }
                 // There are no balance changes required if the node was either valid or
                 // optimistic.
-                Ok(ExecutionStatus::Valid(block_hash))
-                | Ok(ExecutionStatus::Optimistic(block_hash)) => {
-                    if let ProtoNode::V17(node) = node {
-                        node.execution_status = ExecutionStatus::Optimistic(block_hash)
-                    }
+                ExecutionStatus::Valid(block_hash) | ExecutionStatus::Optimistic(block_hash) => {
+                    *node.execution_status_mut() = ExecutionStatus::Optimistic(block_hash);
                 }
                 // An irrelevant node cannot become optimistic, this is a no-op.
-                Ok(ExecutionStatus::Irrelevant(_)) | Err(_) => (),
+                ExecutionStatus::Irrelevant(_) => (),
             }
         }
 
@@ -988,9 +984,7 @@ impl ProtoArrayForkChoice {
             next_epoch_shuffling_id: block.next_epoch_shuffling_id().clone(),
             justified_checkpoint: *block.justified_checkpoint(),
             finalized_checkpoint: *block.finalized_checkpoint(),
-            execution_status: block
-                .execution_status()
-                .unwrap_or_else(|_| ExecutionStatus::irrelevant()),
+            execution_status: block.execution_status(),
             unrealized_justified_checkpoint: block.unrealized_justified_checkpoint(),
             unrealized_finalized_checkpoint: block.unrealized_finalized_checkpoint(),
             execution_payload_parent_hash: block.execution_payload_parent_hash().ok(),
@@ -1060,11 +1054,29 @@ impl ProtoArrayForkChoice {
     /// Returns the `block.execution_status` field, if the block is present.
     pub fn get_block_execution_status(&self, block_root: &Hash256) -> Option<ExecutionStatus> {
         let block = self.get_proto_node(block_root)?;
-        Some(
-            block
-                .execution_status()
-                .unwrap_or_else(|_| ExecutionStatus::irrelevant()),
-        )
+        Some(block.execution_status())
+    }
+
+    /// Execution status of one fork choice node of a Gloas block.
+    ///
+    /// A block has two nodes. `(root, FULL)` takes the status of the payload of the block.
+    /// `(root, EMPTY)` inherits the status of the nearest ancestor across a `FULL` edge.
+    ///
+    /// The status of the block is the wrong answer for an empty head. That payload can be valid
+    /// while the payload that the branch ran is still optimistic. The node then reports the chain
+    /// as validated when no execution layer validated it. `PENDING` counts as empty.
+    pub fn get_node_execution_status(
+        &self,
+        block_root: &Hash256,
+        payload_status: PayloadStatus,
+    ) -> Option<ExecutionStatus> {
+        match payload_status {
+            PayloadStatus::Full => self.get_block_execution_status(block_root),
+            PayloadStatus::Empty | PayloadStatus::Pending => self
+                .proto_array
+                .empty_node_execution_status(*block_root)
+                .ok(),
+        }
     }
 
     /// Returns whether the execution payload for a block has been received.

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -864,79 +864,112 @@ impl ProtoArrayForkChoice {
             .any(|node| node.execution_status().is_invalid())
     }
 
-    /// For all nodes, regardless of their relationship to the finalized block, set their execution
-    /// status to be optimistic.
-    ///
-    /// In practice this means forgetting any `VALID` or `INVALID` statuses.
     pub fn set_all_blocks_to_optimistic<E: EthSpec>(&mut self) -> Result<(), String> {
-        // Iterate backwards through all nodes in the `proto_array`. Whilst it's not strictly
-        // required to do this process in reverse, it seems natural when we consider how LMD votes
-        // are counted.
-        //
-        // This function will touch all blocks, even those that do not descend from the finalized
-        // block. Since this function is expected to run at start-up during very rare
-        // circumstances we prefer simplicity over efficiency.
-        for node_index in (0..self.proto_array.nodes.len()).rev() {
+        // Clear every `VALID`/`INVALID` verdict. `Irrelevant` and `NotYetRevealed` have no verdict
+        // to reset.
+        for node in self.proto_array.nodes.iter_mut() {
+            match node.execution_status() {
+                ExecutionStatus::Valid(hash)
+                | ExecutionStatus::Invalid(hash)
+                | ExecutionStatus::Optimistic(hash) => {
+                    *node.execution_status_mut() = ExecutionStatus::Optimistic(hash);
+                }
+                ExecutionStatus::Irrelevant(_) | ExecutionStatus::NotYetRevealed(_) => (),
+            }
+        }
+
+        // Reset every weight before rebuilding.
+        for node in self.proto_array.nodes.iter_mut() {
+            *node.weight_mut() = 0;
+            match node {
+                ProtoNode::V29(node) => {
+                    node.full_payload_weight = 0;
+                    node.empty_payload_weight = 0;
+                }
+                ProtoNode::V17(_) => (),
+            }
+        }
+
+        // Add each validator's balance to the node it votes for, splitting a Gloas vote into the
+        // full or empty bucket exactly as `compute_deltas` does.
+        for (validator_index, vote) in self.votes.0.iter().enumerate() {
+            let Some(&node_index) = self.proto_array.indices.get(&vote.current_root) else {
+                continue;
+            };
+            // A voting validator without a balance is ignored, consistent with `compute_deltas`.
+            let Some(&balance) = self.balances.effective_balances.get(validator_index) else {
+                continue;
+            };
             let node = self
                 .proto_array
                 .nodes
                 .get_mut(node_index)
                 .ok_or("unreachable index out of bounds in proto_array nodes")?;
+            let node_slot = node.slot();
+            *node.weight_mut() = node
+                .weight()
+                .checked_add(balance)
+                .ok_or("Overflow when adding vote weight")?;
+            let bucket = match node {
+                ProtoNode::V29(node) => match NodeDelta::payload_status(
+                    vote.current_slot,
+                    vote.current_payload_present,
+                    node_slot,
+                ) {
+                    PayloadStatus::Full => Some(&mut node.full_payload_weight),
+                    PayloadStatus::Empty => Some(&mut node.empty_payload_weight),
+                    PayloadStatus::Pending => None,
+                },
+                ProtoNode::V17(_) => None,
+            };
+            if let Some(bucket) = bucket {
+                *bucket = bucket
+                    .checked_add(balance)
+                    .ok_or("Overflow when adding vote weight to a payload bucket")?;
+            }
+        }
 
-            match node.execution_status() {
-                ExecutionStatus::Invalid(block_hash) => {
-                    *node.execution_status_mut() = ExecutionStatus::Optimistic(block_hash);
-
-                    // Restore the weight of the node, it would have been set to `0` in
-                    // `apply_score_changes` when it was invalidated.
-                    let restored_weight: u64 = self
-                        .votes
-                        .0
-                        .iter()
-                        .enumerate()
-                        .filter_map(|(validator_index, vote)| {
-                            if vote.current_root == node.root() {
-                                // Any voting validator that does not have a balance should be
-                                // ignored. This is consistent with `compute_deltas`.
-                                self.balances.effective_balances.get(validator_index)
-                            } else {
-                                None
-                            }
-                        })
-                        .sum();
-
-                    // Add the restored weight to the node and all ancestors.
-                    if restored_weight > 0 {
-                        let mut node_or_ancestor = node;
-                        loop {
-                            *node_or_ancestor.weight_mut() = node_or_ancestor
-                                .weight()
-                                .checked_add(restored_weight)
-                                .ok_or("Overflow when adding weight to ancestor")?;
-
-                            if let Some(parent_index) = node_or_ancestor.parent() {
-                                node_or_ancestor = self
-                                    .proto_array
-                                    .nodes
-                                    .get_mut(parent_index)
-                                    .ok_or(format!("Missing parent index: {}", parent_index))?;
-                            } else {
-                                // This is either the finalized block or a block that does not
-                                // descend from the finalized block.
-                                break;
-                            }
+        // Propagate each node's aggregate weight to its parent, routed into the parent's full or
+        // empty bucket by the edge the child extends. Children have higher indices than parents, so
+        // a reverse pass finishes each node's subtree weight before it reaches the parent.
+        for node_index in (0..self.proto_array.nodes.len()).rev() {
+            let (weight, edge, parent_index) = {
+                let node = self
+                    .proto_array
+                    .nodes
+                    .get(node_index)
+                    .ok_or("unreachable index out of bounds in proto_array nodes")?;
+                (
+                    node.weight(),
+                    node.get_parent_payload_status(),
+                    node.parent(),
+                )
+            };
+            let Some(parent_index) = parent_index else {
+                continue;
+            };
+            let parent = self
+                .proto_array
+                .nodes
+                .get_mut(parent_index)
+                .ok_or(format!("Missing parent index: {}", parent_index))?;
+            *parent.weight_mut() = parent
+                .weight()
+                .checked_add(weight)
+                .ok_or("Overflow when adding weight to ancestor")?;
+            match parent {
+                ProtoNode::V29(parent) => {
+                    let bucket = match edge {
+                        ParentPayloadStatus::Full => &mut parent.full_payload_weight,
+                        ParentPayloadStatus::Empty | ParentPayloadStatus::PreGloas => {
+                            &mut parent.empty_payload_weight
                         }
-                    }
+                    };
+                    *bucket = bucket
+                        .checked_add(weight)
+                        .ok_or("Overflow when adding child weight to a payload bucket")?;
                 }
-                // There are no balance changes required if the node was either valid or
-                // optimistic.
-                ExecutionStatus::Valid(block_hash) | ExecutionStatus::Optimistic(block_hash) => {
-                    *node.execution_status_mut() = ExecutionStatus::Optimistic(block_hash);
-                }
-                // An irrelevant node cannot become optimistic, this is a no-op.
-                ExecutionStatus::Irrelevant(_) => (),
-                // No EL has seen this payload, so there is no verdict to reset.
-                ExecutionStatus::NotYetRevealed(_) => (),
+                ProtoNode::V17(_) => (),
             }
         }
 

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -1,3 +1,4 @@
+use crate::proto_array::ParentPayloadStatus;
 use crate::{
     JustifiedBalances,
     error::Error,
@@ -1044,7 +1045,11 @@ impl ProtoArrayForkChoice {
         let fc_node = IndexedForkChoiceNode {
             root: proto_node.root(),
             proto_node_index: *block_index,
-            payload_status: proto_node.get_parent_payload_status(),
+            payload_status: match proto_node.get_parent_payload_status() {
+                ParentPayloadStatus::Full => PayloadStatus::Full,
+                // A pre-Gloas parent has a single virtual node, conventionally `EMPTY`.
+                ParentPayloadStatus::Empty | ParentPayloadStatus::PreGloas => PayloadStatus::Empty,
+            },
         };
         self.proto_array
             .should_extend_payload::<E>(&fc_node, proto_node, current_slot, proposer_boost_root)

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -207,10 +207,13 @@ impl ExecutionStatus {
     ///     - Has a payload that has not yet been verified by an EL, OR.
     ///     - Has a payload that has been deemed invalid by an EL.
     pub fn is_optimistic_or_invalid(&self) -> bool {
-        matches!(
-            self,
-            ExecutionStatus::Optimistic(_) | ExecutionStatus::Invalid(_)
-        )
+        match self {
+            // An unrevealed payload has no EL verdict, so it is not fully verified.
+            ExecutionStatus::Optimistic(_)
+            | ExecutionStatus::Invalid(_)
+            | ExecutionStatus::NotYetRevealed(_) => true,
+            ExecutionStatus::Valid(_) | ExecutionStatus::Irrelevant(_) => false,
+        }
     }
 
     /// Returns `true` if the block:
@@ -226,6 +229,16 @@ impl ExecutionStatus {
     /// - Does not have execution enabled (before or after Bellatrix fork)
     pub fn is_irrelevant(&self) -> bool {
         matches!(self, ExecutionStatus::Irrelevant(_))
+    }
+
+    pub fn is_not_yet_revealed(&self) -> bool {
+        match self {
+            ExecutionStatus::NotYetRevealed(_) => true,
+            ExecutionStatus::Valid(_)
+            | ExecutionStatus::Invalid(_)
+            | ExecutionStatus::Optimistic(_)
+            | ExecutionStatus::Irrelevant(_) => false,
+        }
     }
 }
 

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -111,6 +111,11 @@ pub enum ExecutionStatus {
     /// This `bool` only exists to satisfy our SSZ implementation which requires all variants
     /// to have a value. It can be set to anything.
     Irrelevant(bool),
+    /// The Gloas envelope carrying this block's committed payload has not arrived yet, so no EL
+    /// has been asked about it. Unlike `Irrelevant`, the payload exists and is unverified.
+    ///
+    /// The `ExecutionBlockHash` is the bid's committed block hash.
+    NotYetRevealed(ExecutionBlockHash),
 }
 
 /// Represents the status of an execution payload post-Gloas.
@@ -228,6 +233,7 @@ impl fmt::Display for ExecutionStatus {
             ExecutionStatus::Invalid(_) => write!(f, "invalid"),
             ExecutionStatus::Optimistic(_) => write!(f, "optimistic"),
             ExecutionStatus::Irrelevant(_) => write!(f, "irrelevant"),
+            ExecutionStatus::NotYetRevealed(_) => write!(f, "not_yet_revealed"),
         }
     }
 }
@@ -913,6 +919,8 @@ impl ProtoArrayForkChoice {
                 }
                 // An irrelevant node cannot become optimistic, this is a no-op.
                 ExecutionStatus::Irrelevant(_) => (),
+                // No EL has seen this payload, so there is no verdict to reset.
+                ExecutionStatus::NotYetRevealed(_) => (),
             }
         }
 

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -160,7 +160,10 @@ impl ExecutionStatus {
             ExecutionStatus::Valid(hash)
             | ExecutionStatus::Invalid(hash)
             | ExecutionStatus::Optimistic(hash) => Some(*hash),
-            ExecutionStatus::Irrelevant(_) => None,
+            // The bid hash of a `NotYetRevealed` payload is known, but callers of this method
+            // treat `Some` as "a payload an EL was told about" (e.g. the latest valid ancestor
+            // lookup), which an unrevealed payload never was.
+            ExecutionStatus::Irrelevant(_) | ExecutionStatus::NotYetRevealed(_) => None,
         }
     }
 

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -1259,7 +1259,11 @@ impl<E: EthSpec> Tester<E> {
                 .chain
                 .canonical_head
                 .fork_choice_write_lock()
-                .on_valid_payload_envelope_received(block_root)
+                .on_payload_envelope_received(
+                    block_root,
+                    PayloadVerificationStatus::Verified,
+                    block_hash,
+                )
                 .map_err(|e| {
                     Error::InternalError(format!(
                         "on_execution_payload for block root {} failed: {:?}",
@@ -1412,10 +1416,12 @@ impl<E: EthSpec> Tester<E> {
                 "confirmed block {confirmed_root:?} not found in fork choice"
             ))
         })?;
+        // In Gloas the confirmation rule applies to the parent block, so the safe hash is the
+        // payload that the confirmed block builds on, not the payload it reveals. Pre-Gloas nodes
+        // have no `execution_payload_parent_hash` and keep the hash of their own payload.
         let actual = block
-            .execution_status
-            .block_hash()
-            .or(block.execution_payload_parent_hash)
+            .execution_payload_parent_hash
+            .or_else(|| block.execution_status.block_hash())
             .unwrap_or_else(ExecutionBlockHash::zero);
         check_equal("safe_execution_block_hash", actual, expected)
     }


### PR DESCRIPTION
## Breaking change

Can we force existing Gloas nodes to resync when updating to this new version? Then we can simplify the migrations as the property `execution_status` has continuity in mainnet from Fulu to Gloas. Otherwise there's an awkward partial disappearance between v29 and v30.

## Issue Addressed

Re-enable optimistic sync for Gloas payload envelopes

## Proposed Changes

Track the status of the payload (FULL) node in ProtoNode::execution_status
