### PR TITLE
Load bids from db if bid is missing

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3023,6 +3023,78 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         handle.await.map_err(Error::TokioJoin)
     }
 
+    /// Load the payload bid with cache and store fallbacks on a blocking worker.
+    pub(crate) async fn load_gloas_payload_bid_blocking(
+        self: &Arc<Self>,
+        block_root: Hash256,
+    ) -> Result<Arc<types::SignedExecutionPayloadBid<T::EthSpec>>, BlockError> {
+        let chain = self.clone();
+        self.spawn_blocking_handle(
+            move || chain.load_gloas_payload_bid(block_root),
+            "load_gloas_payload_bid",
+        )
+        .await??
+        .ok_or(BlockError::AvailabilityCheck(
+            AvailabilityCheckError::MissingBid(block_root),
+        ))
+    }
+
+    /// Loads the Gloas payload bid for `block_root` from the `pending_payload_cache`, the
+    /// `early_attester_cache`, or the on-disk store (in that order).
+    ///
+    /// The store fallback is a synchronous disk read, so this must be called from a blocking
+    /// context, never directly on the async runtime.
+    pub(crate) fn load_gloas_payload_bid(
+        &self,
+        block_root: Hash256,
+    ) -> Result<Option<Arc<types::SignedExecutionPayloadBid<T::EthSpec>>>, BeaconChainError> {
+        if let Some(bid) = self.pending_payload_cache.get_bid(&block_root) {
+            return Ok(Some(bid));
+        }
+
+        let bid = if let Some(block) = self.early_attester_cache.get_block(block_root) {
+            Arc::new(
+                block
+                    .message()
+                    .body()
+                    .signed_execution_payload_bid()
+                    .map_err(BeaconChainError::BeaconStateError)?
+                    .clone(),
+            )
+        } else {
+            match self
+                .store
+                .try_get_full_block(&block_root)
+                .map_err(BeaconChainError::DBError)?
+            {
+                Some(DatabaseBlock::Full(block)) => Arc::new(
+                    block
+                        .message()
+                        .body()
+                        .signed_execution_payload_bid()
+                        .map_err(BeaconChainError::BeaconStateError)?
+                        .clone(),
+                ),
+                Some(DatabaseBlock::Blinded(block)) => Arc::new(
+                    block
+                        .message()
+                        .body()
+                        .signed_execution_payload_bid()
+                        .map_err(BeaconChainError::BeaconStateError)?
+                        .clone(),
+                ),
+                None => {
+                    return Ok(None);
+                }
+            }
+        };
+
+        self.pending_payload_cache
+            .insert_bid(block_root, bid.clone());
+
+        Ok(Some(bid))
+    }
+
     /// Accepts a `chain_segment` and filters out any uninteresting blocks (e.g., pre-finalization
     /// or already-known).
     ///
@@ -3498,9 +3570,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
             KzgVerifiedCustodyPartialDataColumn::Gloas(verified_partial) => {
                 // Gloas: merge directly into the pending payload cache.
+                let bid = self.load_gloas_payload_bid_blocking(block_root).await?;
                 let (availability, merge_result) = self
                     .pending_payload_cache
-                    .merge_partial_data_columns(block_root, &[verified_partial])
+                    .merge_partial_data_columns(block_root, bid, &[verified_partial])
                     .map_err(BlockError::from)?;
                 (merge_result, Some(availability))
             }
