### PR TITLE
Add stateless Gloas block production to the VC

### DIFF
--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -285,6 +285,10 @@ Flags:
       --prefer-builder-proposals
           If this flag is set, Lighthouse will always prefer blocks constructed
           by builders, regardless of payload value.
+      --stateless-block-production
+          Request the execution payload with each Gloas block and publish the
+          self-built payload envelope from that response, so it can be published
+          via any beacon node rather than only the one that built the block.
       --stdin-inputs
           If present, read all user inputs from stdin instead of tty.
       --unencrypted-http-transport

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -597,6 +597,19 @@ fn builder_proposals_flag() {
         .with_config(|config| assert!(config.validator_store.builder_proposals));
 }
 #[test]
+fn no_stateless_block_production_flag() {
+    CommandLineTest::new()
+        .run()
+        .with_config(|config| assert!(!config.stateless_block_production));
+}
+#[test]
+fn stateless_block_production_flag() {
+    CommandLineTest::new()
+        .flag("stateless-block-production", None)
+        .run()
+        .with_config(|config| assert!(config.stateless_block_production));
+}
+#[test]
 fn builder_boost_factor_flag() {
     CommandLineTest::new()
         .flag("builder-boost-factor", Some("150"))

--- a/testing/validator_test_rig/src/lib.rs
+++ b/testing/validator_test_rig/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod mock_beacon_node;
 pub mod mock_validator_store;
+pub mod recording_validator_store;
 pub mod validator_client_harness;

--- a/testing/validator_test_rig/src/mock_beacon_node.rs
+++ b/testing/validator_test_rig/src/mock_beacon_node.rs
@@ -1,4 +1,7 @@
-use eth2::types::{GenericResponse, PublishBlockRequest, SyncingData};
+use eth2::types::{
+    GenericResponse, ProduceBlockV4Response, PublishBlockRequest,
+    SignedExecutionPayloadEnvelopeContents, SyncingData,
+};
 use eth2::{BLOB_DATA_INCLUDED_HEADER, BeaconNodeHttpClient, CONSENSUS_VERSION_HEADER, Timeouts};
 use mockito::{Matcher, Mock, Server, ServerGuard};
 use regex::Regex;
@@ -11,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tracing::info;
 use types::{
-    BeaconBlock, ChainSpec, ConfigAndPreset, EthSpec, ExecutionPayloadEnvelope, ForkName, Hash256,
+    ChainSpec, ConfigAndPreset, EthSpec, ExecutionPayloadEnvelope, ForkName, Hash256,
     PayloadAttestationData, PayloadAttestationMessage, SignedBlindedBeaconBlock,
     SignedExecutionPayloadEnvelope, Slot,
 };
@@ -23,6 +26,8 @@ pub struct MockBeaconNode<E: EthSpec> {
     pub received_blinded_blocks: Arc<Mutex<Vec<SignedBlindedBeaconBlock<E>>>>,
     pub received_full_blocks: Arc<Mutex<Vec<PublishBlockRequest<E>>>>,
     pub execution_payload_envelope: Arc<Mutex<Vec<SignedExecutionPayloadEnvelope<E>>>>,
+    pub execution_payload_envelope_contents:
+        Arc<Mutex<Vec<SignedExecutionPayloadEnvelopeContents<E>>>>,
     pub payload_attestation_message: Arc<Mutex<Vec<PayloadAttestationMessage>>>,
 }
 
@@ -41,6 +46,7 @@ impl<E: EthSpec> MockBeaconNode<E> {
             received_blinded_blocks: Arc::new(Mutex::new(Vec::new())),
             received_full_blocks: Arc::new(Mutex::new(Vec::new())),
             execution_payload_envelope: Arc::new(Mutex::new(Vec::new())),
+            execution_payload_envelope_contents: Arc::new(Mutex::new(Vec::new())),
             payload_attestation_message: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -102,57 +108,73 @@ impl<E: EthSpec> MockBeaconNode<E> {
             .create();
     }
 
-    /// Mocks `POST /eth/v4/validator/blocks/{slot}`
+    /// Mocks `POST /eth/v4/validator/blocks/{slot}`, matching the given `include_payload` query
+    /// value and answering with `response`.
     pub fn mock_post_validator_blocks_v4(
         &mut self,
-        block: &BeaconBlock<E>,
+        response: &ProduceBlockV4Response<E>,
+        include_payload: bool,
         fork_name: ForkName,
         slot: Slot,
     ) -> Mock {
         let path_pattern =
             Regex::new(&format!(r"^/eth/v4/validator/blocks/{}", slot.as_u64())).unwrap();
 
+        let (payload_included, data) = match response {
+            ProduceBlockV4Response::BlockOnly(block) => (false, serde_json::json!(block)),
+            ProduceBlockV4Response::BlockAndEnvelope(contents) => {
+                (true, serde_json::json!(contents))
+            }
+        };
         let body = serde_json::json!({
             "version": fork_name.to_string(),
             "consensus_block_value": "0",
             "execution_payload_value": "0",
-            "execution_payload_included": false,
-            "data": block,
+            "execution_payload_included": payload_included,
+            "data": data,
         });
 
         self.server
             .mock("POST", Matcher::Regex(path_pattern.to_string()))
             .match_query(Matcher::UrlEncoded(
                 "include_payload".into(),
-                "false".into(),
+                include_payload.to_string(),
             ))
             .match_header("accept", "application/json")
             .with_status(200)
             .with_header("Eth-Consensus-Version", &fork_name.to_string())
             .with_header("Eth-Consensus-Block-Value", "0")
             .with_header("Eth-Execution-Payload-Value", "0")
-            .with_header("Eth-Execution-Payload-Included", "false")
+            .with_header(
+                "Eth-Execution-Payload-Included",
+                &payload_included.to_string(),
+            )
             .with_body(serde_json::to_string(&body).unwrap())
             .create()
     }
 
-    /// Mocks `POST /eth/v4/validator/blocks/{slot}` (SSZ)
+    /// Mocks `POST /eth/v4/validator/blocks/{slot}` (SSZ), matching the given `include_payload`
+    /// query value and answering with `response`.
     pub fn mock_post_validator_blocks_v4_ssz(
         &mut self,
-        block: &BeaconBlock<E>,
+        response: &ProduceBlockV4Response<E>,
+        include_payload: bool,
         fork_name: ForkName,
         slot: Slot,
     ) -> Mock {
         let path_pattern =
             Regex::new(&format!(r"^/eth/v4/validator/blocks/{}", slot.as_u64())).unwrap();
 
-        let ssz_bytes = block.as_ssz_bytes();
+        let (payload_included, ssz_bytes) = match response {
+            ProduceBlockV4Response::BlockOnly(block) => (false, block.as_ssz_bytes()),
+            ProduceBlockV4Response::BlockAndEnvelope(contents) => (true, contents.as_ssz_bytes()),
+        };
 
         self.server
             .mock("POST", Matcher::Regex(path_pattern.to_string()))
             .match_query(Matcher::UrlEncoded(
                 "include_payload".into(),
-                "false".into(),
+                include_payload.to_string(),
             ))
             .match_header("accept", "application/octet-stream")
             .with_status(200)
@@ -160,13 +182,21 @@ impl<E: EthSpec> MockBeaconNode<E> {
             .with_header("Eth-Consensus-Version", &fork_name.to_string())
             .with_header("Eth-Consensus-Block-Value", "0")
             .with_header("Eth-Execution-Payload-Value", "0")
-            .with_header("Eth-Execution-Payload-Included", "false")
+            .with_header(
+                "Eth-Execution-Payload-Included",
+                &payload_included.to_string(),
+            )
             .with_body(ssz_bytes)
             .create()
     }
 
-    /// Mocks `POST /eth/v4/validator/blocks/{slot}` (SSZ) returning error
-    pub fn mock_post_validator_blocks_v4_ssz_error(&mut self, slot: Slot) -> Mock {
+    /// Mocks `POST /eth/v4/validator/blocks/{slot}` (SSZ) returning error, matching the given
+    /// `include_payload` query value.
+    pub fn mock_post_validator_blocks_v4_ssz_error(
+        &mut self,
+        slot: Slot,
+        include_payload: bool,
+    ) -> Mock {
         let path_pattern =
             Regex::new(&format!(r"^/eth/v4/validator/blocks/{}", slot.as_u64())).unwrap();
 
@@ -174,7 +204,7 @@ impl<E: EthSpec> MockBeaconNode<E> {
             .mock("POST", Matcher::Regex(path_pattern.to_string()))
             .match_query(Matcher::UrlEncoded(
                 "include_payload".into(),
-                "false".into(),
+                include_payload.to_string(),
             ))
             .match_header("accept", "application/octet-stream")
             .with_status(500)
@@ -390,17 +420,28 @@ impl<E: EthSpec> MockBeaconNode<E> {
             .create()
     }
 
-    /// Mocks `POST /eth/v1/beacon/execution_payload_envelopes` (SSZ) to receive signed envelopes.
-    pub fn mock_post_beacon_execution_payload_envelope_ssz(&mut self) -> Mock {
+    /// Base mock for `POST /eth/v1/beacon/execution_payload_envelopes` (SSZ).
+    fn post_beacon_execution_payload_envelope_ssz_mock(
+        &mut self,
+        blob_data_included: bool,
+    ) -> Mock {
         let path_pattern = Regex::new(r"^/eth/v1/beacon/execution_payload_envelopes$").unwrap();
-
-        let execution_payload_envelope = Arc::clone(&self.execution_payload_envelope);
 
         self.server
             .mock("POST", Matcher::Regex(path_pattern.to_string()))
             .match_header("content-type", "application/octet-stream")
             .match_header(CONSENSUS_VERSION_HEADER, "gloas")
-            .match_header(BLOB_DATA_INCLUDED_HEADER, "false")
+            .match_header(
+                BLOB_DATA_INCLUDED_HEADER,
+                blob_data_included.to_string().as_str(),
+            )
+    }
+
+    /// Mocks `POST /eth/v1/beacon/execution_payload_envelopes` (SSZ) to receive signed envelopes.
+    pub fn mock_post_beacon_execution_payload_envelope_ssz(&mut self) -> Mock {
+        let execution_payload_envelope = Arc::clone(&self.execution_payload_envelope);
+
+        self.post_beacon_execution_payload_envelope_ssz_mock(false)
             .with_status(200)
             .with_body_from_request(move |request| {
                 let body = request.body().expect("Failed to get request body");
@@ -412,15 +453,36 @@ impl<E: EthSpec> MockBeaconNode<E> {
             .create()
     }
 
+    /// Mocks `POST /eth/v1/beacon/execution_payload_envelopes` (SSZ) to receive envelope contents.
+    pub fn mock_post_beacon_execution_payload_envelope_contents_ssz(&mut self) -> Mock {
+        let received = Arc::clone(&self.execution_payload_envelope_contents);
+
+        self.post_beacon_execution_payload_envelope_ssz_mock(true)
+            .with_status(200)
+            .with_body_from_request(move |request| {
+                let body = request.body().expect("Failed to get request body");
+                let contents = SignedExecutionPayloadEnvelopeContents::<E>::from_ssz_bytes(body)
+                    .expect(
+                        "Failed to deserialize SignedExecutionPayloadEnvelopeContents from SSZ",
+                    );
+                received.lock().unwrap().push(contents);
+                vec![]
+            })
+            .create()
+    }
+
+    /// Mocks `POST /eth/v1/beacon/execution_payload_envelopes` (SSZ) returning error for envelope
+    /// contents.
+    pub fn mock_post_beacon_execution_payload_envelope_contents_ssz_error(&mut self) -> Mock {
+        self.post_beacon_execution_payload_envelope_ssz_mock(true)
+            .with_status(500)
+            .with_body(r#"{"message":"Internal server error"}"#)
+            .create()
+    }
+
     /// Mocks `POST /eth/v1/beacon/execution_payload_envelopes` (SSZ) returning error.
     pub fn mock_post_beacon_execution_payload_envelope_ssz_error(&mut self) -> Mock {
-        let path_pattern = Regex::new(r"^/eth/v1/beacon/execution_payload_envelopes$").unwrap();
-
-        self.server
-            .mock("POST", Matcher::Regex(path_pattern.to_string()))
-            .match_header("content-type", "application/octet-stream")
-            .match_header(CONSENSUS_VERSION_HEADER, "gloas")
-            .match_header(BLOB_DATA_INCLUDED_HEADER, "false")
+        self.post_beacon_execution_payload_envelope_ssz_mock(false)
             .with_status(500)
             .with_body(r#"{"message":"Internal server error"}"#)
             .create()

--- a/testing/validator_test_rig/src/mock_validator_store.rs
+++ b/testing/validator_test_rig/src/mock_validator_store.rs
@@ -5,11 +5,11 @@ use futures::{Stream, stream};
 use std::future::Future;
 use std::sync::Arc;
 use types::{
-    Address, Epoch, ExecutionPayloadEnvelope, Graffiti, MainnetEthSpec, PayloadAttestationData,
-    PayloadAttestationMessage, ProposerPreferences, SelectionProof, SignedAggregateAndProof,
-    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedProposerPreferences,
-    SignedValidatorRegistrationData, SingleAttestation, Slot, SyncCommitteeMessage,
-    SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData,
+    Address, Epoch, ExecutionPayloadEnvelope, Graffiti, Hash256, MainnetEthSpec,
+    PayloadAttestationData, PayloadAttestationMessage, ProposerPreferences, SelectionProof,
+    SignedAggregateAndProof, SignedContributionAndProof, SignedExecutionPayloadEnvelope,
+    SignedProposerPreferences, SignedValidatorRegistrationData, SingleAttestation, Slot,
+    SyncCommitteeMessage, SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData,
 };
 use validator_store::{
     AggregateToSign, AttestationToSign, ContributionToSign, DoppelgangerStatus,
@@ -106,6 +106,7 @@ impl ValidatorStore for MockValidatorStore {
         _validator_pubkey: PublicKeyBytes,
         _block: UnsignedBlock<Self::E>,
         _current_slot: Slot,
+        _local_payload_root: Option<Hash256>,
     ) -> Result<SignedBlock<Self::E>, StoreError<Self::Error>> {
         panic!("MockValidatorStore::sign_block called without a hook")
     }

--- a/testing/validator_test_rig/src/recording_validator_store.rs
+++ b/testing/validator_test_rig/src/recording_validator_store.rs
@@ -1,0 +1,222 @@
+use bls::{PublicKeyBytes, Signature};
+use eth2::types::{RequestAuth, SignedRequestAuth};
+use futures::Stream;
+use std::sync::{Arc, Mutex};
+use types::{
+    Address, Epoch, ExecutionPayloadEnvelope, Graffiti, Hash256, PayloadAttestationData,
+    PayloadAttestationMessage, ProposerPreferences, SelectionProof, SignedAggregateAndProof,
+    SignedContributionAndProof, SignedExecutionPayloadEnvelope, SignedProposerPreferences,
+    SignedValidatorRegistrationData, SingleAttestation, Slot, SyncCommitteeMessage,
+    SyncSelectionProof, SyncSubnetId, ValidatorRegistrationData,
+};
+use validator_store::{
+    AggregateToSign, AttestationToSign, ContributionToSign, DoppelgangerStatus,
+    Error as StoreError, ProposalData, SignedBlock, SyncMessageToSign, UnsignedBlock,
+    ValidatorStore,
+};
+
+/// The arguments a service passed to `ValidatorStore::sign_block`.
+#[derive(Debug, Clone)]
+pub struct SignBlockCall {
+    pub validator_pubkey: PublicKeyBytes,
+    pub block_root: Hash256,
+    pub local_payload_root: Option<Hash256>,
+}
+
+/// A `ValidatorStore` that delegates to `inner` and records the `sign_block` calls it receives.
+pub struct RecordingValidatorStore<S> {
+    inner: Arc<S>,
+    sign_block_calls: Mutex<Vec<SignBlockCall>>,
+}
+
+impl<S> RecordingValidatorStore<S> {
+    pub fn new(inner: Arc<S>) -> Self {
+        Self {
+            inner,
+            sign_block_calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn sign_block_calls(&self) -> Vec<SignBlockCall> {
+        self.sign_block_calls.lock().unwrap().clone()
+    }
+}
+
+impl<S: ValidatorStore + 'static> ValidatorStore for RecordingValidatorStore<S> {
+    type Error = S::Error;
+    type E = S::E;
+
+    fn validator_index(&self, pubkey: &PublicKeyBytes) -> Option<u64> {
+        self.inner.validator_index(pubkey)
+    }
+
+    fn voting_pubkeys<I, F>(&self, filter_func: F) -> I
+    where
+        I: FromIterator<PublicKeyBytes>,
+        F: Fn(DoppelgangerStatus) -> Option<PublicKeyBytes>,
+    {
+        self.inner.voting_pubkeys(filter_func)
+    }
+
+    fn doppelganger_protection_allows_signing(&self, validator_pubkey: PublicKeyBytes) -> bool {
+        self.inner
+            .doppelganger_protection_allows_signing(validator_pubkey)
+    }
+
+    fn num_voting_validators(&self) -> usize {
+        self.inner.num_voting_validators()
+    }
+
+    fn graffiti(&self, validator_pubkey: &PublicKeyBytes) -> Option<Graffiti> {
+        self.inner.graffiti(validator_pubkey)
+    }
+
+    fn get_fee_recipient(&self, validator_pubkey: &PublicKeyBytes) -> Option<Address> {
+        self.inner.get_fee_recipient(validator_pubkey)
+    }
+
+    fn determine_builder_boost_factor(&self, validator_pubkey: &PublicKeyBytes) -> Option<u64> {
+        self.inner.determine_builder_boost_factor(validator_pubkey)
+    }
+
+    async fn randao_reveal(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        signing_epoch: Epoch,
+    ) -> Result<Signature, StoreError<Self::Error>> {
+        self.inner
+            .randao_reveal(validator_pubkey, signing_epoch)
+            .await
+    }
+
+    fn set_validator_index(&self, validator_pubkey: &PublicKeyBytes, index: u64) {
+        self.inner.set_validator_index(validator_pubkey, index)
+    }
+
+    async fn sign_block(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        block: UnsignedBlock<Self::E>,
+        current_slot: Slot,
+        local_payload_root: Option<Hash256>,
+    ) -> Result<SignedBlock<Self::E>, StoreError<Self::Error>> {
+        self.sign_block_calls.lock().unwrap().push(SignBlockCall {
+            validator_pubkey,
+            block_root: block.block_root(),
+            local_payload_root,
+        });
+        self.inner
+            .sign_block(validator_pubkey, block, current_slot, local_payload_root)
+            .await
+    }
+
+    fn sign_attestations(
+        self: &Arc<Self>,
+        attestations: Vec<AttestationToSign>,
+    ) -> impl Stream<Item = Result<Vec<SingleAttestation>, StoreError<Self::Error>>> + Send {
+        self.inner.sign_attestations(attestations)
+    }
+
+    async fn sign_validator_registration_data(
+        &self,
+        validator_registration_data: ValidatorRegistrationData,
+    ) -> Result<SignedValidatorRegistrationData, StoreError<Self::Error>> {
+        self.inner
+            .sign_validator_registration_data(validator_registration_data)
+            .await
+    }
+
+    async fn produce_selection_proof(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        slot: Slot,
+    ) -> Result<SelectionProof, StoreError<Self::Error>> {
+        self.inner
+            .produce_selection_proof(validator_pubkey, slot)
+            .await
+    }
+
+    async fn produce_sync_selection_proof(
+        &self,
+        validator_pubkey: &PublicKeyBytes,
+        slot: Slot,
+        subnet_id: SyncSubnetId,
+    ) -> Result<SyncSelectionProof, StoreError<Self::Error>> {
+        self.inner
+            .produce_sync_selection_proof(validator_pubkey, slot, subnet_id)
+            .await
+    }
+
+    fn sign_aggregate_and_proofs(
+        self: &Arc<Self>,
+        aggregates: Vec<AggregateToSign<Self::E>>,
+    ) -> impl Stream<Item = Result<Vec<SignedAggregateAndProof<Self::E>>, StoreError<Self::Error>>> + Send
+    {
+        self.inner.sign_aggregate_and_proofs(aggregates)
+    }
+
+    fn sign_sync_committee_signatures(
+        self: &Arc<Self>,
+        messages: Vec<SyncMessageToSign>,
+    ) -> impl Stream<Item = Result<Vec<SyncCommitteeMessage>, StoreError<Self::Error>>> + Send {
+        self.inner.sign_sync_committee_signatures(messages)
+    }
+
+    fn sign_sync_committee_contributions(
+        self: &Arc<Self>,
+        contributions: Vec<ContributionToSign<Self::E>>,
+    ) -> impl Stream<
+        Item = Result<Vec<SignedContributionAndProof<Self::E>>, StoreError<Self::Error>>,
+    > + Send {
+        self.inner.sign_sync_committee_contributions(contributions)
+    }
+
+    fn prune_slashing_protection_db(&self, current_epoch: Epoch, first_run: bool) {
+        self.inner
+            .prune_slashing_protection_db(current_epoch, first_run)
+    }
+
+    async fn sign_execution_payload_envelope(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        envelope: ExecutionPayloadEnvelope<Self::E>,
+    ) -> Result<SignedExecutionPayloadEnvelope<Self::E>, StoreError<Self::Error>> {
+        self.inner
+            .sign_execution_payload_envelope(validator_pubkey, envelope)
+            .await
+    }
+
+    async fn sign_payload_attestation(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        data: PayloadAttestationData,
+    ) -> Result<PayloadAttestationMessage, StoreError<Self::Error>> {
+        self.inner
+            .sign_payload_attestation(validator_pubkey, data)
+            .await
+    }
+
+    async fn sign_proposer_preferences(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        preferences: ProposerPreferences,
+    ) -> Result<SignedProposerPreferences, StoreError<Self::Error>> {
+        self.inner
+            .sign_proposer_preferences(validator_pubkey, preferences)
+            .await
+    }
+
+    async fn sign_request_auth_v1(
+        &self,
+        validator_pubkey: PublicKeyBytes,
+        request_auth_v1: RequestAuth,
+    ) -> Result<SignedRequestAuth, StoreError<Self::Error>> {
+        self.inner
+            .sign_request_auth_v1(validator_pubkey, request_auth_v1)
+            .await
+    }
+
+    fn proposal_data(&self, pubkey: &PublicKeyBytes) -> Option<ProposalData> {
+        self.inner.proposal_data(pubkey)
+    }
+}

--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -650,7 +650,7 @@ mod tests {
                 let block_slot = block.slot();
                 let unsigned_block = UnsignedBlock::Full(FullBlockContents::Block(block));
                 validator_store
-                    .sign_block(pubkey, unsigned_block, block_slot)
+                    .sign_block(pubkey, unsigned_block, block_slot, None)
                     .await
                     .unwrap()
             }
@@ -724,7 +724,7 @@ mod tests {
                 let unsigned_block =
                     UnsignedBlock::Full(FullBlockContents::Block(altair_block.into()));
                 validator_store
-                    .sign_block(pubkey, unsigned_block, altair_fork_slot)
+                    .sign_block(pubkey, unsigned_block, altair_fork_slot, None)
                     .await
                     .unwrap()
             }
@@ -809,7 +809,7 @@ mod tests {
                 let unsigned_block =
                     UnsignedBlock::Full(FullBlockContents::Block(bellatrix_block.into()));
                 validator_store
-                    .sign_block(pubkey, unsigned_block, bellatrix_fork_slot)
+                    .sign_block(pubkey, unsigned_block, bellatrix_fork_slot, None)
                     .await
                     .unwrap()
             }
@@ -942,7 +942,7 @@ mod tests {
             let slot = block.slot();
             let unsigned_block = UnsignedBlock::Full(FullBlockContents::Block(block));
             validator_store
-                .sign_block(pubkey, unsigned_block, slot)
+                .sign_block(pubkey, unsigned_block, slot, None)
                 .await
                 .unwrap()
         })
@@ -954,7 +954,7 @@ mod tests {
                 let slot = block.slot();
                 let unsigned_block = UnsignedBlock::Full(FullBlockContents::Block(block));
                 validator_store
-                    .sign_block(pubkey, unsigned_block, slot)
+                    .sign_block(pubkey, unsigned_block, slot, None)
                     .await
                     .map(|_| ())
             },

--- a/validator_client/lighthouse_validator_store/src/lib.rs
+++ b/validator_client/lighthouse_validator_store/src/lib.rs
@@ -975,6 +975,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore for LighthouseValidatorS
         validator_pubkey: PublicKeyBytes,
         block: UnsignedBlock<E>,
         current_slot: Slot,
+        _local_payload_root: Option<Hash256>,
     ) -> Result<SignedBlock<E>, Error> {
         match block {
             UnsignedBlock::Full(block) => {

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -199,6 +199,16 @@ pub struct ValidatorClient {
     )]
     pub distributed: bool,
 
+    #[clap(
+        long,
+        help = "Request the execution payload with each Gloas block and publish the self-built \
+                payload envelope from that response, so it can be published via any beacon node \
+                rather than only the one that built the block.",
+        display_order = 0,
+        help_heading = FLAG_HEADER
+    )]
+    pub stateless_block_production: bool,
+
     /* REST API related arguments */
     #[clap(
         long,

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -88,6 +88,8 @@ pub struct Config {
     pub validator_registration_batch_size: usize,
     /// Whether we are running with distributed network support.
     pub distributed: bool,
+    /// Publish self-built Gloas payload envelopes from the produce response (see `BlockService`).
+    pub stateless_block_production: bool,
     /// Configuration for the initialized validators
     #[serde(flatten)]
     pub initialized_validators: InitializedValidatorsConfig,
@@ -139,6 +141,7 @@ impl Default for Config {
             enable_beacon_head_monitor: true,
             validator_registration_batch_size: 500,
             distributed: false,
+            stateless_block_production: false,
             initialized_validators: <_>::default(),
             disable_attesting: false,
             disable_proposer_duties_v2: false,
@@ -257,6 +260,7 @@ impl Config {
         }
 
         config.distributed = validator_client_config.distributed;
+        config.stateless_block_production = validator_client_config.stateless_block_production;
 
         if let Some(mut broadcast_topics) = validator_client_config.broadcast.clone() {
             broadcast_topics.retain(|topic| *topic != ApiTopic::None);

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -531,7 +531,8 @@ impl<E: EthSpec> ProductionValidatorClient<E> {
             .graffiti_file(config.graffiti_file.clone())
             .graffiti_policy(config.graffiti_policy)
             .configured_builders(configured_builders.clone())
-            .request_auth_cache(request_auth_cache.clone());
+            .request_auth_cache(request_auth_cache.clone())
+            .stateless_block_production(config.stateless_block_production);
 
         // If we have proposer nodes, add them to the block service builder.
         if proposer_nodes_num > 0 {

--- a/validator_client/validator_services/src/block_service.rs
+++ b/validator_client/validator_services/src/block_service.rs
@@ -3,7 +3,10 @@ use beacon_node_fallback::{ApiTopic, BeaconNodeFallback, Error as FallbackError,
 use bls::PublicKeyBytes;
 use builder_store::BuilderStore;
 use eth2::BeaconNodeHttpClient;
-use eth2::types::GraffitiPolicy;
+use eth2::types::{
+    BlockAndEnvelope, GraffitiPolicy, ProduceBlockV4Response,
+    SignedExecutionPayloadEnvelopeContents,
+};
 use graffiti_file::{GraffitiFile, determine_graffiti};
 use logging::crit;
 use reqwest::StatusCode;
@@ -16,7 +19,11 @@ use std::time::Duration;
 use task_executor::TaskExecutor;
 use tokio::sync::mpsc;
 use tracing::{Instrument, debug, error, info, info_span, instrument, trace, warn};
-use types::{BlockType, ChainSpec, EthSpec, Graffiti, Hash256, Slot};
+use tree_hash::TreeHash;
+use types::{
+    BeaconBlock, BlobsList, BlockType, ChainSpec, EthSpec, ExecutionPayloadEnvelope, ForkName,
+    Graffiti, Hash256, KzgProofs, Slot, consts::gloas::BUILDER_INDEX_SELF_BUILD,
+};
 use validator_store::{Error as ValidatorStoreError, SignedBlock, UnsignedBlock, ValidatorStore};
 
 #[derive(Debug)]
@@ -57,6 +64,7 @@ pub struct BlockServiceBuilder<S, T> {
     graffiti_policy: Option<GraffitiPolicy>,
     configured_builders: Option<BuilderStore>,
     request_auth_cache: Option<RequestAuthCache>,
+    stateless_block_production: bool,
 }
 
 impl<S: ValidatorStore, T: SlotClock + 'static> BlockServiceBuilder<S, T> {
@@ -73,6 +81,7 @@ impl<S: ValidatorStore, T: SlotClock + 'static> BlockServiceBuilder<S, T> {
             graffiti_policy: None,
             configured_builders: None,
             request_auth_cache: None,
+            stateless_block_production: false,
         }
     }
 
@@ -131,6 +140,11 @@ impl<S: ValidatorStore, T: SlotClock + 'static> BlockServiceBuilder<S, T> {
         self
     }
 
+    pub fn stateless_block_production(mut self, enabled: bool) -> Self {
+        self.stateless_block_production = enabled;
+        self
+    }
+
     pub fn build(self) -> Result<BlockService<S, T>, String> {
         Ok(BlockService {
             inner: Arc::new(Inner {
@@ -159,6 +173,7 @@ impl<S: ValidatorStore, T: SlotClock + 'static> BlockServiceBuilder<S, T> {
                 request_auth_cache: self
                     .request_auth_cache
                     .ok_or("Cannot build BlockService without request_auth_cache")?,
+                stateless_block_production: self.stateless_block_production,
             }),
         })
     }
@@ -230,6 +245,83 @@ pub struct Inner<S, T> {
     /// Caches the per-(slot, proposer, auth_data) request-auth signatures reused when resolving the
     /// builder config.
     request_auth_cache: RequestAuthCache,
+    /// Produce Gloas blocks with `include_payload=true` and publish the self-built envelope from
+    /// the response, rather than fetching it from the beacon node that built the block.
+    stateless_block_production: bool,
+}
+
+/// The envelope, KZG proofs and blobs returned with a self-built block when `include_payload=true`.
+struct LocalPayloadContents<E: EthSpec> {
+    envelope: ExecutionPayloadEnvelope<E>,
+    kzg_proofs: KzgProofs<E>,
+    blobs: BlobsList<E>,
+}
+
+/// What to do about the execution payload envelope once the block is published.
+enum EnvelopeStep<E: EthSpec> {
+    /// Nothing to publish: pre-Gloas, an external builder, or no contents were returned.
+    Skip,
+    /// Fetch the envelope from the beacon node by this block root.
+    Fetch(Hash256),
+    /// Sign and publish the envelope returned with the block.
+    Local(Box<LocalPayloadContents<E>>),
+}
+
+impl<E: EthSpec> EnvelopeStep<E> {
+    /// Split a Gloas produce response into the block and the envelope step it implies. Contents
+    /// that were not requested are ignored, so the stateful path is unchanged.
+    fn from_response(
+        include_payload: bool,
+        response: ProduceBlockV4Response<E>,
+        slot: Slot,
+    ) -> (BeaconBlock<E>, Self) {
+        match (include_payload, response) {
+            (
+                true,
+                ProduceBlockV4Response::BlockAndEnvelope(BlockAndEnvelope {
+                    block,
+                    execution_payload_envelope,
+                    kzg_proofs,
+                    blobs,
+                }),
+            ) => (
+                block,
+                Self::Local(Box::new(LocalPayloadContents {
+                    envelope: execution_payload_envelope,
+                    kzg_proofs,
+                    blobs,
+                })),
+            ),
+            (true, ProduceBlockV4Response::BlockOnly(block)) => {
+                if block
+                    .body()
+                    .signed_execution_payload_bid()
+                    .is_ok_and(|bid| bid.message.builder_index == BUILDER_INDEX_SELF_BUILD)
+                {
+                    // Inconsistent response: publish the block, the envelope cannot be signed.
+                    warn!(
+                        slot = slot.as_u64(),
+                        "Beacon node omitted the payload contents for a self-built block, \
+                         the execution payload envelope will not be published"
+                    );
+                }
+                (block, Self::Skip)
+            }
+            (false, response) => {
+                let block = response.into_block();
+                let block_root = block.canonical_root();
+                (block, Self::Fetch(block_root))
+            }
+        }
+    }
+
+    /// The `hash_tree_root` of the locally built payload, when there is one.
+    fn local_payload_root(&self) -> Option<Hash256> {
+        match self {
+            Self::Local(contents) => Some(contents.envelope.payload.tree_hash_root()),
+            Self::Fetch(_) | Self::Skip => None,
+        }
+    }
 }
 
 /// Attempts to produce attestations for any block producer(s) at the start of the epoch.
@@ -366,13 +458,14 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
         graffiti: Option<Graffiti>,
         validator_pubkey: &PublicKeyBytes,
         unsigned_block: UnsignedBlock<S::E>,
+        local_payload_root: Option<Hash256>,
         builder_url: Option<String>,
     ) -> Result<(), BlockError> {
         let signing_timer = validator_metrics::start_timer(&validator_metrics::BLOCK_SIGNING_TIMES);
 
         let res = self
             .validator_store
-            .sign_block(*validator_pubkey, unsigned_block, slot)
+            .sign_block(*validator_pubkey, unsigned_block, slot, local_payload_root)
             .instrument(info_span!("sign_block"))
             .await;
 
@@ -492,7 +585,9 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
         // Check if Gloas fork is active at this slot
         let fork_name = self_ref.chain_spec.fork_name_at_slot::<S::E>(slot);
 
-        let (block_proposer, unsigned_block, builder_url) = if fork_name.gloas_enabled() {
+        let (block_proposer, unsigned_block, builder_url, envelope_step) = if fork_name
+            .gloas_enabled()
+        {
             // Resolve the validator's builder config for this proposal, signing each builder's
             // request auth via the cache. Sent in the POST `produceBlockV4` body below (the same
             // body is reused on the SSZ-to-JSON fallback and on every proposer-fallback BN). With
@@ -520,6 +615,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
                 "Resolved builder config for block production"
             );
             let builder_config_ref = &builder_config;
+            let include_payload = self_ref.stateless_block_production;
 
             // Use V4 block production for Gloas
             // Request an SSZ block from all beacon nodes in order, returning on the first successful response.
@@ -535,7 +631,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
                             slot,
                             randao_reveal_ref,
                             graffiti.as_ref(),
-                            false,
+                            include_payload,
                             builder_config_ref,
                             self_ref.graffiti_policy,
                             fork_name,
@@ -547,9 +643,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
             // `builder_url` is the `Eth-Builder-Url` from the winning beacon node — echoed on publish
             // so it forwards the block to the builder that won selection.
             let (block_response, builder_url) = match ssz_block_response {
-                Ok((ssz_block_response, metadata)) => {
-                    (ssz_block_response.into_block(), metadata.builder_url)
-                }
+                Ok((ssz_block_response, metadata)) => (ssz_block_response, metadata.builder_url),
                 Err(e) => {
                     warn!(
                         slot = slot.as_u64(),
@@ -568,7 +662,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
                                     slot,
                                     randao_reveal_ref,
                                     graffiti.as_ref(),
-                                    false,
+                                    include_payload,
                                     builder_config_ref,
                                     self_ref.graffiti_policy,
                                     fork_name,
@@ -581,12 +675,15 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
                                     ))
                                 })?;
 
-                            Ok((json_block_response.into_block(), metadata.builder_url))
+                            Ok((json_block_response, metadata.builder_url))
                         })
                         .await
                         .map_err(BlockError::from)?
                 }
             };
+
+            let (block_response, envelope_step) =
+                EnvelopeStep::from_response(include_payload, block_response, slot);
 
             // Gloas blocks don't have blobs (they're in the execution layer)
             let block_contents = eth2::types::FullBlockContents::Block(block_response);
@@ -594,6 +691,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
                 block_contents.block().proposer_index(),
                 UnsignedBlock::Full(block_contents),
                 builder_url,
+                envelope_step,
             )
         } else {
             // Use V3 block production for pre-Gloas forks
@@ -665,10 +763,14 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
                     block.block().proposer_index(),
                     UnsignedBlock::Full(block),
                     None,
+                    EnvelopeStep::Skip,
                 ),
-                eth2::types::ProduceBlockV3Response::Blinded(block) => {
-                    (block.proposer_index(), UnsignedBlock::Blinded(block), None)
-                }
+                eth2::types::ProduceBlockV3Response::Blinded(block) => (
+                    block.proposer_index(),
+                    UnsignedBlock::Blinded(block),
+                    None,
+                    EnvelopeStep::Skip,
+                ),
             }
         };
 
@@ -679,10 +781,7 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
             ));
         }
 
-        // Capture before `sign_and_publish_block` moves `unsigned_block`.
-        let produced_block_root = fork_name
-            .gloas_enabled()
-            .then(|| unsigned_block.block_root());
+        let local_payload_root = envelope_step.local_payload_root();
 
         self_ref
             .sign_and_publish_block(
@@ -691,22 +790,35 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
                 graffiti,
                 &validator_pubkey,
                 unsigned_block,
+                local_payload_root,
                 builder_url,
             )
             .await?;
 
-        // TODO(gloas) we only need to fetch, sign and publish the envelope in the local building case.
-        // Right now we always default to local building. Once we implement trustless/trusted builder logic
-        // we should check the bid for index == BUILDER_INDEX_SELF_BUILD
-        if let Some(beacon_block_root) = produced_block_root {
-            self_ref
-                .fetch_sign_and_publish_payload_envelope(
-                    &proposer_fallback,
-                    slot,
-                    beacon_block_root,
-                    &validator_pubkey,
-                )
-                .await?;
+        match envelope_step {
+            EnvelopeStep::Skip => {}
+            // TODO(gloas): only fetch when the bid is self-build (#9948).
+            EnvelopeStep::Fetch(beacon_block_root) => {
+                self_ref
+                    .fetch_sign_and_publish_payload_envelope(
+                        &proposer_fallback,
+                        slot,
+                        beacon_block_root,
+                        &validator_pubkey,
+                    )
+                    .await?;
+            }
+            EnvelopeStep::Local(contents) => {
+                self_ref
+                    .sign_and_publish_local_payload_envelope(
+                        &proposer_fallback,
+                        slot,
+                        fork_name,
+                        *contents,
+                        &validator_pubkey,
+                    )
+                    .await?;
+            }
         }
 
         Ok(())
@@ -806,6 +918,73 @@ impl<S: ValidatorStore + 'static, T: SlotClock + 'static> BlockService<S, T> {
         Ok(())
     }
 
+    /// Sign the envelope returned with a self-built block and publish it with its blobs and KZG
+    /// proofs via the same nodes as the block, since any beacon node can accept that form.
+    #[instrument(skip_all)]
+    async fn sign_and_publish_local_payload_envelope(
+        &self,
+        proposer_fallback: &ProposerFallback<T>,
+        slot: Slot,
+        fork_name: ForkName,
+        contents: LocalPayloadContents<S::E>,
+        validator_pubkey: &PublicKeyBytes,
+    ) -> Result<(), BlockError> {
+        let LocalPayloadContents {
+            envelope,
+            kzg_proofs,
+            blobs,
+        } = contents;
+        let beacon_block_root = envelope.beacon_block_root;
+        info!(
+            slot = slot.as_u64(),
+            %beacon_block_root,
+            "Signing locally built execution payload envelope"
+        );
+
+        let signed_execution_payload_envelope = self
+            .validator_store
+            .sign_execution_payload_envelope(*validator_pubkey, envelope)
+            .await
+            .map_err(|e| {
+                BlockError::Recoverable(format!(
+                    "Error signing execution payload envelope: {:?}",
+                    e
+                ))
+            })?;
+        let signed_contents = SignedExecutionPayloadEnvelopeContents {
+            signed_execution_payload_envelope,
+            kzg_proofs,
+            blobs,
+        };
+        let signed_contents = &signed_contents;
+
+        proposer_fallback
+            .request_proposers_first(|beacon_node| async move {
+                beacon_node
+                    .post_beacon_execution_payload_envelope_contents_ssz(
+                        signed_contents,
+                        fork_name,
+                        None,
+                    )
+                    .await
+                    .map_err(|e| {
+                        BlockError::Recoverable(format!(
+                            "Error publishing execution payload envelope: {:?}",
+                            e
+                        ))
+                    })
+            })
+            .await?;
+
+        info!(
+            slot = slot.as_u64(),
+            %beacon_block_root,
+            "Successfully published signed execution payload envelope"
+        );
+
+        Ok(())
+    }
+
     #[instrument(skip_all)]
     async fn publish_signed_block_contents(
         &self,
@@ -899,18 +1078,42 @@ fn handle_block_post_error(err: eth2::Error, slot: Slot) -> Result<(), BlockErro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use beacon_node_fallback::{CandidateBeaconNode, Config as BeaconNodeConfig};
     use slot_clock::ManualSlotClock;
     use std::time::Duration;
-    use types::{BeaconBlock, ExecutionPayloadEnvelope, ForkName, Slot};
+    use types::{Blob, KzgProof, MainnetEthSpec};
+    use validator_test_rig::mock_beacon_node::MockBeaconNode;
+    use validator_test_rig::recording_validator_store::RecordingValidatorStore;
     use validator_test_rig::validator_client_harness::{S, ValidatorClientHarness};
+
+    type Store = RecordingValidatorStore<S>;
 
     struct TestHarness {
         harness: ValidatorClientHarness,
-        service: BlockService<S, ManualSlotClock>,
+        service: BlockService<Store, ManualSlotClock>,
     }
 
     impl TestHarness {
         async fn new_with_validators(num_validators: usize) -> Self {
+            Self::new(num_validators, false, None).await
+        }
+
+        async fn new_stateless() -> Self {
+            Self::new(1, true, None).await
+        }
+
+        /// A stateless-mode service that publishes to the returned proposer node first.
+        async fn new_stateless_with_proposer_node() -> (Self, MockBeaconNode<MainnetEthSpec>) {
+            let proposer_node = MockBeaconNode::<MainnetEthSpec>::new().await;
+            let harness = Self::new(1, true, Some(&proposer_node)).await;
+            (harness, proposer_node)
+        }
+
+        async fn new(
+            num_validators: usize,
+            stateless_block_production: bool,
+            proposer_node: Option<&MockBeaconNode<MainnetEthSpec>>,
+        ) -> Self {
             let harness = ValidatorClientHarness::new(num_validators).await;
 
             // advance the time to Slot 1
@@ -918,8 +1121,10 @@ mod tests {
                 .slot_clock
                 .advance_time(harness.spec.get_slot_duration());
 
-            let service = BlockServiceBuilder::new()
-                .validator_store(harness.validator_store.clone())
+            let mut builder = BlockServiceBuilder::new()
+                .validator_store(Arc::new(RecordingValidatorStore::new(
+                    harness.validator_store.clone(),
+                )))
                 .slot_clock(harness.slot_clock.clone())
                 .beacon_nodes(harness.beacon_nodes.clone())
                 .executor(harness.test_runtime.task_executor.clone())
@@ -928,11 +1133,149 @@ mod tests {
                 .configured_builders(
                     BuilderStore::open_or_create(harness._validator_dir.path()).unwrap(),
                 )
-                .build()
-                .unwrap();
+                .stateless_block_production(stateless_block_production);
 
-            Self { harness, service }
+            if let Some(proposer_node) = proposer_node {
+                let candidate =
+                    CandidateBeaconNode::new(proposer_node.beacon_api_client.clone(), 0);
+                builder = builder.proposer_nodes(Arc::new(BeaconNodeFallback::new(
+                    vec![candidate],
+                    BeaconNodeConfig::default(),
+                    vec![],
+                    harness.spec.clone(),
+                )));
+            }
+
+            Self {
+                harness,
+                service: builder.build().unwrap(),
+            }
         }
+
+        fn bn1(&mut self) -> &mut MockBeaconNode<MainnetEthSpec> {
+            &mut self.harness.mock_beacon_node_1
+        }
+
+        fn bn2(&mut self) -> &mut MockBeaconNode<MainnetEthSpec> {
+            &mut self.harness.mock_beacon_node_2
+        }
+
+        /// Propose at `slot` for the first validator and require success.
+        async fn publish(&self, slot: Slot) {
+            let result = self
+                .service
+                .clone()
+                .get_validator_block_and_publish_block(slot, self.harness.pubkeys[0], None)
+                .await;
+            assert!(
+                result.is_ok(),
+                "Block production failed: {:?}",
+                result.err()
+            );
+        }
+
+        /// Assert `sign_block` was called once, for `block`, with `local_payload_root`.
+        fn assert_signed_once(
+            &self,
+            block: &BeaconBlock<MainnetEthSpec>,
+            local_payload_root: Option<Hash256>,
+        ) {
+            let calls = self.service.validator_store.sign_block_calls();
+            assert_eq!(calls.len(), 1, "expected exactly one sign_block call");
+            assert_eq!(calls[0].validator_pubkey, self.harness.pubkeys[0]);
+            assert_eq!(calls[0].block_root, block.canonical_root());
+            assert_eq!(calls[0].local_payload_root, local_payload_root);
+        }
+    }
+
+    fn block_only(block: &BeaconBlock<MainnetEthSpec>) -> ProduceBlockV4Response<MainnetEthSpec> {
+        ProduceBlockV4Response::BlockOnly(block.clone())
+    }
+
+    /// A Gloas block with a self-built bid.
+    fn self_build_block(spec: &ChainSpec) -> BeaconBlock<MainnetEthSpec> {
+        let mut block = BeaconBlock::empty(spec);
+        let BeaconBlock::Gloas(gloas_block) = &mut block else {
+            panic!("expected Gloas block");
+        };
+        gloas_block
+            .body
+            .signed_execution_payload_bid
+            .message
+            .builder_index = BUILDER_INDEX_SELF_BUILD;
+        block
+    }
+
+    /// The `include_payload=true` response for a self-built `block`, with one blob and one proof.
+    fn local_contents(block: &BeaconBlock<MainnetEthSpec>) -> BlockAndEnvelope<MainnetEthSpec> {
+        let mut envelope = ExecutionPayloadEnvelope::empty();
+        envelope.payload.slot_number = block.slot();
+        envelope.payload.block_number = 7;
+        envelope.builder_index = BUILDER_INDEX_SELF_BUILD;
+        envelope.beacon_block_root = block.canonical_root();
+        envelope.parent_beacon_block_root = block.parent_root();
+        BlockAndEnvelope {
+            block: block.clone(),
+            execution_payload_envelope: envelope,
+            kzg_proofs: KzgProofs::<MainnetEthSpec>::try_from(vec![KzgProof::empty()]).unwrap(),
+            blobs: BlobsList::<MainnetEthSpec>::try_from(vec![Blob::<MainnetEthSpec>::default()])
+                .unwrap(),
+        }
+    }
+
+    /// Assert `node` received exactly one envelope publish matching `contents`.
+    fn assert_published_contents(
+        node: &MockBeaconNode<MainnetEthSpec>,
+        contents: &BlockAndEnvelope<MainnetEthSpec>,
+    ) {
+        let received = node.execution_payload_envelope_contents.lock().unwrap();
+        assert_eq!(received.len(), 1, "Expected one envelope contents publish");
+        assert_eq!(
+            received[0].signed_execution_payload_envelope.message,
+            contents.execution_payload_envelope
+        );
+        assert_eq!(received[0].kzg_proofs, contents.kzg_proofs);
+        assert_eq!(received[0].blobs, contents.blobs);
+    }
+
+    /// In stateless mode a `BlockOnly` response publishes the block alone with no payload root.
+    async fn assert_stateless_block_only(
+        make_block: impl FnOnce(&ChainSpec) -> BeaconBlock<MainnetEthSpec>,
+    ) {
+        let mut test_harness = TestHarness::new_stateless().await;
+        let slot = Slot::new(1);
+        let block = make_block(&test_harness.harness.spec);
+
+        test_harness.bn1().mock_post_validator_blocks_v4_ssz(
+            &block_only(&block),
+            true,
+            ForkName::Gloas,
+            slot,
+        );
+        let mock_post_block = test_harness
+            .bn1()
+            .mock_post_beacon_blocks_v2_ssz(ForkName::Gloas);
+        let mock_get_envelope = test_harness
+            .bn1()
+            .mock_get_validator_execution_payload_envelope_ssz(
+                &ExecutionPayloadEnvelope::empty(),
+                slot,
+                block.canonical_root(),
+            );
+        let mock_post_bare_envelope = test_harness
+            .bn1()
+            .mock_post_beacon_execution_payload_envelope_ssz();
+        let mock_post_contents = test_harness
+            .bn1()
+            .mock_post_beacon_execution_payload_envelope_contents_ssz();
+
+        test_harness.publish(slot).await;
+
+        mock_post_block.expect(1).assert();
+        mock_get_envelope.expect(0).assert();
+        mock_post_bare_envelope.expect(0).assert();
+        mock_post_contents.expect(0).assert();
+        test_harness.assert_signed_once(&block, None);
     }
 
     #[tokio::test]
@@ -955,7 +1298,8 @@ mod tests {
             .harness
             .mock_beacon_node_1
             .mock_post_validator_blocks_v4_ssz(
-                &block,
+                &block_only(&block),
+                false,
                 ForkName::Gloas,
                 different_notification_slot,
             );
@@ -980,7 +1324,12 @@ mod tests {
         let mock_same_slot = test_harness
             .harness
             .mock_beacon_node_1
-            .mock_post_validator_blocks_v4_ssz(&block, ForkName::Gloas, same_notification_slot);
+            .mock_post_validator_blocks_v4_ssz(
+                &block_only(&block),
+                false,
+                ForkName::Gloas,
+                same_notification_slot,
+            );
 
         test_harness
             .service
@@ -1008,14 +1357,13 @@ mod tests {
         let mut test_harness = TestHarness::new_with_validators(1).await;
 
         let slot = Slot::new(1);
-        let validator_pubkey = test_harness.harness.pubkeys[0];
         let block = BeaconBlock::empty(&test_harness.harness.spec);
         let envelope = ExecutionPayloadEnvelope::empty();
 
         test_harness
             .harness
             .mock_beacon_node_1
-            .mock_post_validator_blocks_v4_ssz(&block, ForkName::Gloas, slot);
+            .mock_post_validator_blocks_v4_ssz(&block_only(&block), false, ForkName::Gloas, slot);
         let mock_post_block = test_harness
             .harness
             .mock_beacon_node_1
@@ -1033,17 +1381,7 @@ mod tests {
             .mock_beacon_node_1
             .mock_post_beacon_execution_payload_envelope_ssz();
 
-        let result = test_harness
-            .service
-            .clone()
-            .get_validator_block_and_publish_block(slot, validator_pubkey, None)
-            .await;
-
-        assert!(
-            result.is_ok(),
-            "Block production failed: {:?}",
-            result.err()
-        );
+        test_harness.publish(slot).await;
 
         // Both mock BN only being hit once, as it is successful on the first call
         mock_post_block.expect(1).assert();
@@ -1064,6 +1402,191 @@ mod tests {
             .lock()
             .unwrap();
         assert_eq!(received_envelopes.len(), 1, "Expected one envelope");
+
+        test_harness.assert_signed_once(&block, None);
+    }
+
+    #[tokio::test]
+    async fn stateless_self_build_publishes_inline_envelope_contents_through_proposer_node() {
+        let (mut test_harness, mut proposer_node) =
+            TestHarness::new_stateless_with_proposer_node().await;
+
+        let slot = Slot::new(1);
+        let block = self_build_block(&test_harness.harness.spec);
+        let contents = local_contents(&block);
+        let expected_payload_root = contents.execution_payload_envelope.payload.tree_hash_root();
+
+        // Production goes to a beacon node; the block and envelope must go to the proposer node.
+        test_harness.bn1().mock_post_validator_blocks_v4_ssz(
+            &ProduceBlockV4Response::BlockAndEnvelope(contents.clone()),
+            true,
+            ForkName::Gloas,
+            slot,
+        );
+        let mock_get_envelope = test_harness
+            .bn1()
+            .mock_get_validator_execution_payload_envelope_ssz(
+                &contents.execution_payload_envelope,
+                slot,
+                block.canonical_root(),
+            );
+        let mock_beacon_node_post_contents = test_harness
+            .bn1()
+            .mock_post_beacon_execution_payload_envelope_contents_ssz();
+        let mock_post_block = proposer_node.mock_post_beacon_blocks_v2_ssz(ForkName::Gloas);
+        let mock_post_bare_envelope =
+            proposer_node.mock_post_beacon_execution_payload_envelope_ssz();
+        let mock_post_contents =
+            proposer_node.mock_post_beacon_execution_payload_envelope_contents_ssz();
+
+        test_harness.publish(slot).await;
+
+        mock_post_block.expect(1).assert();
+        mock_post_contents.expect(1).assert();
+        mock_post_bare_envelope.expect(0).assert();
+        mock_get_envelope.expect(0).assert();
+        mock_beacon_node_post_contents.expect(0).assert();
+
+        test_harness.assert_signed_once(&block, Some(expected_payload_root));
+        assert_published_contents(&proposer_node, &contents);
+        assert_eq!(
+            proposer_node.received_full_blocks.lock().unwrap().len(),
+            1,
+            "Expected one published block"
+        );
+    }
+
+    #[tokio::test]
+    async fn stateless_ssz_produce_fails_and_json_succeeds_with_inline_contents() {
+        let mut test_harness = TestHarness::new_stateless().await;
+
+        let slot = Slot::new(1);
+        let block = self_build_block(&test_harness.harness.spec);
+        let contents = local_contents(&block);
+        let expected_payload_root = contents.execution_payload_envelope.payload.tree_hash_root();
+
+        let mock_ssz_1 = test_harness
+            .bn1()
+            .mock_post_validator_blocks_v4_ssz_error(slot, true);
+        let mock_ssz_2 = test_harness
+            .bn2()
+            .mock_post_validator_blocks_v4_ssz_error(slot, true);
+        let mock_json = test_harness.bn1().mock_post_validator_blocks_v4(
+            &ProduceBlockV4Response::BlockAndEnvelope(contents.clone()),
+            true,
+            ForkName::Gloas,
+            slot,
+        );
+        let mock_post_block = test_harness
+            .bn1()
+            .mock_post_beacon_blocks_v2_ssz(ForkName::Gloas);
+        let mock_get_envelope = test_harness
+            .bn1()
+            .mock_get_validator_execution_payload_envelope_ssz(
+                &contents.execution_payload_envelope,
+                slot,
+                block.canonical_root(),
+            );
+        let mock_post_contents = test_harness
+            .bn1()
+            .mock_post_beacon_execution_payload_envelope_contents_ssz();
+
+        test_harness.publish(slot).await;
+
+        // `first_success` makes two passes over the candidates before the JSON fallback.
+        mock_ssz_1.expect(2).assert();
+        mock_ssz_2.expect(2).assert();
+        mock_json.expect(1).assert();
+        mock_post_block.expect(1).assert();
+        mock_post_contents.expect(1).assert();
+        mock_get_envelope.expect(0).assert();
+
+        test_harness.assert_signed_once(&block, Some(expected_payload_root));
+        assert_published_contents(&test_harness.harness.mock_beacon_node_1, &contents);
+    }
+
+    #[tokio::test]
+    async fn flag_off_ignores_unsolicited_inline_contents() {
+        let mut test_harness = TestHarness::new_with_validators(1).await;
+
+        let slot = Slot::new(1);
+        let block = self_build_block(&test_harness.harness.spec);
+        let contents = local_contents(&block);
+
+        // The beacon node attaches contents although `include_payload=false` was requested.
+        test_harness.bn1().mock_post_validator_blocks_v4_ssz(
+            &ProduceBlockV4Response::BlockAndEnvelope(contents.clone()),
+            false,
+            ForkName::Gloas,
+            slot,
+        );
+        let mock_post_block = test_harness
+            .bn1()
+            .mock_post_beacon_blocks_v2_ssz(ForkName::Gloas);
+        let mock_get_envelope = test_harness
+            .bn1()
+            .mock_get_validator_execution_payload_envelope_ssz(
+                &contents.execution_payload_envelope,
+                slot,
+                block.canonical_root(),
+            );
+        let mock_post_bare_envelope = test_harness
+            .bn1()
+            .mock_post_beacon_execution_payload_envelope_ssz();
+        let mock_post_contents = test_harness
+            .bn1()
+            .mock_post_beacon_execution_payload_envelope_contents_ssz();
+
+        test_harness.publish(slot).await;
+
+        // The stateful path runs as if the contents had not been returned.
+        mock_post_block.expect(1).assert();
+        mock_get_envelope.expect(1).assert();
+        mock_post_bare_envelope.expect(1).assert();
+        mock_post_contents.expect(0).assert();
+        test_harness.assert_signed_once(&block, None);
+    }
+
+    #[tokio::test]
+    async fn stateless_envelope_falls_back_from_proposer_node_to_beacon_node() {
+        let (mut test_harness, mut proposer_node) =
+            TestHarness::new_stateless_with_proposer_node().await;
+
+        let slot = Slot::new(1);
+        let block = self_build_block(&test_harness.harness.spec);
+        let contents = local_contents(&block);
+
+        test_harness.bn1().mock_post_validator_blocks_v4_ssz(
+            &ProduceBlockV4Response::BlockAndEnvelope(contents.clone()),
+            true,
+            ForkName::Gloas,
+            slot,
+        );
+        let mock_beacon_node_post_contents = test_harness
+            .bn1()
+            .mock_post_beacon_execution_payload_envelope_contents_ssz();
+        let mock_post_block = proposer_node.mock_post_beacon_blocks_v2_ssz(ForkName::Gloas);
+        let mock_proposer_post_contents =
+            proposer_node.mock_post_beacon_execution_payload_envelope_contents_ssz_error();
+
+        test_harness.publish(slot).await;
+
+        // The proposer node accepted the block but rejects the envelope, so the beacon nodes are
+        // tried next with the same contents.
+        mock_post_block.expect(1).assert();
+        mock_proposer_post_contents.expect(2).assert();
+        mock_beacon_node_post_contents.expect(1).assert();
+        assert_published_contents(&test_harness.harness.mock_beacon_node_1, &contents);
+    }
+
+    #[tokio::test]
+    async fn stateless_external_builder_bid_publishes_block_only() {
+        assert_stateless_block_only(BeaconBlock::empty).await;
+    }
+
+    #[tokio::test]
+    async fn stateless_self_build_without_inline_contents_publishes_block_only() {
+        assert_stateless_block_only(self_build_block).await;
     }
 
     #[tokio::test]
@@ -1078,11 +1601,11 @@ mod tests {
         let mock_bn_1 = test_harness
             .harness
             .mock_beacon_node_1
-            .mock_post_validator_blocks_v4_ssz_error(slot);
+            .mock_post_validator_blocks_v4_ssz_error(slot, false);
         let mock_bn_2 = test_harness
             .harness
             .mock_beacon_node_2
-            .mock_post_validator_blocks_v4_ssz_error(slot);
+            .mock_post_validator_blocks_v4_ssz_error(slot, false);
 
         let mock_post_block = test_harness
             .harness
@@ -1126,11 +1649,11 @@ mod tests {
         let mock_ssz = test_harness
             .harness
             .mock_beacon_node_1
-            .mock_post_validator_blocks_v4_ssz_error(slot);
+            .mock_post_validator_blocks_v4_ssz_error(slot, false);
         let mock_json = test_harness
             .harness
             .mock_beacon_node_2
-            .mock_post_validator_blocks_v4(&block, ForkName::Gloas, slot);
+            .mock_post_validator_blocks_v4(&block_only(&block), false, ForkName::Gloas, slot);
 
         let _result = test_harness
             .service

--- a/validator_client/validator_store/src/lib.rs
+++ b/validator_client/validator_store/src/lib.rs
@@ -131,11 +131,17 @@ pub trait ValidatorStore: Send + Sync {
 
     fn set_validator_index(&self, validator_pubkey: &PublicKeyBytes, index: u64);
 
+    /// Sign `block` and apply slashing protection.
+    ///
+    /// `local_payload_root` is the `hash_tree_root` of the locally built execution payload, `Some`
+    /// only for a self-build Gloas bid in stateless block production mode. Lighthouse's store
+    /// ignores it; distributed validator stores commit to it before the block is published.
     fn sign_block(
         &self,
         validator_pubkey: PublicKeyBytes,
         block: UnsignedBlock<Self::E>,
         current_slot: Slot,
+        local_payload_root: Option<Hash256>,
     ) -> impl Future<Output = Result<SignedBlock<Self::E>, Error<Self::Error>>> + Send;
 
     /// Sign a batch of `attestations` and apply slashing protection to them.


### PR DESCRIPTION
## Issue Addressed

#8828 (VC half; the beacon-node half landed in #9568)

## Proposed Changes

Add `--stateless-block-production` (default off). When set, the VC produces Gloas blocks with `include_payload=true`, keeps the returned envelope, blobs and KZG proofs, and after publishing the block signs that envelope and publishes it as `SignedExecutionPayloadEnvelopeContents` through the same node selection as the block. This removes the per-BN envelope cache dependency: the envelope is never fetched, and any beacon node can accept the contents form.

- `ValidatorStore::sign_block` gains `local_payload_root: Option<Hash256>`, the `hash_tree_root` of the locally built payload. Lighthouse's store ignores it.
- With the flag off, behaviour is unchanged.

## Additional Info

`ValidatorStore` is also implemented by DVT clients (e.g. Anchor), where the proposer must commit to its payload root before the block is agreed, which is why the root is passed into `sign_block` rather than derived after publication.

Based on #9807; will retarget `unstable` once it merges.

Verified with `cargo nextest run -p validator_services -p validator_client -p lighthouse_validator_store -p validator_test_rig -p validator_store -p eth2`, `cargo nextest run --release -p lighthouse --test lighthouse_tests validator_client`, `make lint`, and `make cli-local`.
