### PR TITLE
Standardise FCR metrics

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -268,7 +268,7 @@ struct FcrOutcome {
     confirmed_root: Hash256,
     confirmed_slot: Slot,
     confirmed_block_hash: ExecutionBlockHash,
-    new_confirmed_root: bool,
+    old_confirmed_root: Hash256,
     new_update_slot: bool,
 }
 
@@ -971,7 +971,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     confirmed_root,
                     confirmed_slot,
                     confirmed_block_hash,
-                    new_confirmed_root,
+                    old_confirmed_root,
                     new_update_slot,
                 }) => {
                     // FC update params are only updated after successful FCR runs. This is
@@ -982,21 +982,59 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     let delay = current_slot
                         .as_u64()
                         .saturating_sub(confirmed_slot.as_u64());
-                    metrics::set_gauge(&fcr_metrics::FCR_CONFIRMATION_DELAY_SLOTS, delay as i64);
+                    metrics::set_gauge(&fcr_metrics::FAST_CONFIRMATION_DELAY_SLOTS, delay as i64);
                     metrics::set_gauge(
-                        &fcr_metrics::FCR_CONFIRMED_ROOT_SLOT,
+                        &fcr_metrics::FAST_CONFIRMATION_SLOT,
                         confirmed_slot.as_u64() as i64,
                     );
                     // Sample the settled-delay histogram only on the first recompute that advanced
                     // FCR's per-slot update, so intra-slot block-import recomputes don't bias it.
                     if new_update_slot {
                         metrics::observe(
-                            &fcr_metrics::FCR_SETTLED_CONFIRMATION_DELAY_SLOTS,
+                            &fcr_metrics::FAST_CONFIRMATION_SETTLED_DELAY_SLOTS,
                             delay as f64,
                         );
                     }
-                    if new_confirmed_root {
-                        metrics::inc_counter(&fcr_metrics::FCR_CONFIRMED_ROOT_CHANGES);
+                    if confirmed_root != old_confirmed_root {
+                        metrics::inc_counter(&fcr_metrics::FAST_CONFIRMATION_ROOT_CHANGES);
+                    }
+
+                    // Runs every time, not only when the confirmed root moves: the head can reorg
+                    // off a block FCR still confirms. A pruned `old_confirmed_root` is an ancestor
+                    // of finality, which `is_descendant` cannot tell apart from a reorg.
+                    let head_root = new_view.head_block_root;
+                    if let Some(old_confirmed_slot) = fork_choice_read_lock
+                        .get_block(&old_confirmed_root)
+                        .map(|block| block.slot)
+                        && !fork_choice_read_lock.is_descendant(old_confirmed_root, head_root)
+                    {
+                        let fcr_reorg = !fork_choice_read_lock
+                            .is_descendant(old_confirmed_root, confirmed_root);
+                        let reorg_distance = fork_choice_read_lock
+                            .proto_array()
+                            .common_ancestor_slot(old_confirmed_root, head_root)
+                            .map(|ancestor_slot| old_confirmed_slot.saturating_sub(ancestor_slot));
+
+                        if let Some(reorg_distance) = reorg_distance {
+                            metrics::set_gauge(
+                                &fcr_metrics::FAST_CONFIRMATION_REORG_DISTANCE,
+                                reorg_distance.as_u64() as i64,
+                            );
+                        }
+                        metrics::inc_counter(&fcr_metrics::FAST_CONFIRMATION_REORGS);
+                        if fcr_reorg {
+                            metrics::inc_counter(&fcr_metrics::FAST_CONFIRMATION_ROOT_REORGS);
+                        }
+                        warn!(
+                            previous_confirmed = ?old_confirmed_root,
+                            previous_confirmed_slot = %old_confirmed_slot,
+                            head = ?head_root,
+                            confirmed = ?confirmed_root,
+                            fcr_reorg,
+                            slot = %current_slot,
+                            ?reorg_distance,
+                            "FCR confirmed block was reorged out"
+                        );
                     }
 
                     // Emit a `fast_confirmation` event on every FCR run, regardless of
@@ -1015,7 +1053,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 }
                 Err(e) => {
                     let label: &'static str = (&e).into();
-                    metrics::inc_counter_vec(&fcr_metrics::FCR_ERRORS, &[label]);
+                    metrics::inc_counter_vec(&fcr_metrics::FAST_CONFIRMATION_ERRORS, &[label]);
                     error!("Error running FCR: {e:?}");
                 }
             }
