### PR TITLE
Delete unused `engine_getPayloadBodiesByRange` client code

### DIFF
--- a/beacon_node/beacon_chain/src/bellatrix_readiness.rs
+++ b/beacon_node/beacon_chain/src/bellatrix_readiness.rs
@@ -48,7 +48,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let exec_block_hash = latest_execution_payload_header.block_hash();
 
         // Use getBlockByNumber(0) to check that the block hash matches.
-        // At present, Geth does not respond to engine_getPayloadBodiesByRange before genesis.
         let execution_block = execution_layer
             .get_block_by_number(BlockByNumberQuery::Tag("0x0"))
             .await

--- a/beacon_node/beacon_chain/src/payload_envelope_streamer/mod.rs
+++ b/beacon_node/beacon_chain/src/payload_envelope_streamer/mod.rs
@@ -68,7 +68,7 @@ impl<T: BeaconChainTypes> PayloadEnvelopeStreamer<T> {
             Ok(Some(cached_envelope))
         } else {
             // TODO(gloas) we'll want to use the execution layer directly to call
-            //  the engine api method eth_getPayloadBodiesByRange()
+            //  the engine api method engine_getPayloadBodiesByHashV2()
             match self.adapter.get_payload_envelope(beacon_block_root) {
                 Ok(opt_envelope) => Ok(opt_envelope.map(Arc::new)),
                 Err(e) => Err(BeaconChainError::DBError(e)),

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -3,8 +3,7 @@ use crate::http::{
     ENGINE_FORKCHOICE_UPDATED_V1, ENGINE_FORKCHOICE_UPDATED_V2, ENGINE_FORKCHOICE_UPDATED_V3,
     ENGINE_FORKCHOICE_UPDATED_V4, ENGINE_GET_BLOBS_V2, ENGINE_GET_CLIENT_VERSION_V1,
     ENGINE_GET_INCLUSION_LIST_V1, ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1,
-    ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V2, ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1,
-    ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V2, ENGINE_GET_PAYLOAD_V1, ENGINE_GET_PAYLOAD_V2,
+    ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V2, ENGINE_GET_PAYLOAD_V1, ENGINE_GET_PAYLOAD_V2,
     ENGINE_GET_PAYLOAD_V3, ENGINE_GET_PAYLOAD_V4, ENGINE_GET_PAYLOAD_V5, ENGINE_GET_PAYLOAD_V6,
     ENGINE_NEW_PAYLOAD_V1, ENGINE_NEW_PAYLOAD_V2, ENGINE_NEW_PAYLOAD_V3, ENGINE_NEW_PAYLOAD_V4,
     ENGINE_NEW_PAYLOAD_V5,
@@ -450,8 +449,7 @@ pub struct ExecutionPayloadBodyV1<E: EthSpec> {
     pub withdrawals: Option<Withdrawals<E>>,
 }
 
-/// The execution payload body returned by `engine_getPayloadBodiesByHashV2` and
-/// `engine_getPayloadBodiesByRangeV2`.
+/// The execution payload body returned by `engine_getPayloadBodiesByHashV2`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExecutionPayloadBodyV2 {
     pub transactions: ProgressiveTransactions,
@@ -616,8 +614,6 @@ pub struct EngineCapabilities {
     pub forkchoice_updated_v4: bool,
     pub get_payload_bodies_by_hash_v1: bool,
     pub get_payload_bodies_by_hash_v2: bool,
-    pub get_payload_bodies_by_range_v1: bool,
-    pub get_payload_bodies_by_range_v2: bool,
     pub get_payload_v1: bool,
     pub get_payload_v2: bool,
     pub get_payload_v3: bool,
@@ -665,12 +661,6 @@ impl EngineCapabilities {
         }
         if self.get_payload_bodies_by_hash_v2 {
             response.push(ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V2);
-        }
-        if self.get_payload_bodies_by_range_v1 {
-            response.push(ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1);
-        }
-        if self.get_payload_bodies_by_range_v2 {
-            response.push(ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V2);
         }
         if self.get_payload_v1 {
             response.push(ENGINE_GET_PAYLOAD_V1);

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -56,8 +56,6 @@ pub const ENGINE_FORKCHOICE_UPDATED_TIMEOUT: Duration = Duration::from_secs(8);
 
 pub const ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1: &str = "engine_getPayloadBodiesByHashV1";
 pub const ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V2: &str = "engine_getPayloadBodiesByHashV2";
-pub const ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1: &str = "engine_getPayloadBodiesByRangeV1";
-pub const ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V2: &str = "engine_getPayloadBodiesByRangeV2";
 pub const ENGINE_GET_PAYLOAD_BODIES_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub const ENGINE_EXCHANGE_CAPABILITIES: &str = "engine_exchangeCapabilities";
@@ -79,8 +77,6 @@ pub const EIP155_ERROR_STR: &str = "chain not synced beyond EIP-155 replay-prote
 /// (verified geth, nethermind, erigon, besu)
 pub const METHOD_NOT_FOUND_CODE: i64 = -32601;
 
-// We never actually use getPayloadBodiesByRangeV2, but it seems harmless to include it in
-// our supported capabilities to avoid scaring the EL.
 pub static LIGHTHOUSE_CAPABILITIES: &[&str] = &[
     ENGINE_NEW_PAYLOAD_V1,
     ENGINE_NEW_PAYLOAD_V2,
@@ -99,8 +95,6 @@ pub static LIGHTHOUSE_CAPABILITIES: &[&str] = &[
     ENGINE_FORKCHOICE_UPDATED_V4,
     ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1,
     ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V2,
-    ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1,
-    ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V2,
     ENGINE_GET_CLIENT_VERSION_V1,
     ENGINE_GET_BLOBS_V2,
     ENGINE_GET_BLOBS_V3,
@@ -1230,34 +1224,6 @@ impl HttpJsonRpc {
             .collect())
     }
 
-    pub async fn get_payload_bodies_by_range_v1<E: EthSpec>(
-        &self,
-        start: u64,
-        count: u64,
-    ) -> Result<Vec<Option<ExecutionPayloadBodyV1<E>>>, Error> {
-        #[derive(Serialize)]
-        #[serde(transparent)]
-        struct Quantity(#[serde(with = "serde_utils::u64_hex_be")] u64);
-
-        let params = json!([Quantity(start), Quantity(count)]);
-        let response: Vec<Option<JsonExecutionPayloadBodyV1<E>>> = self
-            .rpc_request(
-                ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1,
-                params,
-                ENGINE_GET_PAYLOAD_BODIES_TIMEOUT * self.execution_timeout_multiplier,
-            )
-            .await?;
-
-        response
-            .into_iter()
-            .map(|opt_json| {
-                opt_json
-                    .map(|json| json.try_into().map_err(Error::from))
-                    .transpose()
-            })
-            .collect::<Result<Vec<_>, _>>()
-    }
-
     pub async fn exchange_capabilities(&self) -> Result<EngineCapabilities, Error> {
         let params = json!([LIGHTHOUSE_CAPABILITIES]);
 
@@ -1283,10 +1249,6 @@ impl HttpJsonRpc {
                 .contains(ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1),
             get_payload_bodies_by_hash_v2: capabilities
                 .contains(ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V2),
-            get_payload_bodies_by_range_v1: capabilities
-                .contains(ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1),
-            get_payload_bodies_by_range_v2: capabilities
-                .contains(ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V2),
             get_payload_v1: capabilities.contains(ENGINE_GET_PAYLOAD_V1),
             get_payload_v2: capabilities.contains(ENGINE_GET_PAYLOAD_V2),
             get_payload_v3: capabilities.contains(ENGINE_GET_PAYLOAD_V3),

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -155,7 +155,7 @@ pub enum Error {
     },
     ZeroLengthTransaction,
     PayloadBodiesByHashV2NotSupported,
-    PayloadBodiesByRangeNotSupported,
+    PayloadBodiesByHashNotSupported,
     GetBlobsNotSupported,
     GetInclusionListNotSupported,
     InvalidJWTSecret(String),
@@ -1694,34 +1694,14 @@ impl<E: EthSpec> ExecutionLayer<E> {
             .map_err(Error::EngineError)
     }
 
-    pub async fn get_payload_bodies_by_range(
-        &self,
-        start: u64,
-        count: u64,
-    ) -> Result<Vec<Option<ExecutionPayloadBodyV1<E>>>, Error> {
-        let _timer = metrics::start_timer(&metrics::EXECUTION_LAYER_GET_PAYLOAD_BODIES_BY_RANGE);
-        self.engine()
-            .request(|engine: &Engine| async move {
-                engine
-                    .api
-                    .get_payload_bodies_by_range_v1(start, count)
-                    .await
-            })
-            .await
-            .map_err(Box::new)
-            .map_err(Error::EngineError)
-    }
-
     /// Fetch a full payload from the execution node.
     ///
-    /// This will fail if the payload is not from the finalized portion of the chain.
+    /// Returns `Ok(None)` if the execution engine does not have the body.
     pub async fn get_payload_for_header(
         &self,
         header: &ExecutionPayloadHeader<E>,
         fork: ForkName,
     ) -> Result<Option<ExecutionPayload<E>>, Error> {
-        let block_number = header.block_number();
-
         // Handle default payload body.
         if header.block_hash() == ExecutionBlockHash::zero() {
             let payload = match fork {
@@ -1743,10 +1723,11 @@ impl<E: EthSpec> ExecutionLayer<E> {
             return Ok(Some(payload));
         }
 
-        // Use efficient payload bodies by range method if supported.
         let capabilities = self.get_engine_capabilities(None).await?;
-        if capabilities.get_payload_bodies_by_range_v1 {
-            let mut payload_bodies = self.get_payload_bodies_by_range(block_number, 1).await?;
+        if capabilities.get_payload_bodies_by_hash_v1 {
+            let mut payload_bodies = self
+                .get_payload_bodies_by_hash(vec![header.block_hash()])
+                .await?;
 
             if payload_bodies.len() != 1 {
                 return Ok(None);
@@ -1760,7 +1741,7 @@ impl<E: EthSpec> ExecutionLayer<E> {
                 })
                 .transpose()
         } else {
-            Err(Error::PayloadBodiesByRangeNotSupported)
+            Err(Error::PayloadBodiesByHashNotSupported)
         }
     }
 

--- a/beacon_node/execution_layer/src/metrics.rs
+++ b/beacon_node/execution_layer/src/metrics.rs
@@ -52,13 +52,6 @@ pub static EXECUTION_LAYER_PRE_PREPARED_PAYLOAD_ID: LazyLock<Result<IntCounterVe
         )
     },
 );
-pub static EXECUTION_LAYER_GET_PAYLOAD_BODIES_BY_RANGE: LazyLock<Result<Histogram>> =
-    LazyLock::new(|| {
-        try_create_histogram(
-            "execution_layer_get_payload_bodies_by_range_time",
-            "Time to fetch a range of payload bodies from the EE",
-        )
-    });
 pub static EXECUTION_LAYER_VERIFY_BLOCK_HASH: LazyLock<Result<Histogram>> = LazyLock::new(|| {
     try_create_histogram_with_buckets(
         "execution_layer_verify_block_hash_time",

--- a/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
+++ b/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
@@ -2,7 +2,7 @@ use super::Context;
 use crate::engine_api::{http::*, *};
 use crate::json_structures::*;
 use crate::test_utils::{DEFAULT_CLIENT_VERSION, DEFAULT_MOCK_EL_PAYLOAD_VALUE_WEI};
-use serde::{Deserialize, de::DeserializeOwned};
+use serde::de::DeserializeOwned;
 use serde_json::Value as JsonValue;
 use std::sync::Arc;
 use tracing::debug;
@@ -800,58 +800,6 @@ pub async fn handle_rpc<E: EthSpec>(
                             block_access_list: payload.block_access_list().ok().cloned(),
                         };
                         response.push(Some(JsonExecutionPayloadBodyV2::from(payload_body)));
-                    }
-                    None => response.push(None),
-                }
-            }
-
-            Ok(serde_json::to_value(response).unwrap())
-        }
-        ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1 => {
-            #[derive(Deserialize)]
-            #[serde(transparent)]
-            struct Quantity(#[serde(with = "serde_utils::u64_hex_be")] pub u64);
-
-            let start = get_param::<Quantity>(params, 0)
-                .map_err(|s| (s, BAD_PARAMS_ERROR_CODE))?
-                .0;
-            let count = get_param::<Quantity>(params, 1)
-                .map_err(|s| (s, BAD_PARAMS_ERROR_CODE))?
-                .0;
-
-            let mut response = vec![];
-            for block_num in start..(start + count) {
-                let maybe_payload = ctx
-                    .execution_block_generator
-                    .read()
-                    .execution_payload_by_number(block_num);
-
-                match maybe_payload {
-                    Some(payload) => {
-                        let payload_body: ExecutionPayloadBodyV1<E> = ExecutionPayloadBodyV1 {
-                            transactions: payload
-                                .transactions()
-                                .iter()
-                                .map(|tx| {
-                                    types::Transaction::<E::MaxBytesPerTransaction>::new(
-                                        tx.to_vec(),
-                                    )
-                                })
-                                .collect::<Result<Vec<_>, _>>()
-                                .and_then(ssz_types::VariableList::new)
-                                .unwrap(),
-                            withdrawals: payload
-                                .withdrawals()
-                                .ok()
-                                .map(|withdrawals| {
-                                    ssz_types::VariableList::new(withdrawals.to_vec())
-                                })
-                                .transpose()
-                                .unwrap(),
-                        };
-                        let json_payload_body: JsonExecutionPayloadBodyV1<E> =
-                            payload_body.try_into().unwrap();
-                        response.push(Some(json_payload_body));
                     }
                     None => response.push(None),
                 }

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -50,8 +50,6 @@ pub const DEFAULT_ENGINE_CAPABILITIES: EngineCapabilities = EngineCapabilities {
     forkchoice_updated_v4: true,
     get_payload_bodies_by_hash_v1: true,
     get_payload_bodies_by_hash_v2: true,
-    get_payload_bodies_by_range_v1: true,
-    get_payload_bodies_by_range_v2: true,
     get_payload_v1: true,
     get_payload_v2: true,
     get_payload_v3: true,

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -730,9 +730,9 @@ async fn check_payload_reconstruction<E: GenericExecutionEngine>(
         .unwrap();
 
     assert!(
-        // if the engine doesn't have these capabilities, we need to update the client in our tests
-        capabilities.get_payload_bodies_by_hash_v1 && capabilities.get_payload_bodies_by_range_v1,
-        "Testing engine does not support payload bodies methods"
+        // if the engine doesn't have this capability, we need to update the client in our tests
+        capabilities.get_payload_bodies_by_hash_v1,
+        "Testing engine does not support payload bodies by hash"
     );
 
     let mut bodies = ee


### PR DESCRIPTION
## Description

The only remaining production caller of `engine_getPayloadBodiesByRangeV1` was `ExecutionLayer::get_payload_for_header`, always with `count = 1`. That path now uses `engine_getPayloadBodiesByHashV1` with `header.block_hash()`.

Unused by-range client code is deleted:
- `get_payload_bodies_by_range` / HTTP `get_payload_bodies_by_range_v1`
- by-range metrics and mock RPC handler
- by-range V1/V2 capability fields and `LIGHTHOUSE_CAPABILITIES` entries

`BeaconChain::get_block` and `BeaconBlockStreamer` are unchanged (streamer already used by-hash).

Closes #9996

## Test plan

- [x] `cargo check`
- [x] `cargo nextest run -p execution_layer`