### PR TITLE
Aggregate real public keys in the fake_crypto backend

### DIFF
--- a/crypto/bls/src/impls/fake_crypto.rs
+++ b/crypto/bls/src/impls/fake_crypto.rs
@@ -90,9 +90,40 @@ impl TAggregatePublicKey<PublicKey> for AggregatePublicKey {
         GenericPublicKey::from_point(PublicKey(self.0))
     }
 
-    fn aggregate(_pubkeys: &[GenericPublicKey<PublicKey>]) -> Result<Self, Error> {
-        Ok(Self(INFINITY_PUBLIC_KEY))
+    /// The state commits to this via `SyncCommittee::aggregate_pubkey`, and the spec vectors
+    /// aggregate for real even with signatures stubbed out, so faking it breaks state roots.
+    /// Keys from `SecretKey::public_key` are not curve points, hence the infinity fallback.
+    fn aggregate(pubkeys: &[GenericPublicKey<PublicKey>]) -> Result<Self, Error> {
+        Ok(Self(
+            aggregate_real_pubkeys(pubkeys).unwrap_or(INFINITY_PUBLIC_KEY),
+        ))
     }
+}
+
+#[cfg(feature = "supranational")]
+fn aggregate_real_pubkeys(
+    pubkeys: &[GenericPublicKey<PublicKey>],
+) -> Option<[u8; PUBLIC_KEY_BYTES_LEN]> {
+    use blst::min_pk as blst_core;
+
+    let points = pubkeys
+        .iter()
+        .map(|pubkey| blst_core::PublicKey::key_validate(&pubkey.serialize()))
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?;
+    let point_refs = points.iter().collect::<Vec<_>>();
+
+    // Public keys have been validated above.
+    blst_core::AggregatePublicKey::aggregate(&point_refs, false)
+        .ok()
+        .map(|aggregate| aggregate.to_public_key().compress())
+}
+
+#[cfg(not(feature = "supranational"))]
+fn aggregate_real_pubkeys(
+    _pubkeys: &[GenericPublicKey<PublicKey>],
+) -> Option<[u8; PUBLIC_KEY_BYTES_LEN]> {
+    None
 }
 
 impl Eq for AggregatePublicKey {}

--- a/crypto/bls/src/impls/fake_crypto.rs
+++ b/crypto/bls/src/impls/fake_crypto.rs
@@ -106,15 +106,19 @@ fn aggregate_real_pubkeys(
 ) -> Option<[u8; PUBLIC_KEY_BYTES_LEN]> {
     use blst::min_pk as blst_core;
 
-    let points = pubkeys
+    let serialized = pubkeys
         .iter()
-        .map(|pubkey| blst_core::PublicKey::key_validate(&pubkey.serialize()))
-        .collect::<Result<Vec<_>, _>>()
-        .ok()?;
-    let point_refs = points.iter().collect::<Vec<_>>();
+        .map(|pubkey| pubkey.serialize())
+        .collect::<Vec<_>>();
+    let refs = serialized
+        .iter()
+        .map(|bytes| bytes.as_slice())
+        .collect::<Vec<_>>();
 
-    // Public keys have been validated above.
-    blst_core::AggregatePublicKey::aggregate(&point_refs, false)
+    // Aggregate without the subgroup check, which costs ~4x the aggregation itself and proves
+    // nothing for a backend that verifies no signatures. Keys from `SecretKey::public_key` still
+    // fail to decode, which is what selects the infinity fallback.
+    blst_core::AggregatePublicKey::aggregate_serialized(&refs, false)
         .ok()
         .map(|aggregate| aggregate.to_public_key().compress())
 }

