### PR TITLE
De-bounce full reprocess queue error log

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -47,6 +47,7 @@ use crate::work_reprocessing_queue::{
 use futures::stream::{Stream, StreamExt};
 use futures::task::Poll;
 use lighthouse_network::{MessageId, NetworkGlobals, PeerId};
+use logging::TimeLatch;
 use logging::crit;
 use parking_lot::Mutex;
 pub use scheduler::work_reprocessing_queue;
@@ -738,6 +739,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
 
             let enable_backfill_rate_limiting = self.config.enable_backfill_rate_limiting;
 
+            // De-bounce for the log emitted when the reprocess queue is full.
+            let mut reprocess_queue_debounce = TimeLatch::default();
+
             loop {
                 let (work_event, created_timestamp) = match inbound_events.next().await {
                     Some(InboundEvent::WorkerIdle) => {
@@ -1152,7 +1156,9 @@ impl<E: EthSpec> BeaconProcessor<E> {
 
                         match work {
                             Work::Reprocess(work_event) => {
-                                if let Err(e) = reprocess_work_tx.try_send(work_event) {
+                                if let Err(e) = reprocess_work_tx.try_send(work_event)
+                                    && reprocess_queue_debounce.elapsed()
+                                {
                                     error!(
                                         error = ?e,
                                         "Failed to reprocess work event"


### PR DESCRIPTION
## Issue Addressed

Closes #10040

## Proposed Changes

When the reprocess queue is full, the beacon processor manager emitted
`ERROR Failed to reprocess work event  error: "Full(..)"` once per dropped
event, spamming the logs under sustained load.

The `error!` is now guarded by a `TimeLatch` (`logging` crate,
`LOG_DEBOUNCE_INTERVAL` = 30s) — the same de-bounce primitive used for the
other queue-full logs in `WorkQueues`, `work_reprocessing_queue`, and
`router.rs` — so it is emitted at most once every 30 seconds.

## Additional Info

- `TimeLatch::elapsed()` primes on first call, so the first failure after a
  quiet period is not logged; the log then fires at most once per interval.
  This matches the semantics of all existing `TimeLatch` call sites.
- Verified with `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt
  --check`, and `cargo test` on the `beacon_processor` crate (22 tests pass).
- Disclosure: implemented with AI assistance; the change has been reviewed and verified locally.