### PR TITLE
Ignore exits for all withdrawing validators in Gloas block prod

### DIFF
--- a/beacon_node/beacon_chain/src/block_production/gloas.rs
+++ b/beacon_node/beacon_chain/src/block_production/gloas.rs
@@ -31,12 +31,12 @@ use types::consts::gloas::BUILDER_INDEX_SELF_BUILD;
 use types::{
     Address, Attestation, AttestationGloas, AttesterSlashing, AttesterSlashingGloas, BeaconBlock,
     BeaconBlockBodyGloas, BeaconBlockGloas, BeaconState, BeaconStateError, BlobsList, BuilderIndex,
-    ChainSpec, Deposit, Eth1Data, EthSpec, ExecutionBlockHash, ExecutionPayloadBid,
-    ExecutionPayloadEnvelope, ExecutionRequestsGloas, FullPayload, Graffiti, Hash256,
-    IndexedAttestation, KzgProofs, PayloadAttestation, ProposerSlashing, RelativeEpoch,
-    SignedBeaconBlock, SignedBlsToExecutionChange, SignedExecutionPayloadBid,
-    SignedExecutionPayloadEnvelope, SignedProposerPreferences, SignedVoluntaryExit, Slot,
-    SyncAggregate, Uint256, Withdrawal, Withdrawals,
+    Deposit, Eth1Data, EthSpec, ExecutionBlockHash, ExecutionPayloadBid, ExecutionPayloadEnvelope,
+    ExecutionRequestsGloas, FullPayload, Graffiti, Hash256, IndexedAttestation, KzgProofs,
+    PayloadAttestation, ProposerSlashing, RelativeEpoch, SignedBeaconBlock,
+    SignedBlsToExecutionChange, SignedExecutionPayloadBid, SignedExecutionPayloadEnvelope,
+    SignedProposerPreferences, SignedVoluntaryExit, Slot, SyncAggregate, Uint256, Withdrawal,
+    Withdrawals,
 };
 
 use builder_client::BidRequestContext;
@@ -407,7 +407,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             &mut voluntary_exits,
             parent_execution_requests,
             |idx| state.validators().get(idx as usize).map(|v| v.pubkey),
-            &self.spec,
         );
 
         drop(slashings_and_exits_span);
@@ -1342,37 +1341,42 @@ where
     Ok(block_contents)
 }
 
-/// Drop voluntary exits whose target validators will be exited by the parent envelope's
-/// execution requests.
+/// Drop voluntary exits whose target validators will be made ineligible to exit by the parent
+/// envelope's execution requests.
 ///
 /// In Gloas the parent execution payload is processed before voluntary exits during block