@@ -3739,11 +3812,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .gloas_enabled();
 
         if is_gloas {
+            let bid = self.load_gloas_payload_bid_blocking(block_root).await?;
             let pending_payload_cache = self.pending_payload_cache.clone();
             let result = self
                 .task_executor
                 .spawn_blocking_with_rayon_async(RayonPoolType::HighPriority, move || {
-                    pending_payload_cache.reconstruct_data_columns(&block_root)
+                    pending_payload_cache.reconstruct_data_columns(&block_root, bid)
                 })
                 .await
                 .map_err(|_| BlockError::from(BeaconChainError::RuntimeShutdown))?
@@ -4076,9 +4150,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .fork_name_at_slot::<T::EthSpec>(slot)
             .gloas_enabled()
         {
+            let bid = self.load_gloas_payload_bid_blocking(block_root).await?;
             let availability = self
                 .pending_payload_cache
-                .put_gossip_verified_data_columns(block_root, data_columns)?;
+                .put_gossip_verified_data_columns(block_root, bid, data_columns)?;
             Ok(self
                 .process_payload_envelope_availability(slot, availability, publish_fn)
                 .await?)
@@ -4164,9 +4239,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .fork_name_at_slot::<T::EthSpec>(slot)
             .gloas_enabled()
         {
+            let bid = self.load_gloas_payload_bid_blocking(block_root).await?;
             let availability = self
                 .pending_payload_cache
-                .put_kzg_verified_custody_data_columns(block_root, &engine_get_blobs_output)
+                .put_kzg_verified_custody_data_columns(block_root, bid, &engine_get_blobs_output)
                 .map_err(BlockError::from)?;
             self.process_payload_envelope_availability(slot, availability, || Ok(()))
                 .await
@@ -4202,9 +4278,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .fork_name_at_slot::<T::EthSpec>(slot)
             .gloas_enabled()
         {
+            let bid = self.load_gloas_payload_bid_blocking(block_root).await?;
             let availability = self
                 .pending_payload_cache
-                .put_rpc_custody_columns(block_root, custody_columns)
+                .put_rpc_custody_columns(block_root, bid, custody_columns)
                 .map_err(BlockError::from)?;
             Ok(self
                 .process_payload_envelope_availability(slot, availability, || Ok(()))

--- a/beacon_node/beacon_chain/src/data_column_verification.rs
+++ b/beacon_node/beacon_chain/src/data_column_verification.rs
@@ -22,7 +22,6 @@ use std::iter;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
-use store::DatabaseBlock;
 use superstruct::superstruct;
 use tracing::{debug, instrument};
 use tree_hash::TreeHash;
@@ -33,7 +32,7 @@ use types::data::{
 };
 use types::{
     BeaconStateError, ChainSpec, DataColumnSidecar, DataColumnSubnetId, EthSpec, Hash256,
-    KzgCommitment, PartialDataColumnView, SignedBeaconBlockHeader, SignedExecutionPayloadBid, Slot,
+    KzgCommitment, PartialDataColumnView, SignedBeaconBlockHeader, Slot,
 };
 
 /// An error occurred while validating a gossip data column.
@@ -405,12 +404,12 @@ impl<T: BeaconChainTypes, O: ObservationStrategy> GossipVerifiedDataColumn<T, O>
                 )?;
             }
             DataColumnSidecar::Gloas(_) => {
-                let bid = load_gloas_payload_bid(column_sidecar.block_root(), chain)?.ok_or(
-                    GossipDataColumnError::BlockRootUnknown {
+                let bid = chain
+                    .load_gloas_payload_bid(column_sidecar.block_root())?
+                    .ok_or(GossipDataColumnError::BlockRootUnknown {
                         block_root: column_sidecar.block_root(),
                         slot: column_sidecar.slot(),
-                    },
-                )?;
+                    })?;
                 verify_data_column_sidecar_with_commitments_len(
                     &column_sidecar,
                     bid.message.blob_kzg_commitments.len(),
@@ -1257,12 +1256,12 @@ pub fn validate_data_column_sidecar_for_gossip_gloas<
     verify_slot_greater_than_latest_finalized_slot(chain, column_slot)?;
     verify_is_unknown_sidecar(chain, &data_column)?;
 
-    let bid = load_gloas_payload_bid(data_column.block_root(), chain)?.ok_or(
-        GossipDataColumnError::BlockRootUnknown {
+    let bid = chain
+        .load_gloas_payload_bid(data_column.block_root())?
+        .ok_or(GossipDataColumnError::BlockRootUnknown {
             block_root: data_column.block_root(),
             slot: column_slot,
-        },
-    )?;
+        })?;
     if bid.message.slot != column_slot {
         return Err(GossipDataColumnError::BlockSlotMismatch {
             block_slot: bid.message.slot,
@@ -1403,7 +1402,7 @@ fn validate_partial_data_column_sidecar_for_gossip_gloas<T: BeaconChainTypes>(
 
     // The bid carries the commitments. It is gossip-verified and inserted into the pending
     // payload cache on its own path - we don't cache anything from this code path.
-    let bid = match load_gloas_payload_bid(block_root, chain) {
+    let bid = match chain.load_gloas_payload_bid(block_root) {
         Ok(Some(bid)) => bid,
         Ok(None) => {
             // Block not known, trigger lookup.
@@ -1544,63 +1543,6 @@ fn verify_data_column_sidecar_with_commitments_len<E: EthSpec>(
     }
 
     Ok(())
-}
-
-/// Loads the Gloas payload bid for `block_root` from the `pending_payload_cache`, the
-/// `early_attester_cache`, or the on-disk store (in that order).
-///
-/// The store fallback is a synchronous disk read, so this must be called from a blocking
-/// context, never directly on the async runtime.
-pub(crate) fn load_gloas_payload_bid<T: BeaconChainTypes>(
-    block_root: Hash256,
-    chain: &BeaconChain<T>,
-) -> Result<Option<Arc<SignedExecutionPayloadBid<T::EthSpec>>>, BeaconChainError> {
-    if let Some(bid) = chain.pending_payload_cache.get_bid(&block_root) {
-        return Ok(Some(bid));
-    }
-
-    let bid = if let Some(block) = chain.early_attester_cache.get_block(block_root) {
-        Arc::new(
-            block
-                .message()
-                .body()
-                .signed_execution_payload_bid()
-                .map_err(BeaconChainError::BeaconStateError)?
-                .clone(),
-        )
-    } else {
-        match chain
-            .store
-            .try_get_full_block(&block_root)
-            .map_err(BeaconChainError::DBError)?
-        {
-            Some(DatabaseBlock::Full(block)) => Arc::new(
-                block
-                    .message()
-                    .body()
-                    .signed_execution_payload_bid()
-                    .map_err(BeaconChainError::BeaconStateError)?
-                    .clone(),
-            ),
-            Some(DatabaseBlock::Blinded(block)) => Arc::new(
-                block
-                    .message()
-                    .body()
-                    .signed_execution_payload_bid()
-                    .map_err(BeaconChainError::BeaconStateError)?
-                    .clone(),
-            ),
-            None => {
-                return Ok(None);
-            }
-        }
-    };
-
-    chain
-        .pending_payload_cache
-        .insert_bid(block_root, bid.clone());
-
-    Ok(Some(bid))
 }
 
 fn missing_cells_for_column_sidecar<'a, T: BeaconChainTypes>(
@@ -1873,8 +1815,7 @@ mod test {
     use crate::data_column_verification::{
         GossipDataColumnError, GossipPartialDataColumnError, GossipVerifiedDataColumn,
         GossipVerifiedPartialDataColumnHeader, KzgVerifiedCustodyPartialDataColumnFulu,
-        PartialColumnVerificationResult, load_gloas_payload_bid,
-        validate_data_column_sidecar_for_gossip_fulu,
+        PartialColumnVerificationResult, validate_data_column_sidecar_for_gossip_fulu,
         validate_partial_data_column_sidecar_for_gossip,
     };
     use crate::observed_data_sidecars::Observe;
@@ -1989,7 +1930,9 @@ mod test {
                 .contains_block(block_root)
         );
 
-        let bid = load_gloas_payload_bid(block_root, &harness.chain)
+        let bid = harness
+            .chain
+            .load_gloas_payload_bid(block_root)
             .unwrap()
             .expect("bid should be loaded from the store");
         assert_eq!(*bid, expected_bid);
@@ -2005,7 +1948,9 @@ mod test {
 
         // An unknown block root yields no bid.
         assert!(
-            load_gloas_payload_bid(Hash256::repeat_byte(0x42), &harness.chain)
+            harness
+                .chain
+                .load_gloas_payload_bid(Hash256::repeat_byte(0x42))
                 .unwrap()
                 .is_none()
         );

--- a/beacon_node/beacon_chain/src/fetch_blobs/mod.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs/mod.rs
@@ -327,7 +327,7 @@ async fn fetch_and_process_blobs_v2_or_v3<T: BeaconChainTypes>(
             // publishing.
             let (availability, merge_result) = chain_adapter
                 .pending_payload_cache()
-                .merge_partial_data_columns(block_root, &custody_columns_to_import)
+                .merge_partial_data_columns(block_root, bid.clone(), &custody_columns_to_import)
                 .map_err(|e| {
                     FetchEngineBlobError::InternalError(format!(
                         "Failed to merge partials into pending payload cache: {e:?}"

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -143,9 +143,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         envelope: AvailabilityPendingExecutedEnvelope<T::EthSpec>,
     ) -> Result<AvailabilityProcessingStatus, BlockError> {
         let slot = envelope.envelope.slot();
+        let block_root = envelope.block_root;
+        let bid = self.load_gloas_payload_bid_blocking(block_root).await?;
         let availability = self
             .pending_payload_cache
-            .put_executed_payload_envelope(envelope)?;
+            .put_executed_payload_envelope(envelope, bid)?;
         self.process_payload_envelope_availability(slot, availability, || Ok(()))
             .await
     }

--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -256,11 +256,9 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
     pub fn put_executed_payload_envelope(
         &self,
         executed_envelope: AvailabilityPendingExecutedEnvelope<T::EthSpec>,
+        bid: Arc<SignedExecutionPayloadBid<T::EthSpec>>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
         let beacon_block_root = executed_envelope.envelope.beacon_block_root();
-        let bid = self
-            .get_bid(&beacon_block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(beacon_block_root))?;
 
         let (_, pending_components) =
             self.update_pending_components(beacon_block_root, &bid, |pending_components| {
@@ -329,11 +327,9 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
     pub fn put_rpc_custody_columns(
         &self,
         block_root: Hash256,
+        bid: Arc<SignedExecutionPayloadBid<T::EthSpec>>,
         custody_columns: DataColumnSidecarList<T::EthSpec>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
-        let bid = self
-            .get_bid(&block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
         let kzg_verified_columns = KzgVerifiedDataColumn::from_batch_with_scoring_and_commitments(
             custody_columns,
             &bid.message.blob_kzg_commitments,
@@ -349,7 +345,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
             .map(KzgVerifiedCustodyDataColumn::from_asserted_custody)
             .collect::<Vec<_>>();
 
-        self.put_kzg_verified_custody_data_columns(block_root, &verified_custody_columns)
+        self.put_kzg_verified_custody_data_columns(block_root, bid, &verified_custody_columns)
     }
 
     /// Perform KZG verification on gossip verified custody columns and insert them into the cache.
@@ -358,11 +354,9 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
     pub fn put_gossip_verified_data_columns<O: ObservationStrategy>(
         &self,
         block_root: Hash256,
+        bid: Arc<SignedExecutionPayloadBid<T::EthSpec>>,
         data_columns: Vec<GossipVerifiedDataColumn<T, O>>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
-        let bid = self
-            .get_bid(&block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
         let epoch = bid.message.slot.epoch(T::EthSpec::slots_per_epoch());
         let sampling_columns = self.custody_context.sampling_columns_for_epoch(epoch);
         let custody_columns = data_columns
@@ -371,7 +365,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
             .map(|c| KzgVerifiedCustodyDataColumn::from_asserted_custody(c.into_inner()))
             .collect::<Vec<_>>();
 
-        self.put_kzg_verified_custody_data_columns(block_root, &custody_columns)
+        self.put_kzg_verified_custody_data_columns(block_root, bid, &custody_columns)
     }
 
     /// Merge KZG verified partial custody columns into the cache. Returns the columns that became
@@ -381,14 +375,11 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
     pub fn merge_partial_data_columns(
         &self,
         block_root: Hash256,
+        bid: Arc<SignedExecutionPayloadBid<T::EthSpec>>,
         kzg_verified_partial_data_columns: &[KzgVerifiedCustodyPartialDataColumnGloas<
             T::EthSpec,
         >],
     ) -> Result<AvailabilityAndPartialMergeResult<T::EthSpec>, AvailabilityCheckError> {
-        let bid = self
-            .get_bid(&block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
-
         let (outcome, pending_components) =
             self.update_pending_components(block_root, &bid, |pending_components| {
                 pending_components.merge_partial_data_columns(kzg_verified_partial_data_columns)
@@ -437,12 +428,9 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
     pub fn put_kzg_verified_custody_data_columns(
         &self,
         block_root: Hash256,
+        bid: Arc<SignedExecutionPayloadBid<T::EthSpec>>,
         kzg_verified_data_columns: &[KzgVerifiedCustodyDataColumn<T::EthSpec>],
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
-        let bid = self
-            .get_bid(&block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
-
         let (_, pending_components) =
             self.update_pending_components(block_root, &bid, |pending_components| {
                 pending_components.merge_data_columns(kzg_verified_data_columns)
@@ -464,11 +452,8 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
     pub fn reconstruct_data_columns(
         &self,
         block_root: &Hash256,
+        bid: Arc<SignedExecutionPayloadBid<T::EthSpec>>,
     ) -> Result<DataColumnReconstructionResult<T::EthSpec>, AvailabilityCheckError> {
-        let bid = self
-            .get_bid(block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(*block_root))?;
-
         let verified_data_columns = match self.check_and_set_reconstruction_started(block_root) {
             ReconstructColumnsDecision::Yes(verified_data_columns) => verified_data_columns,
             ReconstructColumnsDecision::No(reason) => {
@@ -526,16 +511,20 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
             "Reconstructed columns"
         );
 
-        self.put_kzg_verified_custody_data_columns(*block_root, &data_columns_to_import_and_publish)
-            .map(|availability| {
-                DataColumnReconstructionResult::Success((
-                    availability,
-                    data_columns_to_import_and_publish
-                        .into_iter()
-                        .map(|d| d.clone_arc())
-                        .collect::<Vec<_>>(),
-                ))
-            })
+        self.put_kzg_verified_custody_data_columns(
+            *block_root,
+            bid,
+            &data_columns_to_import_and_publish,
+        )
+        .map(|availability| {
+            DataColumnReconstructionResult::Success((
+                availability,
+                data_columns_to_import_and_publish
+                    .into_iter()
+                    .map(|d| d.clone_arc())
+                    .collect::<Vec<_>>(),
+            ))
+        })
     }
 
     // ── Metrics ──
@@ -776,6 +765,7 @@ mod data_availability_checker_tests {
             cache,
             block_root,
             custody,
+            bid,
         }
     }
 
@@ -783,23 +773,25 @@ mod data_availability_checker_tests {
         cache: Arc<PendingPayloadCache<T>>,
         block_root: Hash256,
         custody: DataColumnSidecarList<E>,
+        bid: Arc<SignedExecutionPayloadBid<E>>,
     }
 
     impl Setup {
         fn put_envelope(&self) -> Availability<E> {
             self.cache
-                .put_executed_payload_envelope(executed_envelope(self.block_root))
+                .put_executed_payload_envelope(executed_envelope(self.block_root), self.bid.clone())
                 .expect("put envelope")
         }
 
         fn put_columns(&self, columns: DataColumnSidecarList<E>) -> Availability<E> {
             self.cache
-                .put_rpc_custody_columns(self.block_root, columns)
+                .put_rpc_custody_columns(self.block_root, self.bid.clone(), columns)
                 .expect("put columns")
         }
 
         fn reconstruct(&self) -> Result<DataColumnReconstructionResult<E>, AvailabilityCheckError> {
-            self.cache.reconstruct_data_columns(&self.block_root)
+            self.cache
+                .reconstruct_data_columns(&self.block_root, self.bid.clone())
         }
 
         fn cached_indexes(&self) -> Vec<ColumnIndex> {
@@ -1072,7 +1064,7 @@ mod data_availability_checker_tests {
         let first = gloas_partial(s.block_root, slot, 0, 2, &[0]);
         let (availability, result) = s
             .cache
-            .merge_partial_data_columns(s.block_root, &[first])
+            .merge_partial_data_columns(s.block_root, s.bid.clone(), &[first])
             .expect("merge");
         assert_missing(availability);
         assert_eq!(result.added_cells, 1);
@@ -1083,7 +1075,7 @@ mod data_availability_checker_tests {
         let duplicate = gloas_partial(s.block_root, slot, 0, 2, &[0]);
         let (_availability, result) = s
             .cache
-            .merge_partial_data_columns(s.block_root, &[duplicate])
+            .merge_partial_data_columns(s.block_root, s.bid.clone(), &[duplicate])
             .expect("merge");
         assert_eq!(result.added_cells, 0);
 
@@ -1091,7 +1083,7 @@ mod data_availability_checker_tests {
         let second = gloas_partial(s.block_root, slot, 0, 2, &[1]);
         let (_availability, result) = s
             .cache
-            .merge_partial_data_columns(s.block_root, &[second])
+            .merge_partial_data_columns(s.block_root, s.bid.clone(), &[second])
             .expect("merge");
         assert_eq!(result.added_cells, 1);
         assert_eq!(result.full_columns.len(), 1, "column 0 becomes complete");


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

On devnet 9, restarts and cache eviction removed payload bids from the pending cache. This resulted in `MissingBid` errors during envelope and column processing causing repeated lookup failures. 

This fix loads missing bids from the stored blocks in the db if a cache miss occurs instead of rejecting the envelope/column.

Moved the `load_gloas_payload_bid` to beacon_chain as that seemed like a more natural place for it after this refactor.