### PR TITLE
Unify `BlobInfo` and `DataColumnInfo` into `DataInfo`

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -374,13 +374,8 @@ where
         // Stage the database's metadata fields for atomic storage when `build` is called.
         self.pending_io_batch.push(
             store
-                .init_blob_info(genesis.beacon_block.slot())
-                .map_err(|e| format!("Failed to initialize genesis blob info: {:?}", e))?,
-        );
-        self.pending_io_batch.push(
-            store
-                .init_data_column_info(genesis.beacon_block.slot())
-                .map_err(|e| format!("Failed to initialize genesis data column info: {:?}", e))?,
+                .init_data_info(genesis.beacon_block.slot())
+                .map_err(|e| format!("Failed to initialize genesis data info: {:?}", e))?,
         );
 
         let fc_store = BeaconForkChoiceStore::get_forkchoice_store(store, genesis.clone())
@@ -595,13 +590,8 @@ where
         self.pending_io_batch.push(store.store_split_in_batch());
         self.pending_io_batch.push(
             store
-                .init_blob_info(weak_subj_block.slot())
-                .map_err(|e| format!("Failed to initialize blob info: {:?}", e))?,
-        );
-        self.pending_io_batch.push(
-            store
-                .init_data_column_info(weak_subj_block.slot())
-                .map_err(|e| format!("Failed to initialize data column info: {:?}", e))?,
+                .init_data_info(weak_subj_block.slot())
+                .map_err(|e| format!("Failed to initialize data info: {:?}", e))?,
         );
 
         let snapshot = BeaconSnapshot {
@@ -1409,13 +1399,8 @@ where
         self.pending_io_batch.push(store.store_split_in_batch());
         self.pending_io_batch.push(
             store
-                .init_blob_info(initial_block.slot())
-                .map_err(|e| format!("Failed to initialize blob info: {:?}", e))?,
-        );
-        self.pending_io_batch.push(
-            store
-                .init_data_column_info(initial_block.slot())
-                .map_err(|e| format!("Failed to initialize data column info: {:?}", e))?,
+                .init_data_info(initial_block.slot())
+                .map_err(|e| format!("Failed to initialize data info: {:?}", e))?,
         );
 
         {

--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -11,8 +11,7 @@ use state_processing::{
 use std::borrow::Cow;
 use std::iter;
 use std::time::Duration;
-use store::metadata::DataColumnInfo;
-use store::{AnchorInfo, BlobInfo, DBColumn, Error as StoreError, KeyValueStore, KeyValueStoreOp};
+use store::{AnchorInfo, DBColumn, DataInfo, Error as StoreError, KeyValueStore, KeyValueStoreOp};
 use strum::IntoStaticStr;
 use tracing::{debug, debug_span, instrument};
 use types::{EthSpec, Hash256, Slot, consts::gloas::BUILDER_INDEX_SELF_BUILD};
@@ -87,8 +86,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         mut blocks: Vec<RangeSyncBlock<T::EthSpec>>,
     ) -> Result<usize, HistoricalBlockError> {
         let anchor_info = self.store.get_anchor_info();
-        let blob_info = self.store.get_blob_info();
-        let data_column_info = self.store.get_data_column_info();
+        let data_info = self.store.get_data_info();
 
         // Take all blocks with slots less than or equal to the oldest block slot.
         //
@@ -117,8 +115,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let mut expected_block_root = anchor_info.oldest_block_parent;
         let mut last_block_root = expected_block_root;
         let mut prev_block_slot = anchor_info.oldest_block_slot;
-        let mut new_oldest_blob_slot = blob_info.oldest_blob_slot;
-        let mut new_oldest_data_column_slot = data_column_info.oldest_data_column_slot;
+        let mut new_oldest_data_slot = data_info.oldest_data_slot;
 
         // A Gloas block's payload was revealed ("full") if its child's bid `parent_block_hash`
         // matches its own bid `block_hash`, see `process_parent_execution_payload` in the spec.
@@ -212,12 +209,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 );
             }
 
-            match &block_data {
-                AvailableBlockData::NoData => (),
-                AvailableBlockData::Blobs(_) => new_oldest_blob_slot = Some(block.slot()),
-                AvailableBlockData::DataColumns(_) => {
-                    new_oldest_data_column_slot = Some(block.slot())
-                }
+            if !matches!(block_data, AvailableBlockData::NoData) {
+                new_oldest_data_slot = block.slot();
             }
 
             // Store the blobs or data columns too
@@ -282,7 +275,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     }
                     let (signed_envelope, columns) = envelope.deconstruct();
                     if !columns.is_empty() {
-                        new_oldest_data_column_slot = Some(block.slot());
+                        new_oldest_data_slot = block.slot();
                         if let Some(op) = self.get_blobs_or_columns_store_op(
                             block_root,
                             block.slot(),
@@ -434,32 +427,16 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             self.store.cold_db.do_atomically(cold_batch)?;
         }
 
-        let mut anchor_and_blob_batch = Vec::with_capacity(3);
+        let mut anchor_and_blob_batch = Vec::with_capacity(2);
 
-        // Update the blob info.
-        if new_oldest_blob_slot != blob_info.oldest_blob_slot
-            && let Some(oldest_blob_slot) = new_oldest_blob_slot
-        {
-            let new_blob_info = BlobInfo {
-                oldest_blob_slot: Some(oldest_blob_slot),
-                ..blob_info.clone()
+        // Update the data info.
+        if new_oldest_data_slot != data_info.oldest_data_slot {
+            let new_data_info = DataInfo {
+                oldest_data_slot: new_oldest_data_slot,
             };
             anchor_and_blob_batch.push(
                 self.store
-                    .compare_and_set_blob_info(blob_info, new_blob_info)?,
-            );
-        }
-
-        // Update the data column info.
-        if new_oldest_data_column_slot != data_column_info.oldest_data_column_slot
-            && let Some(oldest_data_column_slot) = new_oldest_data_column_slot
-        {
-            let new_data_column_info = DataColumnInfo {
-                oldest_data_column_slot: Some(oldest_data_column_slot),
-            };
-            anchor_and_blob_batch.push(
-                self.store
-                    .compare_and_set_data_column_info(data_column_info, new_data_column_info)?,
+                    .compare_and_set_data_info(data_info, new_data_info)?,
             );
         }
 

--- a/beacon_node/beacon_chain/src/schema_change.rs
+++ b/beacon_node/beacon_chain/src/schema_change.rs
@@ -1,27 +1,26 @@
 //! Utilities for managing database schema changes.
 mod migration_schema_v29;
 mod migration_schema_v30;
+mod migration_schema_v31;
 
 use crate::beacon_chain::BeaconChainTypes;
 use migration_schema_v29::{downgrade_from_v29, upgrade_to_v29};
 use migration_schema_v30::{downgrade_from_v30, upgrade_to_v30};
+use migration_schema_v31::{downgrade_from_v31, upgrade_to_v31};
 use std::sync::Arc;
 use store::Error as StoreError;
 use store::hot_cold_store::{HotColdDB, HotColdDBError};
-use store::metadata::{CURRENT_SCHEMA_VERSION, SchemaVersion};
+use store::metadata::{CURRENT_SCHEMA_VERSION, OLDEST_SUPPORTED_SCHEMA_VERSION, SchemaVersion};
 
 /// Migrate the database from one schema version to another, applying all requisite mutations.
 ///
-/// All migrations for schema versions up to and including v28 have been removed. Nodes on live
-/// networks are already running v28, so only the current version check remains.
+/// Migrations from schema versions older than `OLDEST_SUPPORTED_SCHEMA_VERSION` have been removed.
 pub fn migrate_schema<T: BeaconChainTypes>(
     db: Arc<HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>>,
     from: SchemaVersion,
     to: SchemaVersion,
 ) -> Result<(), StoreError> {
     match (from, to) {
-        // Migrating from the current schema version to itself is always OK, a no-op.
-        (_, _) if from == to && to == CURRENT_SCHEMA_VERSION => Ok(()),
         // Upgrade from v28 to v29.
         (SchemaVersion(28), SchemaVersion(29)) => {
             let ops = upgrade_to_v29::<T>(&db)?;
@@ -41,6 +40,59 @@ pub fn migrate_schema<T: BeaconChainTypes>(
         (SchemaVersion(30), SchemaVersion(29)) => {
             let ops = downgrade_from_v30::<T>(&db)?;
             db.store_schema_version_atomically(to, ops)
+        }
+        // Upgrade from v30 to v31.
+        (SchemaVersion(30), SchemaVersion(31)) => {
+            let ops = upgrade_to_v31::<T>(&db)?;
+            db.store_schema_version_atomically(to, ops)
+        }
+        // Downgrade from v31 to v30.
+        (SchemaVersion(31), SchemaVersion(30)) => {
+            let ops = downgrade_from_v31::<T>(&db)?;
+            db.store_schema_version_atomically(to, ops)
+        }
+        // Chain multi-step upgrades and downgrades through the intermediate versions, e.g.
+        // v29 -> v31 as v29 -> v30 -> v31. Every adjacent pair of versions within
+        // [OLDEST_SCHEMA_VERSION, CURRENT_SCHEMA_VERSION] has a single-step arm above, so
+        // requiring both endpoints to lie in that range means every step is supported; anything
+        // outside it falls through to the error arm untouched.
+        //
+        // Each step is committed before the next one runs, as a migration reads what the
+        // previous one wrote. A failing step therefore leaves the database at the last version
+        // that did commit, which the error names so that the operator can retry from there.
+        (_, _)
+            if from >= OLDEST_SUPPORTED_SCHEMA_VERSION
+                && to >= OLDEST_SUPPORTED_SCHEMA_VERSION
+                && from <= CURRENT_SCHEMA_VERSION
+                && to <= CURRENT_SCHEMA_VERSION =>
+        {
+            let mut current = from;
+            while current != to {
+                let step = if current < to {
+                    SchemaVersion(current.as_u64() + 1)
+                } else {
+                    SchemaVersion(current.as_u64() - 1)
+                };
+                migrate_schema::<T>(db.clone(), current, step).map_err(|e| {
+                    if current == from {
+                        // Nothing has been committed, so the error stands on its own.
+                        e
+                    } else {
+                        StoreError::MigrationError(format!(
+                            "migrating from v{} to v{} failed at v{} -> v{}; the database is now \
+                             at v{}: {:?}",
+                            from.as_u64(),
+                            to.as_u64(),
+                            current.as_u64(),
+                            step.as_u64(),
+                            current.as_u64(),
+                            e,
+                        ))
+                    }
+                })?;
+                current = step;
+            }
+            Ok(())
         }
         // Anything else is an error.
         (_, _) => Err(HotColdDBError::UnsupportedSchemaVersion {

--- a/beacon_node/beacon_chain/src/schema_change/migration_schema_v31.rs
+++ b/beacon_node/beacon_chain/src/schema_change/migration_schema_v31.rs
@@ -1,0 +1,123 @@
+use crate::beacon_chain::BeaconChainTypes;
+use std::cmp::{max, min};
+use store::hot_cold_store::HotColdDB;
+use store::metadata::{
+    BLOB_INFO_KEY, BlobInfo, DATA_COLUMN_INFO_KEY, DATA_INFO_KEY, DataColumnInfo, DataInfo,
+};
+use store::{DBColumn, Error as StoreError, ItemStore, KeyValueStoreOp, StoreItem};
+use tracing::info;
+use types::EthSpec;
+
+/// Upgrade from schema v30 to v31.
+///
+/// Merges the legacy `BlobInfo` and `DataColumnInfo` metadata into the single `DataInfo`, which
+/// tracks one low-water mark for all sidecar data (blobs pre-Fulu, data columns from Fulu
+/// onwards).
+///
+/// Returns a list of store ops to be applied atomically with the schema version write.
+pub fn upgrade_to_v31<T: BeaconChainTypes>(
+    db: &HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>,
+) -> Result<Vec<KeyValueStoreOp>, StoreError> {
+    let oldest_blob_slot = db
+        .hot_db
+        .get::<BlobInfo>(&BLOB_INFO_KEY)?
+        .and_then(|blob_info| blob_info.oldest_blob_slot);
+    let oldest_data_column_slot = db
+        .hot_db
+        .get::<DataColumnInfo>(&DATA_COLUMN_INFO_KEY)?
+        .and_then(|data_column_info| data_column_info.oldest_data_column_slot);
+
+    let oldest_data_slot = match (oldest_blob_slot, oldest_data_column_slot) {
+        (Some(blob_slot), Some(column_slot)) => {
+            // If the blob marker lies in a PeerDAS epoch then no blobs can exist before it: it
+            // was either initialized at a post-Fulu anchor (fresh checkpoint sync) or advanced
+            // past the fork by the final blob prune, and was never updated since. In the latter
+            // case that final prune also deleted the data columns up to the blob marker but left
+            // the column marker stale at the Fulu fork slot, so taking the newer of the two
+            // markers avoids claiming data that has been pruned. This can overshoot in the
+            // former case (backfill lowers only the column marker, leaving the blob marker at
+            // the anchor), which merely under-advertises backfilled columns until pruning
+            // advances the marker past the anchor. Outside PeerDAS epochs pre-Fulu blobs may
+            // still be stored (e.g. on nodes with blob pruning disabled) and the older of the
+            // two markers is correct.
+            if db
+                .spec
+                .is_peer_das_enabled_for_epoch(blob_slot.epoch(T::EthSpec::slots_per_epoch()))
+            {
+                max(blob_slot, column_slot)
+            } else {
+                min(blob_slot, column_slot)
+            }
+        }
+        (Some(blob_slot), None) => blob_slot,
+        (None, Some(column_slot)) => column_slot,
+        (None, None) => {
+            return Err(StoreError::MigrationError(
+                "No BlobInfo or DataColumnInfo found".to_string(),
+            ));
+        }
+    };
+
+    info!(
+        ?oldest_blob_slot,
+        ?oldest_data_column_slot,
+        %oldest_data_slot,
+        "Merging blob info and data column info into data info"
+    );
+
+    // `DATA_INFO_KEY` cannot exist on disk before this migration runs: fresh databases start at
+    // the current schema version, and the only tool that writes it without migrating first
+    // (`lighthouse db prune-blobs`) refuses to run on pre-v31 schemas. The merged legacy value is
+    // therefore always the true marker. Update the in-memory data info (still the default, as
+    // `open()` found no `DATA_INFO_KEY`) along with staging the on-disk write.
+    let put_data_info_op =
+        db.compare_and_set_data_info(db.get_data_info(), DataInfo { oldest_data_slot })?;
+
+    Ok(vec![
+        put_data_info_op,
+        KeyValueStoreOp::DeleteKey(DBColumn::BeaconMeta, BLOB_INFO_KEY.as_slice().to_vec()),
+        KeyValueStoreOp::DeleteKey(
+            DBColumn::BeaconMeta,
+            DATA_COLUMN_INFO_KEY.as_slice().to_vec(),
+        ),
+    ])
+}
+
+/// Downgrade from schema v31 to v30.
+///
+/// Splits `DataInfo` back into the legacy `BlobInfo` and `DataColumnInfo` at the Fulu fork
+/// boundary.
+///
+/// Returns a list of store ops to be applied atomically with the schema version write.
+pub fn downgrade_from_v31<T: BeaconChainTypes>(
+    db: &HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>,
+) -> Result<Vec<KeyValueStoreOp>, StoreError> {
+    let oldest_data_slot = db.get_data_info().oldest_data_slot;
+
+    let blob_info = BlobInfo {
+        oldest_blob_slot: Some(oldest_data_slot),
+        blobs_db: true,
+    };
+    let data_column_info = DataColumnInfo {
+        // Data columns exist from the Fulu fork at the earliest.
+        oldest_data_column_slot: db.spec.fulu_fork_epoch.map(|fork_epoch| {
+            max(
+                oldest_data_slot,
+                fork_epoch.start_slot(T::EthSpec::slots_per_epoch()),
+            )
+        }),
+    };
+
+    info!(
+        %oldest_data_slot,
+        oldest_blob_slot = ?blob_info.oldest_blob_slot,
+        oldest_data_column_slot = ?data_column_info.oldest_data_column_slot,
+        "Splitting data info into blob info and data column info"
+    );
+
+    Ok(vec![
+        blob_info.as_kv_store_op(BLOB_INFO_KEY),
+        data_column_info.as_kv_store_op(DATA_COLUMN_INFO_KEY),
+        KeyValueStoreOp::DeleteKey(DBColumn::BeaconMeta, DATA_INFO_KEY.as_slice().to_vec()),
+    ])
+}

--- a/beacon_node/beacon_chain/tests/schema_stability.rs
+++ b/beacon_node/beacon_chain/tests/schema_stability.rs
@@ -13,7 +13,7 @@ use store::{
     DBColumn, HotColdDB, StoreConfig, StoreItem,
     database::interface::BeaconNodeBackend,
     hot_cold_store::Split,
-    metadata::{DataColumnCustodyInfo, DataColumnInfo},
+    metadata::{BlobInfo, DataColumnCustodyInfo, DataColumnInfo},
 };
 use strum::IntoEnumIterator;
 use tempfile::{TempDir, tempdir};
@@ -126,16 +126,25 @@ fn insert_data_column_custody_info(store: &Store<E>, spec: &ChainSpec) {
 fn check_metadata_sizes(store: &Store<E>) {
     assert_eq!(Split::default().ssz_bytes_len(), 40);
     assert_eq!(store.get_anchor_info().ssz_bytes_len(), 64);
+    assert_eq!(store.get_data_info().ssz_bytes_len(), 8);
+    assert_eq!(DataColumnCustodyInfo::default().ssz_bytes_len(), 5);
     assert_eq!(
-        store.get_blob_info().ssz_bytes_len(),
-        if store.get_chain_spec().deneb_fork_epoch.is_some() {
-            14
-        } else {
-            6
+        BlobInfo {
+            oldest_blob_slot: Some(Slot::new(0)),
+            blobs_db: true,
         }
+        .ssz_bytes_len(),
+        14
+    );
+    assert_eq!(BlobInfo::default().ssz_bytes_len(), 6);
+    assert_eq!(
+        DataColumnInfo {
+            oldest_data_column_slot: Some(Slot::new(0)),
+        }
+        .ssz_bytes_len(),
+        13
     );
     assert_eq!(DataColumnInfo::default().ssz_bytes_len(), 5);
-    assert_eq!(DataColumnCustodyInfo::default().ssz_bytes_len(), 5);
 }
 
 fn check_op_pool(store: &Store<E>) {

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -46,14 +46,18 @@ use std::convert::TryInto;
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
-use store::KeyValueStore;
 use store::database::interface::BeaconNodeBackend;
-use store::metadata::{CURRENT_SCHEMA_VERSION, STATE_UPPER_LIMIT_NO_RETAIN, SchemaVersion};
+use store::metadata::{
+    BLOB_INFO_KEY, BlobInfo, CURRENT_SCHEMA_VERSION, DATA_COLUMN_INFO_KEY, DATA_INFO_KEY,
+    DataColumnInfo, DataInfo, OLDEST_SUPPORTED_SCHEMA_VERSION, STATE_UPPER_LIMIT_NO_RETAIN,
+    SchemaVersion,
+};
 use store::{
-    BlobInfo, DBColumn, HotColdDB, StoreConfig, StoreOp,
+    DBColumn, HotColdDB, StoreConfig, StoreOp,
     hdiff::HierarchyConfig,
     iter::{BlockRootsIterator, StateRootsIterator},
 };
+use store::{ItemStore, KeyValueStore};
 use tempfile::{TempDir, tempdir};
 use tracing::info;
 use types::test_utils::test_arbitrary_instance;
@@ -4404,7 +4408,13 @@ async fn schema_downgrade_to_min_version(store_config: StoreConfig, archive: boo
         )
         .await;
 
-    let min_version = SchemaVersion(29);
+    // Downgrading below v29 is only possible before the Gloas fork: the v28 fork choice format
+    // cannot represent Gloas proto nodes.
+    let min_version = if spec.gloas_fork_epoch.is_some() {
+        SchemaVersion(29)
+    } else {
+        OLDEST_SUPPORTED_SCHEMA_VERSION
+    };
 
     // Save the slot clock so that the new harness doesn't revert in time.
     let slot_clock = harness.chain.slot_clock.clone();
@@ -4450,10 +4460,15 @@ async fn schema_downgrade_to_min_version(store_config: StoreConfig, archive: boo
     );
     check_iterators_from_slot(&harness, chain_dump_start_slot);
 
-    // Check that downgrading beyond the minimum version fails (bound is *tight*).
-    let min_version_sub_1 = SchemaVersion(min_version.as_u64().checked_sub(1).unwrap());
-    migrate_schema::<DiskHarnessType<E>>(store.clone(), CURRENT_SCHEMA_VERSION, min_version_sub_1)
-        .expect_err("should not downgrade below minimum version");
+    // Check that downgrading below the oldest supported version fails (bound is *tight*).
+    let below_oldest = SchemaVersion(
+        OLDEST_SUPPORTED_SCHEMA_VERSION
+            .as_u64()
+            .checked_sub(1)
+            .unwrap(),
+    );
+    migrate_schema::<DiskHarnessType<E>>(store.clone(), CURRENT_SCHEMA_VERSION, below_oldest)
+        .expect_err("should not downgrade below the oldest supported version");
 }
 
 // Schema upgrade/downgrade on an archive node where the optimised migration does apply due
@@ -4605,6 +4620,147 @@ async fn light_client_update_schema_v30_migration() {
     }
 }
 
+#[tokio::test]
+async fn data_info_schema_v31_migration() {
+    let mut spec = ForkName::Electra.make_genesis_spec(E::default_spec());
+    let fulu_fork_epoch = Epoch::new(4);
+    spec.fulu_fork_epoch = Some(fulu_fork_epoch);
+    let fulu_fork_slot = fulu_fork_epoch.start_slot(E::slots_per_epoch());
+
+    let db_path = tempdir().unwrap();
+    let mut store = get_store_generic(&db_path, StoreConfig::default(), spec.clone());
+
+    // Turn the store's on-disk layout into a pre-v31 one (legacy blob/data column markers,
+    // schema v30, and optionally a stray unified marker) and reopen it. `get_store_generic`
+    // opens with a no-op migration callback, exactly like the database manager, so the reopened
+    // store's in-memory marker is the value `open()` establishes without running the migration.
+    let reopen_at_v30 = |store: Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>>,
+                         blob_slot: Slot,
+                         column_slot: Slot,
+                         data_slot: Option<Slot>| {
+        store
+            .hot_db
+            .put(
+                &BLOB_INFO_KEY,
+                &BlobInfo {
+                    oldest_blob_slot: Some(blob_slot),
+                    blobs_db: true,
+                },
+            )
+            .unwrap();
+        store
+            .hot_db
+            .put(
+                &DATA_COLUMN_INFO_KEY,
+                &DataColumnInfo {
+                    oldest_data_column_slot: Some(column_slot),
+                },
+            )
+            .unwrap();
+        match data_slot {
+            Some(oldest_data_slot) => store
+                .hot_db
+                .put(&DATA_INFO_KEY, &DataInfo { oldest_data_slot })
+                .unwrap(),
+            None => store.hot_db.delete::<DataInfo>(&DATA_INFO_KEY).unwrap(),
+        }
+        store.store_schema_version(SchemaVersion(30)).unwrap();
+        drop(store);
+        get_store_generic(&db_path, StoreConfig::default(), spec.clone())
+    };
+
+    // Upgrade the store to v31 and check that the given marker was persisted and the legacy
+    // keys removed.
+    let upgrade_to_v31 = |store: &Arc<HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend>>,
+                          expected_data_slot: Slot| {
+        migrate_schema::<DiskHarnessType<E>>(store.clone(), SchemaVersion(30), SchemaVersion(31))
+            .expect("schema upgrade to v31 should succeed");
+        assert_eq!(
+            store
+                .hot_db
+                .get::<DataInfo>(&DATA_INFO_KEY)
+                .unwrap()
+                .unwrap()
+                .oldest_data_slot,
+            expected_data_slot
+        );
+        assert!(
+            store
+                .hot_db
+                .get::<BlobInfo>(&BLOB_INFO_KEY)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            store
+                .hot_db
+                .get::<DataColumnInfo>(&DATA_COLUMN_INFO_KEY)
+                .unwrap()
+                .is_none()
+        );
+    };
+
+    // Case 1: node retaining pre-Fulu blobs (e.g. blob pruning disabled). The blob marker is the
+    // true low-water mark and must win the merge.
+    let blob_slot = Slot::new(8);
+    assert!(blob_slot < fulu_fork_slot);
+    store = reopen_at_v30(store, blob_slot, fulu_fork_slot, None);
+    // Without migrating, the in-memory marker stays at the uninitialized default. This is why
+    // `lighthouse db prune-blobs` refuses to run on pre-v31 schemas.
+    assert_eq!(store.get_data_info().oldest_data_slot, Slot::new(0));
+    upgrade_to_v31(&store, blob_slot);
+    assert_eq!(store.get_data_info().oldest_data_slot, blob_slot);
+
+    // Downgrade splits the marker at the Fulu fork boundary.
+    migrate_schema::<DiskHarnessType<E>>(store.clone(), SchemaVersion(31), SchemaVersion(30))
+        .expect("schema downgrade to v30 should succeed");
+    assert_eq!(
+        store
+            .hot_db
+            .get::<BlobInfo>(&BLOB_INFO_KEY)
+            .unwrap()
+            .unwrap()
+            .oldest_blob_slot,
+        Some(blob_slot)
+    );
+    assert_eq!(
+        store
+            .hot_db
+            .get::<DataColumnInfo>(&DATA_COLUMN_INFO_KEY)
+            .unwrap()
+            .unwrap()
+            .oldest_data_column_slot,
+        Some(fulu_fork_slot)
+    );
+
+    // Case 2: pruned node whose legacy blob marker froze at a post-Fulu slot (no blobs exist).
+    // The data column marker is the true low-water mark and must win the merge.
+    let stale_blob_slot = fulu_fork_slot + 16;
+    let column_slot = fulu_fork_slot + 24;
+    store = reopen_at_v30(store, stale_blob_slot, column_slot, None);
+    assert_eq!(store.get_data_info().oldest_data_slot, Slot::new(0));
+    upgrade_to_v31(&store, column_slot);
+
+    // Case 3: pruned node whose final blob prune crossed the Fulu fork, advancing the blob
+    // marker past the fork while leaving the data column marker stale at the fork slot (the
+    // pre-v31 pruner only updated the blob marker in this case, despite deleting the columns
+    // too). The blob marker is the true low-water mark and must win the merge.
+    let advanced_blob_slot = fulu_fork_slot + 16;
+    store = reopen_at_v30(store, advanced_blob_slot, fulu_fork_slot, None);
+    assert_eq!(store.get_data_info().oldest_data_slot, Slot::new(0));
+    upgrade_to_v31(&store, advanced_blob_slot);
+
+    // Case 4: pre-v31 database that unexpectedly contains a unified marker. This cannot arise
+    // in practice: the beacon node always migrates on startup, and `lighthouse db prune-blobs`
+    // (the only other writer) refuses to run on pre-v31 schemas. The migration therefore
+    // assumes no unified marker exists and re-derives it from the legacy keys.
+    let stray_data_slot = fulu_fork_slot + 32;
+    store = reopen_at_v30(store, stale_blob_slot, column_slot, Some(stray_data_slot));
+    // `open()` loads an existing `DATA_INFO_KEY` regardless of the schema version.
+    assert_eq!(store.get_data_info().oldest_data_slot, stray_data_slot);
+    upgrade_to_v31(&store, column_slot);
+}
+
 /// Check that blob pruning prunes blobs older than the data availability boundary.
 #[tokio::test]
 async fn deneb_prune_blobs_happy_case() {
@@ -4635,10 +4791,7 @@ async fn deneb_prune_blobs_happy_case() {
 
     // Prior to manual pruning with an artifically low data availability boundary all blobs should
     // be stored.
-    assert_eq!(
-        store.get_blob_info().oldest_blob_slot,
-        Some(deneb_fork_slot)
-    );
+    assert_eq!(store.get_data_info().oldest_data_slot, deneb_fork_slot);
     check_blob_existence(&harness, Slot::new(1), harness.head_slot(), true);
 
     // Trigger blob pruning of blobs older than epoch 2.
@@ -4648,7 +4801,7 @@ async fn deneb_prune_blobs_happy_case() {
         .unwrap();
 
     // Check oldest blob slot is updated accordingly and prior blobs have been deleted.
-    let oldest_blob_slot = store.get_blob_info().oldest_blob_slot.unwrap();
+    let oldest_blob_slot = store.get_data_info().oldest_data_slot;
     assert_eq!(
         oldest_blob_slot,
         data_availability_boundary.start_slot(E::slots_per_epoch())
@@ -4703,10 +4856,7 @@ async fn deneb_prune_blobs_no_finalization() {
     assert_eq!(store.get_split_slot(), finalized_slot);
 
     // All blobs should still be available.
-    assert_eq!(
-        store.get_blob_info().oldest_blob_slot,
-        Some(deneb_fork_slot)
-    );
+    assert_eq!(store.get_data_info().oldest_data_slot, deneb_fork_slot);
     check_blob_existence(&harness, Slot::new(0), harness.head_slot(), true);
 
     // Attempt blob pruning of blobs older than epoch 4, which is newer than finalization.
@@ -4716,7 +4866,7 @@ async fn deneb_prune_blobs_no_finalization() {
         .unwrap();
 
     // Check oldest blob slot is only updated to finalization, and NOT to the DAB.
-    let oldest_blob_slot = store.get_blob_info().oldest_blob_slot.unwrap();
+    let oldest_blob_slot = store.get_data_info().oldest_data_slot;
     assert_eq!(oldest_blob_slot, finalized_slot);
     check_blob_existence(&harness, Slot::new(0), finalized_slot - 1, false);
     check_blob_existence(&harness, finalized_slot, harness.head_slot(), true);
@@ -4773,10 +4923,7 @@ async fn prune_blobs_across_fork_boundary() {
     assert_eq!(store.get_split_slot(), finalized_slot);
 
     // All blobs should still be available.
-    assert_eq!(
-        store.get_blob_info().oldest_blob_slot,
-        Some(deneb_fork_slot)
-    );
+    assert_eq!(store.get_data_info().oldest_data_slot, deneb_fork_slot);
     check_blob_existence(&harness, Slot::new(0), harness.head_slot(), true);
 
     // Attempt pruning with data availability epochs that precede the fork epoch.
@@ -4787,11 +4934,8 @@ async fn prune_blobs_across_fork_boundary() {
             .try_prune_blobs(true, data_availability_boundary)
             .unwrap();
 
-        // Check oldest blob slot is not updated.
-        assert_eq!(
-            store.get_blob_info().oldest_blob_slot,
-            Some(deneb_fork_slot)
-        );
+        // Check oldest data slot is not updated.
+        assert_eq!(store.get_data_info().oldest_data_slot, deneb_fork_slot);
     }
     // All blobs should still be available.
     check_blob_existence(&harness, Slot::new(0), harness.head_slot(), true);
@@ -4799,7 +4943,7 @@ async fn prune_blobs_across_fork_boundary() {
     // Prune one epoch past the fork.
     let pruned_slot = (deneb_fork_epoch + 1).start_slot(E::slots_per_epoch());
     store.try_prune_blobs(true, deneb_fork_epoch + 1).unwrap();
-    assert_eq!(store.get_blob_info().oldest_blob_slot, Some(pruned_slot));
+    assert_eq!(store.get_data_info().oldest_data_slot, pruned_slot);
     check_blob_existence(&harness, Slot::new(0), pruned_slot - 1, false);
     check_blob_existence(&harness, pruned_slot, harness.head_slot(), true);
 
@@ -4824,7 +4968,7 @@ async fn prune_blobs_across_fork_boundary() {
     assert_eq!(store.get_split_slot(), finalized_slot);
 
     // All blobs since last pruning during Deneb should still be available.
-    assert_eq!(store.get_blob_info().oldest_blob_slot, Some(pruned_slot));
+    assert_eq!(store.get_data_info().oldest_data_slot, pruned_slot);
 
     let electra_first_slot = electra_fork_epoch.start_slot(E::slots_per_epoch());
     // Check that blobs exist from the pruned slot to electra
@@ -4834,7 +4978,7 @@ async fn prune_blobs_across_fork_boundary() {
     let pruned_slot = (electra_fork_epoch + 1).start_slot(E::slots_per_epoch());
 
     store.try_prune_blobs(true, finalized_epoch).unwrap();
-    assert_eq!(store.get_blob_info().oldest_blob_slot, Some(finalized_slot));
+    assert_eq!(store.get_data_info().oldest_data_slot, finalized_slot);
     check_blob_existence(&harness, Slot::new(0), pruned_slot - 1, false);
     check_blob_existence(&harness, pruned_slot, harness.head_slot(), true);
 
@@ -4864,7 +5008,7 @@ async fn prune_blobs_across_fork_boundary() {
     assert_eq!(store.get_split_slot(), finalized_slot);
 
     // All blobs since last pruning during Electra should still be available.
-    assert_eq!(store.get_blob_info().oldest_blob_slot, Some(pruned_slot));
+    assert_eq!(store.get_data_info().oldest_data_slot, pruned_slot);
 
     let fulu_first_slot = fulu_fork_epoch.start_slot(E::slots_per_epoch());
     // Check that blobs have been pruned up to the pruned slot
@@ -4894,18 +5038,15 @@ async fn prune_blobs_across_fork_boundary() {
 
         if data_availability_boundary < fulu_fork_epoch {
             // Pre Fulu fork epochs
-            // Check oldest blob slot is not updated.
-            assert!(store.get_blob_info().oldest_blob_slot >= Some(oldest_slot));
+            // Check oldest data slot is not updated.
+            assert!(store.get_data_info().oldest_data_slot >= oldest_slot);
             check_blob_existence(&harness, Slot::new(0), oldest_slot - 1, false);
             // Blobs should exist
             check_blob_existence(&harness, oldest_slot, harness.head_slot(), true);
         } else {
             // Fulu fork epochs
             // Pruning should have been triggered
-            assert!(store.get_blob_info().oldest_blob_slot <= Some(oldest_slot));
-            // Oldest blob slot should never be greater than the first fulu slot
-            let fulu_first_slot = fulu_fork_epoch.start_slot(E::slots_per_epoch());
-            assert!(store.get_blob_info().oldest_blob_slot <= Some(fulu_first_slot));
+            assert!(store.get_data_info().oldest_data_slot <= oldest_slot);
             // Blobs should not exist post-Fulu
             check_blob_existence(&harness, oldest_slot, harness.head_slot(), false);
             // Data columns should exist post-Fulu
@@ -4963,10 +5104,7 @@ async fn deneb_prune_blobs_margin_test(margin: u64) {
 
     // Prior to manual pruning with an artifically low data availability boundary all blobs should
     // be stored.
-    assert_eq!(
-        store.get_blob_info().oldest_blob_slot,
-        Some(deneb_fork_slot)
-    );
+    assert_eq!(store.get_data_info().oldest_data_slot, deneb_fork_slot);
     check_blob_existence(&harness, Slot::new(1), harness.head_slot(), true);
 
     // Trigger blob pruning of blobs older than epoch 6 - margin (6 is the minimum, due to
@@ -4983,47 +5121,13 @@ async fn deneb_prune_blobs_margin_test(margin: u64) {
         .unwrap();
 
     // Check oldest blob slot is updated accordingly and prior blobs have been deleted.
-    let oldest_blob_slot = store.get_blob_info().oldest_blob_slot.unwrap();
+    let oldest_blob_slot = store.get_data_info().oldest_data_slot;
     assert_eq!(
         oldest_blob_slot,
         effective_data_availability_boundary.start_slot(E::slots_per_epoch())
     );
     check_blob_existence(&harness, Slot::new(0), oldest_blob_slot - 1, false);
     check_blob_existence(&harness, oldest_blob_slot, harness.head_slot(), true);
-}
-
-/// Check that a database with `blobs_db=false` can be upgraded to `blobs_db=true` before Deneb.
-#[tokio::test]
-async fn change_to_separate_blobs_db_before_deneb() {
-    let db_path = tempdir().unwrap();
-    let store = get_store(&db_path);
-
-    // Only run this test on forks prior to Deneb. If the blobs database already has blobs, we can't
-    // move it.
-    if store.get_chain_spec().deneb_fork_epoch.is_some() {
-        return;
-    }
-
-    let init_blob_info = store.get_blob_info();
-    assert!(
-        init_blob_info.blobs_db,
-        "separate blobs DB should be the default"
-    );
-
-    // Change to `blobs_db=false` to emulate legacy Deneb DB.
-    let legacy_blob_info = BlobInfo {
-        blobs_db: false,
-        ..init_blob_info
-    };
-    store
-        .compare_and_set_blob_info_with_write(init_blob_info.clone(), legacy_blob_info.clone())
-        .unwrap();
-    assert_eq!(store.get_blob_info(), legacy_blob_info);
-
-    // Re-open the DB and check that `blobs_db` gets changed back to true.
-    drop(store);
-    let store = get_store(&db_path);
-    assert_eq!(store.get_blob_info(), init_blob_info);
 }
 
 /// Check that there are blob sidecars (or not) at every slot in the range.
@@ -5086,10 +5190,7 @@ async fn fulu_prune_data_columns_happy_case() {
 
     // Prior to manual pruning with an artifically low data availability boundary all data columns
     // should be stored.
-    assert_eq!(
-        store.get_data_column_info().oldest_data_column_slot,
-        Some(fulu_fork_slot)
-    );
+    assert_eq!(store.get_data_info().oldest_data_slot, fulu_fork_slot);
     check_data_column_existence(&harness, Slot::new(1), harness.head_slot(), true);
 
     // Trigger pruning of data columns older than epoch 2.
@@ -5100,10 +5201,7 @@ async fn fulu_prune_data_columns_happy_case() {
 
     // Check oldest data column slot is updated accordingly and prior data columns have been
     // deleted.
-    let oldest_data_column_slot = store
-        .get_data_column_info()
-        .oldest_data_column_slot
-        .unwrap();
+    let oldest_data_column_slot = store.get_data_info().oldest_data_slot;
     assert_eq!(
         oldest_data_column_slot,
         data_availability_boundary.start_slot(E::slots_per_epoch())
@@ -5161,10 +5259,7 @@ async fn fulu_prune_data_columns_no_finalization() {
     assert_eq!(store.get_split_slot(), finalized_slot);
 
     // All data columns should still be available.
-    assert_eq!(
-        store.get_data_column_info().oldest_data_column_slot,
-        Some(fulu_fork_slot)
-    );
+    assert_eq!(store.get_data_info().oldest_data_slot, fulu_fork_slot);
     check_data_column_existence(&harness, Slot::new(0), harness.head_slot(), true);
 
     // Attempt pruning of data columns older than epoch 4, which is newer than finalization.
@@ -5174,10 +5269,7 @@ async fn fulu_prune_data_columns_no_finalization() {
         .unwrap();
 
     // Check oldest data column slot is only updated to finalization, and NOT to the DAB.
-    let oldest_data_column_slot = store
-        .get_data_column_info()
-        .oldest_data_column_slot
-        .unwrap();
+    let oldest_data_column_slot = store.get_data_info().oldest_data_slot;
     assert_eq!(oldest_data_column_slot, finalized_slot);
     check_data_column_existence(&harness, Slot::new(0), finalized_slot - 1, false);
     check_data_column_existence(&harness, finalized_slot, harness.head_slot(), true);
@@ -5222,26 +5314,21 @@ async fn fulu_prune_data_columns_fork_boundary() {
     );
     assert_eq!(store.get_split_slot(), finalized_slot);
 
-    // All data columns should still be available.
-    assert_eq!(
-        store.get_data_column_info().oldest_data_column_slot,
-        Some(fulu_fork_slot)
-    );
+    // The oldest data slot starts at the Deneb fork slot (genesis for this spec), and all data
+    // columns should be available.
+    assert_eq!(store.get_data_info().oldest_data_slot, Slot::new(0));
     check_data_column_existence(&harness, Slot::new(0), harness.head_slot(), true);
 
     // Attempt pruning with data availability epochs that precede the fork epoch.
-    // No pruning should occur.
+    // Pre-fork blobs may be pruned, but no data columns must be pruned.
     assert!(fulu_fork_epoch < finalized_epoch);
     for data_availability_boundary in [Epoch::new(0), Epoch::new(3), fulu_fork_epoch] {
         store
             .try_prune_blobs(true, data_availability_boundary)
             .unwrap();
 
-        // Check oldest data column slot is not updated.
-        assert_eq!(
-            store.get_data_column_info().oldest_data_column_slot,
-            Some(fulu_fork_slot)
-        );
+        // Check the oldest data slot has not advanced past the fork slot.
+        assert!(store.get_data_info().oldest_data_slot <= fulu_fork_slot);
     }
     // All data columns should still be available.
     check_data_column_existence(&harness, Slot::new(0), harness.head_slot(), true);
@@ -5249,10 +5336,7 @@ async fn fulu_prune_data_columns_fork_boundary() {
     // Prune one epoch past the fork.
     let pruned_slot = (fulu_fork_epoch + 1).start_slot(E::slots_per_epoch());
     store.try_prune_blobs(true, fulu_fork_epoch + 1).unwrap();
-    assert_eq!(
-        store.get_data_column_info().oldest_data_column_slot,
-        Some(pruned_slot)
-    );
+    assert_eq!(store.get_data_info().oldest_data_slot, pruned_slot);
     check_data_column_existence(&harness, Slot::new(0), pruned_slot - 1, false);
     check_data_column_existence(&harness, pruned_slot, harness.head_slot(), true);
 }
@@ -5371,10 +5455,7 @@ async fn fulu_prune_data_columns_margin_test(margin: u64) {
 
     // Prior to manual pruning with an artifically low data availability boundary all blobs should
     // be stored.
-    assert_eq!(
-        store.get_data_column_info().oldest_data_column_slot,
-        Some(fulu_fork_slot)
-    );
+    assert_eq!(store.get_data_info().oldest_data_slot, fulu_fork_slot);
     check_data_column_existence(&harness, Slot::new(1), harness.head_slot(), true);
 
     // Trigger blob pruning of blobs older than epoch 6 - margin (6 is the minimum, due to
@@ -5391,10 +5472,7 @@ async fn fulu_prune_data_columns_margin_test(margin: u64) {
         .unwrap();
 
     // Check oldest blob slot is updated accordingly and prior blobs have been deleted.
-    let oldest_data_column_slot = store
-        .get_data_column_info()
-        .oldest_data_column_slot
-        .unwrap();
+    let oldest_data_column_slot = store.get_data_info().oldest_data_slot;
     assert_eq!(
         oldest_data_column_slot,
         effective_data_availability_boundary.start_slot(E::slots_per_epoch())

--- a/beacon_node/http_api/src/database.rs
+++ b/beacon_node/http_api/src/database.rs
@@ -3,7 +3,7 @@ use beacon_chain::{BeaconChain, BeaconChainTypes};
 use serde::Serialize;
 use std::sync::Arc;
 use store::invariants::InvariantCheckResult;
-use store::{AnchorInfo, BlobInfo, Split, StoreConfig};
+use store::{AnchorInfo, DataInfo, Split, StoreConfig};
 
 #[derive(Debug, Serialize)]
 pub struct DatabaseInfo {
@@ -11,7 +11,7 @@ pub struct DatabaseInfo {
     pub config: StoreConfig,
     pub split: Split,
     pub anchor: AnchorInfo,
-    pub blob_info: BlobInfo,
+    pub data_info: DataInfo,
 }
 
 pub fn info<T: BeaconChainTypes>(
@@ -21,14 +21,14 @@ pub fn info<T: BeaconChainTypes>(
     let split = store.get_split_info();
     let config = store.get_config().clone();
     let anchor = store.get_anchor_info();
-    let blob_info = store.get_blob_info();
+    let data_info = store.get_data_info();
 
     Ok(DatabaseInfo {
         schema_version: CURRENT_SCHEMA_VERSION.as_u64(),
         config,
         split,
         anchor,
-        blob_info,
+        data_info,
     })
 }
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2384,7 +2384,7 @@ impl ApiTester {
             .try_prune_blobs(force_prune, split_epoch)
             .unwrap();
 
-        let oldest_blob_slot = store.get_blob_info().oldest_blob_slot.unwrap();
+        let oldest_blob_slot = store.get_data_info().oldest_data_slot;
 
         assert_ne!(
             oldest_blob_slot, 0,
@@ -2430,7 +2430,7 @@ impl ApiTester {
     }
 
     pub async fn test_get_blob_sidecars_pre_deneb(self) -> Self {
-        let oldest_blob_slot = self.chain.store.get_blob_info().oldest_blob_slot.unwrap();
+        let oldest_blob_slot = self.chain.store.get_data_info().oldest_data_slot;
         assert_ne!(
             oldest_blob_slot, 0,
             "oldest_blob_slot should be non-zero and post-Deneb"

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -1622,21 +1622,16 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 }
             };
 
-        let oldest_blob_slot = self
-            .chain
-            .store
-            .get_blob_info()
-            .oldest_blob_slot
-            .unwrap_or(data_availability_boundary_slot);
-        if request_start_slot < oldest_blob_slot {
+        let oldest_data_slot = self.chain.store.get_data_info().oldest_data_slot;
+        if request_start_slot < oldest_data_slot {
             debug!(
                 %request_start_slot,
-                %oldest_blob_slot,
+                %oldest_data_slot,
                 %data_availability_boundary_slot,
                 "Range request start slot is older than data availability boundary."
             );
 
-            return if data_availability_boundary_slot < oldest_blob_slot {
+            return if data_availability_boundary_slot < oldest_data_slot {
                 Err((
                     RpcErrorResponse::ResourceUnavailable,
                     "blobs pruned within boundary",

--- a/beacon_node/store/src/errors.rs
+++ b/beacon_node/store/src/errors.rs
@@ -28,10 +28,8 @@ pub enum Error {
     AnchorUninitialized,
     /// The store's `anchor_info` was mutated concurrently, the latest modification wasn't applied.
     AnchorInfoConcurrentMutation,
-    /// The store's `blob_info` was mutated concurrently, the latest modification wasn't applied.
-    BlobInfoConcurrentMutation,
-    /// The store's `data_column_info` was mutated concurrently, the latest modification wasn't applied.
-    DataColumnInfoConcurrentMutation,
+    /// The store's `data_info` was mutated concurrently, the latest modification wasn't applied.
+    DataInfoConcurrentMutation,
     /// The block or state is unavailable due to weak subjectivity sync.
     HistoryUnavailable,
     /// State reconstruction cannot commence because not all historic blocks are known.
@@ -90,8 +88,7 @@ pub enum Error {
     },
     LoadAnchorInfo(Box<Error>),
     LoadSplit(Box<Error>),
-    LoadBlobInfo(Box<Error>),
-    LoadDataColumnInfo(Box<Error>),
+    LoadDataInfo(Box<Error>),
     LoadConfig(Box<Error>),
     LoadHotStateSummary(Hash256, Box<Error>),
     LoadHotStateSummaryForSplit(Box<Error>),

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -6,10 +6,10 @@ use crate::historic_state_cache::HistoricStateCache;
 use crate::iter::{BlockRootsIterator, ParentRootBlockIterator, RootsIterator};
 use crate::memory_store::MemoryStore;
 use crate::metadata::{
-    ANCHOR_INFO_KEY, ANCHOR_UNINITIALIZED, AnchorInfo, BLOB_INFO_KEY, BlobInfo,
-    COMPACTION_TIMESTAMP_KEY, CONFIG_KEY, CURRENT_SCHEMA_VERSION, CompactionTimestamp,
-    DATA_COLUMN_CUSTODY_INFO_KEY, DATA_COLUMN_INFO_KEY, DataColumnCustodyInfo, DataColumnInfo,
-    SCHEMA_VERSION_KEY, SPLIT_KEY, STATE_UPPER_LIMIT_NO_RETAIN, SchemaVersion,
+    ANCHOR_INFO_KEY, ANCHOR_UNINITIALIZED, AnchorInfo, COMPACTION_TIMESTAMP_KEY, CONFIG_KEY,
+    CURRENT_SCHEMA_VERSION, CompactionTimestamp, DATA_COLUMN_CUSTODY_INFO_KEY, DATA_INFO_KEY,
+    DataColumnCustodyInfo, DataInfo, SCHEMA_VERSION_KEY, SPLIT_KEY, STATE_UPPER_LIMIT_NO_RETAIN,
+    SchemaVersion,
 };
 use crate::state_cache::{PutStateOutcome, StateCache};
 use crate::{
@@ -57,10 +57,9 @@ pub struct HotColdDB<E: EthSpec, Hot: ItemStore, Cold: ItemStore> {
     pub(crate) split: RwLock<Split>,
     /// The starting slots for the range of blocks & states stored in the database.
     anchor_info: RwLock<AnchorInfo>,
-    /// The starting slots for the range of blobs stored in the database.
-    blob_info: RwLock<BlobInfo>,
-    /// The starting slots for the range of data columns stored in the database.
-    data_column_info: RwLock<DataColumnInfo>,
+    /// The starting slot for the range of sidecar data (blobs/data columns) stored in the
+    /// database.
+    data_info: RwLock<DataInfo>,
     pub(crate) config: StoreConfig,
     pub hierarchy: HierarchyModuli,
     /// Cold database containing compact historical data.
@@ -193,7 +192,6 @@ pub enum HotColdDBError {
     MissingFrozenBlockSlot(Hash256),
     MissingFrozenBlock(Slot),
     MissingPathToBlobsDatabase,
-    BlobsPreviouslyInDefaultStore,
     HdiffGetPriorStateRootError(Slot, Slot),
     RestorePointDecodeError(ssz::DecodeError),
     BlockReplayBeaconError(BeaconStateError),
@@ -205,7 +203,6 @@ pub enum HotColdDBError {
         slots_per_epoch: u64,
     },
     ZeroEpochsPerBlobPrune,
-    BlobPruneLogicError,
     RestorePointBlockHashError(BeaconStateError),
     IterationError {
         unexpected_key: BytesKey,
@@ -232,8 +229,7 @@ impl<E: EthSpec> HotColdDB<E, MemoryStore, MemoryStore> {
         let db = HotColdDB {
             split: RwLock::new(Split::default()),
             anchor_info: RwLock::new(ANCHOR_UNINITIALIZED),
-            blob_info: RwLock::new(BlobInfo::default()),
-            data_column_info: RwLock::new(DataColumnInfo::default()),
+            data_info: RwLock::new(DataInfo::default()),
             cold_db: MemoryStore::open(),
             blobs_db: MemoryStore::open(),
             hot_db: MemoryStore::open(),
@@ -285,8 +281,7 @@ impl<E: EthSpec> HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend> {
         let db = HotColdDB {
             split: RwLock::new(Split::default()),
             anchor_info,
-            blob_info: RwLock::new(BlobInfo::default()),
-            data_column_info: RwLock::new(DataColumnInfo::default()),
+            data_info: RwLock::new(DataInfo::default()),
             blobs_db: BeaconNodeBackend::open(&config, blobs_db_path)?,
             cold_db: BeaconNodeBackend::open(&config, cold_path)?,
             hot_db,
@@ -338,69 +333,23 @@ impl<E: EthSpec> HotColdDB<E, BeaconNodeBackend, BeaconNodeBackend> {
             );
         }
 
-        // Open separate blobs directory if configured and same configuration was used on previous
-        // run.
-        let blob_info = db.load_blob_info()?;
-        let deneb_fork_slot = db
-            .spec
-            .deneb_fork_epoch
-            .map(|epoch| epoch.start_slot(E::slots_per_epoch()));
-        let new_blob_info = match &blob_info {
-            Some(blob_info) => {
-                // If the oldest block slot is already set do not allow the blob DB path to be
-                // changed (require manual migration).
-                if blob_info.oldest_blob_slot.is_some() && !blob_info.blobs_db {
-                    return Err(HotColdDBError::BlobsPreviouslyInDefaultStore.into());
-                }
-                // Set the oldest blob slot to the Deneb fork slot if it is not yet set.
-                // Always initialize `blobs_db` to true, we no longer support storing the blobs
-                // in the freezer DB, because the UX is strictly worse for relocating the DB.
-                let oldest_blob_slot = blob_info.oldest_blob_slot.or(deneb_fork_slot);
-                BlobInfo {
-                    oldest_blob_slot,
-                    blobs_db: true,
-                }
-            }
-            // First start.
-            None => BlobInfo {
-                // Set the oldest blob slot to the Deneb fork slot if it is not yet set.
-                oldest_blob_slot: deneb_fork_slot,
-                blobs_db: true,
-            },
-        };
-        db.compare_and_set_blob_info_with_write(<_>::default(), new_blob_info.clone())?;
+        // Load the data info from disk (if any). If absent, this is either a first start, in
+        // which case the beacon chain builder initializes it, or a pre-v31 database, in which
+        // case the v31 schema migration (which runs below) writes a value merged from the legacy
+        // blob/data column info.
+        //
+        // Callers that open the database without migrating (like the database manager) are stuck
+        // with the default on pre-v31 databases and must not rely on the marker; see the schema
+        // version check guarding `lighthouse db prune-blobs`.
+        if let Some(data_info) = db.load_data_info()? {
+            *db.data_info.write() = data_info;
 
-        let data_column_info = db.load_data_column_info()?;
-        let fulu_fork_slot = db
-            .spec
-            .fulu_fork_epoch
-            .map(|epoch| epoch.start_slot(E::slots_per_epoch()));
-        let new_data_column_info = match &data_column_info {
-            Some(data_column_info) => {
-                // Set the oldest data column slot to the fork slot if it is not yet set.
-                let oldest_data_column_slot =
-                    data_column_info.oldest_data_column_slot.or(fulu_fork_slot);
-                DataColumnInfo {
-                    oldest_data_column_slot,
-                }
-            }
-            // First start.
-            None => DataColumnInfo {
-                // Set the oldest data column slot to the fork slot if it is not yet set.
-                oldest_data_column_slot: fulu_fork_slot,
-            },
-        };
-        db.compare_and_set_data_column_info_with_write(
-            <_>::default(),
-            new_data_column_info.clone(),
-        )?;
-
-        info!(
-            path = ?blobs_db_path,
-            oldest_blob_slot = ?new_blob_info.oldest_blob_slot,
-            oldest_data_column_slot = ?new_data_column_info.oldest_data_column_slot,
-            "Blob DB initialized"
-        );
+            info!(
+                path = ?blobs_db_path,
+                oldest_data_slot = %data_info.oldest_data_slot,
+                "Blob DB initialized"
+            );
+        }
 
         // Ensure that any on-disk config is compatible with the supplied config.
         //
@@ -2857,138 +2806,66 @@ impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
         anchor_info.as_kv_store_op(ANCHOR_INFO_KEY)
     }
 
-    /// Initialize the `BlobInfo` when starting from genesis or a checkpoint.
-    pub fn init_blob_info(&self, anchor_slot: Slot) -> Result<KeyValueStoreOp, Error> {
-        let oldest_blob_slot = self.spec.deneb_fork_epoch.map(|fork_epoch| {
-            std::cmp::max(anchor_slot, fork_epoch.start_slot(E::slots_per_epoch()))
-        });
-        let blob_info = BlobInfo {
-            oldest_blob_slot,
-            blobs_db: true,
-        };
-        self.compare_and_set_blob_info(self.get_blob_info(), blob_info)
+    /// Initialize the `DataInfo` when starting from genesis or a checkpoint.
+    pub fn init_data_info(&self, anchor_slot: Slot) -> Result<KeyValueStoreOp, Error> {
+        // Deneb should always be scheduled by now. If it isn't, the value herein is meaningless
+        // anyway, so we use the anchor slot.
+        let oldest_data_slot = self
+            .spec
+            .deneb_fork_epoch
+            .map_or(anchor_slot, |fork_epoch| {
+                std::cmp::max(anchor_slot, fork_epoch.start_slot(E::slots_per_epoch()))
+            });
+        let data_info = DataInfo { oldest_data_slot };
+        self.compare_and_set_data_info(self.get_data_info(), data_info)
     }
 
-    /// Get a clone of the store's blob info.
+    /// Get a copy of the store's data info.
     ///
-    /// To do mutations, use `compare_and_set_blob_info`.
-    pub fn get_blob_info(&self) -> BlobInfo {
-        self.blob_info.read_recursive().clone()
-    }
-
-    /// Initialize the `DataColumnInfo` when starting from genesis or a checkpoint.
-    pub fn init_data_column_info(&self, anchor_slot: Slot) -> Result<KeyValueStoreOp, Error> {
-        let oldest_data_column_slot = self.spec.fulu_fork_epoch.map(|fork_epoch| {
-            std::cmp::max(anchor_slot, fork_epoch.start_slot(E::slots_per_epoch()))
-        });
-        let data_column_info = DataColumnInfo {
-            oldest_data_column_slot,
-        };
-        self.compare_and_set_data_column_info(self.get_data_column_info(), data_column_info)
-    }
-
-    /// Get a clone of the store's data column info.
+    /// Only meaningful once the marker has been initialized: on a pre-v31 database opened
+    /// without migrating (as the database manager does), this returns the default value. Such
+    /// callers must gate on the schema version before relying on it.
     ///
-    /// To do mutations, use `compare_and_set_data_column_info`.
-    pub fn get_data_column_info(&self) -> DataColumnInfo {
-        self.data_column_info.read_recursive().clone()
+    /// To do mutations, use `compare_and_set_data_info`.
+    pub fn get_data_info(&self) -> DataInfo {
+        *self.data_info.read_recursive()
     }
 
-    /// Atomically update the blob info from `prev_value` to `new_value`.
+    /// Atomically update the data info from `prev_value` to `new_value`.
     ///
     /// Return a `KeyValueStoreOp` which should be written to disk, possibly atomically with other
     /// values.
     ///
-    /// Return an `BlobInfoConcurrentMutation` error if the `prev_value` provided
+    /// Return a `DataInfoConcurrentMutation` error if the `prev_value` provided
     /// is not correct.
-    pub fn compare_and_set_blob_info(
+    pub fn compare_and_set_data_info(
         &self,
-        prev_value: BlobInfo,
-        new_value: BlobInfo,
+        prev_value: DataInfo,
+        new_value: DataInfo,
     ) -> Result<KeyValueStoreOp, Error> {
-        let mut blob_info = self.blob_info.write();
-        if *blob_info == prev_value {
-            let kv_op = self.store_blob_info_in_batch(&new_value);
-            *blob_info = new_value;
+        let mut data_info = self.data_info.write();
+        if *data_info == prev_value {
+            let kv_op = self.store_data_info_in_batch(&new_value);
+            *data_info = new_value;
             Ok(kv_op)
         } else {
-            Err(Error::BlobInfoConcurrentMutation)
+            Err(Error::DataInfoConcurrentMutation)
         }
     }
 
-    /// As for `compare_and_set_blob_info`, but also writes the blob info to disk immediately.
-    pub fn compare_and_set_blob_info_with_write(
-        &self,
-        prev_value: BlobInfo,
-        new_value: BlobInfo,
-    ) -> Result<(), Error> {
-        let kv_store_op = self.compare_and_set_blob_info(prev_value, new_value)?;
-        self.hot_db.do_atomically(vec![kv_store_op])
-    }
-
-    /// Load the blob info from disk, but do not set `self.blob_info`.
-    fn load_blob_info(&self) -> Result<Option<BlobInfo>, Error> {
+    /// Load the data info from disk, but do not set `self.data_info`.
+    fn load_data_info(&self) -> Result<Option<DataInfo>, Error> {
         self.hot_db
-            .get(&BLOB_INFO_KEY)
-            .map_err(|e| Error::LoadBlobInfo(e.into()))
+            .get(&DATA_INFO_KEY)
+            .map_err(|e| Error::LoadDataInfo(e.into()))
     }
 
-    /// Store the given `blob_info` to disk.
+    /// Store the given `data_info` to disk.
     ///
-    /// The argument is intended to be `self.blob_info`, but is passed manually to avoid issues
+    /// The argument is intended to be `self.data_info`, but is passed manually to avoid issues
     /// with recursive locking.
-    fn store_blob_info_in_batch(&self, blob_info: &BlobInfo) -> KeyValueStoreOp {
-        blob_info.as_kv_store_op(BLOB_INFO_KEY)
-    }
-
-    /// Atomically update the data column info from `prev_value` to `new_value`.
-    ///
-    /// Return a `KeyValueStoreOp` which should be written to disk, possibly atomically with other
-    /// values.
-    ///
-    /// Return an `DataColumnInfoConcurrentMutation` error if the `prev_value` provided
-    /// is not correct.
-    pub fn compare_and_set_data_column_info(
-        &self,
-        prev_value: DataColumnInfo,
-        new_value: DataColumnInfo,
-    ) -> Result<KeyValueStoreOp, Error> {
-        let mut data_column_info = self.data_column_info.write();
-        if *data_column_info == prev_value {
-            let kv_op = self.store_data_column_info_in_batch(&new_value);
-            *data_column_info = new_value;
-            Ok(kv_op)
-        } else {
-            Err(Error::DataColumnInfoConcurrentMutation)
-        }
-    }
-
-    /// As for `compare_and_set_data_column_info`, but also writes the blob info to disk immediately.
-    pub fn compare_and_set_data_column_info_with_write(
-        &self,
-        prev_value: DataColumnInfo,
-        new_value: DataColumnInfo,
-    ) -> Result<(), Error> {
-        let kv_store_op = self.compare_and_set_data_column_info(prev_value, new_value)?;
-        self.hot_db.do_atomically(vec![kv_store_op])
-    }
-
-    /// Load the blob info from disk, but do not set `self.data_column_info`.
-    fn load_data_column_info(&self) -> Result<Option<DataColumnInfo>, Error> {
-        self.hot_db
-            .get(&DATA_COLUMN_INFO_KEY)
-            .map_err(|e| Error::LoadDataColumnInfo(e.into()))
-    }
-
-    /// Store the given `data_column_info` to disk.
-    ///
-    /// The argument is intended to be `self.data_column_info`, but is passed manually to avoid issues
-    /// with recursive locking.
-    fn store_data_column_info_in_batch(
-        &self,
-        data_column_info: &DataColumnInfo,
-    ) -> KeyValueStoreOp {
-        data_column_info.as_kv_store_op(DATA_COLUMN_INFO_KEY)
+    fn store_data_info_in_batch(&self, data_info: &DataInfo) -> KeyValueStoreOp {
+        data_info.as_kv_store_op(DATA_INFO_KEY)
     }
 
     /// Return the slot-window describing the available historic states.
@@ -3342,17 +3219,12 @@ impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
             return Ok(());
         }
 
-        let blob_info = self.get_blob_info();
-        let data_column_info = self.get_data_column_info();
-        let Some(oldest_blob_slot) = blob_info.oldest_blob_slot else {
-            error!("Slot of oldest blob is not known");
-            return Err(HotColdDBError::BlobPruneLogicError.into());
-        };
+        let data_info = self.get_data_info();
+        let oldest_data_slot = data_info.oldest_data_slot;
 
         // The start epoch is not necessarily iterated back to, but is used for deciding whether we
-        // should attempt pruning. We could probably refactor it out eventually (while reducing our
-        // dependence on BlobInfo).
-        let start_epoch = oldest_blob_slot.epoch(E::slots_per_epoch());
+        // should attempt pruning.
+        let start_epoch = oldest_data_slot.epoch(E::slots_per_epoch());
 
         // Prune blobs up until the `data_availability_boundary - margin` or the split
         // slot's epoch, whichever is older. We can't prune blobs newer than the split.
@@ -3369,7 +3241,7 @@ impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
 
         if !force && !should_prune || !can_prune {
             debug!(
-                %oldest_blob_slot,
+                %oldest_data_slot,
                 %data_availability_boundary,
                 %split.slot,
                 %end_epoch,
@@ -3465,6 +3337,13 @@ impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
             }
         }
 
+        // Update the DataInfo first to avoid advertising deleted blobs in case the update fails.
+        let new_data_info = DataInfo {
+            oldest_data_slot: end_slot + 1,
+        };
+        let op = self.compare_and_set_data_info(data_info, new_data_info)?;
+        self.do_atomically_with_block_and_blobs_cache(vec![StoreOp::KeyValueOp(op)])?;
+
         // Remove deleted blobs from the cache.
         if let Some(mut block_cache) = self.block_cache.as_ref().map(|cache| cache.lock()) {
             for block_root in removed_block_roots {
@@ -3481,8 +3360,6 @@ impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
             );
             self.blobs_db.do_atomically(blobs_db_ops)?;
         }
-
-        self.update_blob_or_data_column_info(start_epoch, end_slot, blob_info, data_column_info)?;
 
         debug!("Blob pruning complete");
 
@@ -3546,31 +3423,6 @@ impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
 
         // In order to reclaim space, we need to compact the freezer DB as well.
         self.compact_freezer()?;
-
-        Ok(())
-    }
-
-    fn update_blob_or_data_column_info(
-        &self,
-        start_epoch: Epoch,
-        end_slot: Slot,
-        blob_info: BlobInfo,
-        data_column_info: DataColumnInfo,
-    ) -> Result<(), Error> {
-        let op = if self.spec.is_peer_das_enabled_for_epoch(start_epoch) {
-            let new_data_column_info = DataColumnInfo {
-                oldest_data_column_slot: Some(end_slot + 1),
-            };
-            self.compare_and_set_data_column_info(data_column_info, new_data_column_info)?
-        } else {
-            let new_blob_info = BlobInfo {
-                oldest_blob_slot: Some(end_slot + 1),
-                blobs_db: blob_info.blobs_db,
-            };
-            self.compare_and_set_blob_info(blob_info, new_blob_info)?
-        };
-
-        self.do_atomically_with_block_and_blobs_cache(vec![StoreOp::KeyValueOp(op)])?;
 
         Ok(())
     }

--- a/beacon_node/store/src/invariants.rs
+++ b/beacon_node/store/src/invariants.rs
@@ -323,8 +323,7 @@ impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
             .spec
             .gloas_fork_epoch
             .map(|epoch| epoch.start_slot(E::slots_per_epoch()));
-        let oldest_blob_slot = self.get_blob_info().oldest_blob_slot;
-        let oldest_data_column_slot = self.get_data_column_info().oldest_data_column_slot;
+        let oldest_data_slot = self.get_data_info().oldest_data_slot;
 
         for res in self.hot_db.iter_column::<Hash256>(DBColumn::BeaconBlock) {
             let (block_root, block_bytes) = res?;
@@ -375,9 +374,8 @@ impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
             // Only check blocks that actually have blob KZG commitments — blocks with 0
             // commitments legitimately have no blob sidecars stored.
             if let Some(deneb_slot) = deneb_fork_slot
-                && let Some(oldest_blob) = oldest_blob_slot
                 && slot >= deneb_slot
-                && slot >= oldest_blob
+                && slot >= oldest_data_slot
                 && fulu_fork_slot.is_none_or(|fulu_slot| slot < fulu_slot)
                 && block.num_expected_blobs() > 0
             {
@@ -396,9 +394,8 @@ impl<E: EthSpec, Hot: ItemStore, Cold: ItemStore> HotColdDB<E, Hot, Cold> {
             // their data column sidecars stored.
             if !ctx.custody_columns.is_empty()
                 && let Some(fulu_slot) = fulu_fork_slot
-                && let Some(oldest_dc) = oldest_data_column_slot
                 && slot >= fulu_slot
-                && slot >= oldest_dc
+                && slot >= oldest_data_slot
                 && block.num_expected_blobs() > 0
             {
                 let stored_columns = self.get_data_column_keys(block_root)?;

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -29,7 +29,7 @@ pub use self::blob_sidecar_list_from_root::BlobSidecarListFromRoot;
 pub use self::config::StoreConfig;
 pub use self::hot_cold_store::{HotColdDB, HotStateSummary, Split};
 pub use self::memory_store::MemoryStore;
-pub use crate::metadata::BlobInfo;
+pub use crate::metadata::DataInfo;
 pub use errors::Error;
 pub use metadata::AnchorInfo;
 pub use metrics::scrape_for_metrics;

--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -4,7 +4,11 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use types::{Hash256, Slot};
 
-pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(30);
+pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(31);
+
+/// The oldest schema version that can still be migrated to `CURRENT_SCHEMA_VERSION`.
+/// Migrations for older versions have been removed.
+pub const OLDEST_SUPPORTED_SCHEMA_VERSION: SchemaVersion = SchemaVersion(28);
 
 // All the keys that get stored under the `BeaconMeta` column.
 //
@@ -16,9 +20,12 @@ pub const SPLIT_KEY: Hash256 = Hash256::repeat_byte(2);
 // pub const PRUNING_CHECKPOINT_KEY: Hash256 = Hash256::repeat_byte(3);
 pub const COMPACTION_TIMESTAMP_KEY: Hash256 = Hash256::repeat_byte(4);
 pub const ANCHOR_INFO_KEY: Hash256 = Hash256::repeat_byte(5);
+// Legacy keys used by schema versions < 31. Retained for the v31 migration, which merges
+// `BlobInfo` and `DataColumnInfo` into `DataInfo`.
 pub const BLOB_INFO_KEY: Hash256 = Hash256::repeat_byte(6);
 pub const DATA_COLUMN_INFO_KEY: Hash256 = Hash256::repeat_byte(7);
 pub const DATA_COLUMN_CUSTODY_INFO_KEY: Hash256 = Hash256::repeat_byte(8);
+pub const DATA_INFO_KEY: Hash256 = Hash256::repeat_byte(9);
 
 /// State upper limit value used to indicate that a node is not storing historic states.
 pub const STATE_UPPER_LIMIT_NO_RETAIN: Slot = Slot::new(u64::MAX);
@@ -177,6 +184,9 @@ impl StoreItem for AnchorInfo {
 }
 
 /// Database parameters relevant to blob sync.
+///
+/// Legacy: superseded by [`DataInfo`] at schema v31. Retained (with its `StoreItem` impl) only
+/// for the v31 schema migration.
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Serialize, Deserialize, Default)]
 pub struct BlobInfo {
     /// The slot after which blobs are or *will be* available (>=).
@@ -230,6 +240,9 @@ impl StoreItem for DataColumnCustodyInfo {
 }
 
 /// Database parameters relevant to data column sync.
+///
+/// Legacy: superseded by [`DataInfo`] at schema v31. Retained (with its `StoreItem` impl) only
+/// for the v31 schema migration.
 #[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Serialize, Deserialize, Default)]
 pub struct DataColumnInfo {
     /// The slot after which data columns are or *will be* available (>=).
@@ -243,6 +256,32 @@ pub struct DataColumnInfo {
 }
 
 impl StoreItem for DataColumnInfo {
+    fn db_column() -> DBColumn {
+        DBColumn::BeaconMeta
+    }
+
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
+    }
+
+    fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(Self::from_ssz_bytes(bytes)?)
+    }
+}
+
+/// Database parameters relevant to blob and data column sync.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, Serialize, Deserialize, Default)]
+pub struct DataInfo {
+    /// The slot from which sidecar data is or *will be* stored (>=): all data-bearing blocks (or,
+    /// post-gloas, payloads) with slots greater than or equal to this value have their blobs or
+    /// data columns stored.
+    ///
+    /// Progressively decreases during backfill sync as data is imported, and increases during
+    /// pruning as data older than the data availability window is deleted.
+    pub oldest_data_slot: Slot,
+}
+
+impl StoreItem for DataInfo {
     fn db_column() -> DBColumn {
         DBColumn::BeaconMeta
     }

--- a/book/src/api_lighthouse.md
+++ b/book/src/api_lighthouse.md
@@ -421,9 +421,8 @@ curl "http://localhost:5052/lighthouse/database/info" | jq
     "state_upper_limit": "7454720",
     "state_lower_limit": "0"
   },
-  "blob_info": {
-    "oldest_blob_slot": "7413769",
-    "blobs_db": true
+  "data_info": {
+    "oldest_data_slot": "7413769"
   }
 }
 ```

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -363,14 +363,30 @@ pub fn prune_blobs<E: EthSpec>(
     let cold_path = client_config.get_freezer_db_path();
     let blobs_path = client_config.get_blobs_db_path();
 
+    let mut schema_version = CURRENT_SCHEMA_VERSION;
     let db = HotColdDB::<E, BeaconNodeBackend, BeaconNodeBackend>::open(
         &hot_path,
         &cold_path,
         &blobs_path,
-        |_, _, _| Ok(()),
+        |_, db_initial_version, _| {
+            schema_version = db_initial_version;
+            Ok(())
+        },
         client_config.store,
         spec.clone(),
     )?;
+
+    // Pruning relies on the in-memory `DataInfo` marker, which `open` only loads on schema v31
+    // and later (schema migrations are deliberately not applied here). Refuse to prune with the
+    // uninitialized marker on older schemas.
+    if schema_version < SchemaVersion(31) {
+        return Err(Error::MigrationError(format!(
+            "database schema v{} is too old for blob pruning: run `lighthouse db migrate --to \
+             {}` or start the beacon node to upgrade the database first",
+            schema_version.as_u64(),
+            CURRENT_SCHEMA_VERSION.as_u64(),
+        )));
+    }
 
     // If we're triggering a prune manually then ignore the check on `epochs_per_blob_prune` that
     // bails out early by passing true to the force parameter.


### PR DESCRIPTION
## Issue Addressed

Pruning can behave weirdly on freshly synced nodes, as the `oldest_blob_slot` is not correctly updated.

## Proposed Changes

To avoid this and possibly other related issues, we unify the two separate markers into one: `DataInfo`.

Details:

- `DataInfo` is now initialized in a way similar to the split: `open` does not set any presumptive value if `DataInfo` is not set, but relies on the initialisation method (migration, checkpoint sync, genesis sync) to set an appropriate value
- `oldest_data_slot` is not an `Option` - nowadays nodes only operate with Fulu in the past (we explicitly dropped support for running during earlier forks when we ripped out Blob gossiping etc). So this always has a sensible value, except during initialization - similar to the split.

## Additional Info

K-46