-/// processing. EL-triggered withdrawal-full-exit requests (EIP-7002) and cross-pubkey
-/// consolidation requests (EIP-7251) call `initiate_validator_exit`, setting the target's
-/// `exit_epoch`. A voluntary exit for the same validator would then fail with `AlreadyExited`.
+/// processing. EL-triggered withdrawal requests (EIP-7002) can completely exit validators or
+/// add pending partial withdrawals, making voluntary exits fail with `AlreadyExited` or
+/// `PendingWithdrawalInQueue`, respectively.
+///
+/// Similarly consolidation request processing (EIP-7251) can call `initiate_validator_exit`,
+/// setting the target's `exit_epoch`. A voluntary exit for the same validator would then fail with
+/// `AlreadyExited`.
+///
+/// This filter is conservative: it excludes matching exits even if request processing would
+/// ignore the request after checking the validator's credentials, balance, or other conditions.
 fn filter_voluntary_exits_for_parent_execution_requests<E: EthSpec>(
     voluntary_exits: &mut Vec<SignedVoluntaryExit>,
     parent_execution_requests: &ExecutionRequestsGloas<E>,
     pubkey_at_index: impl Fn(u64) -> Option<PublicKeyBytes>,
-    spec: &ChainSpec,
 ) {
-    let mut exited_pubkeys = HashSet::with_capacity(
+    let mut ineligible_pubkeys = HashSet::with_capacity(
         parent_execution_requests.withdrawals.len()
             + parent_execution_requests.consolidations.len(),
     );
     for req in &parent_execution_requests.withdrawals {
-        if req.amount == spec.full_exit_request_amount {
-            exited_pubkeys.insert(req.validator_pubkey);
-        }
+        // Any withdrawal amount can make a validator ineligible to exit.
+        ineligible_pubkeys.insert(req.validator_pubkey);
     }
     for req in &parent_execution_requests.consolidations {
         if req.source_pubkey != req.target_pubkey {
-            exited_pubkeys.insert(req.source_pubkey);
+            ineligible_pubkeys.insert(req.source_pubkey);
         }
     }
-    if !exited_pubkeys.is_empty() {
+    if !ineligible_pubkeys.is_empty() {
         voluntary_exits.retain(|exit| {
             pubkey_at_index(exit.message.validator_index)
-                .map(|pk| !exited_pubkeys.contains(&pk))
+                .map(|pk| !ineligible_pubkeys.contains(&pk))
                 .unwrap_or(false)
         });
     }
@@ -1382,7 +1386,9 @@ fn filter_voluntary_exits_for_parent_execution_requests<E: EthSpec>(
 mod tests {
     use super::*;
     use ssz_types::ProgressiveVariableList;
-    use types::{ConsolidationRequest, Epoch, MainnetEthSpec, VoluntaryExit, WithdrawalRequest};
+    use types::{
+        ChainSpec, ConsolidationRequest, Epoch, MainnetEthSpec, VoluntaryExit, WithdrawalRequest,
+    };
 
     type TestSpec = MainnetEthSpec;
 
@@ -1418,14 +1424,10 @@ mod tests {
         exits: &mut Vec<SignedVoluntaryExit>,
         requests: &ExecutionRequestsGloas<TestSpec>,
         validator_pubkeys: &[PublicKeyBytes],
-        spec: &ChainSpec,
     ) {
-        filter_voluntary_exits_for_parent_execution_requests(
-            exits,
-            requests,
-            |idx| validator_pubkeys.get(idx as usize).copied(),
-            spec,
-        );
+        filter_voluntary_exits_for_parent_execution_requests(exits, requests, |idx| {
+            validator_pubkeys.get(idx as usize).copied()
+        });
     }
 
     #[test]
@@ -1442,17 +1444,17 @@ mod tests {
             vec![],
         );
 
-        run_filter(&mut exits, &reqs, &validators, &spec);
+        run_filter(&mut exits, &reqs, &validators);
 
         assert_eq!(exits.len(), 1);
         assert_eq!(exits[0].message.validator_index, 1);
     }
 
     #[test]
-    fn partial_withdrawal_request_does_not_filter_voluntary_exit() {
+    fn partial_withdrawal_request_filters_matching_voluntary_exit() {
         let spec = ChainSpec::mainnet();
-        let validators = vec![pubkey(1)];
-        let mut exits = vec![exit(0)];
+        let validators = vec![pubkey(1), pubkey(2)];
+        let mut exits = vec![exit(0), exit(1)];
         let reqs = requests(
             vec![WithdrawalRequest {
                 source_address: Address::repeat_byte(0xaa),
@@ -1462,14 +1464,14 @@ mod tests {
             vec![],
         );
 
-        run_filter(&mut exits, &reqs, &validators, &spec);
+        run_filter(&mut exits, &reqs, &validators);
 
         assert_eq!(exits.len(), 1);
+        assert_eq!(exits[0].message.validator_index, 1);
     }
 
     #[test]
     fn cross_pubkey_consolidation_filters_voluntary_exit_for_source_only() {
-        let spec = ChainSpec::mainnet();
         let validators = vec![pubkey(1), pubkey(2), pubkey(3)];
         let mut exits = vec![exit(0), exit(1), exit(2)];
         let reqs = requests(
@@ -1481,7 +1483,7 @@ mod tests {
             }],
         );
 
-        run_filter(&mut exits, &reqs, &validators, &spec);
+        run_filter(&mut exits, &reqs, &validators);
 
         // The source (validator 1) is exited; the target (validator 2) is not.
         let remaining: Vec<u64> = exits.iter().map(|e| e.message.validator_index).collect();
@@ -1490,7 +1492,6 @@ mod tests {
 
     #[test]
     fn self_consolidation_does_not_filter_voluntary_exit() {
-        let spec = ChainSpec::mainnet();
         let validators = vec![pubkey(1)];
         let mut exits = vec![exit(0)];
         let reqs = requests(
@@ -1502,19 +1503,18 @@ mod tests {
             }],
         );
 
-        run_filter(&mut exits, &reqs, &validators, &spec);
+        run_filter(&mut exits, &reqs, &validators);
 
         assert_eq!(exits.len(), 1);
     }
 
     #[test]
     fn empty_parent_requests_preserve_voluntary_exits() {
-        let spec = ChainSpec::mainnet();
         let validators = vec![pubkey(1), pubkey(2)];
         let mut exits = vec![exit(0), exit(1)];
         let reqs = requests(vec![], vec![]);
 
-        run_filter(&mut exits, &reqs, &validators, &spec);
+        run_filter(&mut exits, &reqs, &validators);
 
         assert_eq!(exits.len(), 2);
     }

--- a/beacon_node/beacon_chain/tests/block_production.rs
+++ b/beacon_node/beacon_chain/tests/block_production.rs
@@ -1,0 +1,129 @@
+use beacon_chain::{
+    observed_operations::ObservationOutcome,
+    test_utils::{BeaconChainHarness, test_spec},
+};
+use std::sync::Arc;
+use types::{
+    Address, Epoch, ExecutionRequests, ExecutionRequestsGloas, Hash256, MinimalEthSpec, Slot,
+    WithdrawalRequest,
+};
+
+type E = MinimalEthSpec;
+
+/// Parent partial withdrawals must be accounted for when packing voluntary exits.
+/// https://github.com/sigp/lighthouse/issues/9981
+#[tokio::test]
+async fn gloas_block_production_filters_exits_with_parent_partial_withdrawals() {
+    let mut spec = test_spec::<E>();
+    if !spec.fork_name_at_slot::<E>(Slot::new(0)).gloas_enabled() {
+        return;
+    }
+
+    // Allow exits and withdrawal requests without waiting for the activation period.
+    spec.shard_committee_period = 0;
+    let spec = Arc::new(spec);
+    let initial_balance = spec.min_activation_balance * 2;
+    let withdrawal_amount = spec.effective_balance_increment;
+    let withdrawal_address = Address::repeat_byte(0xaa);
+
+    let harness = BeaconChainHarness::builder(E::default())
+        .spec(spec.clone())
+        .deterministic_keypairs(64)
+        .with_genesis_state_builder(|builder| {
+            builder
+                .set_initial_balance_fn(Box::new(move |_| initial_balance))
+                .set_withdrawal_credentials_fn(Box::new(move |_, _, spec| {
+                    let mut credentials = [0; 32];
+                    credentials[0] = spec.compounding_withdrawal_prefix_byte;
+                    credentials[12..].copy_from_slice(withdrawal_address.as_slice());
+                    Hash256::from(credentials)
+                }))
+        })
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build();
+
+    harness.extend_to_slot(Slot::new(1)).await;
+
+    let mut requests = ExecutionRequestsGloas::<E>::default();
+    requests.withdrawals.push(WithdrawalRequest {
+        source_address: withdrawal_address,
+        validator_pubkey: harness.get_current_state().get_validator(0).unwrap().pubkey,
+        amount: withdrawal_amount,
+    });
+    harness
+        .execution_block_generator()
+        .set_next_execution_requests(ExecutionRequests::Gloas(requests.clone()));
+
+    // Import the parent block and envelope. Its withdrawal request is deferred until the child.
+    harness.extend_to_slot(Slot::new(2)).await;
+    let parent_state = harness.get_current_state();
+    assert!(
+        parent_state
+            .pending_partial_withdrawals()
+            .unwrap()
+            .is_empty()
+    );
+
+    for validator_index in [0, 1] {
+        let exit = harness.make_voluntary_exit(validator_index, Epoch::new(0));
+        let ObservationOutcome::New(verified_exit) = harness
+            .chain
+            .verify_voluntary_exit_for_gossip(exit)
+            .unwrap()
+        else {
+            panic!("voluntary exit should be newly verified");
+        };
+        harness.chain.import_voluntary_exit(verified_exit);
+    }
+    assert_eq!(
+        harness
+            .chain
+            .op_pool
+            .get_slashings_and_exits(&parent_state, &spec)
+            .2
+            .len(),
+        2,
+        "both exits must be eligible before the parent requests are applied"
+    );
+
+    harness.advance_slot();
+    let child_slot = Slot::new(3);
+    let (block_contents, _, _) = harness
+        .make_block_with_envelope(parent_state, child_slot)
+        .await;
+    let body = block_contents.0.message().body();
+    assert_eq!(body.parent_execution_requests().unwrap(), &requests);
+    let included_exits: Vec<_> = body
+        .voluntary_exits()
+        .iter()
+        .map(|exit| exit.message.validator_index)
+        .collect();
+    assert_eq!(included_exits, vec![1]);
+
+    // Import verifies the produced block, including the remaining exit's signature and state root.
+    let child_root = block_contents.0.canonical_root();
+    harness
+        .process_block(child_slot, child_root, block_contents)
+        .await
+        .expect("block with a parent partial withdrawal should import");
+    assert_eq!(
+        harness.chain.head_beacon_block().canonical_root(),
+        child_root
+    );
+
+    let state = harness.get_current_state();
+    let pending_withdrawals = state.pending_partial_withdrawals().unwrap();
+    assert_eq!(pending_withdrawals.len(), 1);
+    let pending_withdrawal = pending_withdrawals.get(0).unwrap();
+    assert_eq!(pending_withdrawal.validator_index, 0);
+    assert_eq!(pending_withdrawal.amount, withdrawal_amount);
+    assert_eq!(
+        state.get_validator(0).unwrap().exit_epoch,
+        spec.far_future_epoch
+    );
+    assert_ne!(
+        state.get_validator(1).unwrap().exit_epoch,
+        spec.far_future_epoch
+    );
+}

--- a/beacon_node/beacon_chain/tests/main.rs
+++ b/beacon_node/beacon_chain/tests/main.rs
@@ -1,6 +1,7 @@
 mod attestation_production;
 mod attestation_verification;
 mod blob_verification;
+mod block_production;
 mod block_verification;
 mod column_verification;
 mod envelope_verification;


### PR DESCRIPTION
## Issue Addressed

Closes:

- https://github.com/sigp/lighthouse/issues/9981

## Proposed Changes

Filter out exits for validators which _could_ be impacted by any withdrawal triggered in the parent execution payload. See linked issue for details of the bug.

This fix prevents production of invalid blocks (!!) in some scenarios post-Gloas.

## Additional Info

Fix & comments written manually, tests fixed by Codex. Regression test by Codex with manual review.
