### PR TITLE
Recover evicted payload bids instead of failing with MissingBid

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -27,7 +27,8 @@ use crate::data_column_verification::{
     GossipDataColumnError, GossipPartialDataColumnError, GossipVerifiedDataColumn,
     GossipVerifiedPartialDataColumnHeader, KzgVerifiedCustodyDataColumn,
     KzgVerifiedCustodyPartialDataColumn, KzgVerifiedPartialDataColumn,
-    PartialColumnVerificationResult, validate_partial_data_column_sidecar_for_gossip,
+    PartialColumnVerificationResult, load_gloas_payload_bid,
+    validate_partial_data_column_sidecar_for_gossip,
 };
 use crate::early_attester_cache::EarlyAttesterCache;
 use crate::envelope_times_cache::EnvelopeTimesCache;
@@ -3498,9 +3499,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
             KzgVerifiedCustodyPartialDataColumn::Gloas(verified_partial) => {
                 // Gloas: merge directly into the pending payload cache.
+                let bid = self.load_payload_bid_for_cache(block_root).await?;
                 let (availability, merge_result) = self
                     .pending_payload_cache
-                    .merge_partial_data_columns(block_root, &[verified_partial])
+                    .merge_partial_data_columns(block_root, &[verified_partial], &bid)
                     .map_err(BlockError::from)?;
                 (merge_result, Some(availability))
             }
@@ -3740,10 +3742,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         if is_gloas {
             let pending_payload_cache = self.pending_payload_cache.clone();
+            let bid = self.load_payload_bid_for_cache(block_root).await?;
             let result = self
                 .task_executor
                 .spawn_blocking_with_rayon_async(RayonPoolType::HighPriority, move || {
-                    pending_payload_cache.reconstruct_data_columns(&block_root)
+                    pending_payload_cache.reconstruct_data_columns(&block_root, &bid)
                 })
                 .await
                 .map_err(|_| BlockError::from(BeaconChainError::RuntimeShutdown))?
@@ -4050,6 +4053,25 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .await
     }
 
+    /// Resolve the payload bid for `block_root` on an async path.
+    ///
+    /// The store read is blocking, so it runs on a blocking thread, and only on a cache miss.
+    async fn load_payload_bid_for_cache(
+        self: &Arc<Self>,
+        block_root: Hash256,
+    ) -> Result<Arc<SignedExecutionPayloadBid<T::EthSpec>>, BlockError> {
+        if let Some(bid) = self.pending_payload_cache.get_bid(&block_root) {
+            return Ok(bid);
+        }
+        let chain = self.clone();
+        self.spawn_blocking_handle(
+            move || load_gloas_payload_bid(block_root, &chain),
+            "pending_payload_cache_bid_load",
+        )
+        .await??
+        .ok_or_else(|| BlockError::InternalError(format!("no block for {block_root}")))
+    }
+
     /// Checks if the provided data column can make any cached blocks available, and imports immediately
     /// if so, otherwise caches the data column in the data availability checker.
     /// Check gossip data columns for availability and import. Only accepts full columns.