@@ -1328,7 +1366,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         head_state: &BeaconState<T::EthSpec>,
         slot_assignments: &SlotAssignments,
     ) -> Result<FcrOutcome, FastConfirmationError> {
-        let _fcr_timer = metrics::start_timer(&fcr_metrics::FCR_TIMES);
+        let _fcr_timer = metrics::start_timer(&fcr_metrics::FAST_CONFIRMATION_TIMES);
         let old_confirmed_root = fcr.confirmed_root;
 
         let finalized_cp = fork_choice.finalized_checkpoint();
@@ -1377,7 +1415,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             confirmed_root: fcr.confirmed_root,
             confirmed_slot: confirmed_node.slot,
             confirmed_block_hash,
-            new_confirmed_root: fcr.confirmed_root != old_confirmed_root,
+            old_confirmed_root,
             new_update_slot: fcr.last_update_slot() != old_update_slot,
         })
     }

--- a/consensus/fast_confirmation/src/lib.rs
+++ b/consensus/fast_confirmation/src/lib.rs
@@ -85,11 +85,11 @@ impl From<ArithError> for Error {
 /// Rich outcome of `is_one_confirmed` to track metrics in case of `BelowThreshold`..
 enum Confirmation {
     Confirmed,
-    NotConfirmed(Unconfirmed),
+    NotConfirmed(NotConfirmedReason),
 }
 
 /// Why a block failed `is_one_confirmed`.
-enum Unconfirmed {
+enum NotConfirmedReason {
     /// The block's execution status is optimistic or invalid.
     Optimistic,
     /// Attestation support did not exceed the safety threshold.
@@ -384,8 +384,8 @@ impl FastConfirmationRule {
 
         let confirmed_block_epoch_result = get_block_epoch::<E>(confirmed_root, proto_array);
 
-        // Revert to finalized block if either of the following is true:
-        let should_revert_to_finalized_reason = if confirmed_block_epoch_result
+        // Fall back to the finalized block if either of the following is true:
+        let should_fall_back_reason = if confirmed_block_epoch_result
             .as_ref()
             .map_or(true, |block_epoch| {
                 block_epoch.saturating_add(1u64) < current_epoch
@@ -417,16 +417,22 @@ impl FastConfirmationRule {
         } else {
             None
         };
-        if let Some(reason) = should_revert_to_finalized_reason {
-            debug!(
-                prev_confirmed = %confirmed_root,
-                finalized = %finalized_checkpoint.root,
-                slot = %current_slot,
-                reason = reason,
-                "FCR reverted to finalized"
-            );
+        if let Some(reason) = should_fall_back_reason {
+            // Report only a fallback that moves the confirmed root. FCR starts out at the
+            // finalized block, so `epoch_too_old` matches on every run until it first confirms
+            // something, and again whenever it falls back here.
+            if confirmed_root != finalized_checkpoint.root {
+                debug!(
+                    prev_confirmed = %confirmed_root,
+                    finalized = %finalized_checkpoint.root,
+                    slot = %current_slot,
+                    reason = reason,
+                    "FCR fell back to finalized"
+                );
+                metrics::inc_counter(&metrics::FAST_CONFIRMATION_FALLBACKS);
+                metrics::inc_counter_vec(&metrics::FAST_CONFIRMATION_FALLBACK_REASONS, &[reason]);
+            }
             confirmed_root = finalized_checkpoint.root;
-            metrics::inc_counter_vec(&metrics::FCR_REVERT_TO_FINALIZED, &[reason]);
         }
 
         // Restart the confirmation chain if each of the following conditions are true:
@@ -458,7 +464,7 @@ impl FastConfirmationRule {
                 "FCR restarted from observed justified"
             );
             confirmed_root = self.current_epoch_observed_justified.checkpoint().root;
-            metrics::inc_counter(&metrics::FCR_RESTART_FROM_JUSTIFIED);
+            metrics::inc_counter(&metrics::FAST_CONFIRMATION_RESTARTS);
         }
 
         // Attempt to further advance the latest confirmed block
@@ -644,7 +650,7 @@ impl FastConfirmationRule {
                 prev = %latest_confirmed_root,
                 "FCR advanced"
             );
-            metrics::inc_counter(&metrics::FCR_ADVANCE);
+            metrics::inc_counter(&metrics::FAST_CONFIRMATION_ADVANCES);
         }
         Ok(confirmed_root)
     }
@@ -655,7 +661,7 @@ impl FastConfirmationRule {
     /// precomputes scores once and uses `is_one_confirmed_with_score`.
     ///
     /// `Ok(None)` = the confirmed chain is safe (re-confirmable). `Ok(Some(reason))` = it
-    /// isn't, with `reason` naming which check failed (surfaced as the revert metric label).
+    /// isn't, with `reason` naming which check failed (surfaced as the fallback metric label).
     fn is_confirmed_chain_safe<E: EthSpec>(
         &self,
         confirmed_root: Hash256,
@@ -714,7 +720,7 @@ impl FastConfirmationRule {
         )?;
 
         for root in &chain_roots {
-            if let Confirmation::NotConfirmed(unconfirmed) = self.is_one_confirmed::<E>(
+            if let Confirmation::NotConfirmed(reason) = self.is_one_confirmed::<E>(
                 self.get_previous_balance_source(),
                 *root,
                 &attestation_scores,
@@ -723,22 +729,22 @@ impl FastConfirmationRule {
                 votes,
                 equivocating_indices,
             )? {
-                // `root` is not confirmed; surface why for the revert metric.
-                match unconfirmed {
-                    Unconfirmed::BelowThreshold {
+                // `root` is not confirmed; surface why for the fallback metric.
+                match reason {
+                    NotConfirmedReason::BelowThreshold {
                         support,
                         safety_threshold,
                     } => {
                         if safety_threshold > 0 {
                             metrics::observe(
-                                &metrics::FCR_UNCONFIRMED_SUPPORT_RATIO,
+                                &metrics::FAST_CONFIRMATION_FALLBACK_SUPPORT_RATIO,
                                 support as f64 / safety_threshold as f64,
                             );
                         }
-                        return Ok(Some("unconfirmed_below_threshold"));
+                        return Ok(Some("below_safety_threshold"));
                     }
-                    Unconfirmed::Optimistic => {
-                        return Ok(Some("unconfirmed_optimistic"));
+                    NotConfirmedReason::Optimistic => {
+                        return Ok(Some("optimistic_or_invalid"));
                     }
                 }
             }
@@ -1169,7 +1175,7 @@ impl FastConfirmationRule {
     ) -> Result<Confirmation, Error> {
         // Spec MUST: not confirmed if the block's execution status is not VALID.
         if is_optimistic_or_invalid(block_root, proto_array)? {
-            return Ok(Confirmation::NotConfirmed(Unconfirmed::Optimistic));
+            return Ok(Confirmation::NotConfirmed(NotConfirmedReason::Optimistic));
         }
         let support = get_attestation_score(block_root, attestation_scores)?;
         let safety_threshold = self.compute_safety_threshold::<E>(
@@ -1183,10 +1189,12 @@ impl FastConfirmationRule {
         if support > safety_threshold {
             Ok(Confirmation::Confirmed)
         } else {
-            Ok(Confirmation::NotConfirmed(Unconfirmed::BelowThreshold {
-                support,
-                safety_threshold,
-            }))
+            Ok(Confirmation::NotConfirmed(
+                NotConfirmedReason::BelowThreshold {
+                    support,
+                    safety_threshold,
+                },
+            ))
         }
     }
 }

--- a/consensus/fast_confirmation/src/metrics.rs
+++ b/consensus/fast_confirmation/src/metrics.rs
@@ -62,8 +62,7 @@ pub(crate) static FAST_CONFIRMATION_FALLBACK_REASONS: LazyLock<Result<IntCounter
     LazyLock::new(|| {
         try_create_int_counter_vec(
             "beacon_fast_confirmation_fallback_reasons_total",
-            "Breakdown of `beacon_fast_confirmation_fallbacks_total` by reason. Kept separate because \
-         the standardised metric is specified without labels",
+            "Breakdown of `beacon_fast_confirmation_fallbacks_total` by reason",
             &["reason"],
         )
     });

--- a/consensus/fast_confirmation/src/metrics.rs
+++ b/consensus/fast_confirmation/src/metrics.rs
@@ -3,42 +3,42 @@
 pub use metrics::*;
 use std::sync::LazyLock;
 
-pub static FCR_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+pub static FAST_CONFIRMATION_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
     try_create_histogram_with_buckets(
-        "beacon_fcr_seconds",
+        "beacon_fast_confirmation_seconds",
         "Runtime of the fast confirmation rule computation",
         exponential_buckets(1e-3, 2.0, 12),
     )
 });
-pub static FCR_CONFIRMED_ROOT_SLOT: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
+pub static FAST_CONFIRMATION_SLOT: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
     try_create_int_gauge(
-        "beacon_fcr_confirmed_root_slot",
-        "Slot of the current FCR confirmed root",
+        "beacon_fast_confirmation_slot",
+        "Slot of the most recent confirmed block",
     )
 });
-pub static FCR_CONFIRMED_ROOT_CHANGES: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+pub static FAST_CONFIRMATION_ROOT_CHANGES: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
     try_create_int_counter(
-        "beacon_fcr_confirmed_root_changes_total",
+        "beacon_fast_confirmation_root_changes_total",
         "Count of times the FCR confirmed root has changed",
     )
 });
-pub static FCR_ERRORS: LazyLock<Result<IntCounterVec>> = LazyLock::new(|| {
+pub static FAST_CONFIRMATION_ERRORS: LazyLock<Result<IntCounterVec>> = LazyLock::new(|| {
     try_create_int_counter_vec(
-        "beacon_fcr_errors_total",
+        "beacon_fast_confirmation_errors_total",
         "Count of FCR errors by error category",
         &["error"],
     )
 });
-pub static FCR_CONFIRMATION_DELAY_SLOTS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
+pub static FAST_CONFIRMATION_DELAY_SLOTS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
     try_create_int_gauge(
-        "beacon_fcr_confirmation_delay_slots",
+        "beacon_fast_confirmation_delay_slots",
         "Confirmation delay: current head slot minus confirmed root slot",
     )
 });
-pub static FCR_SETTLED_CONFIRMATION_DELAY_SLOTS: LazyLock<Result<Histogram>> = LazyLock::new(
+pub static FAST_CONFIRMATION_SETTLED_DELAY_SLOTS: LazyLock<Result<Histogram>> = LazyLock::new(
     || {
         try_create_histogram_with_buckets(
-            "beacon_fcr_settled_confirmation_delay_slots",
+            "beacon_fast_confirmation_settled_delay_slots",
             "Distribution of the FCR confirmation delay (current slot minus confirmed root slot, in \
          slots), sampled once per slot at the FCR per-slot update so block-import recomputes don't \
          bias the distribution",
@@ -46,31 +46,58 @@ pub static FCR_SETTLED_CONFIRMATION_DELAY_SLOTS: LazyLock<Result<Histogram>> = L
         )
     },
 );
-pub(crate) static FCR_REVERT_TO_FINALIZED: LazyLock<Result<IntCounterVec>> = LazyLock::new(|| {
-    try_create_int_counter_vec(
-        "beacon_fcr_revert_to_finalized_total",
-        "Count of FCR reverts of the confirmed root to the finalized block, by reason",
-        &["reason"],
+pub(crate) static FAST_CONFIRMATION_FALLBACKS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
+        "beacon_fast_confirmation_fallbacks_total",
+        "Total number of fallbacks to finality",
     )
 });
-pub(crate) static FCR_UNCONFIRMED_SUPPORT_RATIO: LazyLock<Result<Histogram>> =
+pub static FAST_CONFIRMATION_REORG_DISTANCE: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "beacon_fast_confirmation_reorg_distance",
+        "Slots between a block FCR had confirmed and the point the confirmation withdrew to",
+    )
+});
+pub(crate) static FAST_CONFIRMATION_FALLBACK_REASONS: LazyLock<Result<IntCounterVec>> =
+    LazyLock::new(|| {
+        try_create_int_counter_vec(
+            "beacon_fast_confirmation_fallback_reasons_total",
+            "Breakdown of `beacon_fast_confirmation_fallbacks_total` by reason. Kept separate because \
+         the standardised metric is specified without labels",
+            &["reason"],
+        )
+    });
+pub static FAST_CONFIRMATION_ROOT_REORGS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
+        "beacon_fast_confirmation_root_reorgs_total",
+        "Count of times the newly confirmed root was not a descendant of the block FCR had \
+         previously confirmed, i.e. FCR itself moved off a block it had confirmed",
+    )
+});
+pub static FAST_CONFIRMATION_REORGS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
+        "beacon_fast_confirmation_reorgs_total",
+        "Total number of confirmed block reorganizations",
+    )
+});
+pub(crate) static FAST_CONFIRMATION_FALLBACK_SUPPORT_RATIO: LazyLock<Result<Histogram>> =
     LazyLock::new(|| {
         try_create_histogram_with_buckets(
-            "beacon_fcr_unconfirmed_support_ratio",
-            "support / safety_threshold of the block that triggered an unconfirmed_block revert; \
-         values near 1.0 are marginal, lower values indicate real support loss",
+            "beacon_fast_confirmation_fallback_support_ratio",
+            "support / safety_threshold of the block that triggered a below_safety_threshold \
+         fallback; values near 1.0 are marginal, lower values indicate real support loss",
             Ok(vec![0.5, 0.7, 0.8, 0.9, 0.95, 0.98, 0.99, 1.0]),
         )
     });
