### PR TITLE
Remove unused return value and rename `ingoing` to `incoming` in peer manager

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -848,8 +848,17 @@ impl<E: EthSpec> PeerManager<E> {
     /* Internal functions */
 
     /// Sets a peer as connected as long as their reputation allows it
-    fn inject_connect_ingoing(&mut self, peer_id: &PeerId, multiaddr: Multiaddr, enr: Option<Enr>) {
-        self.inject_peer_connection(peer_id, ConnectingType::IngoingConnected { multiaddr }, enr);
+    fn inject_connect_incoming(
+        &mut self,
+        peer_id: &PeerId,
+        multiaddr: Multiaddr,
+        enr: Option<Enr>,
+    ) {
+        self.inject_peer_connection(
+            peer_id,
+            ConnectingType::IncomingConnected { multiaddr },
+            enr,
+        );
     }
 
     /// Sets a peer as connected as long as their reputation allows it
@@ -892,10 +901,10 @@ impl<E: EthSpec> PeerManager<E> {
         );
     }
 
-    /// Registers a peer as connected. The `ingoing` parameter determines if the peer is being
+    /// Registers a peer as connected. The `connection` parameter determines if the peer is being
     /// dialed or connecting to us.
     ///
-    /// This is called by `connect_ingoing` and `connect_outgoing`.
+    /// This is called by `connect_incoming` and `connect_outgoing`.
     fn inject_peer_connection(
         &mut self,
         peer_id: &PeerId,
@@ -914,8 +923,8 @@ impl<E: EthSpec> PeerManager<E> {
                     peerdb.dialing_peer(peer_id, enr);
                     return;
                 }
-                ConnectingType::IngoingConnected { multiaddr } => {
-                    peerdb.connect_ingoing(peer_id, multiaddr, enr);
+                ConnectingType::IncomingConnected { multiaddr } => {
+                    peerdb.connect_incoming(peer_id, multiaddr, enr);
                     // start a timer to ping inbound peers.
                     self.inbound_ping_peers.insert(*peer_id);
                 }
@@ -1701,7 +1710,7 @@ enum ConnectingType {
     /// We are in the process of dialing this peer.
     Dialing,
     /// A peer has dialed us.
-    IngoingConnected {
+    IncomingConnected {
         // The multiaddr the peer connected to us on.
         multiaddr: Multiaddr,
     },
@@ -1790,10 +1799,10 @@ mod tests {
         // Create 6 peers to connect to with a target of 3.
         // 2 will be outbound-only, and have the lowest score.
         // 1 will be a trusted peer.
-        // The other 3 will be ingoing peers.
+        // The other 3 will be incoming peers.
 
         // We expect this test to disconnect from 3 peers. 1 from the outbound peer (the other must
-        // remain due to the outbound peer limit) and 2 from the ingoing peers (the trusted peer
+        // remain due to the outbound peer limit) and 2 from the incoming peers (the trusted peer
         // should remain connected).
         let peer0 = PeerId::random();
         let peer1 = PeerId::random();
@@ -1804,10 +1813,10 @@ mod tests {
 
         let mut peer_manager = build_peer_manager_with_trusted_peers(vec![trusted_peer], 3).await;
 
-        peer_manager.inject_connect_ingoing(&peer0, "/ip4/0.0.0.0".parse().unwrap(), None);
-        peer_manager.inject_connect_ingoing(&peer1, "/ip4/0.0.0.0".parse().unwrap(), None);
-        peer_manager.inject_connect_ingoing(&peer2, "/ip4/0.0.0.0".parse().unwrap(), None);
-        peer_manager.inject_connect_ingoing(&trusted_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&peer0, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&peer1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&peer2, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&trusted_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
         peer_manager.inject_connect_outgoing(
             &outbound_only_peer1,
             "/ip4/0.0.0.0".parse().unwrap(),
@@ -1888,16 +1897,16 @@ mod tests {
     async fn test_peer_manager_not_enough_outbound_peers_no_panic_during_heartbeat() {
         let mut peer_manager = build_peer_manager(20).await;
 
-        // Connect to 20 ingoing-only peers.
+        // Connect to 20 incoming-only peers.
         for _i in 0..19 {
             let peer = PeerId::random();
-            peer_manager.inject_connect_ingoing(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            peer_manager.inject_connect_incoming(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
         }
 
         // Connect an outbound-only peer.
         // Give it the lowest score so that it is evaluated first in the disconnect list iterator.
         let outbound_only_peer = PeerId::random();
-        peer_manager.inject_connect_ingoing(
+        peer_manager.inject_connect_incoming(
             &outbound_only_peer,
             "/ip4/0.0.0.0".parse().unwrap(),
             None,
@@ -1929,11 +1938,19 @@ mod tests {
         let inbound_only_peer1 = PeerId::random();
         let outbound_only_peer1 = PeerId::random();
 
-        peer_manager.inject_connect_ingoing(&peer0, "/ip4/0.0.0.0/tcp/8000".parse().unwrap(), None);
-        peer_manager.inject_connect_ingoing(&peer1, "/ip4/0.0.0.0/tcp/8000".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(
+            &peer0,
+            "/ip4/0.0.0.0/tcp/8000".parse().unwrap(),
+            None,
+        );
+        peer_manager.inject_connect_incoming(
+            &peer1,
+            "/ip4/0.0.0.0/tcp/8000".parse().unwrap(),
+            None,
+        );
 
         // Connect to two peers that are on the threshold of being disconnected.
-        peer_manager.inject_connect_ingoing(
+        peer_manager.inject_connect_incoming(
             &inbound_only_peer1,
             "/ip4/0.0.0.0/tcp/8000".parse().unwrap(),
             None,
@@ -1989,16 +2006,16 @@ mod tests {
         let inbound_only_peer1 = PeerId::random();
         let outbound_only_peer1 = PeerId::random();
 
-        peer_manager.inject_connect_ingoing(&peer0, "/ip4/0.0.0.0".parse().unwrap(), None);
-        peer_manager.inject_connect_ingoing(&peer1, "/ip4/0.0.0.0".parse().unwrap(), None);
-        peer_manager.inject_connect_ingoing(&peer2, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&peer0, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&peer1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&peer2, "/ip4/0.0.0.0".parse().unwrap(), None);
         peer_manager.inject_connect_outgoing(
             &outbound_only_peer1,
             "/ip4/0.0.0.0".parse().unwrap(),
             None,
         );
         // Have one peer be on the verge of disconnection.
-        peer_manager.inject_connect_ingoing(
+        peer_manager.inject_connect_incoming(
             &inbound_only_peer1,
             "/ip4/0.0.0.0".parse().unwrap(),
             None,
@@ -2044,11 +2061,11 @@ mod tests {
         println!("{}", peer3);
         println!("{}", peer4);
 
-        peer_manager.inject_connect_ingoing(&peer0, "/ip4/0.0.0.0".parse().unwrap(), None);
-        peer_manager.inject_connect_ingoing(&peer1, "/ip4/0.0.0.0".parse().unwrap(), None);
-        peer_manager.inject_connect_ingoing(&peer2, "/ip4/0.0.0.0".parse().unwrap(), None);
-        peer_manager.inject_connect_ingoing(&peer3, "/ip4/0.0.0.0".parse().unwrap(), None);
-        peer_manager.inject_connect_ingoing(&peer4, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&peer0, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&peer1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&peer2, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&peer3, "/ip4/0.0.0.0".parse().unwrap(), None);
+        peer_manager.inject_connect_incoming(&peer4, "/ip4/0.0.0.0".parse().unwrap(), None);
 
         // Have some of the peers be on a long-lived subnet
         let mut attnets = crate::types::EnrAttestationBitfield::<E>::new();
@@ -2151,7 +2168,7 @@ mod tests {
         let mut peer_manager = build_peer_manager_with_opts(vec![], 1, spec).await;
         let pubkey = Keypair::generate_secp256k1().public();
         let peer_id = PeerId::from_public_key(&pubkey);
-        peer_manager.inject_connect_ingoing(
+        peer_manager.inject_connect_incoming(
             &peer_id,
             Multiaddr::empty().with_p2p(peer_id).unwrap(),
             None,
@@ -2199,7 +2216,7 @@ mod tests {
             let subnet: u64 = { if x < 15 { x % 4 } else { x } };
 
             let peer = PeerId::random();
-            peer_manager.inject_connect_ingoing(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            peer_manager.inject_connect_incoming(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
 
             // Have some of the peers be on a long-lived subnet
             {
@@ -2293,7 +2310,7 @@ mod tests {
         let mut peers = Vec::new();
         for x in 0..6 {
             let peer = PeerId::random();
-            peer_manager.inject_connect_ingoing(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            peer_manager.inject_connect_incoming(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
 
             // Have some of the peers be on a long-lived subnet
             let custody_subnets = match x {
@@ -2383,7 +2400,7 @@ mod tests {
         let mut peers = Vec::new();
         for x in 0..6 {
             let peer = PeerId::random();
-            peer_manager.inject_connect_ingoing(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            peer_manager.inject_connect_incoming(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
 
             // Have some of the peers be on a long-lived subnet
             let mut syncnets = crate::types::EnrSyncCommitteeBitfield::<E>::new();
@@ -2494,7 +2511,7 @@ mod tests {
         let mut peers = Vec::new();
         for peer_idx in 0..8 {
             let peer = PeerId::random();
-            peer_manager.inject_connect_ingoing(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            peer_manager.inject_connect_incoming(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
 
             // Have some of the peers be on a long-lived subnet
             let custody_subnets = match peer_idx {
@@ -2658,7 +2675,7 @@ mod tests {
                     HashSet::from([DataColumnSubnetId::new(3)])
                 }
                 6 => {
-                    peer_manager.inject_connect_ingoing(
+                    peer_manager.inject_connect_incoming(
                         &peer,
                         "/ip4/0.0.0.0".parse().unwrap(),
                         None,
@@ -2666,7 +2683,7 @@ mod tests {
                     HashSet::from([DataColumnSubnetId::new(4)])
                 }
                 7 => {
-                    peer_manager.inject_connect_ingoing(
+                    peer_manager.inject_connect_incoming(
                         &peer,
                         "/ip4/0.0.0.0".parse().unwrap(),
                         None,
@@ -2753,7 +2770,7 @@ mod tests {
 
         for &subnet in subnet_assignments.iter() {
             let peer = PeerId::random();
-            peer_manager.inject_connect_ingoing(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            peer_manager.inject_connect_incoming(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
 
             let mut attnets = crate::types::EnrAttestationBitfield::<E>::new();
             attnets.set(subnet, true).unwrap();
@@ -2840,7 +2857,7 @@ mod tests {
         let current_peer_count = 6;
         for i in 0..current_peer_count {
             let peer = PeerId::random();
-            peer_manager.inject_connect_ingoing(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            peer_manager.inject_connect_incoming(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
 
             let sync_status = match i {
                 0 => SyncStatus::Behind {
@@ -2934,7 +2951,7 @@ mod tests {
         let mut peers = Vec::new();
         for i in 0..12 {
             let peer = PeerId::random();
-            peer_manager.inject_connect_ingoing(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            peer_manager.inject_connect_incoming(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
 
             let custody_subnet = match i {
                 ..4 => 0,
@@ -3151,7 +3168,7 @@ mod tests {
                                 None,
                             );
                         } else {
-                            peer_manager.inject_connect_ingoing(
+                            peer_manager.inject_connect_incoming(
                                 &condition.peer_id,
                                 "/ip4/0.0.0.0".parse().unwrap(),
                                 None,

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -848,29 +848,22 @@ impl<E: EthSpec> PeerManager<E> {
     /* Internal functions */
 
     /// Sets a peer as connected as long as their reputation allows it
-    /// Informs if the peer was accepted
-    fn inject_connect_ingoing(
-        &mut self,
-        peer_id: &PeerId,
-        multiaddr: Multiaddr,
-        enr: Option<Enr>,
-    ) -> bool {
-        self.inject_peer_connection(peer_id, ConnectingType::IngoingConnected { multiaddr }, enr)
+    fn inject_connect_ingoing(&mut self, peer_id: &PeerId, multiaddr: Multiaddr, enr: Option<Enr>) {
+        self.inject_peer_connection(peer_id, ConnectingType::IngoingConnected { multiaddr }, enr);
     }
 
     /// Sets a peer as connected as long as their reputation allows it
-    /// Informs if the peer was accepted
     fn inject_connect_outgoing(
         &mut self,
         peer_id: &PeerId,
         multiaddr: Multiaddr,
         enr: Option<Enr>,
-    ) -> bool {
+    ) {
         self.inject_peer_connection(
             peer_id,
             ConnectingType::OutgoingConnected { multiaddr },
             enr,
-        )
+        );
     }
 
     /// Updates the state of the peer as disconnected.
@@ -903,14 +896,12 @@ impl<E: EthSpec> PeerManager<E> {
     /// dialed or connecting to us.
     ///
     /// This is called by `connect_ingoing` and `connect_outgoing`.
-    ///
-    /// Informs if the peer was accepted in to the db or not.
     fn inject_peer_connection(
         &mut self,
         peer_id: &PeerId,
         connection: ConnectingType,
         enr: Option<Enr>,
-    ) -> bool {
+    ) {
         {
             let mut peerdb = self.network_globals.peers.write();
             if peerdb.ban_status(peer_id).is_some() {
@@ -921,7 +912,7 @@ impl<E: EthSpec> PeerManager<E> {
             match connection {
                 ConnectingType::Dialing => {
                     peerdb.dialing_peer(peer_id, enr);
-                    return true;
+                    return;
                 }
                 ConnectingType::IngoingConnected { multiaddr } => {
                     peerdb.connect_ingoing(peer_id, multiaddr, enr);
@@ -938,8 +929,6 @@ impl<E: EthSpec> PeerManager<E> {
 
         // start a ping and status timer for the peer
         self.status_peers.insert(*peer_id);
-
-        true
     }
 
     // Gracefully disconnects a peer without banning them.

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -269,7 +269,7 @@ impl<E: EthSpec> PeerManager<E> {
         // does not need to know about these peers.
         match endpoint {
             ConnectedPoint::Listener { send_back_addr, .. } => {
-                self.inject_connect_ingoing(&peer_id, send_back_addr.clone(), None);
+                self.inject_connect_incoming(&peer_id, send_back_addr.clone(), None);
                 self.events
                     .push(PeerManagerEvent::PeerConnectedIncoming(peer_id));
             }

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -750,9 +750,9 @@ impl<E: EthSpec> PeerDB<E> {
         self.update_connection_state(peer_id, NewConnectionState::Dialing { enr });
     }
 
-    /// Sets a peer as connected with an ingoing connection.
+    /// Sets a peer as connected with an incoming connection.
     // VISIBILITY: Only the peer manager can adjust the connection state.
-    pub(super) fn connect_ingoing(
+    pub(super) fn connect_incoming(
         &mut self,
         peer_id: &PeerId,
         seen_address: Multiaddr,
@@ -953,7 +953,7 @@ impl<E: EthSpec> PeerDB<E> {
 
                 // Update the connection state
                 match direction {
-                    ConnectionDirection::Incoming => info.connect_ingoing(seen_address),
+                    ConnectionDirection::Incoming => info.connect_incoming(seen_address),
                     ConnectionDirection::Outgoing => info.connect_outgoing(seen_address),
                 }
             }
@@ -1514,7 +1514,7 @@ mod tests {
 
         let (n_in, n_out) = (10, 20);
         for _ in 0..n_in {
-            pdb.connect_ingoing(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            pdb.connect_incoming(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
         }
         for _ in 0..n_out {
             pdb.connect_outgoing(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
@@ -1542,8 +1542,8 @@ mod tests {
         // Create peer with no connections.
         let _p3 = PeerId::random();
 
-        pdb.connect_ingoing(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
-        pdb.connect_ingoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
         pdb.connect_outgoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
         pdb.connect_outgoing(&p2, "/ip4/0.0.0.0".parse().unwrap(), None);
 
@@ -1560,7 +1560,7 @@ mod tests {
         let mut peer_list = BTreeMap::new();
         for id in 0..MAX_DC_PEERS + 1 {
             let new_peer = PeerId::random();
-            pdb.connect_ingoing(&new_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            pdb.connect_incoming(&new_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
             peer_list.insert(id, new_peer);
         }
         assert_eq!(pdb.disconnected_peers, 0);
@@ -1596,7 +1596,7 @@ mod tests {
         let mut peer_list = BTreeMap::new();
         for id in 0..MAX_DC_PEERS + 20 {
             let new_peer = PeerId::random();
-            pdb.connect_ingoing(&new_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            pdb.connect_incoming(&new_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
             peer_list.insert(id, new_peer);
         }
         assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
@@ -1609,7 +1609,7 @@ mod tests {
         peer_list.clear();
         for id in 0..MAX_DC_PEERS + 20 {
             let new_peer = PeerId::random();
-            pdb.connect_ingoing(&new_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+            pdb.connect_incoming(&new_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
             peer_list.insert(id, new_peer);
         }
 
@@ -1640,7 +1640,7 @@ mod tests {
 
         for _ in 0..MAX_DC_PEERS + 1 {
             let p = PeerId::random();
-            pdb.connect_ingoing(&p, "/ip4/0.0.0.0".parse().unwrap(), None);
+            pdb.connect_incoming(&p, "/ip4/0.0.0.0".parse().unwrap(), None);
         }
         assert_eq!(pdb.disconnected_peers, 0);
 
@@ -1658,7 +1658,7 @@ mod tests {
 
         for _ in 0..MAX_BANNED_PEERS + 1 {
             let p = PeerId::random();
-            pdb.connect_ingoing(&p, "/ip4/0.0.0.0".parse().unwrap(), None);
+            pdb.connect_incoming(&p, "/ip4/0.0.0.0".parse().unwrap(), None);
         }
         assert_eq!(pdb.banned_peers_count.banned_peers(), 0);
 
@@ -1677,9 +1677,9 @@ mod tests {
         let p0 = PeerId::random();
         let p1 = PeerId::random();
         let p2 = PeerId::random();
-        pdb.connect_ingoing(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
-        pdb.connect_ingoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
-        pdb.connect_ingoing(&p2, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&p2, "/ip4/0.0.0.0".parse().unwrap(), None);
         add_score(&mut pdb, &p0, 70.0);
         add_score(&mut pdb, &p1, 100.0);
         add_score(&mut pdb, &p2, 50.0);
@@ -1699,9 +1699,9 @@ mod tests {
         let p0 = PeerId::random();
         let p1 = PeerId::random();
         let p2 = PeerId::random();
-        pdb.connect_ingoing(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
-        pdb.connect_ingoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
-        pdb.connect_ingoing(&p2, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&p2, "/ip4/0.0.0.0".parse().unwrap(), None);
         add_score(&mut pdb, &p0, 70.0);
         add_score(&mut pdb, &p1, 100.0);
         add_score(&mut pdb, &p2, 50.0);
@@ -1719,10 +1719,10 @@ mod tests {
 
         let random_peer = PeerId::random();
 
-        pdb.connect_ingoing(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
         assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
 
-        pdb.connect_ingoing(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&random_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
         assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
         pdb.inject_disconnect(&random_peer);
         assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
@@ -1772,10 +1772,10 @@ mod tests {
         println!("{}", random_peer3);
 
         // All 4 peers connected on the same IP
-        pdb.connect_ingoing(&random_peer, multiaddr.clone(), None);
-        pdb.connect_ingoing(&random_peer1, multiaddr.clone(), None);
-        pdb.connect_ingoing(&random_peer2, multiaddr.clone(), None);
-        pdb.connect_ingoing(&random_peer3, multiaddr.clone(), None);
+        pdb.connect_incoming(&random_peer, multiaddr.clone(), None);
+        pdb.connect_incoming(&random_peer1, multiaddr.clone(), None);
+        pdb.connect_incoming(&random_peer2, multiaddr.clone(), None);
+        pdb.connect_incoming(&random_peer3, multiaddr.clone(), None);
 
         // Should be no disconnected or banned peers
         assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
@@ -1828,7 +1828,7 @@ mod tests {
             pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
         );
         // Re-connect peer3, should have no effect
-        pdb.connect_ingoing(&random_peer3, multiaddr.clone(), None);
+        pdb.connect_incoming(&random_peer3, multiaddr.clone(), None);
         assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
         assert_eq!(
             pdb.banned_peers_count.banned_peers(),
@@ -1932,7 +1932,7 @@ mod tests {
         );
 
         // Unban peer 1
-        pdb.connect_ingoing(&random_peer1, multiaddr.clone(), None);
+        pdb.connect_incoming(&random_peer1, multiaddr.clone(), None);
         pdb.peer_info_mut(&random_peer1)
             .unwrap()
             .add_to_score(100.0);
@@ -1967,7 +1967,7 @@ mod tests {
         );
 
         // Add peer 0
-        pdb.connect_ingoing(&random_peer, multiaddr, None);
+        pdb.connect_incoming(&random_peer, multiaddr, None);
         pdb.peer_info_mut(&random_peer).unwrap().add_to_score(100.0);
 
         // Should have 1 disconnect (peer 2) and one banned (peer 3)
@@ -2031,7 +2031,7 @@ mod tests {
             let mut addr = Multiaddr::empty();
             addr.push(Protocol::from(ip));
             addr.push(Protocol::Tcp(9000));
-            pdb.connect_ingoing(&p, addr, None);
+            pdb.connect_incoming(&p, addr, None);
         }
         p
     }
@@ -2162,7 +2162,7 @@ mod tests {
         let mut socker_addr = Multiaddr::from(ip2);
         socker_addr.push(Protocol::Tcp(8080));
         for p in &peers {
-            pdb.connect_ingoing(p, socker_addr.clone(), None);
+            pdb.connect_incoming(p, socker_addr.clone(), None);
             let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager, "");
             pdb.inject_disconnect(p);
         }
@@ -2203,7 +2203,7 @@ mod tests {
         let trusted_peer = PeerId::random();
         let mut pdb: PeerDB<M> = PeerDB::new(vec![trusted_peer], false);
 
-        pdb.connect_ingoing(&trusted_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&trusted_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
 
         // Check trusted status and score
         assert!(pdb.peer_info(&trusted_peer).unwrap().is_trusted());
@@ -2239,7 +2239,7 @@ mod tests {
 
         let add_custody_peer = |pdb: &mut PeerDB<M>, sync_status: SyncStatus| {
             let peer_id = PeerId::random();
-            pdb.connect_ingoing(&peer_id, "/ip4/0.0.0.0".parse().unwrap(), None);
+            pdb.connect_incoming(&peer_id, "/ip4/0.0.0.0".parse().unwrap(), None);
             pdb.__set_custody_subnets(&peer_id, HashSet::from([subnet]))
                 .unwrap();
             pdb.update_sync_status(&peer_id, sync_status);
@@ -2309,7 +2309,7 @@ mod tests {
         let peer = PeerId::random();
         let mut pdb: PeerDB<M> = PeerDB::new(vec![], true);
 
-        pdb.connect_ingoing(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_incoming(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
 
         // Check trusted status and score
         assert!(pdb.peer_info(&peer).unwrap().is_trusted());

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -499,9 +499,9 @@ impl<E: EthSpec> PeerInfo<E> {
         Ok(())
     }
 
-    /// Modifies the status to Connected and increases the number of ingoing
+    /// Modifies the status to Connected and increases the number of incoming
     /// connections by one
-    pub(super) fn connect_ingoing(&mut self, multiaddr: Multiaddr) {
+    pub(super) fn connect_incoming(&mut self, multiaddr: Multiaddr) {
         self.seen_multiaddrs.insert(multiaddr.clone());
 
         match &mut self.connection_status {
@@ -582,7 +582,7 @@ pub enum PeerConnectionStatus {
     Connected {
         /// The multiaddr that we are connected via.
         multiaddr: Multiaddr,
-        /// number of ingoing connections.
+        /// number of incoming connections.
         n_in: u8,
         /// number of outgoing connections.
         n_out: u8,


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

This PR contains two cleanups for the `peer_manager` module.

1. Remove the unused return value from `inject_connect_***`.
2. Rename `ingoing` to `incoming` for consistency since `ConnectionDirection::Incoming` is already the spelling used for this concept.

<!--
## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->