### PR TITLE
Fix validator is not aggregator when VC is in DVT mode involving middleware

### DIFF
--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -1007,13 +1007,18 @@ async fn poll_beacon_attesters<S: ValidatorStore + 'static, T: SlotClock + 'stat
                 let duty = &duty_and_proof.duty;
                 let is_aggregator = duty_and_proof.selection_proof.is_some();
 
-                subscriptions.push(BeaconCommitteeSubscription {
+                let beacon_committee = BeaconCommitteeSubscription {
                     validator_index: duty.validator_index,
                     committee_index: duty.committee_index,
                     committees_at_slot: duty.committees_at_slot,
                     slot: duty.slot,
                     is_aggregator,
-                });
+                };
+                subscriptions.push(beacon_committee.clone());
+                debug!(
+                    subscription = ?beacon_committee,
+                    "Beacon committee subscription",
+                );
                 subscription_slots_to_confirm.push(duty_and_proof.subscription_slots.clone());
             });
     }
@@ -1429,7 +1434,7 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
 
     // Create a HashMap for BeaconCommitteeSelection to match the duty later for distributed case involving middleware
     let mut selection_hashmap = HashMap::new();
-    let mut call_selection_endpoint = false;
+    let mut call_selection_endpoint = true;
 
     while !duties_by_slot.is_empty() {
         if let Some(duration) = slot_clock.duration_to_next_slot() {
@@ -1446,7 +1451,7 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
 
             let lookahead_slot = current_slot + selection_lookahead;
 
-            let relevant_duties = if duties_service.selection_proof_config.parallel_sign {
+            let mut relevant_duties = if duties_service.selection_proof_config.parallel_sign {
                 // Remove old slot duties and only keep current duties in distributed mode
                 duties_by_slot
                     .remove(&lookahead_slot)
@@ -1501,6 +1506,15 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
                     }
                     // Once we have the selection_proof, we don't call the selections_endpoint again
                     call_selection_endpoint = false;
+
+                    // Insert all remaining duties into relevant_duties so they are
+                    // processed at once with the full selection proofs from the middleware
+                    for (slot, attester_data) in std::mem::take(&mut duties_by_slot) {
+                        relevant_duties
+                            .entry(slot)
+                            .or_default()
+                            .extend(attester_data);
+                    }
                 }
 
                 for duty in relevant_duties.into_values().flatten() {

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -1463,23 +1463,13 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
                 duties
             };
 
-            let batch_size = relevant_duties.values().map(Vec::len).sum::<usize>();
-
-            if batch_size == 0 {
-                continue;
-            }
-
-            let timer = validator_metrics::start_timer_vec(
-                &validator_metrics::DUTIES_SERVICE_TIMES,
-                &[validator_metrics::ATTESTATION_SELECTION_PROOFS],
-            );
-
-            // for distributed case that uses the selections_endpoint
+            // For distributed case that uses the selections_endpoint, call the endpoint
+            // and drain all remaining duties BEFORE the batch_size check. This ensures
+            // selection proofs are stored in the attesters map early enough for
+            // beacon committee subscriptions to include the correct is_aggregator value.
             if duties_service.selection_proof_config.selections_endpoint {
-                // Using lookahead_slot to determine if it is the first slot of an epoch
                 let is_lookahead_slot_epoch_start = lookahead_slot % S::E::slots_per_epoch() == 0;
 
-                // Call the selection endpoint only at the first slot of an epoch or when it errors
                 if is_lookahead_slot_epoch_start || call_selection_endpoint {
                     let beacon_committee_selections =
                         make_beacon_committee_selection(&duties_service, &duties).await;
@@ -1516,6 +1506,21 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
                             .extend(attester_data);
                     }
                 }
+            }
+
+            let batch_size = relevant_duties.values().map(Vec::len).sum::<usize>();
+
+            if batch_size == 0 {
+                continue;
+            }
+
+            let timer = validator_metrics::start_timer_vec(
+                &validator_metrics::DUTIES_SERVICE_TIMES,
+                &[validator_metrics::ATTESTATION_SELECTION_PROOFS],
+            );
+
+            // for distributed case that uses the selections_endpoint
+            if duties_service.selection_proof_config.selections_endpoint {
 
                 for duty in relevant_duties.into_values().flatten() {
                     let key = (duty.validator_index, duty.slot);

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -1463,6 +1463,11 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
                 duties
             };
 
+            let timer = validator_metrics::start_timer_vec(
+                &validator_metrics::DUTIES_SERVICE_TIMES,
+                &[validator_metrics::ATTESTATION_SELECTION_PROOFS],
+            );
+
             // For distributed case that uses the selections_endpoint, call the endpoint
             // and drain all remaining duties BEFORE the batch_size check. This ensures
             // selection proofs are stored in the attesters map early enough for
@@ -1513,11 +1518,6 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
             if batch_size == 0 {
                 continue;
             }
-
-            let timer = validator_metrics::start_timer_vec(
-                &validator_metrics::DUTIES_SERVICE_TIMES,
-                &[validator_metrics::ATTESTATION_SELECTION_PROOFS],
-            );
 
             // for distributed case that uses the selections_endpoint
             if duties_service.selection_proof_config.selections_endpoint {

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -1463,18 +1463,19 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
                 duties
             };
 
+            let batch_size = relevant_duties.values().map(Vec::len).sum::<usize>();
+
             let timer = validator_metrics::start_timer_vec(
                 &validator_metrics::DUTIES_SERVICE_TIMES,
                 &[validator_metrics::ATTESTATION_SELECTION_PROOFS],
             );
 
-            // For distributed case that uses the selections_endpoint, call the endpoint
-            // and drain all remaining duties BEFORE the batch_size check. This ensures
-            // selection proofs are stored in the attesters map early enough for
-            // beacon committee subscriptions to include the correct is_aggregator value.
+            // for distributed case that uses the selections_endpoint
             if duties_service.selection_proof_config.selections_endpoint {
+                // Using lookahead_slot to determine if it is the first slot of an epoch
                 let is_lookahead_slot_epoch_start = lookahead_slot % S::E::slots_per_epoch() == 0;
 
+                // Call the selection endpoint only at the first slot of an epoch or when it errors
                 if is_lookahead_slot_epoch_start || call_selection_endpoint {
                     let beacon_committee_selections =
                         make_beacon_committee_selection(&duties_service, &duties).await;
@@ -1510,10 +1511,8 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
                             .or_default()
                             .extend(attester_data);
                     }
-                }
+                
             }
-
-            let batch_size = relevant_duties.values().map(Vec::len).sum::<usize>();
 
             if batch_size == 0 {
                 continue;
@@ -1521,7 +1520,6 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
 
             // for distributed case that uses the selections_endpoint
             if duties_service.selection_proof_config.selections_endpoint {
-
                 for duty in relevant_duties.into_values().flatten() {
                     let key = (duty.validator_index, duty.slot);
 

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -1465,6 +1465,10 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
 
             let batch_size = relevant_duties.values().map(Vec::len).sum::<usize>();
 
+            if batch_size == 0 && !duties_service.selection_proof_config.selections_endpoint {
+                continue;
+            }
+
             let timer = validator_metrics::start_timer_vec(
                 &validator_metrics::DUTIES_SERVICE_TIMES,
                 &[validator_metrics::ATTESTATION_SELECTION_PROOFS],
@@ -1511,15 +1515,8 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
                             .or_default()
                             .extend(attester_data);
                     }
-                
-            }
+                }
 
-            if batch_size == 0 {
-                continue;
-            }
-
-            // for distributed case that uses the selections_endpoint
-            if duties_service.selection_proof_config.selections_endpoint {
                 for duty in relevant_duties.into_values().flatten() {
                     let key = (duty.validator_index, duty.slot);
 

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -1603,38 +1603,30 @@ async fn fill_in_selection_proofs_selections_endpoint<
             })
             .collect::<HashMap<_, _>>();
 
-        // Add all duties of the epoch to the attesters store at once. The write lock is scoped so
-        // that it is released before sleeping below.
-        {
-            let mut attesters = duties_service.attesters.write();
-            for duty in &duties {
-                let key = (duty.validator_index, duty.slot);
-                let result = match selection_hashmap.remove(&key) {
-                    Some(selection_proof) => match selection_proof
-                        .is_aggregator(duty.committee_length as usize, &duties_service.spec)
-                    {
-                        // Aggregator, return the result
-                        Ok(true) => Ok((duty.clone(), Some(selection_proof))),
-                        // Not an aggregator, do nothing and continue
-                        Ok(false) => continue,
-                        Err(e) => Err(Error::InvalidModulo(e)),
-                    },
-                    None => Err(Error::FailedToProduceSelectionProof(
-                        ValidatorStoreError::Middleware(format!(
-                            "Missing selection proof for validator {} slot {}",
-                            duty.validator_index, duty.slot
-                        )),
+        for duty in &duties {
+            let key = (duty.validator_index, duty.slot);
+            let result = match selection_hashmap.remove(&key) {
+                Some(selection_proof) => match selection_proof
+                    .is_aggregator(duty.committee_length as usize, &duties_service.spec)
+                {
+                    // Aggregator, return the result
+                    Ok(true) => Ok((duty.clone(), Some(selection_proof))),
+                    // Not an aggregator, do nothing and continue
+                    Ok(false) => continue,
+                    Err(e) => Err(Error::InvalidModulo(e)),
+                },
+                None => Err(Error::FailedToProduceSelectionProof(
+                    ValidatorStoreError::Middleware(format!(
+                        "Missing selection proof for validator {} slot {}",
+                        duty.validator_index, duty.slot
                     )),
-                };
+                )),
+            };
 
-                if !process_duty_and_proof::<S>(
-                    &mut attesters,
-                    result,
-                    dependent_root,
-                    current_slot,
-                ) {
-                    return;
-                }
+            let mut attesters = duties_service.attesters.write();
+            // if process_duty_and_proof returns false, exit the loop
+            if !process_duty_and_proof::<S>(&mut attesters, result, dependent_root, current_slot) {
+                return;
             }
         }
 

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -1233,7 +1233,17 @@ async fn poll_beacon_attesters_for_epoch<S: ValidatorStore + 'static, T: SlotClo
     let subservice = duties_service.clone();
     duties_service.executor.spawn(
         async move {
-            fill_in_selection_proofs(subservice, new_duties, dependent_root).await;
+            if subservice.selection_proof_config.selections_endpoint {
+                fill_in_selection_proofs_selections_endpoint(
+                    subservice,
+                    new_duties,
+                    dependent_root,
+                    epoch,
+                )
+                .await;
+            } else {
+                fill_in_selection_proofs(subservice, new_duties, dependent_root).await;
+            }
         },
         "duties_service_selection_proofs_background",
     );
@@ -1432,10 +1442,6 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
     // of selection proofs and insert them into the duties service `attesters` map.
     let slot_clock = &duties_service.slot_clock;
 
-    // Create a HashMap for BeaconCommitteeSelection to match the duty later for distributed case involving middleware
-    let mut selection_hashmap = HashMap::new();
-    let mut call_selection_endpoint = true;
-
     while !duties_by_slot.is_empty() {
         if let Some(duration) = slot_clock.duration_to_next_slot() {
             sleep(
@@ -1451,7 +1457,7 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
 
             let lookahead_slot = current_slot + selection_lookahead;
 
-            let mut relevant_duties = if duties_service.selection_proof_config.parallel_sign {
+            let relevant_duties = if duties_service.selection_proof_config.parallel_sign {
                 // Remove old slot duties and only keep current duties in distributed mode
                 duties_by_slot
                     .remove(&lookahead_slot)
@@ -1465,7 +1471,7 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
 
             let batch_size = relevant_duties.values().map(Vec::len).sum::<usize>();
 
-            if batch_size == 0 && !duties_service.selection_proof_config.selections_endpoint {
+            if batch_size == 0 {
                 continue;
             }
 
@@ -1474,86 +1480,8 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
                 &[validator_metrics::ATTESTATION_SELECTION_PROOFS],
             );
 
-            // for distributed case that uses the selections_endpoint
-            if duties_service.selection_proof_config.selections_endpoint {
-                // Using lookahead_slot to determine if it is the first slot of an epoch
-                let is_lookahead_slot_epoch_start = lookahead_slot % S::E::slots_per_epoch() == 0;
-
-                // Call the selection endpoint only at the first slot of an epoch or when it errors
-                if is_lookahead_slot_epoch_start || call_selection_endpoint {
-                    let beacon_committee_selections =
-                        make_beacon_committee_selection(&duties_service, &duties).await;
-
-                    let selections = match beacon_committee_selections {
-                        Ok(selections) => selections,
-                        Err(e) => {
-                            error!(
-                                error = ?e,
-                                "Failed to fetch selection proofs"
-                            );
-                            // If calling the endpoint fails, change to true so that it will retry the next slot
-                            call_selection_endpoint = true;
-                            continue;
-                        }
-                    };
-
-                    for selection in &selections {
-                        // This is a full_selection_proof returned by middleware
-                        let selection_proof =
-                            SelectionProof::from(selection.selection_proof.clone());
-                        selection_hashmap
-                            .insert((selection.validator_index, selection.slot), selection_proof);
-                    }
-                    // Once we have the selection_proof, we don't call the selections_endpoint again
-                    call_selection_endpoint = false;
-
-                    // Insert all remaining duties into relevant_duties so they are
-                    // processed at once with the full selection proofs from the middleware
-                    for (slot, attester_data) in std::mem::take(&mut duties_by_slot) {
-                        relevant_duties
-                            .entry(slot)
-                            .or_default()
-                            .extend(attester_data);
-                    }
-                }
-
-                for duty in relevant_duties.into_values().flatten() {
-                    let key = (duty.validator_index, duty.slot);
-
-                    let result = if let Some(selection_proof) = selection_hashmap.remove(&key) {
-                        match selection_proof
-                            .is_aggregator(duty.committee_length as usize, &duties_service.spec)
-                            .map_err(Error::<S::Error>::InvalidModulo)
-                        {
-                            // Aggregator, return the result
-                            Ok(true) => Ok((duty, Some(selection_proof))),
-                            // Not an aggregator, do nothing and continue
-                            Ok(false) => continue,
-                            Err(_) => return,
-                        }
-                    } else {
-                        Err(Error::FailedToProduceSelectionProof(
-                            ValidatorStoreError::Middleware(format!(
-                                "Missing selection proof for validator {} slot {}",
-                                duty.validator_index, duty.slot
-                            )),
-                        ))
-                    };
-
-                    let mut attesters = duties_service.attesters.write();
-                    // if process_duty_and_proof returns false, exit the loop
-                    if !process_duty_and_proof::<S>(
-                        &mut attesters,
-                        result,
-                        dependent_root,
-                        current_slot,
-                    ) {
-                        return;
-                    }
-                }
-            }
             // For distributed case that uses parallel_sign
-            else if duties_service.selection_proof_config.parallel_sign {
+            if duties_service.selection_proof_config.parallel_sign {
                 let mut duty_and_proof_results = relevant_duties
                     .into_values()
                     .flatten()
@@ -1623,6 +1551,135 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
             // us an opportunity for the clock to eventually come good.
             sleep(duties_service.slot_clock.slot_duration()).await;
         }
+    }
+}
+
+/// Exchange the partial selection proofs for the `duties` of `epoch` for full selection proofs via
+/// the selections endpoint of the DVT middleware and add them to the `attesters` map.
+///
+/// As required by the beacon API spec, the selections endpoint is queried at the start of an epoch
+/// for all slots of the current epoch and, in a separate request, for all slots of the next epoch.
+/// Since the duties for the next epoch are downloaded at the start of the current epoch, this task
+/// makes the request for `epoch` immediately (the next epoch request, or the current epoch request
+/// on startup) and then again once `epoch` starts (the current epoch request). Requesting the
+/// proofs an epoch in advance ensures that the aggregator status is known before the attestation
+/// subscriptions for the first slots of the epoch are sent to the BN.
+///
+/// A failed request is retried at the next slot. If a re-org is detected then the process will
+/// terminate early as it is assumed the selection proofs from `duties` are no longer relevant.
+async fn fill_in_selection_proofs_selections_endpoint<
+    S: ValidatorStore + 'static,
+    T: SlotClock + 'static,
+>(
+    duties_service: Arc<DutiesService<S, T>>,
+    duties: Vec<AttesterData>,
+    dependent_root: Hash256,
+    epoch: Epoch,
+) {
+    let slot_clock = &duties_service.slot_clock;
+    let epoch_start_slot = epoch.start_slot(S::E::slots_per_epoch());
+    let epoch_end_slot = epoch.end_slot(S::E::slots_per_epoch());
+
+    loop {
+        let Some(current_slot) = slot_clock.now() else {
+            continue;
+        };
+
+        // If the current slot already passed the epoch, return early so we don't call the selections endpoint for stale duties
+        if current_slot > epoch_end_slot {
+            return;
+        }
+
+        let timer = validator_metrics::start_timer_vec(
+            &validator_metrics::DUTIES_SERVICE_TIMES,
+            &[validator_metrics::ATTESTATION_SELECTION_PROOFS],
+        );
+
+        let beacon_committee_selections =
+            match make_beacon_committee_selection(&duties_service, &duties).await {
+                Ok(selections) => selections,
+                Err(e) => {
+                    error!(
+                        error = ?e,
+                        %epoch,
+                        "Failed to fetch selection proofs"
+                    );
+                    // If fails, retry at the next slot.
+                    let duration_to_next_slot = slot_clock
+                        .duration_to_next_slot()
+                        .unwrap_or_else(|| slot_clock.slot_duration());
+                    sleep(duration_to_next_slot).await;
+                    continue;
+                }
+            };
+
+        // Create a full_selection_proofs hashmap. Key is (validator_index (type u64), Slot) and Value is full_selection_proof
+        let mut selection_hashmap = beacon_committee_selections
+            .into_iter()
+            .map(|selection| {
+                (
+                    (selection.validator_index, selection.slot),
+                    SelectionProof::from(selection.selection_proof),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        // Add all duties of the epoch to the attesters store at once. The write lock is scoped so
+        // that it is released before sleeping below.
+        {
+            let mut attesters = duties_service.attesters.write();
+            for duty in &duties {
+                let key = (duty.validator_index, duty.slot);
+                let result = match selection_hashmap.remove(&key) {
+                    Some(selection_proof) => match selection_proof
+                        .is_aggregator(duty.committee_length as usize, &duties_service.spec)
+                    {
+                        // Aggregator, return the result
+                        Ok(true) => Ok((duty.clone(), Some(selection_proof))),
+                        // Not an aggregator, do nothing and continue
+                        Ok(false) => continue,
+                        Err(e) => Err(Error::InvalidModulo(e)),
+                    },
+                    None => Err(Error::FailedToProduceSelectionProof(
+                        ValidatorStoreError::Middleware(format!(
+                            "Missing selection proof for validator {} slot {}",
+                            duty.validator_index, duty.slot
+                        )),
+                    )),
+                };
+
+                if !process_duty_and_proof::<S>(
+                    &mut attesters,
+                    result,
+                    dependent_root,
+                    current_slot,
+                ) {
+                    return;
+                }
+            }
+        }
+
+        let time_taken_ms =
+            Duration::from_secs_f64(timer.map_or(0.0, |t| t.stop_and_record())).as_millis();
+        debug!(
+            batch_size = duties.len(),
+            %epoch,
+            time_taken_ms,
+            "Computed attestation full selection proofs"
+        );
+
+        let is_epoch_started = current_slot >= epoch_start_slot;
+        // for current epoch request, return early when the task is successful
+        // for next epoch request, this will be false and we wait till the next epoch to call the endpoint again
+        if is_epoch_started {
+            return;
+        }
+
+        // Wait until the next epoch such that the next epoch becomes the current epoch
+        let duration_to_next_epoch = slot_clock
+            .duration_to_slot(epoch_start_slot)
+            .unwrap_or_else(|| slot_clock.slot_duration());
+        sleep(duration_to_next_epoch).await;
     }
 }
 

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -1457,17 +1457,8 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
 
             let lookahead_slot = current_slot + selection_lookahead;
 
-            let relevant_duties = if duties_service.selection_proof_config.parallel_sign {
-                // Remove old slot duties and only keep current duties in distributed mode
-                duties_by_slot
-                    .remove(&lookahead_slot)
-                    .map(|duties| BTreeMap::from([(lookahead_slot, duties)]))
-                    .unwrap_or_default()
-            } else {
-                let mut duties = duties_by_slot.split_off(&lookahead_slot);
-                std::mem::swap(&mut duties, &mut duties_by_slot);
-                duties
-            };
+            let mut relevant_duties = duties_by_slot.split_off(&lookahead_slot);
+            std::mem::swap(&mut relevant_duties, &mut duties_by_slot);
 
             let batch_size = relevant_duties.values().map(Vec::len).sum::<usize>();
 
@@ -1554,19 +1545,7 @@ async fn fill_in_selection_proofs<S: ValidatorStore + 'static, T: SlotClock + 's
     }
 }
 
-/// Exchange the partial selection proofs for the `duties` of `epoch` for full selection proofs via
-/// the selections endpoint of the DVT middleware and add them to the `attesters` map.
-///
-/// As required by the beacon API spec, the selections endpoint is queried at the start of an epoch
-/// for all slots of the current epoch and, in a separate request, for all slots of the next epoch.
-/// Since the duties for the next epoch are downloaded at the start of the current epoch, this task
-/// makes the request for `epoch` immediately (the next epoch request, or the current epoch request
-/// on startup) and then again once `epoch` starts (the current epoch request). Requesting the
-/// proofs an epoch in advance ensures that the aggregator status is known before the attestation
-/// subscriptions for the first slots of the epoch are sent to the BN.
-///
-/// A failed request is retried at the next slot. If a re-org is detected then the process will
-/// terminate early as it is assumed the selection proofs from `duties` are no longer relevant.
+/// fill_in_selection_proofs involving middleware (DVT mode)
 async fn fill_in_selection_proofs_selections_endpoint<
     S: ValidatorStore + 'static,
     T: SlotClock + 'static,


### PR DESCRIPTION
@KaloyanTanev reported a bug when Lighthouse VC is running in `--distributed` mode involving middleware (Charon), when it sends the `beacon_committee_subscriptions` to the beacon node, it always send with `is_aggregator: false`.

This is because when Lighthouse VC received the full selection proofs from Charon, it doesn't store them but rather, processed it one slot at a time. This PR fixes it by storing the duties in relevant_duties BTreeMap once the VC received the full selection proofs from the middleware.

~~I tested this with Kurtosis-Charon and can see `is_aggregator: true` for some validators now. But it's best to get confirmation from @KaloyanTanev (hence marking as blocked now)~~

~~I will remove the debug log when it's confirmed working~~ removed

Move the `fill_in_selections_proof` for DVT mode involving selections_endpoint to another function `fill_in_selection_proofs_selections_endpoint` as it involves another input `Epoch` (the calling of selections endpoint calls for current and next epoch at slot 0 as per the beacon API specs) and it is more flexible to have it's own function for any future modifications. 

The modification only involves the code when VC is using `--distributed` and it involves a middleware. It does not affect Lighthouse VC and Anchor.