@@ -4076,9 +4098,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .fork_name_at_slot::<T::EthSpec>(slot)
             .gloas_enabled()
         {
+            let bid = self.load_payload_bid_for_cache(block_root).await?;
             let availability = self
                 .pending_payload_cache
-                .put_gossip_verified_data_columns(block_root, data_columns)?;
+                .put_gossip_verified_data_columns(block_root, data_columns, &bid)?;
             Ok(self
                 .process_payload_envelope_availability(slot, availability, publish_fn)
                 .await?)
@@ -4164,9 +4187,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .fork_name_at_slot::<T::EthSpec>(slot)
             .gloas_enabled()
         {
+            let bid = self.load_payload_bid_for_cache(block_root).await?;
             let availability = self
                 .pending_payload_cache
-                .put_kzg_verified_custody_data_columns(block_root, &engine_get_blobs_output)
+                .put_kzg_verified_custody_data_columns(block_root, &engine_get_blobs_output, &bid)
                 .map_err(BlockError::from)?;
             self.process_payload_envelope_availability(slot, availability, || Ok(()))
                 .await
@@ -4202,9 +4226,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .fork_name_at_slot::<T::EthSpec>(slot)
             .gloas_enabled()
         {
+            let bid = self.load_payload_bid_for_cache(block_root).await?;
             let availability = self
                 .pending_payload_cache
-                .put_rpc_custody_columns(block_root, custody_columns)
+                .put_rpc_custody_columns(block_root, custody_columns, &bid)
                 .map_err(BlockError::from)?;
             Ok(self
                 .process_payload_envelope_availability(slot, availability, || Ok(()))
@@ -4226,9 +4251,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         verified_proof: GossipVerifiedExecutionProof,
     ) -> Result<AvailabilityProcessingStatus, BlockError> {
         let GossipVerifiedExecutionProof { proof, block_slot } = verified_proof;
+        let bid = self
+            .load_payload_bid_for_cache(proof.beacon_block_root())
+            .await?;
         let availability = self
             .pending_payload_cache
-            .put_execution_proof(proof)
+            .put_execution_proof(proof, &bid)
             .map_err(BlockError::from)?;
         self.process_payload_envelope_availability(block_slot, availability, || Ok(()))
             .await

--- a/beacon_node/beacon_chain/src/data_availability_checker/error.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/error.rs
@@ -5,7 +5,6 @@ use types::{BeaconStateError, ColumnIndex, Hash256};
 #[derive(Debug, IntoStaticStr)]
 pub enum Error {
     InvalidBlobs(KzgError),
-    MissingBid(Hash256),
     InvalidColumn((Option<ColumnIndex>, KzgError)),
     ReconstructColumnsError(KzgError),
     KzgCommitmentMismatch {
@@ -41,7 +40,6 @@ impl Error {
         match self {
             Error::SszTypes(_)
             | Error::MissingBlobs
-            | Error::MissingBid(_)
             | Error::MissingCustodyColumns
             | Error::StoreError(_)
             | Error::DecodeError(_)

--- a/beacon_node/beacon_chain/src/fetch_blobs/mod.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs/mod.rs
@@ -319,15 +319,11 @@ async fn fetch_and_process_blobs_v2_or_v3<T: BeaconChainTypes>(
                     KzgVerifiedCustodyPartialDataColumn::from_asserted_custody(column).into_gloas()
                 })
                 .collect();
-            // Ensure the bid is present in the cache.
-            chain_adapter
-                .pending_payload_cache()
-                .insert_bid(block_root, bid.clone());
             // Merge partials into the pending payload cache and return any full columns for
-            // publishing.
+            // publishing. We already hold the bid, so the cache seeds its entry from it.
             let (availability, merge_result) = chain_adapter
                 .pending_payload_cache()
-                .merge_partial_data_columns(block_root, &custody_columns_to_import)
+                .merge_partial_data_columns(block_root, &custody_columns_to_import, bid)
                 .map_err(|e| {
                     FetchEngineBlobError::InternalError(format!(
                         "Failed to merge partials into pending payload cache: {e:?}"

--- a/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_verification/import.rs
@@ -7,7 +7,10 @@ use slot_clock::SlotClock;
 use state_processing::{VerifySignatures, envelope_processing::verify_execution_payload_envelope};
 use store::StoreOp;
 use tracing::{debug, error, info, info_span, instrument, warn};
-use types::{BlockImportSource, Hash256, SignedBeaconBlock, SignedExecutionPayloadEnvelope};
+use types::{
+    BlockImportSource, Hash256, SignedBeaconBlock, SignedExecutionPayloadBid,
+    SignedExecutionPayloadEnvelope,
+};
 
 use super::{
     AvailableEnvelope, AvailableExecutedEnvelope, EnvelopeError,
@@ -70,6 +73,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         metrics::inc_counter(&metrics::ENVELOPE_PROCESSING_REQUESTS);
 
+        // Take the bid from the block we already hold. The cache can evict its entry before
+        // execution finishes, and this path must not block on a store read.
+        let bid = Arc::new(
+            unverified_envelope
+                .block
+                .message()
+                .body()
+                .signed_execution_payload_bid()
+                .map_err(BeaconChainError::BeaconStateError)?
+                .clone(),
+        );
+
         // A small closure to group the verification and import errors.
         let chain = self.clone();
         let import_envelope = async move {
@@ -101,7 +116,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     .set_time_executed(block_root, block_slot, timestamp);
             }
 
-            self.check_envelope_availability_and_import(executed_envelope)
+            self.check_envelope_availability_and_import(executed_envelope, bid)
                 .await
         };
 
@@ -141,11 +156,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     async fn check_envelope_availability_and_import(
         self: &Arc<Self>,
         envelope: AvailabilityPendingExecutedEnvelope<T::EthSpec>,
+        bid: Arc<SignedExecutionPayloadBid<T::EthSpec>>,
     ) -> Result<AvailabilityProcessingStatus, BlockError> {
         let slot = envelope.envelope.slot();
         let availability = self
             .pending_payload_cache
-            .put_executed_payload_envelope(envelope)?;
+            .put_executed_payload_envelope(envelope, &bid)?;
         self.process_payload_envelope_availability(slot, availability, || Ok(()))
             .await
     }

--- a/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
+++ b/beacon_node/beacon_chain/src/pending_payload_cache/mod.rs
@@ -256,14 +256,12 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
     pub fn put_executed_payload_envelope(
         &self,
         executed_envelope: AvailabilityPendingExecutedEnvelope<T::EthSpec>,
+        bid: &Arc<SignedExecutionPayloadBid<T::EthSpec>>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
         let beacon_block_root = executed_envelope.envelope.beacon_block_root();
-        let bid = self
-            .get_bid(&beacon_block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(beacon_block_root))?;
 
         let (_, pending_components) =
-            self.update_pending_components(beacon_block_root, &bid, |pending_components| {
+            self.update_pending_components(beacon_block_root, bid, |pending_components| {
                 pending_components.insert_executed_payload_envelope(executed_envelope);
             })?;
 
@@ -295,14 +293,12 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
     pub fn put_execution_proof(
         &self,
         proof: Arc<SignedExecutionProof>,
+        bid: &Arc<SignedExecutionPayloadBid<T::EthSpec>>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
         let block_root = proof.beacon_block_root();
-        let bid = self
-            .get_bid(&block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
 
         let (inserted, pending_components) =
-            self.update_pending_components(block_root, &bid, |pending_components| {
+            self.update_pending_components(block_root, bid, |pending_components| {
                 pending_components.insert_execution_proof(proof)
             })?;
 
@@ -330,10 +326,8 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         &self,
         block_root: Hash256,
         custody_columns: DataColumnSidecarList<T::EthSpec>,
+        bid: &Arc<SignedExecutionPayloadBid<T::EthSpec>>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
-        let bid = self
-            .get_bid(&block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
         let kzg_verified_columns = KzgVerifiedDataColumn::from_batch_with_scoring_and_commitments(
             custody_columns,
             &bid.message.blob_kzg_commitments,
@@ -349,7 +343,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
             .map(KzgVerifiedCustodyDataColumn::from_asserted_custody)
             .collect::<Vec<_>>();
 
-        self.put_kzg_verified_custody_data_columns(block_root, &verified_custody_columns)
+        self.put_kzg_verified_custody_data_columns(block_root, &verified_custody_columns, bid)
     }
 
     /// Perform KZG verification on gossip verified custody columns and insert them into the cache.
@@ -359,10 +353,8 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         &self,
         block_root: Hash256,
         data_columns: Vec<GossipVerifiedDataColumn<T, O>>,
+        bid: &Arc<SignedExecutionPayloadBid<T::EthSpec>>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
-        let bid = self
-            .get_bid(&block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
         let epoch = bid.message.slot.epoch(T::EthSpec::slots_per_epoch());
         let sampling_columns = self.custody_context.sampling_columns_for_epoch(epoch);
         let custody_columns = data_columns
@@ -371,7 +363,7 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
             .map(|c| KzgVerifiedCustodyDataColumn::from_asserted_custody(c.into_inner()))
             .collect::<Vec<_>>();
 
-        self.put_kzg_verified_custody_data_columns(block_root, &custody_columns)
+        self.put_kzg_verified_custody_data_columns(block_root, &custody_columns, bid)
     }
 
     /// Merge KZG verified partial custody columns into the cache. Returns the columns that became
@@ -384,13 +376,10 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         kzg_verified_partial_data_columns: &[KzgVerifiedCustodyPartialDataColumnGloas<
             T::EthSpec,
         >],
+        bid: &Arc<SignedExecutionPayloadBid<T::EthSpec>>,
     ) -> Result<AvailabilityAndPartialMergeResult<T::EthSpec>, AvailabilityCheckError> {
-        let bid = self
-            .get_bid(&block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
-
         let (outcome, pending_components) =
-            self.update_pending_components(block_root, &bid, |pending_components| {
+            self.update_pending_components(block_root, bid, |pending_components| {
                 pending_components.merge_partial_data_columns(kzg_verified_partial_data_columns)
             })?;
 
@@ -438,13 +427,10 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
         &self,
         block_root: Hash256,
         kzg_verified_data_columns: &[KzgVerifiedCustodyDataColumn<T::EthSpec>],
+        bid: &Arc<SignedExecutionPayloadBid<T::EthSpec>>,
     ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
-        let bid = self
-            .get_bid(&block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(block_root))?;
-
         let (_, pending_components) =
-            self.update_pending_components(block_root, &bid, |pending_components| {
+            self.update_pending_components(block_root, bid, |pending_components| {
                 pending_components.merge_data_columns(kzg_verified_data_columns)
             })?;
 
@@ -464,11 +450,8 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
     pub fn reconstruct_data_columns(
         &self,
         block_root: &Hash256,
+        bid: &Arc<SignedExecutionPayloadBid<T::EthSpec>>,
     ) -> Result<DataColumnReconstructionResult<T::EthSpec>, AvailabilityCheckError> {
-        let bid = self
-            .get_bid(block_root)
-            .ok_or(AvailabilityCheckError::MissingBid(*block_root))?;
-
         let verified_data_columns = match self.check_and_set_reconstruction_started(block_root) {
             ReconstructColumnsDecision::Yes(verified_data_columns) => verified_data_columns,
             ReconstructColumnsDecision::No(reason) => {
@@ -526,16 +509,20 @@ impl<T: BeaconChainTypes> PendingPayloadCache<T> {
             "Reconstructed columns"
         );
 
-        self.put_kzg_verified_custody_data_columns(*block_root, &data_columns_to_import_and_publish)
-            .map(|availability| {
-                DataColumnReconstructionResult::Success((
-                    availability,
-                    data_columns_to_import_and_publish
-                        .into_iter()
-                        .map(|d| d.clone_arc())
-                        .collect::<Vec<_>>(),
-                ))
-            })
+        self.put_kzg_verified_custody_data_columns(
+            *block_root,
+            &data_columns_to_import_and_publish,
+            bid,
+        )
+        .map(|availability| {
+            DataColumnReconstructionResult::Success((
+                availability,
+                data_columns_to_import_and_publish
+                    .into_iter()
+                    .map(|d| d.clone_arc())
+                    .collect::<Vec<_>>(),
+            ))
+        })
     }
 
     // ── Metrics ──
@@ -775,6 +762,7 @@ mod data_availability_checker_tests {
         Setup {
             cache,
             block_root,
+            bid,
             custody,
         }
     }
@@ -782,24 +770,26 @@ mod data_availability_checker_tests {
     struct Setup {
         cache: Arc<PendingPayloadCache<T>>,
         block_root: Hash256,
+        bid: Arc<SignedExecutionPayloadBid<E>>,
         custody: DataColumnSidecarList<E>,
     }
 
     impl Setup {
         fn put_envelope(&self) -> Availability<E> {
             self.cache
-                .put_executed_payload_envelope(executed_envelope(self.block_root))
+                .put_executed_payload_envelope(executed_envelope(self.block_root), &self.bid)
                 .expect("put envelope")
         }
 
         fn put_columns(&self, columns: DataColumnSidecarList<E>) -> Availability<E> {
             self.cache
-                .put_rpc_custody_columns(self.block_root, columns)
+                .put_rpc_custody_columns(self.block_root, columns, &self.bid)
                 .expect("put columns")
         }
 
         fn reconstruct(&self) -> Result<DataColumnReconstructionResult<E>, AvailabilityCheckError> {
-            self.cache.reconstruct_data_columns(&self.block_root)
+            self.cache
+                .reconstruct_data_columns(&self.block_root, &self.bid)
         }
 
         fn cached_indexes(&self) -> Vec<ColumnIndex> {
@@ -810,7 +800,10 @@ mod data_availability_checker_tests {
 
         fn put_proof(&self, proof_type: ProofType) -> Availability<E> {
             self.cache
-                .put_execution_proof(Arc::new(execution_proof(self.block_root, proof_type)))
+                .put_execution_proof(
+                    Arc::new(execution_proof(self.block_root, proof_type)),
+                    &self.bid,
+                )
                 .expect("put execution proof")
         }
     }
@@ -1072,7 +1065,7 @@ mod data_availability_checker_tests {
         let first = gloas_partial(s.block_root, slot, 0, 2, &[0]);
         let (availability, result) = s
             .cache
-            .merge_partial_data_columns(s.block_root, &[first])
+            .merge_partial_data_columns(s.block_root, &[first], &s.bid)
             .expect("merge");
         assert_missing(availability);
         assert_eq!(result.added_cells, 1);
@@ -1083,7 +1076,7 @@ mod data_availability_checker_tests {
         let duplicate = gloas_partial(s.block_root, slot, 0, 2, &[0]);
         let (_availability, result) = s
             .cache
-            .merge_partial_data_columns(s.block_root, &[duplicate])
+            .merge_partial_data_columns(s.block_root, &[duplicate], &s.bid)
             .expect("merge");
         assert_eq!(result.added_cells, 0);
 
@@ -1091,7 +1084,7 @@ mod data_availability_checker_tests {
         let second = gloas_partial(s.block_root, slot, 0, 2, &[1]);
         let (_availability, result) = s
             .cache
-            .merge_partial_data_columns(s.block_root, &[second])
+            .merge_partial_data_columns(s.block_root, &[second], &s.bid)
             .expect("merge");
         assert_eq!(result.added_cells, 1);
         assert_eq!(result.full_columns.len(), 1, "column 0 becomes complete");

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -466,7 +466,7 @@ impl<E: EthSpec> RangeBlockComponentsRequest<E> {
                     .body()
                     .signed_execution_payload_bid()
                     // this really should never fail
-                    .map_err(|_| AvailabilityCheckError::MissingBid(block_root))?;
+                    .map_err(|_| AvailabilityCheckError::InvalidVariant)?;
                 let available_envelope = envelope
                     .map(|env| AvailableEnvelope::new(env, custody_columns, bid, custody_context))
                     .transpose()?;


### PR DESCRIPTION
## Issue Addressed

`MissingBid` error was seen 230,461 times in glamsterdam-devnet-9

`PendingPayloadCache` returned `MissingBid` when its 32-entry LRU had evicted the bid. That dropped the component.

The bid is a field of the block body, so it is still there while the block is known. And every caller here has the block. Dropping the component also threw away a full state load and an `engine_newPayload` call for an envelope. Refetching did not help: the RPC paths looked up the bid the same way and failed again.

## Proposed Changes

Pass the bid in, instead of looking it up.

- The nine cache methods now take `bid: &Arc<SignedExecutionPayloadBid<E>>`, like `get_partials_and_mark_as_local_fetched` already did. You cannot call them without a bid.
- Callers that hold the bid pass it. Envelope import takes it from the block it verifies against.
- Callers that do not use `load_payload_bid_for_cache`. It reads the cache first, and reads the store only on a miss, on a blocking thread.