-pub(crate) static FCR_RESTART_FROM_JUSTIFIED: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+pub(crate) static FAST_CONFIRMATION_RESTARTS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
     try_create_int_counter(
-        "beacon_fcr_restart_from_justified_total",
-        "Count of FCR restarts of the confirmed root from the observed justified checkpoint",
+        "beacon_fast_confirmation_restarts_total",
+        "Total number of restarts from a safe unrealized justified block",
     )
 });
-pub(crate) static FCR_ADVANCE: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+pub(crate) static FAST_CONFIRMATION_ADVANCES: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
     try_create_int_counter(
-        "beacon_fcr_advance_total",
+        "beacon_fast_confirmation_advances_total",
         "Count of FCR advances of the confirmed root to a descendant",
     )
 });

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -1832,6 +1832,23 @@ impl ProtoArray {
             .unwrap_or(false)
     }
 
+    /// Slot at which the chains of `block_root` and `other_root` last agree. `None` if either
+    /// root is unknown.
+    pub fn common_ancestor_slot(&self, block_root: Hash256, other_root: Hash256) -> Option<Slot> {
+        let mut chain = self.iter_nodes(&block_root).peekable();
+        let mut other = self.iter_nodes(&other_root).peekable();
+        loop {
+            let (node, other_node) = (chain.peek()?, other.peek()?);
+            if node.root() == other_node.root() {
+                return Some(node.slot());
+            } else if node.slot() >= other_node.slot() {
+                chain.next();
+            } else {
+                other.next();
+            }
+        }
+    }
+
     pub fn get_block(&self, root: Hash256) -> Option<&ProtoNode> {
         self.indices.get(&root).and_then(|&idx| self.nodes.get(idx))
     }

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -1112,6 +1112,12 @@ impl ProtoArrayForkChoice {
     }
 
     /// See `ProtoArray` documentation.
+    pub fn common_ancestor_slot(&self, block_root: Hash256, other_root: Hash256) -> Option<Slot> {
+        self.proto_array
+            .common_ancestor_slot(block_root, other_root)
+    }
+
+    /// See `ProtoArray` documentation.
     pub fn is_finalized_checkpoint_or_descendant<E: EthSpec>(
         &self,
         descendant_root: Hash256,


### PR DESCRIPTION
## Issue Addressed

Closes #9663

## Proposed Changes

Adopt [beacon-metrics](https://github.com/ethereum/beacon-metrics/blob/master/metrics.md#fast-confirmation) 

| Standard metric | Was | Fires |
|---|---|---|
| `beacon_fast_confirmation_slot` | `beacon_fcr_confirmed_root_slot` | after each FCR run |
| `beacon_fast_confirmation_reorgs_total` | new | head reorgs off a confirmed block |
| `beacon_fast_confirmation_fallbacks_total` | `beacon_fcr_revert_to_finalized_total` | confirmed root reverts to finalized |
| `beacon_fast_confirmation_restarts_total` | `beacon_fcr_restart_from_justified_total` | restart from the observed justified checkpoint |

Added a metric to track head reorgs out of the previous confirmed root:
- `_confirmed_root_reorgs_total` 

