### PR TITLE
Avoid walking already indexed validators in the monitor

### DIFF
--- a/.ai/DEVELOPMENT.md
+++ b/.ai/DEVELOPMENT.md
@@ -146,6 +146,11 @@ Avoid using the rayon global thread pool - it causes CPU oversubscription when b
 - Use spans per meaningful computation step, not every function
 - **Never** use `span.enter()` or `span.entered()` in async tasks
 
+### Milhouse Lists
+
+- To start partway through a Milhouse list, use `iter_from(index)`. `iter().skip(index)` walks the skipped prefix.
+- Preserve absolute indices when enumerating the suffix. Check end and beyond-end starts, and pending updates in both fixed and progressive lists.
+
 ### Documentation
 
 - All `TODO` comments must link to a GitHub issue

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -484,19 +484,18 @@ impl<E: EthSpec> ValidatorMonitor<E> {
         state: &BeaconState<E>,
         spec: &ChainSpec,
     ) {
-        // Add any new validator indices.
-        state
-            .validators()
-            .iter()
-            .enumerate()
-            .skip(self.indices.len())
-            .for_each(|(i, validator)| {
+        // Start after known indices without walking the entire registry. A shorter fork can have
+        // fewer validators than we have already indexed, in which case there is nothing to add.
+        let start_index = self.indices.len();
+        if let Ok(validators) = state.validators().iter_from(start_index) {
+            for (i, validator) in (start_index..).zip(validators) {
                 let i = i as u64;
                 if let Some(validator) = self.validators.get_mut(&validator.pubkey) {
                     validator.set_index(i)
                 }
                 self.indices.insert(i, validator.pubkey);
-            });
+            }
+        }
 
         // Add missed non-finalized blocks for the monitored validators
         self.add_validators_missed_blocks(state, spec);
@@ -2163,5 +2162,81 @@ fn min_opt<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
         (Some(x), None) => Some(x),
         (None, Some(y)) => Some(y),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use execution_layer::test_utils::generate_genesis_header;
+    use genesis::InteropGenesisBuilder;
+    use types::{ForkName, MinimalEthSpec, test_utils::generate_deterministic_keypairs};
+
+    #[test]
+    fn registry_indices_across_growth_and_shorter_forks() {
+        type E = MinimalEthSpec;
+        let keypairs = generate_deterministic_keypairs(33);
+
+        for fork in [ForkName::Base, ForkName::Gloas] {
+            let spec = fork.make_genesis_spec(E::default_spec());
+            let mut state = InteropGenesisBuilder::<E>::new()
+                .set_opt_execution_payload_header(generate_genesis_header::<E>(&spec))
+                .build_genesis_state(&keypairs, 0, Hash256::ZERO, &spec)
+                .unwrap();
+            let validators = state.validators().to_vec();
+            state.take_validators();
+            let mut monitor = ValidatorMonitor::new(
+                ValidatorMonitorConfig::default(),
+                Arc::new(Mutex::new(BeaconProposerCache::default())),
+            );
+            assert!(!monitor.auto_register);
+            assert_eq!(monitor.num_validators(), 0);
+            monitor.process_valid_state(Epoch::new(0), &state, &spec);
+            assert!(monitor.indices.is_empty());
+
+            for validator in &validators[..32] {
+                state.validators_mut().push(validator.clone()).unwrap();
+            }
+            state.validators_mut().apply_updates().unwrap();
+            monitor.process_valid_state(Epoch::new(0), &state, &spec);
+            assert_eq!(monitor.indices.len(), 32);
+            assert_eq!(monitor.num_validators(), 0);
+
+            monitor.add_validator_pubkey(validators[31].pubkey);
+            monitor.add_validator_pubkey(validators[32].pubkey);
+            assert_eq!(monitor.validators[&validators[31].pubkey].index, Some(31));
+            assert_eq!(monitor.validators[&validators[32].pubkey].index, None);
+            let mut shorter_state = state.clone();
+
+            // Leave the append and the new validator's pubkey update pending in Milhouse.
+            state.validators_mut().push(validators[31].clone()).unwrap();
+            state.validators_mut().get_mut(32).unwrap().pubkey = validators[32].pubkey;
+            assert!(state.validators().has_pending_updates());
+            monitor.process_valid_state(Epoch::new(0), &state, &spec);
+            assert_eq!(monitor.validators[&validators[32].pubkey].index, Some(32));
+            let expected_indices = validators
+                .iter()
+                .enumerate()
+                .map(|(i, validator)| (i as u64, validator.pubkey))
+                .collect::<HashMap<_, _>>();
+            assert_eq!(monitor.indices, expected_indices);
+
+            // A shorter registry must still update the monitored validators' balances.
+            *shorter_state.balances_mut().get_mut(31).unwrap() = 123;
+            monitor.process_valid_state(Epoch::new(0), &shorter_state, &spec);
+            assert_eq!(monitor.indices, expected_indices);
+            assert_eq!(
+                monitor.validators[&validators[31].pubkey].get_total_balance(Epoch::new(0)),
+                Some(123)
+            );
+
+            state.validators_mut().apply_updates().unwrap();
+            monitor.process_valid_state(Epoch::new(0), &state, &spec);
+            assert_eq!(monitor.indices, expected_indices);
+            assert_eq!(
+                monitor.validators[&validators[31].pubkey].get_total_balance(Epoch::new(0)),
+                state.balances().get(31).copied()
+            );
+        }
     }
 }


### PR DESCRIPTION
## Issue Addressed

The [validator monitor](https://github.com/sigp/lighthouse/blob/115bd16fb565c3df2b169a740fa5754adde00762/beacon_node/beacon_chain/src/validator_monitor.rs#L484-L502) walks the already indexed registry during recent block imports, including with default monitoring and zero monitored validators. Milhouse's `iter().skip(index)` traverses the skipped prefix even when there are no new validators.

## Proposed Changes

Start the iterator at the first unknown index with `iter_from`, keeping absolute validator indices. A regression test covers empty registries, growth, shorter forks, late registration and pending updates for both fixed and progressive lists.

## Additional Info

A local mainnet A/B on 7 Sep 2026 used two Lighthouse followers with separate mock ELs, zero monitored validators and a registry of about 2.36 million validators. Each follower had a 3-CPU quota on the same AMD EPYC-Milan VM. The builds used baseline `1256bd99`, with only this loop changed in the treatment. Each window followed one epoch of settling, with binaries swapped between nodes for the second window.

| Median `import_block` duration | Baseline | Treatment | Matched blocks |
| --- | ---: | ---: | ---: |
| 19:29-19:43 UTC | 199.87 ms | 38.47 ms | 66 |
| 19:53-20:07 UTC, after swap | 191.60 ms | 40.56 ms | 66 |

One first-window trace was unmatched and excluded; baseline logs confirm that block was received and became head. All slow outliers are included.

All 132 matched imports improved. Mean paired import savings were 159.70 ms and 152.68 ms; the monitor child span accounted for 158.24 ms and 150.67 ms respectively.

This measures local import completion with simulated execution validity. The monitor runs under the fork-choice write lock, normally after early attestability. These results do not establish earlier attestations, whole-client CPU savings or the same absolute saving in production.
