### PR TITLE
Fix order of fields in `PartialDataColumnGroupId`

### DIFF
--- a/consensus/types/src/data/partial_data_column_sidecar.rs
+++ b/consensus/types/src/data/partial_data_column_sidecar.rs
@@ -335,8 +335,8 @@ impl<E: EthSpec> Display for PartialDataColumnPartsMetadata<E> {
 
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct PartialDataColumnGroupId {
-    pub slot: Slot,
     pub beacon_block_root: Hash256,
+    pub slot: Slot,
 }
 
 #[superstruct(


### PR DESCRIPTION
## Issue Addressed

The order of fields in `PartialDataColumnGroupId` has been swapped in the spec, and need to be swapped as well in our impl.

https://github.com/ethereum/consensus-specs/commit/b70c9ec87c639aa5c91de4f606870688bc312230#diff-7dccdd0e4f706e5a9503316db2a896724035a1b6f0feec17f42b0e69d77f95a6L48

## Proposed Changes

Swap the fields so that `Encode` and `Decode` match the spec.

## Additional Info

Thanks to @aarshkshah1992 for spotting this!