--- a/testing/ef_tests/src/cases/epoch_processing.rs
+++ b/testing/ef_tests/src/cases/epoch_processing.rs
@@ -452,31 +452,19 @@ impl<E: EthSpec, T: EpochTransition<E>> Case for EpochProcessing<E, T> {
         compare_beacon_state_results_without_caches(&mut result, &mut expected)?;
 
         if let Some(pre_epoch_state) = &self.pre_epoch {
-            // fake_crypto aggregates pubkeys to INFINITY_PUBLIC_KEY, so a transition that rotates
-            // the sync committee can't reproduce `post_epoch`. Covered by the blst run.
-            let rotates_sync_committee = pre_epoch_state.fork_name_unchecked().altair_enabled()
-                && pre_epoch_state.next_epoch().unwrap().as_u64()
-                    % spec.epochs_per_sync_committee_period.as_u64()
-                    == 0;
+            let mut pre_epoch_state = pre_epoch_state.clone();
+            // No `post_epoch` means the spec expects the transition to abort (the `invalid_*` cases).
+            let mut expected_post_epoch_state = self.post_epoch.clone();
 
-            let skip_full_epoch_transition =
-                cfg!(feature = "fake_crypto") && rotates_sync_committee;
+            // Proposer index computation (e.g. proposer lookahead) requires the slashings cache post-Gloas
+            pre_epoch_state.build_slashings_cache().unwrap();
 
-            if !skip_full_epoch_transition {
-                let mut pre_epoch_state = pre_epoch_state.clone();
-                // No `post_epoch` means the spec expects the transition to abort (the `invalid_*` cases).
-                let mut expected_post_epoch_state = self.post_epoch.clone();
-
-                // Proposer index computation (e.g. proposer lookahead) requires the slashings cache post-Gloas
-                pre_epoch_state.build_slashings_cache().unwrap();
-
-                let mut result = process_epoch(&mut pre_epoch_state, spec).map(|_| pre_epoch_state);
-                compare_beacon_state_results_without_caches(
-                    &mut result,
-                    &mut expected_post_epoch_state,
-                )
-                .map_err(|e| Error::NotEqual(format!("full epoch transition: {e:?}")))?;
-            }
+            let mut result = process_epoch(&mut pre_epoch_state, spec).map(|_| pre_epoch_state);
+            compare_beacon_state_results_without_caches(
+                &mut result,
+                &mut expected_post_epoch_state,
+            )
+            .map_err(|e| Error::NotEqual(format!("full epoch transition: {e:?}")))?;
         }
 
         Ok(())

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -406,13 +406,6 @@ impl<E: EthSpec> Case for ForkChoiceTest<E> {
     }
 
     fn result(&self, _case_index: usize, fork_name: ForkName) -> Result<(), Error> {
-        // These cases run past a sync committee period boundary. The vectors contain a real
-        // `next_sync_committee.aggregate_pubkey`, but `fake_crypto` aggregation returns the
-        // infinity pubkey, so the state roots cannot match.
-        const IGNORED_FAST_CONFIRMATION_CASES: &[&str] = &[
-            "is_one_confirmed_passes_with_new_validator_activated_in_head_state",
-            "is_one_confirmed_fails_recently_activated_validator_voting_in_empty_slot",
-        ];
         // Lighthouse permits epoch-boundary proposer re-orgs on all forks. The proposer lookahead
         // introduced in Fulu makes this consistent with the specification from Fulu onward.
         // See: https://github.com/ethereum/consensus-specs/pull/5547
@@ -424,9 +417,8 @@ impl<E: EthSpec> Case for ForkChoiceTest<E> {
             "on_block_parent_full_accepts_verified_payload",
         ];
 
-        if IGNORED_FAST_CONFIRMATION_CASES.contains(&self.description.as_str())
-            || (!fork_name.fulu_enabled()
-                && IGNORED_PRE_FULU_CASES.contains(&self.description.as_str()))
+        if (!fork_name.fulu_enabled()
+            && IGNORED_PRE_FULU_CASES.contains(&self.description.as_str()))
             || (fork_name == ForkName::Gloas
                 && IGNORED_STALE_GLOAS_CASES.contains(&self.description.as_str()))
         {

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -406,16 +406,12 @@ impl<E: EthSpec> Case for ForkChoiceTest<E> {
     }
 
     fn result(&self, _case_index: usize, fork_name: ForkName) -> Result<(), Error> {
-        // TODO(alpha.12): remove once fast confirmation matches the v1.7.0-alpha.12 spec. These
-        // cases are new in alpha.12 and test behaviour that is not implemented yet.
+        // These cases run past a sync committee period boundary. The vectors contain a real
+        // `next_sync_committee.aggregate_pubkey`, but `fake_crypto` aggregation returns the
+        // infinity pubkey, so the state roots cannot match.
         const IGNORED_FAST_CONFIRMATION_CASES: &[&str] = &[
-            "is_one_confirmed_fails_recently_activated_validator_voting_in_empty_slot",
-            "is_one_confirmed_passes_with_empty_slot_and_attester_in_two_consecutive_slots_2",
-            "fcr_no_restart_if_head_gu_is_stale",
-            // This case runs past a sync committee period boundary. The vectors contain a real
-            // `next_sync_committee.aggregate_pubkey`, but `fake_crypto` aggregation returns the
-            // infinity pubkey, so the state roots cannot match.
             "is_one_confirmed_passes_with_new_validator_activated_in_head_state",
+            "is_one_confirmed_fails_recently_activated_validator_voting_in_empty_slot",
         ];
         // Lighthouse permits epoch-boundary proposer re-orgs on all forks. The proposer lookahead
         // introduced in Fulu makes this consistent with the specification from Fulu onward.

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -529,11 +529,6 @@ impl<E: EthSpec + TypeName> Handler for SanitySlotsHandler<E> {
     fn handler_name(&self) -> String {
         "slots".into()
     }
-
-    fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
-        // Some sanity tests compute sync committees, which requires real crypto.
-        fork_name == ForkName::Base || cfg!(not(feature = "fake_crypto"))
-    }
 }
 
 #[derive(Educe)]


### PR DESCRIPTION
## Proposed Changes

`fake_crypto` aggregated every pubkey set to `INFINITY_PUBLIC_KEY`. `SyncCommittee::aggregate_pubkey` is committed to in the state and the spec vectors contain a real aggregate, so any transition that rotates the sync committee produced a state root that could not match the vectors. That was worked around in three separate places.

`AggregatePublicKey::aggregate` now aggregates for real when every input key is a valid curve point, and falls back to the infinity pubkey otherwise. Keys produced by `fake_crypto`'s `SecretKey::public_key` are `0x01` followed by the secret key bytes, which is not a valid compressed encoding, so harness-generated states keep the old behaviour and stay cheap.

With that fixed, the three workarounds go away:

- the `rotates_sync_committee` skip of the full epoch transition in `epoch_processing.rs`
- `SanitySlotsHandler::is_enabled_for_fork`, which disabled every non-Base sanity slots test under `fake_crypto`
- the last entry of `IGNORED_FAST_CONFIRMATION_CASES`, `is_one_confirmed_passes_with_new_validator_activated_in_head_state`, which empties the list so the const and its branch go with it

## Additional Info

Validation matches the `blst` backend. `key_validate` is what [`blst.rs` uses in `TPublicKey::deserialize`](https://github.com/sigp/lighthouse/blob/115bd16fb565c3df2b169a740fa5754adde00762/crypto/bls/src/impls/blst.rs#L138), and infinity is [rejected one level up](https://github.com/sigp/lighthouse/blob/115bd16fb565c3df2b169a740fa5754adde00762/crypto/bls/src/generic_public_key.rs#L88) in `generic_public_key.rs`, so both ef-test runs check the same things.

