### PR TITLE
Update Docker builder to Debian Bookworm

### DIFF
--- a/.github/workflows/docker-reproducible.yml
+++ b/.github/workflows/docker-reproducible.yml
@@ -46,13 +46,13 @@ jobs:
           - arch: amd64
             rust_target: x86_64-unknown-linux-gnu
             rust_image: >-
-              rust:1.88-bullseye@sha256:8e3c421122bf4cd3b2a866af41a4dd52d87ad9e315fd2cb5100e87a7187a9816
+              rust:1.88-bookworm@sha256:4727898c104ecd2e22d780925832502faee9fe4e70581b8572af081370b315a0
             platform: linux/amd64
             runner: ubuntu-22.04
           - arch: arm64
             rust_target: aarch64-unknown-linux-gnu
             rust_image: >-
-              rust:1.88-bullseye@sha256:8b22455a7ce2adb1355067638284ee99d21cc516fab63a96c4514beaf370aa94
+              rust:1.88-bookworm@sha256:8aa70d1416cf5b1cff4b95ec6c57f1c5e4e649a3b53d616a26695cda6fbb46bc
             platform: linux/arm64
             runner: ubuntu-22.04-arm
     runs-on: ${{ matrix.runner }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88.0-bullseye AS builder
+FROM rust:1.88.0-bookworm AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
 ARG FEATURES
 ARG PROFILE=release
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/lighthouse/target \
     make
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -1,9 +1,9 @@
-# Define the Rust image as an argument with a default to x86_64 Rust 1.88 image based on Debian Bullseye
-ARG RUST_IMAGE="rust:1.88-bullseye@sha256:8e3c421122bf4cd3b2a866af41a4dd52d87ad9e315fd2cb5100e87a7187a9816"
+# Define the Rust image as an argument with a default to x86_64 Rust 1.88 image based on Debian Bookworm
+ARG RUST_IMAGE="rust:1.88-bookworm@sha256:4727898c104ecd2e22d780925832502faee9fe4e70581b8572af081370b315a0"
 FROM ${RUST_IMAGE} AS builder
 
 # Install specific version of the build dependencies
-RUN apt-get update && apt-get install -y libclang-dev=1:11.0-51+nmu5 cmake=3.18.4-2+deb11u1 libjemalloc-dev=5.2.1-3
+RUN apt-get update && apt-get install -y libclang-dev=1:14.0-55.7~deb12u1 cmake=3.25.1-1 libjemalloc-dev=5.3.0-1
 
 ARG RUST_TARGET="x86_64-unknown-linux-gnu"
 

--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,8 @@ JEMALLOC_OVERRIDE = /usr/lib/$(JEMALLOC_LIB_ARCH)-linux-gnu/libjemalloc.a
 RUST_TARGET ?= x86_64-unknown-linux-gnu
 
 # Default images for different architectures
-RUST_IMAGE_AMD64 ?= rust:1.88-bullseye@sha256:8e3c421122bf4cd3b2a866af41a4dd52d87ad9e315fd2cb5100e87a7187a9816
-RUST_IMAGE_ARM64 ?= rust:1.88-bullseye@sha256:8b22455a7ce2adb1355067638284ee99d21cc516fab63a96c4514beaf370aa94
+RUST_IMAGE_AMD64 ?= rust:1.88-bookworm@sha256:4727898c104ecd2e22d780925832502faee9fe4e70581b8572af081370b315a0
+RUST_IMAGE_ARM64 ?= rust:1.88-bookworm@sha256:8aa70d1416cf5b1cff4b95ec6c57f1c5e4e649a3b53d616a26695cda6fbb46bc
 
 .PHONY: build-reproducible
 build-reproducible: ## Build the lighthouse binary into `target` directory with reproducible builds

--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -1,13 +1,13 @@
 # `lcli` requires the full project to be in scope, so this should be built either:
 #  - from the `lighthouse` dir with the command: `docker build -f ./lcli/Dockerflie .`
 #  - from the current directory with the command: `docker build -f ./Dockerfile ../`
-FROM rust:1.88.0-bullseye AS builder
+FROM rust:1.88.0-bookworm AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
 COPY . lighthouse
 ARG FEATURES
 ENV FEATURES=$FEATURES
 RUN cd lighthouse && make install-lcli
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/lcli /usr/local/bin/lcli


### PR DESCRIPTION
## Issue Addressed

Fix failing CI observed here:

- https://github.com/sigp/lighthouse/actions/runs/34082051165/job/101627302362?pr=9983

## Proposed Changes

Keep Rust at 1.88.0 while moving the builder off Bullseye to avoid the failing Debian security package downloads. Update the Ubuntu runtime to 24.04 so its glibc is newer than the builder's.
